### PR TITLE
feat(aws): make Region optional, defaulting to the authenticated one

### DIFF
--- a/packages/aws/scripts/spec.ts
+++ b/packages/aws/scripts/spec.ts
@@ -948,7 +948,6 @@ export const awsSpec = (
 
   // Import refs aliased only where a generated schema name conflicts.
   const credsRef = allSchemaNames.has("Credentials") ? "Creds" : "Credentials";
-  const rgnRef = allSchemaNames.has("Region") ? "Rgn" : "Region";
   const commonErrorsRef = allSchemaNames.has("CommonErrors")
     ? "CommonErr"
     : "CommonErrors";
@@ -2397,7 +2396,9 @@ export const awsSpec = (
 
       // Explicit type annotations avoid TypeScript resolving internal
       // imports in emitted .d.ts files (type portability for consumers).
-      const depsType = `${credsRef} | ${rgnRef} | HttpClient.HttpClient`;
+      // `Region` is NOT listed: it's an override resolved with
+      // `Effect.serviceOption`, falling back to AWS_REGION (see region.ts).
+      const depsType = `${credsRef} | HttpClient.HttpClient`;
       let typeAnnotation: string;
       if (paginatedTrait) {
         const itemType = resolvePaginatedItemType(
@@ -2435,10 +2436,6 @@ export const awsSpec = (
         credsRef === "Creds"
           ? 'import type { Credentials as Creds } from "../credentials.ts";'
           : 'import type { Credentials } from "../credentials.ts";';
-      const regionImport =
-        rgnRef === "Rgn"
-          ? 'import type { Region as Rgn } from "../region.ts";'
-          : 'import type { Region } from "../region.ts";';
       const commonErrorsImport =
         commonErrorsRef === "CommonErr"
           ? 'import type { CommonErrors as CommonErr } from "../errors.ts";'
@@ -2460,7 +2457,6 @@ export const awsSpec = (
         "__CATEGORY_IMPORT__",
         credentialsImport,
         commonErrorsImport,
-        regionImport,
         "__SENSITIVE_IMPORT__",
       ].join("\n");
 

--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -20,6 +20,7 @@ import {
   InvalidSSOProfile,
   InvalidSSOToken,
   ProfileNotFound,
+  regionFromEnv,
   SsoPortalError,
   SsoRegion,
   SsoStartUrl,
@@ -152,6 +153,13 @@ export const makeAuthService = () =>
 
       const profile = yield* loadProfile(profileName);
 
+      // The region these credentials belong to. An SSO profile always
+      // configures one (`sso_region` is required); `region` overrides it when
+      // the profile calls a different region than its SSO portal lives in.
+      // The environment is the last resort, for a profile carrying neither.
+      const region =
+        profile.region ?? profile.sso_region ?? (yield* regionFromEnv);
+
       // Both SSO formats cache the access token under sha1 of the cache key: the
       // `sso_session` name (modern) or the `sso_start_url` (legacy inline format).
       const ssoCacheKey = profile.sso_session ?? profile.sso_start_url;
@@ -194,6 +202,7 @@ export const makeAuthService = () =>
             sessionToken: cachedCreds.sessionToken
               ? Redacted.make(cachedCreds.sessionToken)
               : undefined,
+            region,
             expiration: cachedCreds.expiry,
           } satisfies ResolvedCredentials;
         }
@@ -279,6 +288,7 @@ export const makeAuthService = () =>
           accessKeyId: Redacted.make(credentials.accessKeyId),
           secretAccessKey: Redacted.make(credentials.secretAccessKey),
           sessionToken: Redacted.make(credentials.sessionToken),
+          region,
           expiration: credentials.expiration,
         } satisfies ResolvedCredentials;
       }

--- a/packages/aws/src/credentials.browser.ts
+++ b/packages/aws/src/credentials.browser.ts
@@ -11,6 +11,8 @@ import * as Layer from "effect/Layer";
 import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
 import type { HttpClientError } from "effect/unstable/http/HttpClientError";
+import { fromEnvironment as regionFromEnvironment } from "./region.ts";
+import type { RegionName } from "./region.ts";
 export * as AWSTypes from "@aws-sdk/types";
 
 export interface AwsCredentials {
@@ -21,11 +23,18 @@ export interface AwsCredentials {
 
 /**
  * Resolved credential values ready for request signing.
+ *
+ * `region` is not optional. Authenticating always establishes one — from the
+ * environment, the profile, or the SSO session — and carrying it here is what
+ * lets operations drop `Region` from their requirements: the region an
+ * operation uses is the one its credentials came with, unless a `Region`
+ * override says otherwise.
  */
 export interface ResolvedCredentials {
   readonly accessKeyId: Redacted.Redacted<string>;
   readonly secretAccessKey: Redacted.Redacted<string>;
   readonly sessionToken: Redacted.Redacted<string> | undefined;
+  readonly region: RegionName;
   readonly expiration?: number;
 }
 
@@ -38,6 +47,7 @@ export interface ResolvedCredentials {
  */
 export type CredentialsError =
   | AwsCredentialProviderError
+  | MissingRegion
   | ProfileNotFound
   | InvalidSSOProfile
   | InvalidSSOToken
@@ -59,22 +69,62 @@ export const mock = Layer.succeed(
     accessKeyId: Redacted.make("test"),
     secretAccessKey: Redacted.make("test"),
     sessionToken: Redacted.make("test"),
+    region: "us-east-1" as RegionName,
   }),
 );
 
 /**
  * Create resolved credentials from an AWS credential identity.
+ *
+ * The identity carries no region — `AwsCredentialIdentity` never has one —
+ * so the provider that resolved it supplies the region it authenticated
+ * against.
  */
 export const fromAwsCredentialIdentity = (
   identity: AwsCredentialIdentity,
+  region: RegionName,
 ): ResolvedCredentials => ({
   accessKeyId: Redacted.make(identity.accessKeyId),
   secretAccessKey: Redacted.make(identity.secretAccessKey),
   sessionToken: identity.sessionToken
     ? Redacted.make(identity.sessionToken)
     : undefined,
+  region,
   expiration: identity.expiration?.getTime(),
 });
+
+/**
+ * A credentials layer resolved a set of credentials but could not determine
+ * which region they belong to.
+ *
+ * A credential-resolution failure like any other, rather than a defect: the
+ * caller's fix is the same shape as for a missing key — configure the
+ * environment, the profile, or pass it explicitly.
+ */
+export class MissingRegion extends Data.TaggedError(
+  "Alchemy::AWS::MissingRegion",
+)<{
+  message: string;
+  hints?: ReadonlyArray<string>;
+}> {}
+
+/**
+ * The region a credentials provider authenticated against, from the
+ * environment. Node providers that read a profile override this with the
+ * profile's own region.
+ */
+export const regionFromEnv = regionFromEnvironment.pipe(
+  Effect.catchCause(
+    () =>
+      new MissingRegion({
+        message: "Resolved credentials, but no region is configured.",
+        hints: [
+          "Set AWS_REGION (or AWS_DEFAULT_REGION).",
+          'Or provide one explicitly with Region.of("us-east-1").',
+        ],
+      }),
+  ),
+);
 
 type ProviderName =
   | "env"
@@ -155,6 +205,11 @@ export const createCachedCredentialsEffect = <E, R>(
 export const createLazyProvider = (
   provider: (config: {}) => AwsCredentialIdentityProvider,
   providerName: ProviderName,
+  /**
+   * Where this provider's region comes from. Defaults to the environment;
+   * providers that read a profile pass the profile's region instead.
+   */
+  region: Effect.Effect<RegionName, CredentialsError> = regionFromEnv,
 ): Layer.Layer<Credentials> => {
   const resolve = Effect.gen(function* () {
     const hints = providerHints(providerName);
@@ -168,7 +223,7 @@ export const createLazyProvider = (
           hints,
         }),
     });
-    return fromAwsCredentialIdentity(identity);
+    return fromAwsCredentialIdentity(identity, yield* region);
   });
 
   return Layer.succeed(Credentials, createCachedCredentialsEffect(resolve));
@@ -180,10 +235,15 @@ export const createLazyProvider = (
  */
 export const fromCredentials = (
   credentials: AwsCredentialIdentity,
+  /** Defaults to the environment, like every other provider. */
+  region?: RegionName,
 ): Layer.Layer<Credentials> =>
   Layer.succeed(
     Credentials,
-    Effect.succeed(fromAwsCredentialIdentity(credentials)),
+    Effect.map(
+      region === undefined ? regionFromEnv : Effect.succeed(region),
+      (resolved) => fromAwsCredentialIdentity(credentials, resolved),
+    ),
   );
 
 export const fromHttp = () => createLazyProvider(_fromHttp, "http");

--- a/packages/aws/src/credentials.ts
+++ b/packages/aws/src/credentials.ts
@@ -9,10 +9,48 @@ import {
 import * as BrowserCredentials from "./credentials.browser.ts";
 export * from "./credentials.browser.ts";
 
+import { loadSharedConfigFiles } from "@smithy/shared-ini-file-loader";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Auth } from "./auth.ts";
-import * as Region from "./region.ts";
+import type * as Region from "./region.ts";
+
+/**
+ * The region a node credentials provider authenticated against: the
+ * environment first, then the active profile's `region` in `~/.aws/config`
+ * — the same order, and the same files, the AWS CLI reads.
+ *
+ * The profile is only consulted when the environment is silent, so
+ * `AWS_REGION` still wins for a one-off override without editing config.
+ */
+const regionFromEnvOrProfile = BrowserCredentials.regionFromEnv.pipe(
+  Effect.catchTag("Alchemy::AWS::MissingRegion", (missing) =>
+    Effect.flatMap(
+      Effect.tryPromise({
+        try: () => loadSharedConfigFiles(),
+        catch: () => missing,
+      }),
+      (files) => {
+        const profileName =
+          process.env.AWS_PROFILE ??
+          process.env.AWS_DEFAULT_PROFILE ??
+          "default";
+        const region = files.configFile?.[profileName]?.region;
+        return region === undefined
+          ? Effect.fail(
+              new BrowserCredentials.MissingRegion({
+                message: missing.message,
+                hints: [
+                  ...(missing.hints ?? []),
+                  `Or set \`region\` on the [profile ${profileName}] section of ~/.aws/config.`,
+                ],
+              }),
+            )
+          : Effect.succeed(region as Region.RegionName);
+      },
+    ),
+  ),
+);
 
 export const fromEnv = () =>
   BrowserCredentials.createLazyProvider(_fromEnv, "env");
@@ -21,18 +59,27 @@ export const fromChain = () =>
   BrowserCredentials.createLazyProvider(
     () => _fromNodeProviderChain(),
     "chain",
+    regionFromEnvOrProfile,
   );
 
 // export const fromSSO = () => createLazyProvider(_fromSSO);
 
 export const fromIni = () =>
-  BrowserCredentials.createLazyProvider(_fromIni, "ini");
+  BrowserCredentials.createLazyProvider(
+    _fromIni,
+    "ini",
+    regionFromEnvOrProfile,
+  );
 
 export const fromContainerMetadata = () =>
   BrowserCredentials.createLazyProvider(_fromContainerMetadata, "container");
 
 export const fromProcess = () =>
-  BrowserCredentials.createLazyProvider(_fromProcess, "process");
+  BrowserCredentials.createLazyProvider(
+    _fromProcess,
+    "process",
+    regionFromEnvOrProfile,
+  );
 
 export const fromTokenFile = () =>
   BrowserCredentials.createLazyProvider(_fromTokenFile, "token-file");
@@ -43,54 +90,14 @@ export const fromTokenFile = () =>
  * and credentials are cached until they expire.
  */
 export const fromSSO = (profileName: string = "default") =>
-  Layer.merge(
-    Layer.effect(
-      BrowserCredentials.Credentials,
-      Auth.use((auth) =>
-        Effect.succeed(
-          BrowserCredentials.createCachedCredentialsEffect(
-            auth.loadProfileCredentials(profileName),
-          ),
-        ),
-      ),
-    ),
-    regionFromProfile(profileName),
-  );
-
-/**
- * The `Region` for a profile, from its configured `region` (falling back to
- * `sso_region`, which an SSO profile always carries).
- *
- * `fromSSO` merges this in, so authenticating through a profile also settles
- * the region — the profile already says which one it is, and restating it in
- * code is how the two drift apart. It stays a separate layer so a caller can
- * take the region from one profile while authenticating some other way.
- *
- * Region resolution is by precedence, not by failure: a `Region` layer
- * provided closer to the call wins, and a profile with no region at all
- * simply leaves the environment (`AWS_REGION`) to answer. Neither is an
- * error here.
- */
-export const regionFromProfile = (profileName: string = "default") =>
   Layer.effect(
-    Region.Region,
-    // `Auth.use` rather than the module-level `loadProfile`: it reads the
-    // Auth service the caller already provides for `fromSSO`, instead of
-    // constructing one and dragging FileSystem/Path into this layer's
-    // requirements.
+    BrowserCredentials.Credentials,
     Auth.use((auth) =>
-      auth.loadProfile(profileName).pipe(
-        Effect.map((profile) => profile.region ?? profile.sso_region),
-        // An unreadable or absent profile isn't fatal — the environment
-        // still gets its turn below.
-        Effect.catchCause(() => Effect.succeed(undefined)),
-        Effect.map((region) =>
-          region === undefined
-            ? // Defer to the environment, NOT to `Region.resolve` — this
-              // layer provides `Region`, so `resolve` would find it and
-              // re-enter itself.
-              Region.fromEnvironment
-            : Effect.succeed(region as Region.RegionName),
+      Effect.succeed(
+        BrowserCredentials.createCachedCredentialsEffect(
+          // The resolved credentials carry the profile's own region — see
+          // `loadProfileCredentials` in auth.ts.
+          auth.loadProfileCredentials(profileName),
         ),
       ),
     ),

--- a/packages/aws/src/credentials.ts
+++ b/packages/aws/src/credentials.ts
@@ -12,6 +12,7 @@ export * from "./credentials.browser.ts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Auth } from "./auth.ts";
+import * as Region from "./region.ts";
 
 export const fromEnv = () =>
   BrowserCredentials.createLazyProvider(_fromEnv, "env");
@@ -42,12 +43,54 @@ export const fromTokenFile = () =>
  * and credentials are cached until they expire.
  */
 export const fromSSO = (profileName: string = "default") =>
+  Layer.merge(
+    Layer.effect(
+      BrowserCredentials.Credentials,
+      Auth.use((auth) =>
+        Effect.succeed(
+          BrowserCredentials.createCachedCredentialsEffect(
+            auth.loadProfileCredentials(profileName),
+          ),
+        ),
+      ),
+    ),
+    regionFromProfile(profileName),
+  );
+
+/**
+ * The `Region` for a profile, from its configured `region` (falling back to
+ * `sso_region`, which an SSO profile always carries).
+ *
+ * `fromSSO` merges this in, so authenticating through a profile also settles
+ * the region — the profile already says which one it is, and restating it in
+ * code is how the two drift apart. It stays a separate layer so a caller can
+ * take the region from one profile while authenticating some other way.
+ *
+ * Region resolution is by precedence, not by failure: a `Region` layer
+ * provided closer to the call wins, and a profile with no region at all
+ * simply leaves the environment (`AWS_REGION`) to answer. Neither is an
+ * error here.
+ */
+export const regionFromProfile = (profileName: string = "default") =>
   Layer.effect(
-    BrowserCredentials.Credentials,
+    Region.Region,
+    // `Auth.use` rather than the module-level `loadProfile`: it reads the
+    // Auth service the caller already provides for `fromSSO`, instead of
+    // constructing one and dragging FileSystem/Path into this layer's
+    // requirements.
     Auth.use((auth) =>
-      Effect.succeed(
-        BrowserCredentials.createCachedCredentialsEffect(
-          auth.loadProfileCredentials(profileName),
+      auth.loadProfile(profileName).pipe(
+        Effect.map((profile) => profile.region ?? profile.sso_region),
+        // An unreadable or absent profile isn't fatal — the environment
+        // still gets its turn below.
+        Effect.catchCause(() => Effect.succeed(undefined)),
+        Effect.map((region) =>
+          region === undefined
+            ? // Defer to the environment, NOT to `Region.resolve` — this
+              // layer provides `Region`, so `resolve` would find it and
+              // re-enter itself.
+              Region.fromEnvironment
+            : Effect.succeed(region as Region.RegionName),
         ),
       ),
     ),

--- a/packages/aws/src/protocol.ts
+++ b/packages/aws/src/protocol.ts
@@ -156,7 +156,13 @@ const encode = ({
     yield* Effect.logDebug("Built Request", request);
 
     const credentials = yield* yield* Credentials.Credentials;
-    const region = yield* Region.resolve;
+    // The region the credentials authenticated against, unless this scope
+    // provides a `Region` override. `Region` is optional — it isn't in any
+    // operation's requirements — so it's read with `serviceOption`.
+    const regionOverride = yield* Effect.serviceOption(Region.Region);
+    const region = Option.isSome(regionOverride)
+      ? yield* regionOverride.value
+      : credentials.region;
     const serviceName = sigv4?.name ?? "s3";
 
     // Resolve endpoint and adjust request path if needed

--- a/packages/aws/src/protocol.ts
+++ b/packages/aws/src/protocol.ts
@@ -53,11 +53,15 @@ import {
 } from "./traits.ts";
 import { getIdentifier } from "./util/ast.ts";
 
-/** Context (requirements) shared by every generated AWS operation. */
-export type AwsOpContext =
-  | Credentials.Credentials
-  | Region.Region
-  | HttpClient.HttpClient;
+/**
+ * Context (requirements) shared by every generated AWS operation.
+ *
+ * `Region` is deliberately absent: it is an override read with
+ * `Effect.serviceOption` (see `region.ts`), falling back to the environment,
+ * so callers who already configured a region for their credentials don't
+ * have to state it again.
+ */
+export type AwsOpContext = Credentials.Credentials | HttpClient.HttpClient;
 
 interface Prepared {
   readonly buildRequest: (input: unknown) => Effect.Effect<Request, any, any>;
@@ -152,7 +156,7 @@ const encode = ({
     yield* Effect.logDebug("Built Request", request);
 
     const credentials = yield* yield* Credentials.Credentials;
-    const region = yield* yield* Region.Region;
+    const region = yield* Region.resolve;
     const serviceName = sigv4?.name ?? "s3";
 
     // Resolve endpoint and adjust request path if needed

--- a/packages/aws/src/region.ts
+++ b/packages/aws/src/region.ts
@@ -1,20 +1,83 @@
+/**
+ * The region an operation is dispatched to.
+ *
+ * {@link Region} is an OVERRIDE, not a requirement: operations don't list it
+ * in their context, and {@link resolve} reads it with `Effect.serviceOption`.
+ * When nothing provides it, the region falls back to the environment — the
+ * same `AWS_REGION`/`AWS_DEFAULT_REGION` variables every AWS tool reads — so
+ * a caller that has already authenticated through the environment or an SSO
+ * profile doesn't have to state the region twice.
+ *
+ * Precedence, highest first:
+ *
+ * 1. a `Region` layer provided by the caller (`Region.fromEnv()`, or any
+ *    `Layer.succeed(Region, …)`),
+ * 2. a `Region` layer provided by the credentials layer — `Credentials.fromSSO`
+ *    contributes the profile's configured region,
+ * 3. `AWS_REGION`, then `AWS_DEFAULT_REGION`.
+ *
+ * With none of those, {@link resolve} dies. A missing region is a
+ * configuration defect, not a recoverable API failure, and dying keeps it out
+ * of every operation's error channel — the same call `fromEnv()` already made
+ * for an unset variable.
+ */
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 
 export class Region extends Context.Service<
   Region,
   Effect.Effect<RegionName>
 >()("AWS::Region") {}
 
-export const fromEnv = () =>
-  Layer.succeed(
-    Region,
-    Config.string("AWS_REGION")
-      .pipe(Config.orElse(() => Config.string("AWS_DEFAULT_REGION")))
-      .pipe(Effect.orDie),
-  );
+/** `AWS_REGION`, then `AWS_DEFAULT_REGION`. */
+const fromEnvConfig = Config.string("AWS_REGION").pipe(
+  Config.orElse(() => Config.string("AWS_DEFAULT_REGION")),
+);
+
+/**
+ * The region from the environment alone, ignoring any provided {@link Region}.
+ *
+ * This is {@link resolve}'s last step, exported because a layer that PROVIDES
+ * `Region` cannot call `resolve` to defer to the environment — `resolve` would
+ * find that same layer and re-enter it forever. Such layers fall back here.
+ *
+ * Dies when neither variable is set: a missing region is a configuration
+ * defect, not a recoverable API failure, and keeping it out of the error
+ * channel is what lets every operation drop `Region` from its requirements.
+ */
+export const fromEnvironment: Effect.Effect<RegionName> = fromEnvConfig.pipe(
+  Effect.catchCause(() =>
+    Effect.die(
+      new Error(
+        "No AWS region configured. Set AWS_REGION (or AWS_DEFAULT_REGION), " +
+          'provide one with Region.of("us-east-1"), or authenticate with a ' +
+          "profile that configures a region (Credentials.fromSSO).",
+      ),
+    ),
+  ),
+);
+
+export const fromEnv = () => Layer.succeed(Region, fromEnvironment);
+
+/** Provide a fixed region, e.g. `Region.of("us-west-2")`. */
+export const of = (region: RegionName) =>
+  Layer.succeed(Region, Effect.succeed(region));
+
+/**
+ * The region for the current request: the provided {@link Region} if there is
+ * one, otherwise {@link fromEnvironment}. Requires nothing — that is what
+ * makes the service optional at every call site.
+ */
+export const resolve: Effect.Effect<RegionName> = Effect.flatMap(
+  Effect.serviceOption(Region),
+  Option.match({
+    onSome: (region) => region,
+    onNone: () => fromEnvironment,
+  }),
+);
 
 export type RegionName =
   | "us-east-1"

--- a/packages/aws/src/region.ts
+++ b/packages/aws/src/region.ts
@@ -1,83 +1,46 @@
 /**
  * The region an operation is dispatched to.
  *
- * {@link Region} is an OVERRIDE, not a requirement: operations don't list it
- * in their context, and {@link resolve} reads it with `Effect.serviceOption`.
- * When nothing provides it, the region falls back to the environment — the
- * same `AWS_REGION`/`AWS_DEFAULT_REGION` variables every AWS tool reads — so
- * a caller that has already authenticated through the environment or an SSO
- * profile doesn't have to state the region twice.
+ * Every credentials layer resolves a region as part of authenticating — the
+ * environment variables, the profile, the SSO session all carry one — so
+ * {@link ResolvedCredentials.region} is where the region normally comes from
+ * and it is never absent.
  *
- * Precedence, highest first:
- *
- * 1. a `Region` layer provided by the caller (`Region.fromEnv()`, or any
- *    `Layer.succeed(Region, …)`),
- * 2. a `Region` layer provided by the credentials layer — `Credentials.fromSSO`
- *    contributes the profile's configured region,
- * 3. `AWS_REGION`, then `AWS_DEFAULT_REGION`.
- *
- * With none of those, {@link resolve} dies. A missing region is a
- * configuration defect, not a recoverable API failure, and dying keeps it out
- * of every operation's error channel — the same call `fromEnv()` already made
- * for an unset variable.
+ * {@link Region} is the OVERRIDE on top of that: an optional service that
+ * generated operations do NOT list in their requirements. The protocol reads
+ * it with `Effect.serviceOption` and uses the credentials' region when
+ * nothing provides it, so a caller who already said "authenticate with the
+ * `dev` profile" doesn't have to repeat which region `dev` uses, but a caller
+ * who wants one call in another region can still say so.
  */
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 export class Region extends Context.Service<
   Region,
   Effect.Effect<RegionName>
 >()("AWS::Region") {}
 
-/** `AWS_REGION`, then `AWS_DEFAULT_REGION`. */
-const fromEnvConfig = Config.string("AWS_REGION").pipe(
-  Config.orElse(() => Config.string("AWS_DEFAULT_REGION")),
-);
-
 /**
- * The region from the environment alone, ignoring any provided {@link Region}.
- *
- * This is {@link resolve}'s last step, exported because a layer that PROVIDES
- * `Region` cannot call `resolve` to defer to the environment — `resolve` would
- * find that same layer and re-enter it forever. Such layers fall back here.
- *
- * Dies when neither variable is set: a missing region is a configuration
- * defect, not a recoverable API failure, and keeping it out of the error
- * channel is what lets every operation drop `Region` from its requirements.
+ * `AWS_REGION`, then `AWS_DEFAULT_REGION` — the variables every AWS tool
+ * reads. Credentials providers use this as their region source; it fails
+ * (rather than dying) so a provider can turn it into a typed
+ * `MissingRegion` alongside its other credential-resolution failures.
  */
-export const fromEnvironment: Effect.Effect<RegionName> = fromEnvConfig.pipe(
-  Effect.catchCause(() =>
-    Effect.die(
-      new Error(
-        "No AWS region configured. Set AWS_REGION (or AWS_DEFAULT_REGION), " +
-          'provide one with Region.of("us-east-1"), or authenticate with a ' +
-          "profile that configures a region (Credentials.fromSSO).",
-      ),
-    ),
-  ),
+export const fromEnvironment = Config.string("AWS_REGION").pipe(
+  Config.orElse(() => Config.string("AWS_DEFAULT_REGION")),
+  Effect.map((region) => region as RegionName),
 );
 
-export const fromEnv = () => Layer.succeed(Region, fromEnvironment);
+/** Override the region with whatever the environment names. */
+export const fromEnv = () =>
+  Layer.succeed(Region, fromEnvironment.pipe(Effect.orDie));
 
-/** Provide a fixed region, e.g. `Region.of("us-west-2")`. */
+/** Override the region for a scope, e.g. `Region.of("us-west-2")`. */
 export const of = (region: RegionName) =>
   Layer.succeed(Region, Effect.succeed(region));
-
-/**
- * The region for the current request: the provided {@link Region} if there is
- * one, otherwise {@link fromEnvironment}. Requires nothing — that is what
- * makes the service optional at every call site.
- */
-export const resolve: Effect.Effect<RegionName> = Effect.flatMap(
-  Effect.serviceOption(Region),
-  Option.match({
-    onSome: (region) => region,
-    onNone: () => fromEnvironment,
-  }),
-);
 
 export type RegionName =
   | "us-east-1"

--- a/packages/aws/src/services/accessanalyzer.ts
+++ b/packages/aws/src/services/accessanalyzer.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AccessAnalyzer",
@@ -3234,7 +3233,7 @@ export const applyArchiveRule: API.OperationMethod<
   ApplyArchiveRuleRequest,
   ApplyArchiveRuleResponse,
   ApplyArchiveRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyArchiveRuleRequest,
   output: ApplyArchiveRuleResponse,
@@ -3263,7 +3262,7 @@ export const cancelPolicyGeneration: API.OperationMethod<
   CancelPolicyGenerationRequest,
   CancelPolicyGenerationResponse,
   CancelPolicyGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelPolicyGenerationRequest,
   output: CancelPolicyGenerationResponse,
@@ -3293,7 +3292,7 @@ export const checkAccessNotGranted: API.OperationMethod<
   CheckAccessNotGrantedRequest,
   CheckAccessNotGrantedResponse,
   CheckAccessNotGrantedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckAccessNotGrantedRequest,
   output: CheckAccessNotGrantedResponse,
@@ -3327,7 +3326,7 @@ export const checkNoNewAccess: API.OperationMethod<
   CheckNoNewAccessRequest,
   CheckNoNewAccessResponse,
   CheckNoNewAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckNoNewAccessRequest,
   output: CheckNoNewAccessResponse,
@@ -3359,7 +3358,7 @@ export const checkNoPublicAccess: API.OperationMethod<
   CheckNoPublicAccessRequest,
   CheckNoPublicAccessResponse,
   CheckNoPublicAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckNoPublicAccessRequest,
   output: CheckNoPublicAccessResponse,
@@ -3392,7 +3391,7 @@ export const createAccessPreview: API.OperationMethod<
   CreateAccessPreviewRequest,
   CreateAccessPreviewResponse,
   CreateAccessPreviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPreviewRequest,
   output: CreateAccessPreviewResponse,
@@ -3425,7 +3424,7 @@ export const createAnalyzer: API.OperationMethod<
   CreateAnalyzerRequest,
   CreateAnalyzerResponse,
   CreateAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnalyzerRequest,
   output: CreateAnalyzerResponse,
@@ -3460,7 +3459,7 @@ export const createArchiveRule: API.OperationMethod<
   CreateArchiveRuleRequest,
   CreateArchiveRuleResponse,
   CreateArchiveRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateArchiveRuleRequest,
   output: CreateArchiveRuleResponse,
@@ -3495,7 +3494,7 @@ export const createServiceLinkedAnalyzer: API.OperationMethod<
   CreateServiceLinkedAnalyzerRequest,
   CreateServiceLinkedAnalyzerResponse,
   CreateServiceLinkedAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceLinkedAnalyzerRequest,
   output: CreateServiceLinkedAnalyzerResponse,
@@ -3526,7 +3525,7 @@ export const deleteAnalyzer: API.OperationMethod<
   DeleteAnalyzerRequest,
   DeleteAnalyzerResponse,
   DeleteAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnalyzerRequest,
   output: DeleteAnalyzerResponse,
@@ -3556,7 +3555,7 @@ export const deleteArchiveRule: API.OperationMethod<
   DeleteArchiveRuleRequest,
   DeleteArchiveRuleResponse,
   DeleteArchiveRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArchiveRuleRequest,
   output: DeleteArchiveRuleResponse,
@@ -3589,7 +3588,7 @@ export const deleteServiceLinkedAnalyzer: API.OperationMethod<
   DeleteServiceLinkedAnalyzerRequest,
   DeleteServiceLinkedAnalyzerResponse,
   DeleteServiceLinkedAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceLinkedAnalyzerRequest,
   output: DeleteServiceLinkedAnalyzerResponse,
@@ -3619,7 +3618,7 @@ export const generateFindingRecommendation: API.OperationMethod<
   GenerateFindingRecommendationRequest,
   GenerateFindingRecommendationResponse,
   GenerateFindingRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateFindingRecommendationRequest,
   output: GenerateFindingRecommendationResponse,
@@ -3648,7 +3647,7 @@ export const getAccessPreview: API.OperationMethod<
   GetAccessPreviewRequest,
   GetAccessPreviewResponse,
   GetAccessPreviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPreviewRequest,
   output: GetAccessPreviewResponse,
@@ -3680,7 +3679,7 @@ export const getAnalyzedResource: API.OperationMethod<
   GetAnalyzedResourceRequest,
   GetAnalyzedResourceResponse,
   GetAnalyzedResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnalyzedResourceRequest,
   output: GetAnalyzedResourceResponse,
@@ -3710,7 +3709,7 @@ export const getAnalyzer: API.OperationMethod<
   GetAnalyzerRequest,
   GetAnalyzerResponse,
   GetAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnalyzerRequest,
   output: GetAnalyzerResponse,
@@ -3742,7 +3741,7 @@ export const getArchiveRule: API.OperationMethod<
   GetArchiveRuleRequest,
   GetArchiveRuleResponse,
   GetArchiveRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveRuleRequest,
   output: GetArchiveRuleResponse,
@@ -3774,7 +3773,7 @@ export const getFinding: API.OperationMethod<
   GetFindingRequest,
   GetFindingResponse,
   GetFindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingRequest,
   output: GetFindingResponse,
@@ -3804,7 +3803,7 @@ export const getFindingRecommendation: API.PaginatedOperationMethod<
   GetFindingRecommendationRequest,
   GetFindingRecommendationResponse,
   GetFindingRecommendationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendedStep
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingRecommendationRequest,
@@ -3841,7 +3840,7 @@ export const getFindingsStatistics: API.OperationMethod<
   GetFindingsStatisticsRequest,
   GetFindingsStatisticsResponse,
   GetFindingsStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsStatisticsRequest,
   output: GetFindingsStatisticsResponse,
@@ -3871,7 +3870,7 @@ export const getFindingV2: API.PaginatedOperationMethod<
   GetFindingV2Request,
   GetFindingV2Response,
   GetFindingV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingV2Request,
@@ -3907,7 +3906,7 @@ export const getGeneratedPolicy: API.OperationMethod<
   GetGeneratedPolicyRequest,
   GetGeneratedPolicyResponse,
   GetGeneratedPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeneratedPolicyRequest,
   output: GetGeneratedPolicyResponse,
@@ -3937,7 +3936,7 @@ export const listAccessPreviewFindings: API.PaginatedOperationMethod<
   ListAccessPreviewFindingsRequest,
   ListAccessPreviewFindingsResponse,
   ListAccessPreviewFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessPreviewFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPreviewFindingsRequest,
@@ -3975,7 +3974,7 @@ export const listAccessPreviews: API.PaginatedOperationMethod<
   ListAccessPreviewsRequest,
   ListAccessPreviewsResponse,
   ListAccessPreviewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessPreviewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPreviewsRequest,
@@ -4012,7 +4011,7 @@ export const listAnalyzedResources: API.PaginatedOperationMethod<
   ListAnalyzedResourcesRequest,
   ListAnalyzedResourcesResponse,
   ListAnalyzedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalyzedResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalyzedResourcesRequest,
@@ -4048,7 +4047,7 @@ export const listAnalyzers: API.PaginatedOperationMethod<
   ListAnalyzersRequest,
   ListAnalyzersResponse,
   ListAnalyzersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalyzerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalyzersRequest,
@@ -4083,7 +4082,7 @@ export const listArchiveRules: API.PaginatedOperationMethod<
   ListArchiveRulesRequest,
   ListArchiveRulesResponse,
   ListArchiveRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ArchiveRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArchiveRulesRequest,
@@ -4123,7 +4122,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsRequest,
   ListFindingsResponse,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsRequest,
@@ -4162,7 +4161,7 @@ export const listFindingsV2: API.PaginatedOperationMethod<
   ListFindingsV2Request,
   ListFindingsV2Response,
   ListFindingsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingSummaryV2
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsV2Request,
@@ -4198,7 +4197,7 @@ export const listPolicyGenerations: API.PaginatedOperationMethod<
   ListPolicyGenerationsRequest,
   ListPolicyGenerationsResponse,
   ListPolicyGenerationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyGeneration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyGenerationsRequest,
@@ -4234,7 +4233,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4265,7 +4264,7 @@ export const startPolicyGeneration: API.OperationMethod<
   StartPolicyGenerationRequest,
   StartPolicyGenerationResponse,
   StartPolicyGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPolicyGenerationRequest,
   output: StartPolicyGenerationResponse,
@@ -4298,7 +4297,7 @@ export const startResourceScan: API.OperationMethod<
   StartResourceScanRequest,
   StartResourceScanResponse,
   StartResourceScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceScanRequest,
   output: StartResourceScanResponse,
@@ -4328,7 +4327,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4358,7 +4357,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4391,7 +4390,7 @@ export const updateAnalyzer: API.OperationMethod<
   UpdateAnalyzerRequest,
   UpdateAnalyzerResponse,
   UpdateAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnalyzerRequest,
   output: UpdateAnalyzerResponse,
@@ -4422,7 +4421,7 @@ export const updateArchiveRule: API.OperationMethod<
   UpdateArchiveRuleRequest,
   UpdateArchiveRuleResponse,
   UpdateArchiveRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateArchiveRuleRequest,
   output: UpdateArchiveRuleResponse,
@@ -4452,7 +4451,7 @@ export const updateFindings: API.OperationMethod<
   UpdateFindingsRequest,
   UpdateFindingsResponse,
   UpdateFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingsRequest,
   output: UpdateFindingsResponse,
@@ -4481,7 +4480,7 @@ export const validatePolicy: API.PaginatedOperationMethod<
   ValidatePolicyRequest,
   ValidatePolicyResponse,
   ValidatePolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ValidatePolicyFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ValidatePolicyRequest,

--- a/packages/aws/src/services/account.ts
+++ b/packages/aws/src/services/account.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Account", serviceShapeName: "Account" });
 const auth = T.AwsAuthSigv4({ name: "account" });
@@ -715,7 +714,7 @@ export const acceptPrimaryEmailUpdate: API.OperationMethod<
   AcceptPrimaryEmailUpdateRequest,
   AcceptPrimaryEmailUpdateResponse,
   AcceptPrimaryEmailUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptPrimaryEmailUpdateRequest,
   output: AcceptPrimaryEmailUpdateResponse,
@@ -750,7 +749,7 @@ export const deleteAlternateContact: API.OperationMethod<
   DeleteAlternateContactRequest,
   DeleteAlternateContactResponse,
   DeleteAlternateContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlternateContactRequest,
   output: DeleteAlternateContactResponse,
@@ -782,7 +781,7 @@ export const disableRegion: API.OperationMethod<
   DisableRegionRequest,
   DisableRegionResponse,
   DisableRegionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRegionRequest,
   output: DisableRegionResponse,
@@ -812,7 +811,7 @@ export const enableRegion: API.OperationMethod<
   EnableRegionRequest,
   EnableRegionResponse,
   EnableRegionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRegionRequest,
   output: EnableRegionResponse,
@@ -841,7 +840,7 @@ export const getAccountInformation: API.OperationMethod<
   GetAccountInformationRequest,
   GetAccountInformationResponse,
   GetAccountInformationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountInformationRequest,
   output: GetAccountInformationResponse,
@@ -874,7 +873,7 @@ export const getAlternateContact: API.OperationMethod<
   GetAlternateContactRequest,
   GetAlternateContactResponse,
   GetAlternateContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAlternateContactRequest,
   output: GetAlternateContactResponse,
@@ -906,7 +905,7 @@ export const getContactInformation: API.OperationMethod<
   GetContactInformationRequest,
   GetContactInformationResponse,
   GetContactInformationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactInformationRequest,
   output: GetContactInformationResponse,
@@ -937,7 +936,7 @@ export const getGovCloudAccountInformation: API.OperationMethod<
   GetGovCloudAccountInformationRequest,
   GetGovCloudAccountInformationResponse,
   GetGovCloudAccountInformationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGovCloudAccountInformationRequest,
   output: GetGovCloudAccountInformationResponse,
@@ -968,7 +967,7 @@ export const getPrimaryEmail: API.OperationMethod<
   GetPrimaryEmailRequest,
   GetPrimaryEmailResponse,
   GetPrimaryEmailError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPrimaryEmailRequest,
   output: GetPrimaryEmailResponse,
@@ -997,7 +996,7 @@ export const getRegionOptStatus: API.OperationMethod<
   GetRegionOptStatusRequest,
   GetRegionOptStatusResponse,
   GetRegionOptStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegionOptStatusRequest,
   output: GetRegionOptStatusResponse,
@@ -1025,7 +1024,7 @@ export const listRegions: API.PaginatedOperationMethod<
   ListRegionsRequest,
   ListRegionsResponse,
   ListRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Region
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegionsRequest,
@@ -1060,7 +1059,7 @@ export const putAccountName: API.OperationMethod<
   PutAccountNameRequest,
   PutAccountNameResponse,
   PutAccountNameError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountNameRequest,
   output: PutAccountNameResponse,
@@ -1092,7 +1091,7 @@ export const putAlternateContact: API.OperationMethod<
   PutAlternateContactRequest,
   PutAlternateContactResponse,
   PutAlternateContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAlternateContactRequest,
   output: PutAlternateContactResponse,
@@ -1122,7 +1121,7 @@ export const putContactInformation: API.OperationMethod<
   PutContactInformationRequest,
   PutContactInformationResponse,
   PutContactInformationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutContactInformationRequest,
   output: PutContactInformationResponse,
@@ -1152,7 +1151,7 @@ export const startPrimaryEmailUpdate: API.OperationMethod<
   StartPrimaryEmailUpdateRequest,
   StartPrimaryEmailUpdateResponse,
   StartPrimaryEmailUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPrimaryEmailUpdateRequest,
   output: StartPrimaryEmailUpdateResponse,

--- a/packages/aws/src/services/acm-pca.ts
+++ b/packages/aws/src/services/acm-pca.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ACM PCA",
   serviceShapeName: "ACMPrivateCA",
@@ -1285,7 +1284,7 @@ export const createCertificateAuthority: API.OperationMethod<
   CreateCertificateAuthorityRequest,
   CreateCertificateAuthorityResponse,
   CreateCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCertificateAuthorityRequest,
   output: CreateCertificateAuthorityResponse,
@@ -1321,7 +1320,7 @@ export const createCertificateAuthorityAuditReport: API.OperationMethod<
   CreateCertificateAuthorityAuditReportRequest,
   CreateCertificateAuthorityAuditReportResponse,
   CreateCertificateAuthorityAuditReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCertificateAuthorityAuditReportRequest,
   output: CreateCertificateAuthorityAuditReportResponse,
@@ -1362,7 +1361,7 @@ export const createPermission: API.OperationMethod<
   CreatePermissionRequest,
   CreatePermissionResponse,
   CreatePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePermissionRequest,
   output: CreatePermissionResponse,
@@ -1402,7 +1401,7 @@ export const deleteCertificateAuthority: API.OperationMethod<
   DeleteCertificateAuthorityRequest,
   DeleteCertificateAuthorityResponse,
   DeleteCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateAuthorityRequest,
   output: DeleteCertificateAuthorityResponse,
@@ -1441,7 +1440,7 @@ export const deletePermission: API.OperationMethod<
   DeletePermissionRequest,
   DeletePermissionResponse,
   DeletePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionRequest,
   output: DeletePermissionResponse,
@@ -1486,7 +1485,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -1528,7 +1527,7 @@ export const describeCertificateAuthority: API.OperationMethod<
   DescribeCertificateAuthorityRequest,
   DescribeCertificateAuthorityResponse,
   DescribeCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateAuthorityRequest,
   output: DescribeCertificateAuthorityResponse,
@@ -1550,7 +1549,7 @@ export const describeCertificateAuthorityAuditReport: API.OperationMethod<
   DescribeCertificateAuthorityAuditReportRequest,
   DescribeCertificateAuthorityAuditReportResponse,
   DescribeCertificateAuthorityAuditReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateAuthorityAuditReportRequest,
   output: DescribeCertificateAuthorityAuditReportResponse,
@@ -1578,7 +1577,7 @@ export const getCertificate: API.OperationMethod<
   GetCertificateRequest,
   GetCertificateResponse,
   GetCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateRequest,
   output: GetCertificateResponse,
@@ -1606,7 +1605,7 @@ export const getCertificateAuthorityCertificate: API.OperationMethod<
   GetCertificateAuthorityCertificateRequest,
   GetCertificateAuthorityCertificateResponse,
   GetCertificateAuthorityCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateAuthorityCertificateRequest,
   output: GetCertificateAuthorityCertificateResponse,
@@ -1634,7 +1633,7 @@ export const getCertificateAuthorityCsr: API.OperationMethod<
   GetCertificateAuthorityCsrRequest,
   GetCertificateAuthorityCsrResponse,
   GetCertificateAuthorityCsrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateAuthorityCsrRequest,
   output: GetCertificateAuthorityCsrResponse,
@@ -1674,7 +1673,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -1781,7 +1780,7 @@ export const importCertificateAuthorityCertificate: API.OperationMethod<
   ImportCertificateAuthorityCertificateRequest,
   ImportCertificateAuthorityCertificateResponse,
   ImportCertificateAuthorityCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCertificateAuthorityCertificateRequest,
   output: ImportCertificateAuthorityCertificateResponse,
@@ -1818,7 +1817,7 @@ export const issueCertificate: API.OperationMethod<
   IssueCertificateRequest,
   IssueCertificateResponse,
   IssueCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IssueCertificateRequest,
   output: IssueCertificateResponse,
@@ -1845,7 +1844,7 @@ export const listCertificateAuthorities: API.PaginatedOperationMethod<
   ListCertificateAuthoritiesRequest,
   ListCertificateAuthoritiesResponse,
   ListCertificateAuthoritiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CertificateAuthority
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificateAuthoritiesRequest,
@@ -1887,7 +1886,7 @@ export const listPermissions: API.PaginatedOperationMethod<
   ListPermissionsRequest,
   ListPermissionsResponse,
   ListPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Permission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionsRequest,
@@ -1923,7 +1922,7 @@ export const listTags: API.PaginatedOperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsRequest,
@@ -1974,7 +1973,7 @@ export const putPolicy: API.OperationMethod<
   PutPolicyRequest,
   PutPolicyResponse,
   PutPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPolicyRequest,
   output: PutPolicyResponse,
@@ -2004,7 +2003,7 @@ export const restoreCertificateAuthority: API.OperationMethod<
   RestoreCertificateAuthorityRequest,
   RestoreCertificateAuthorityResponse,
   RestoreCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreCertificateAuthorityRequest,
   output: RestoreCertificateAuthorityResponse,
@@ -2042,7 +2041,7 @@ export const revokeCertificate: API.OperationMethod<
   RevokeCertificateRequest,
   RevokeCertificateResponse,
   RevokeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeCertificateRequest,
   output: RevokeCertificateResponse,
@@ -2078,7 +2077,7 @@ export const tagCertificateAuthority: API.OperationMethod<
   TagCertificateAuthorityRequest,
   TagCertificateAuthorityResponse,
   TagCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagCertificateAuthorityRequest,
   output: TagCertificateAuthorityResponse,
@@ -2107,7 +2106,7 @@ export const untagCertificateAuthority: API.OperationMethod<
   UntagCertificateAuthorityRequest,
   UntagCertificateAuthorityResponse,
   UntagCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagCertificateAuthorityRequest,
   output: UntagCertificateAuthorityResponse,
@@ -2139,7 +2138,7 @@ export const updateCertificateAuthority: API.OperationMethod<
   UpdateCertificateAuthorityRequest,
   UpdateCertificateAuthorityResponse,
   UpdateCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCertificateAuthorityRequest,
   output: UpdateCertificateAuthorityResponse,

--- a/packages/aws/src/services/acm.ts
+++ b/packages/aws/src/services/acm.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ACM",
@@ -1559,7 +1558,7 @@ export const addTagsToCertificate: API.OperationMethod<
   AddTagsToCertificateRequest,
   AddTagsToCertificateResponse,
   AddTagsToCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToCertificateRequest,
   output: AddTagsToCertificateResponse,
@@ -1598,7 +1597,7 @@ export const deleteCertificate: API.OperationMethod<
   DeleteCertificateRequest,
   DeleteCertificateResponse,
   DeleteCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateRequest,
   output: DeleteCertificateResponse,
@@ -1628,7 +1627,7 @@ export const describeCertificate: API.OperationMethod<
   DescribeCertificateRequest,
   DescribeCertificateResponse,
   DescribeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateRequest,
   output: DescribeCertificateResponse,
@@ -1655,7 +1654,7 @@ export const exportCertificate: API.OperationMethod<
   ExportCertificateRequest,
   ExportCertificateResponse,
   ExportCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportCertificateRequest,
   output: ExportCertificateResponse,
@@ -1681,7 +1680,7 @@ export const getAccountConfiguration: API.OperationMethod<
   GetAccountConfigurationRequest,
   GetAccountConfigurationResponse,
   GetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountConfigurationRequest,
   output: GetAccountConfigurationResponse,
@@ -1703,7 +1702,7 @@ export const getCertificate: API.OperationMethod<
   GetCertificateRequest,
   GetCertificateResponse,
   GetCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateRequest,
   output: GetCertificateResponse,
@@ -1762,7 +1761,7 @@ export const importCertificate: API.OperationMethod<
   ImportCertificateRequest,
   ImportCertificateResponse,
   ImportCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCertificateRequest,
   output: ImportCertificateResponse,
@@ -1792,7 +1791,7 @@ export const listCertificates: API.PaginatedOperationMethod<
   ListCertificatesRequest,
   ListCertificatesResponse,
   ListCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CertificateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificatesRequest,
@@ -1820,7 +1819,7 @@ export const listTagsForCertificate: API.OperationMethod<
   ListTagsForCertificateRequest,
   ListTagsForCertificateResponse,
   ListTagsForCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForCertificateRequest,
   output: ListTagsForCertificateResponse,
@@ -1845,7 +1844,7 @@ export const putAccountConfiguration: API.OperationMethod<
   PutAccountConfigurationRequest,
   PutAccountConfigurationResponse,
   PutAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountConfigurationRequest,
   output: PutAccountConfigurationResponse,
@@ -1877,7 +1876,7 @@ export const removeTagsFromCertificate: API.OperationMethod<
   RemoveTagsFromCertificateRequest,
   RemoveTagsFromCertificateResponse,
   RemoveTagsFromCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromCertificateRequest,
   output: RemoveTagsFromCertificateResponse,
@@ -1906,7 +1905,7 @@ export const renewCertificate: API.OperationMethod<
   RenewCertificateRequest,
   RenewCertificateResponse,
   RenewCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenewCertificateRequest,
   output: RenewCertificateResponse,
@@ -1942,7 +1941,7 @@ export const requestCertificate: API.OperationMethod<
   RequestCertificateRequest,
   RequestCertificateResponse,
   RequestCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestCertificateRequest,
   output: RequestCertificateResponse,
@@ -1973,7 +1972,7 @@ export const resendValidationEmail: API.OperationMethod<
   ResendValidationEmailRequest,
   ResendValidationEmailResponse,
   ResendValidationEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResendValidationEmailRequest,
   output: ResendValidationEmailResponse,
@@ -2005,7 +2004,7 @@ export const revokeCertificate: API.OperationMethod<
   RevokeCertificateRequest,
   RevokeCertificateResponse,
   RevokeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeCertificateRequest,
   output: RevokeCertificateResponse,
@@ -2034,7 +2033,7 @@ export const searchCertificates: API.PaginatedOperationMethod<
   SearchCertificatesRequest,
   SearchCertificatesResponse,
   SearchCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CertificateSearchResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchCertificatesRequest,
@@ -2064,7 +2063,7 @@ export const updateCertificateOptions: API.OperationMethod<
   UpdateCertificateOptionsRequest,
   UpdateCertificateOptionsResponse,
   UpdateCertificateOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCertificateOptionsRequest,
   output: UpdateCertificateOptionsResponse,

--- a/packages/aws/src/services/aiops.ts
+++ b/packages/aws/src/services/aiops.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "AIOps", serviceShapeName: "AIOps" });
 const auth = T.AwsAuthSigv4({ name: "aiops" });
@@ -598,7 +597,7 @@ export const createInvestigationGroup: API.OperationMethod<
   CreateInvestigationGroupInput,
   CreateInvestigationGroupOutput,
   CreateInvestigationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvestigationGroupInput,
   output: CreateInvestigationGroupOutput,
@@ -630,7 +629,7 @@ export const deleteInvestigationGroup: API.OperationMethod<
   DeleteInvestigationGroupRequest,
   DeleteInvestigationGroupResponse,
   DeleteInvestigationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvestigationGroupRequest,
   output: DeleteInvestigationGroupResponse,
@@ -661,7 +660,7 @@ export const deleteInvestigationGroupPolicy: API.OperationMethod<
   DeleteInvestigationGroupPolicyRequest,
   DeleteInvestigationGroupPolicyOutput,
   DeleteInvestigationGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvestigationGroupPolicyRequest,
   output: DeleteInvestigationGroupPolicyOutput,
@@ -692,7 +691,7 @@ export const getInvestigationGroup: API.OperationMethod<
   GetInvestigationGroupRequest,
   GetInvestigationGroupResponse,
   GetInvestigationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvestigationGroupRequest,
   output: GetInvestigationGroupResponse,
@@ -723,7 +722,7 @@ export const getInvestigationGroupPolicy: API.OperationMethod<
   GetInvestigationGroupPolicyRequest,
   GetInvestigationGroupPolicyResponse,
   GetInvestigationGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvestigationGroupPolicyRequest,
   output: GetInvestigationGroupPolicyResponse,
@@ -752,7 +751,7 @@ export const listInvestigationGroups: API.PaginatedOperationMethod<
   ListInvestigationGroupsInput,
   ListInvestigationGroupsOutput,
   ListInvestigationGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListInvestigationGroupsModel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvestigationGroupsInput,
@@ -784,7 +783,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceOutput,
@@ -821,7 +820,7 @@ export const putInvestigationGroupPolicy: API.OperationMethod<
   PutInvestigationGroupPolicyRequest,
   PutInvestigationGroupPolicyResponse,
   PutInvestigationGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInvestigationGroupPolicyRequest,
   output: PutInvestigationGroupPolicyResponse,
@@ -860,7 +859,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -892,7 +891,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -925,7 +924,7 @@ export const updateInvestigationGroup: API.OperationMethod<
   UpdateInvestigationGroupRequest,
   UpdateInvestigationGroupOutput,
   UpdateInvestigationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInvestigationGroupRequest,
   output: UpdateInvestigationGroupOutput,

--- a/packages/aws/src/services/amp.ts
+++ b/packages/aws/src/services/amp.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "amp",
   serviceShapeName: "AmazonPrometheusService",
@@ -2316,7 +2315,7 @@ export const createAlertManagerDefinition: API.OperationMethod<
   CreateAlertManagerDefinitionRequest,
   CreateAlertManagerDefinitionResponse,
   CreateAlertManagerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAlertManagerDefinitionRequest,
   output: CreateAlertManagerDefinitionResponse,
@@ -2349,7 +2348,7 @@ export const createAnomalyDetector: API.OperationMethod<
   CreateAnomalyDetectorRequest,
   CreateAnomalyDetectorResponse,
   CreateAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnomalyDetectorRequest,
   output: CreateAnomalyDetectorResponse,
@@ -2382,7 +2381,7 @@ export const createLoggingConfiguration: API.OperationMethod<
   CreateLoggingConfigurationRequest,
   CreateLoggingConfigurationResponse,
   CreateLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoggingConfigurationRequest,
   output: CreateLoggingConfigurationResponse,
@@ -2412,7 +2411,7 @@ export const createQueryLoggingConfiguration: API.OperationMethod<
   CreateQueryLoggingConfigurationRequest,
   CreateQueryLoggingConfigurationResponse,
   CreateQueryLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueryLoggingConfigurationRequest,
   output: CreateQueryLoggingConfigurationResponse,
@@ -2448,7 +2447,7 @@ export const createRuleGroupsNamespace: API.OperationMethod<
   CreateRuleGroupsNamespaceRequest,
   CreateRuleGroupsNamespaceResponse,
   CreateRuleGroupsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleGroupsNamespaceRequest,
   output: CreateRuleGroupsNamespaceResponse,
@@ -2490,7 +2489,7 @@ export const createScraper: API.OperationMethod<
   CreateScraperRequest,
   CreateScraperResponse,
   CreateScraperError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScraperRequest,
   output: CreateScraperResponse,
@@ -2523,7 +2522,7 @@ export const createWorkspace: API.OperationMethod<
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
   CreateWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceRequest,
   output: CreateWorkspaceResponse,
@@ -2555,7 +2554,7 @@ export const deleteAlertManagerDefinition: API.OperationMethod<
   DeleteAlertManagerDefinitionRequest,
   DeleteAlertManagerDefinitionResponse,
   DeleteAlertManagerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlertManagerDefinitionRequest,
   output: DeleteAlertManagerDefinitionResponse,
@@ -2587,7 +2586,7 @@ export const deleteAnomalyDetector: API.OperationMethod<
   DeleteAnomalyDetectorRequest,
   DeleteAnomalyDetectorResponse,
   DeleteAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnomalyDetectorRequest,
   output: DeleteAnomalyDetectorResponse,
@@ -2620,7 +2619,7 @@ export const deleteLoggingConfiguration: API.OperationMethod<
   DeleteLoggingConfigurationRequest,
   DeleteLoggingConfigurationResponse,
   DeleteLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggingConfigurationRequest,
   output: DeleteLoggingConfigurationResponse,
@@ -2650,7 +2649,7 @@ export const deleteQueryLoggingConfiguration: API.OperationMethod<
   DeleteQueryLoggingConfigurationRequest,
   DeleteQueryLoggingConfigurationResponse,
   DeleteQueryLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueryLoggingConfigurationRequest,
   output: DeleteQueryLoggingConfigurationResponse,
@@ -2681,7 +2680,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -2713,7 +2712,7 @@ export const deleteRuleGroupsNamespace: API.OperationMethod<
   DeleteRuleGroupsNamespaceRequest,
   DeleteRuleGroupsNamespaceResponse,
   DeleteRuleGroupsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleGroupsNamespaceRequest,
   output: DeleteRuleGroupsNamespaceResponse,
@@ -2745,7 +2744,7 @@ export const deleteScraper: API.OperationMethod<
   DeleteScraperRequest,
   DeleteScraperResponse,
   DeleteScraperError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScraperRequest,
   output: DeleteScraperResponse,
@@ -2776,7 +2775,7 @@ export const deleteScraperLoggingConfiguration: API.OperationMethod<
   DeleteScraperLoggingConfigurationRequest,
   DeleteScraperLoggingConfigurationResponse,
   DeleteScraperLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScraperLoggingConfigurationRequest,
   output: DeleteScraperLoggingConfigurationResponse,
@@ -2809,7 +2808,7 @@ export const deleteWorkspace: API.OperationMethod<
   DeleteWorkspaceRequest,
   DeleteWorkspaceResponse,
   DeleteWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceRequest,
   output: DeleteWorkspaceResponse,
@@ -2840,7 +2839,7 @@ export const describeAlertManagerDefinition: API.OperationMethod<
   DescribeAlertManagerDefinitionRequest,
   DescribeAlertManagerDefinitionResponse,
   DescribeAlertManagerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlertManagerDefinitionRequest,
   output: DescribeAlertManagerDefinitionResponse,
@@ -2870,7 +2869,7 @@ export const describeAnomalyDetector: API.OperationMethod<
   DescribeAnomalyDetectorRequest,
   DescribeAnomalyDetectorResponse,
   DescribeAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnomalyDetectorRequest,
   output: DescribeAnomalyDetectorResponse,
@@ -2901,7 +2900,7 @@ export const describeLoggingConfiguration: API.OperationMethod<
   DescribeLoggingConfigurationRequest,
   DescribeLoggingConfigurationResponse,
   DescribeLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoggingConfigurationRequest,
   output: DescribeLoggingConfigurationResponse,
@@ -2929,7 +2928,7 @@ export const describeQueryLoggingConfiguration: API.OperationMethod<
   DescribeQueryLoggingConfigurationRequest,
   DescribeQueryLoggingConfigurationResponse,
   DescribeQueryLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQueryLoggingConfigurationRequest,
   output: DescribeQueryLoggingConfigurationResponse,
@@ -2958,7 +2957,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -2988,7 +2987,7 @@ export const describeRuleGroupsNamespace: API.OperationMethod<
   DescribeRuleGroupsNamespaceRequest,
   DescribeRuleGroupsNamespaceResponse,
   DescribeRuleGroupsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleGroupsNamespaceRequest,
   output: DescribeRuleGroupsNamespaceResponse,
@@ -3018,7 +3017,7 @@ export const describeScraper: API.OperationMethod<
   DescribeScraperRequest,
   DescribeScraperResponse,
   DescribeScraperError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScraperRequest,
   output: DescribeScraperResponse,
@@ -3047,7 +3046,7 @@ export const describeScraperLoggingConfiguration: API.OperationMethod<
   DescribeScraperLoggingConfigurationRequest,
   DescribeScraperLoggingConfigurationResponse,
   DescribeScraperLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScraperLoggingConfigurationRequest,
   output: DescribeScraperLoggingConfigurationResponse,
@@ -3076,7 +3075,7 @@ export const describeWorkspace: API.OperationMethod<
   DescribeWorkspaceRequest,
   DescribeWorkspaceResponse,
   DescribeWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceRequest,
   output: DescribeWorkspaceResponse,
@@ -3106,7 +3105,7 @@ export const describeWorkspaceConfiguration: API.OperationMethod<
   DescribeWorkspaceConfigurationRequest,
   DescribeWorkspaceConfigurationResponse,
   DescribeWorkspaceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceConfigurationRequest,
   output: DescribeWorkspaceConfigurationResponse,
@@ -3134,7 +3133,7 @@ export const getDefaultScraperConfiguration: API.OperationMethod<
   GetDefaultScraperConfigurationRequest,
   GetDefaultScraperConfigurationResponse,
   GetDefaultScraperConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultScraperConfigurationRequest,
   output: GetDefaultScraperConfigurationResponse,
@@ -3158,7 +3157,7 @@ export const listAnomalyDetectors: API.PaginatedOperationMethod<
   ListAnomalyDetectorsRequest,
   ListAnomalyDetectorsResponse,
   ListAnomalyDetectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnomalyDetectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnomalyDetectorsRequest,
@@ -3195,7 +3194,7 @@ export const listRuleGroupsNamespaces: API.PaginatedOperationMethod<
   ListRuleGroupsNamespacesRequest,
   ListRuleGroupsNamespacesResponse,
   ListRuleGroupsNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleGroupsNamespaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRuleGroupsNamespacesRequest,
@@ -3231,7 +3230,7 @@ export const listScrapers: API.PaginatedOperationMethod<
   ListScrapersRequest,
   ListScrapersResponse,
   ListScrapersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScraperSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScrapersRequest,
@@ -3267,7 +3266,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3296,7 +3295,7 @@ export const listWorkspaces: API.PaginatedOperationMethod<
   ListWorkspacesRequest,
   ListWorkspacesResponse,
   ListWorkspacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkspaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspacesRequest,
@@ -3334,7 +3333,7 @@ export const putAlertManagerDefinition: API.OperationMethod<
   PutAlertManagerDefinitionRequest,
   PutAlertManagerDefinitionResponse,
   PutAlertManagerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAlertManagerDefinitionRequest,
   output: PutAlertManagerDefinitionResponse,
@@ -3367,7 +3366,7 @@ export const putAnomalyDetector: API.OperationMethod<
   PutAnomalyDetectorRequest,
   PutAnomalyDetectorResponse,
   PutAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAnomalyDetectorRequest,
   output: PutAnomalyDetectorResponse,
@@ -3405,7 +3404,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -3444,7 +3443,7 @@ export const putRuleGroupsNamespace: API.OperationMethod<
   PutRuleGroupsNamespaceRequest,
   PutRuleGroupsNamespaceResponse,
   PutRuleGroupsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRuleGroupsNamespaceRequest,
   output: PutRuleGroupsNamespaceResponse,
@@ -3478,7 +3477,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3508,7 +3507,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3540,7 +3539,7 @@ export const updateLoggingConfiguration: API.OperationMethod<
   UpdateLoggingConfigurationRequest,
   UpdateLoggingConfigurationResponse,
   UpdateLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoggingConfigurationRequest,
   output: UpdateLoggingConfigurationResponse,
@@ -3570,7 +3569,7 @@ export const updateQueryLoggingConfiguration: API.OperationMethod<
   UpdateQueryLoggingConfigurationRequest,
   UpdateQueryLoggingConfigurationResponse,
   UpdateQueryLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueryLoggingConfigurationRequest,
   output: UpdateQueryLoggingConfigurationResponse,
@@ -3604,7 +3603,7 @@ export const updateScraper: API.OperationMethod<
   UpdateScraperRequest,
   UpdateScraperResponse,
   UpdateScraperError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScraperRequest,
   output: UpdateScraperResponse,
@@ -3636,7 +3635,7 @@ export const updateScraperLoggingConfiguration: API.OperationMethod<
   UpdateScraperLoggingConfigurationRequest,
   UpdateScraperLoggingConfigurationResponse,
   UpdateScraperLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScraperLoggingConfigurationRequest,
   output: UpdateScraperLoggingConfigurationResponse,
@@ -3668,7 +3667,7 @@ export const updateWorkspaceAlias: API.OperationMethod<
   UpdateWorkspaceAliasRequest,
   UpdateWorkspaceAliasResponse,
   UpdateWorkspaceAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceAliasRequest,
   output: UpdateWorkspaceAliasResponse,
@@ -3704,7 +3703,7 @@ export const updateWorkspaceConfiguration: API.OperationMethod<
   UpdateWorkspaceConfigurationRequest,
   UpdateWorkspaceConfigurationResponse,
   UpdateWorkspaceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceConfigurationRequest,
   output: UpdateWorkspaceConfigurationResponse,

--- a/packages/aws/src/services/amplify.ts
+++ b/packages/aws/src/services/amplify.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://amplify.amazonaws.com");
 const svc = T.AwsApiService({ sdkId: "Amplify", serviceShapeName: "Amplify" });
@@ -2143,7 +2142,7 @@ export const createApp: API.OperationMethod<
   CreateAppRequest,
   CreateAppResult,
   CreateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppRequest,
   output: CreateAppResult,
@@ -2181,7 +2180,7 @@ export const createBackendEnvironment: API.OperationMethod<
   CreateBackendEnvironmentRequest,
   CreateBackendEnvironmentResult,
   CreateBackendEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendEnvironmentRequest,
   output: CreateBackendEnvironmentResult,
@@ -2214,7 +2213,7 @@ export const createBranch: API.OperationMethod<
   CreateBranchRequest,
   CreateBranchResult,
   CreateBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBranchRequest,
   output: CreateBranchResult,
@@ -2252,7 +2251,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   CreateDeploymentResult,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: CreateDeploymentResult,
@@ -2285,7 +2284,7 @@ export const createDomainAssociation: API.OperationMethod<
   CreateDomainAssociationRequest,
   CreateDomainAssociationResult,
   CreateDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainAssociationRequest,
   output: CreateDomainAssociationResult,
@@ -2319,7 +2318,7 @@ export const createWebhook: API.OperationMethod<
   CreateWebhookRequest,
   CreateWebhookResult,
   CreateWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebhookRequest,
   output: CreateWebhookResult,
@@ -2352,7 +2351,7 @@ export const deleteApp: API.OperationMethod<
   DeleteAppRequest,
   DeleteAppResult,
   DeleteAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppRequest,
   output: DeleteAppResult,
@@ -2390,7 +2389,7 @@ export const deleteBackendEnvironment: API.OperationMethod<
   DeleteBackendEnvironmentRequest,
   DeleteBackendEnvironmentResult,
   DeleteBackendEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackendEnvironmentRequest,
   output: DeleteBackendEnvironmentResult,
@@ -2422,7 +2421,7 @@ export const deleteBranch: API.OperationMethod<
   DeleteBranchRequest,
   DeleteBranchResult,
   DeleteBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBranchRequest,
   output: DeleteBranchResult,
@@ -2454,7 +2453,7 @@ export const deleteDomainAssociation: API.OperationMethod<
   DeleteDomainAssociationRequest,
   DeleteDomainAssociationResult,
   DeleteDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainAssociationRequest,
   output: DeleteDomainAssociationResult,
@@ -2486,7 +2485,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResult,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResult,
@@ -2518,7 +2517,7 @@ export const deleteWebhook: API.OperationMethod<
   DeleteWebhookRequest,
   DeleteWebhookResult,
   DeleteWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebhookRequest,
   output: DeleteWebhookResult,
@@ -2549,7 +2548,7 @@ export const generateAccessLogs: API.OperationMethod<
   GenerateAccessLogsRequest,
   GenerateAccessLogsResult,
   GenerateAccessLogsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateAccessLogsRequest,
   output: GenerateAccessLogsResult,
@@ -2579,7 +2578,7 @@ export const getApp: API.OperationMethod<
   GetAppRequest,
   GetAppResult,
   GetAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppRequest,
   output: GetAppResult,
@@ -2610,7 +2609,7 @@ export const getArtifactUrl: API.OperationMethod<
   GetArtifactUrlRequest,
   GetArtifactUrlResult,
   GetArtifactUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArtifactUrlRequest,
   output: GetArtifactUrlResult,
@@ -2647,7 +2646,7 @@ export const getBackendEnvironment: API.OperationMethod<
   GetBackendEnvironmentRequest,
   GetBackendEnvironmentResult,
   GetBackendEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendEnvironmentRequest,
   output: GetBackendEnvironmentResult,
@@ -2677,7 +2676,7 @@ export const getBranch: API.OperationMethod<
   GetBranchRequest,
   GetBranchResult,
   GetBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBranchRequest,
   output: GetBranchResult,
@@ -2707,7 +2706,7 @@ export const getDomainAssociation: API.OperationMethod<
   GetDomainAssociationRequest,
   GetDomainAssociationResult,
   GetDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainAssociationRequest,
   output: GetDomainAssociationResult,
@@ -2738,7 +2737,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResult,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResult,
@@ -2770,7 +2769,7 @@ export const getWebhook: API.OperationMethod<
   GetWebhookRequest,
   GetWebhookResult,
   GetWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebhookRequest,
   output: GetWebhookResult,
@@ -2800,7 +2799,7 @@ export const listApps: API.PaginatedOperationMethod<
   ListAppsRequest,
   ListAppsResult,
   ListAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   App
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppsRequest,
@@ -2843,7 +2842,7 @@ export const listArtifacts: API.OperationMethod<
   ListArtifactsRequest,
   ListArtifactsResult,
   ListArtifactsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListArtifactsRequest,
   output: ListArtifactsResult,
@@ -2878,7 +2877,7 @@ export const listBackendEnvironments: API.OperationMethod<
   ListBackendEnvironmentsRequest,
   ListBackendEnvironmentsResult,
   ListBackendEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBackendEnvironmentsRequest,
   output: ListBackendEnvironmentsResult,
@@ -2906,7 +2905,7 @@ export const listBranches: API.PaginatedOperationMethod<
   ListBranchesRequest,
   ListBranchesResult,
   ListBranchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Branch
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBranchesRequest,
@@ -2941,7 +2940,7 @@ export const listDomainAssociations: API.PaginatedOperationMethod<
   ListDomainAssociationsRequest,
   ListDomainAssociationsResult,
   ListDomainAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainAssociationsRequest,
@@ -2977,7 +2976,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResult,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -3013,7 +3012,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3042,7 +3041,7 @@ export const listWebhooks: API.OperationMethod<
   ListWebhooksRequest,
   ListWebhooksResult,
   ListWebhooksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebhooksRequest,
   output: ListWebhooksResult,
@@ -3079,7 +3078,7 @@ export const startDeployment: API.OperationMethod<
   StartDeploymentRequest,
   StartDeploymentResult,
   StartDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeploymentRequest,
   output: StartDeploymentResult,
@@ -3111,7 +3110,7 @@ export const startJob: API.OperationMethod<
   StartJobRequest,
   StartJobResult,
   StartJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRequest,
   output: StartJobResult,
@@ -3143,7 +3142,7 @@ export const stopJob: API.OperationMethod<
   StopJobRequest,
   StopJobResult,
   StopJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopJobRequest,
   output: StopJobResult,
@@ -3173,7 +3172,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3201,7 +3200,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3230,7 +3229,7 @@ export const updateApp: API.OperationMethod<
   UpdateAppRequest,
   UpdateAppResult,
   UpdateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppRequest,
   output: UpdateAppResult,
@@ -3261,7 +3260,7 @@ export const updateBranch: API.OperationMethod<
   UpdateBranchRequest,
   UpdateBranchResult,
   UpdateBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBranchRequest,
   output: UpdateBranchResult,
@@ -3293,7 +3292,7 @@ export const updateDomainAssociation: API.OperationMethod<
   UpdateDomainAssociationRequest,
   UpdateDomainAssociationResult,
   UpdateDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainAssociationRequest,
   output: UpdateDomainAssociationResult,
@@ -3325,7 +3324,7 @@ export const updateWebhook: API.OperationMethod<
   UpdateWebhookRequest,
   UpdateWebhookResult,
   UpdateWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebhookRequest,
   output: UpdateWebhookResult,

--- a/packages/aws/src/services/amplifybackend.ts
+++ b/packages/aws/src/services/amplifybackend.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "AmplifyBackend",
   serviceShapeName: "AmplifyBackend",
@@ -2661,7 +2660,7 @@ export const cloneBackend: API.OperationMethod<
   CloneBackendRequest,
   CloneBackendResponse,
   CloneBackendError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloneBackendRequest,
   output: CloneBackendResponse,
@@ -2689,7 +2688,7 @@ export const createBackend: API.OperationMethod<
   CreateBackendRequest,
   CreateBackendResponse,
   CreateBackendError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendRequest,
   output: CreateBackendResponse,
@@ -2717,7 +2716,7 @@ export const createBackendAPI: API.OperationMethod<
   CreateBackendAPIRequest,
   CreateBackendAPIResponse,
   CreateBackendAPIError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendAPIRequest,
   output: CreateBackendAPIResponse,
@@ -2745,7 +2744,7 @@ export const createBackendAuth: API.OperationMethod<
   CreateBackendAuthRequest,
   CreateBackendAuthResponse,
   CreateBackendAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendAuthRequest,
   output: CreateBackendAuthResponse,
@@ -2773,7 +2772,7 @@ export const createBackendConfig: API.OperationMethod<
   CreateBackendConfigRequest,
   CreateBackendConfigResponse,
   CreateBackendConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendConfigRequest,
   output: CreateBackendConfigResponse,
@@ -2801,7 +2800,7 @@ export const createBackendStorage: API.OperationMethod<
   CreateBackendStorageRequest,
   CreateBackendStorageResponse,
   CreateBackendStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackendStorageRequest,
   output: CreateBackendStorageResponse,
@@ -2829,7 +2828,7 @@ export const createToken: API.OperationMethod<
   CreateTokenRequest,
   CreateTokenResponse,
   CreateTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTokenRequest,
   output: CreateTokenResponse,
@@ -2857,7 +2856,7 @@ export const deleteBackend: API.OperationMethod<
   DeleteBackendRequest,
   DeleteBackendResponse,
   DeleteBackendError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackendRequest,
   output: DeleteBackendResponse,
@@ -2885,7 +2884,7 @@ export const deleteBackendAPI: API.OperationMethod<
   DeleteBackendAPIRequest,
   DeleteBackendAPIResponse,
   DeleteBackendAPIError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackendAPIRequest,
   output: DeleteBackendAPIResponse,
@@ -2913,7 +2912,7 @@ export const deleteBackendAuth: API.OperationMethod<
   DeleteBackendAuthRequest,
   DeleteBackendAuthResponse,
   DeleteBackendAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackendAuthRequest,
   output: DeleteBackendAuthResponse,
@@ -2941,7 +2940,7 @@ export const deleteBackendStorage: API.OperationMethod<
   DeleteBackendStorageRequest,
   DeleteBackendStorageResponse,
   DeleteBackendStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackendStorageRequest,
   output: DeleteBackendStorageResponse,
@@ -2969,7 +2968,7 @@ export const deleteToken: API.OperationMethod<
   DeleteTokenRequest,
   DeleteTokenResponse,
   DeleteTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTokenRequest,
   output: DeleteTokenResponse,
@@ -2997,7 +2996,7 @@ export const generateBackendAPIModels: API.OperationMethod<
   GenerateBackendAPIModelsRequest,
   GenerateBackendAPIModelsResponse,
   GenerateBackendAPIModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateBackendAPIModelsRequest,
   output: GenerateBackendAPIModelsResponse,
@@ -3025,7 +3024,7 @@ export const getBackend: API.OperationMethod<
   GetBackendRequest,
   GetBackendResponse,
   GetBackendError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendRequest,
   output: GetBackendResponse,
@@ -3053,7 +3052,7 @@ export const getBackendAPI: API.OperationMethod<
   GetBackendAPIRequest,
   GetBackendAPIResponse,
   GetBackendAPIError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendAPIRequest,
   output: GetBackendAPIResponse,
@@ -3081,7 +3080,7 @@ export const getBackendAPIModels: API.OperationMethod<
   GetBackendAPIModelsRequest,
   GetBackendAPIModelsResponse,
   GetBackendAPIModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendAPIModelsRequest,
   output: GetBackendAPIModelsResponse,
@@ -3109,7 +3108,7 @@ export const getBackendAuth: API.OperationMethod<
   GetBackendAuthRequest,
   GetBackendAuthResponse,
   GetBackendAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendAuthRequest,
   output: GetBackendAuthResponse,
@@ -3137,7 +3136,7 @@ export const getBackendJob: API.OperationMethod<
   GetBackendJobRequest,
   GetBackendJobResponse,
   GetBackendJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendJobRequest,
   output: GetBackendJobResponse,
@@ -3165,7 +3164,7 @@ export const getBackendStorage: API.OperationMethod<
   GetBackendStorageRequest,
   GetBackendStorageResponse,
   GetBackendStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackendStorageRequest,
   output: GetBackendStorageResponse,
@@ -3193,7 +3192,7 @@ export const getToken: API.OperationMethod<
   GetTokenRequest,
   GetTokenResponse,
   GetTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTokenRequest,
   output: GetTokenResponse,
@@ -3221,7 +3220,7 @@ export const importBackendAuth: API.OperationMethod<
   ImportBackendAuthRequest,
   ImportBackendAuthResponse,
   ImportBackendAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportBackendAuthRequest,
   output: ImportBackendAuthResponse,
@@ -3249,7 +3248,7 @@ export const importBackendStorage: API.OperationMethod<
   ImportBackendStorageRequest,
   ImportBackendStorageResponse,
   ImportBackendStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportBackendStorageRequest,
   output: ImportBackendStorageResponse,
@@ -3277,7 +3276,7 @@ export const listBackendJobs: API.OperationMethod<
   ListBackendJobsRequest,
   ListBackendJobsResponse,
   ListBackendJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBackendJobsRequest,
   output: ListBackendJobsResponse,
@@ -3305,7 +3304,7 @@ export const listS3Buckets: API.OperationMethod<
   ListS3BucketsRequest,
   ListS3BucketsResponse,
   ListS3BucketsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListS3BucketsRequest,
   output: ListS3BucketsResponse,
@@ -3333,7 +3332,7 @@ export const removeAllBackends: API.OperationMethod<
   RemoveAllBackendsRequest,
   RemoveAllBackendsResponse,
   RemoveAllBackendsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAllBackendsRequest,
   output: RemoveAllBackendsResponse,
@@ -3361,7 +3360,7 @@ export const removeBackendConfig: API.OperationMethod<
   RemoveBackendConfigRequest,
   RemoveBackendConfigResponse,
   RemoveBackendConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveBackendConfigRequest,
   output: RemoveBackendConfigResponse,
@@ -3389,7 +3388,7 @@ export const updateBackendAPI: API.OperationMethod<
   UpdateBackendAPIRequest,
   UpdateBackendAPIResponse,
   UpdateBackendAPIError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackendAPIRequest,
   output: UpdateBackendAPIResponse,
@@ -3417,7 +3416,7 @@ export const updateBackendAuth: API.OperationMethod<
   UpdateBackendAuthRequest,
   UpdateBackendAuthResponse,
   UpdateBackendAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackendAuthRequest,
   output: UpdateBackendAuthResponse,
@@ -3445,7 +3444,7 @@ export const updateBackendConfig: API.OperationMethod<
   UpdateBackendConfigRequest,
   UpdateBackendConfigResponse,
   UpdateBackendConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackendConfigRequest,
   output: UpdateBackendConfigResponse,
@@ -3473,7 +3472,7 @@ export const updateBackendJob: API.OperationMethod<
   UpdateBackendJobRequest,
   UpdateBackendJobResponse,
   UpdateBackendJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackendJobRequest,
   output: UpdateBackendJobResponse,
@@ -3501,7 +3500,7 @@ export const updateBackendStorage: API.OperationMethod<
   UpdateBackendStorageRequest,
   UpdateBackendStorageResponse,
   UpdateBackendStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackendStorageRequest,
   output: UpdateBackendStorageResponse,

--- a/packages/aws/src/services/amplifyuibuilder.ts
+++ b/packages/aws/src/services/amplifyuibuilder.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AmplifyUIBuilder",
@@ -2620,7 +2619,7 @@ export const createComponent: API.OperationMethod<
   CreateComponentRequest,
   CreateComponentResponse,
   CreateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentRequest,
   output: CreateComponentResponse,
@@ -2648,7 +2647,7 @@ export const createForm: API.OperationMethod<
   CreateFormRequest,
   CreateFormResponse,
   CreateFormError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFormRequest,
   output: CreateFormResponse,
@@ -2676,7 +2675,7 @@ export const createTheme: API.OperationMethod<
   CreateThemeRequest,
   CreateThemeResponse,
   CreateThemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThemeRequest,
   output: CreateThemeResponse,
@@ -2703,7 +2702,7 @@ export const deleteComponent: API.OperationMethod<
   DeleteComponentRequest,
   DeleteComponentResponse,
   DeleteComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentRequest,
   output: DeleteComponentResponse,
@@ -2729,7 +2728,7 @@ export const deleteForm: API.OperationMethod<
   DeleteFormRequest,
   DeleteFormResponse,
   DeleteFormError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFormRequest,
   output: DeleteFormResponse,
@@ -2755,7 +2754,7 @@ export const deleteTheme: API.OperationMethod<
   DeleteThemeRequest,
   DeleteThemeResponse,
   DeleteThemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThemeRequest,
   output: DeleteThemeResponse,
@@ -2781,7 +2780,7 @@ export const exchangeCodeForToken: API.OperationMethod<
   ExchangeCodeForTokenRequest,
   ExchangeCodeForTokenResponse,
   ExchangeCodeForTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExchangeCodeForTokenRequest,
   output: ExchangeCodeForTokenResponse,
@@ -2802,7 +2801,7 @@ export const exportComponents: API.PaginatedOperationMethod<
   ExportComponentsRequest,
   ExportComponentsResponse,
   ExportComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Component
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ExportComponentsRequest,
@@ -2829,7 +2828,7 @@ export const exportForms: API.PaginatedOperationMethod<
   ExportFormsRequest,
   ExportFormsResponse,
   ExportFormsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Form
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ExportFormsRequest,
@@ -2856,7 +2855,7 @@ export const exportThemes: API.PaginatedOperationMethod<
   ExportThemesRequest,
   ExportThemesResponse,
   ExportThemesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Theme
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ExportThemesRequest,
@@ -2885,7 +2884,7 @@ export const getCodegenJob: API.OperationMethod<
   GetCodegenJobRequest,
   GetCodegenJobResponse,
   GetCodegenJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodegenJobRequest,
   output: GetCodegenJobResponse,
@@ -2912,7 +2911,7 @@ export const getComponent: API.OperationMethod<
   GetComponentRequest,
   GetComponentResponse,
   GetComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentRequest,
   output: GetComponentResponse,
@@ -2938,7 +2937,7 @@ export const getForm: API.OperationMethod<
   GetFormRequest,
   GetFormResponse,
   GetFormError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFormRequest,
   output: GetFormResponse,
@@ -2963,7 +2962,7 @@ export const getMetadata: API.OperationMethod<
   GetMetadataRequest,
   GetMetadataResponse,
   GetMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetadataRequest,
   output: GetMetadataResponse,
@@ -2985,7 +2984,7 @@ export const getTheme: API.OperationMethod<
   GetThemeRequest,
   GetThemeResponse,
   GetThemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThemeRequest,
   output: GetThemeResponse,
@@ -3011,7 +3010,7 @@ export const listCodegenJobs: API.PaginatedOperationMethod<
   ListCodegenJobsRequest,
   ListCodegenJobsResponse,
   ListCodegenJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodegenJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodegenJobsRequest,
@@ -3044,7 +3043,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsRequest,
   ListComponentsResponse,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsRequest,
@@ -3072,7 +3071,7 @@ export const listForms: API.PaginatedOperationMethod<
   ListFormsRequest,
   ListFormsResponse,
   ListFormsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FormSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFormsRequest,
@@ -3103,7 +3102,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3131,7 +3130,7 @@ export const listThemes: API.PaginatedOperationMethod<
   ListThemesRequest,
   ListThemesResponse,
   ListThemesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThemeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThemesRequest,
@@ -3159,7 +3158,7 @@ export const putMetadataFlag: API.OperationMethod<
   PutMetadataFlagRequest,
   PutMetadataFlagResponse,
   PutMetadataFlagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetadataFlagRequest,
   output: PutMetadataFlagResponse,
@@ -3179,7 +3178,7 @@ export const refreshToken: API.OperationMethod<
   RefreshTokenRequest,
   RefreshTokenResponse,
   RefreshTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RefreshTokenRequest,
   output: RefreshTokenResponse,
@@ -3201,7 +3200,7 @@ export const startCodegenJob: API.OperationMethod<
   StartCodegenJobRequest,
   StartCodegenJobResponse,
   StartCodegenJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCodegenJobRequest,
   output: StartCodegenJobResponse,
@@ -3229,7 +3228,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3259,7 +3258,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3287,7 +3286,7 @@ export const updateComponent: API.OperationMethod<
   UpdateComponentRequest,
   UpdateComponentResponse,
   UpdateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComponentRequest,
   output: UpdateComponentResponse,
@@ -3313,7 +3312,7 @@ export const updateForm: API.OperationMethod<
   UpdateFormRequest,
   UpdateFormResponse,
   UpdateFormError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFormRequest,
   output: UpdateFormResponse,
@@ -3339,7 +3338,7 @@ export const updateTheme: API.OperationMethod<
   UpdateThemeRequest,
   UpdateThemeResponse,
   UpdateThemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThemeRequest,
   output: UpdateThemeResponse,

--- a/packages/aws/src/services/api-gateway.ts
+++ b/packages/aws/src/services/api-gateway.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "API Gateway",
@@ -4893,7 +4892,7 @@ export const createApiKey: API.OperationMethod<
   CreateApiKeyRequest,
   ApiKey,
   CreateApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiKeyRequest,
   output: ApiKey,
@@ -4925,7 +4924,7 @@ export const createAuthorizer: API.OperationMethod<
   CreateAuthorizerRequest,
   Authorizer,
   CreateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAuthorizerRequest,
   output: Authorizer,
@@ -4957,7 +4956,7 @@ export const createBasePathMapping: API.OperationMethod<
   CreateBasePathMappingRequest,
   BasePathMapping,
   CreateBasePathMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBasePathMappingRequest,
   output: BasePathMapping,
@@ -4990,7 +4989,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   Deployment,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: Deployment,
@@ -5023,7 +5022,7 @@ export const createDocumentationPart: API.OperationMethod<
   CreateDocumentationPartRequest,
   DocumentationPart,
   CreateDocumentationPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDocumentationPartRequest,
   output: DocumentationPart,
@@ -5055,7 +5054,7 @@ export const createDocumentationVersion: API.OperationMethod<
   CreateDocumentationVersionRequest,
   DocumentationVersion,
   CreateDocumentationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDocumentationVersionRequest,
   output: DocumentationVersion,
@@ -5086,7 +5085,7 @@ export const createDomainName: API.OperationMethod<
   CreateDomainNameRequest,
   DomainName,
   CreateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainNameRequest,
   output: DomainName,
@@ -5117,7 +5116,7 @@ export const createDomainNameAccessAssociation: API.OperationMethod<
   CreateDomainNameAccessAssociationRequest,
   DomainNameAccessAssociation,
   CreateDomainNameAccessAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainNameAccessAssociationRequest,
   output: DomainNameAccessAssociation,
@@ -5148,7 +5147,7 @@ export const createModel: API.OperationMethod<
   CreateModelRequest,
   Model,
   CreateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelRequest,
   output: Model,
@@ -5180,7 +5179,7 @@ export const createRequestValidator: API.OperationMethod<
   CreateRequestValidatorRequest,
   RequestValidator,
   CreateRequestValidatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRequestValidatorRequest,
   output: RequestValidator,
@@ -5212,7 +5211,7 @@ export const createResource: API.OperationMethod<
   CreateResourceRequest,
   Resource,
   CreateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceRequest,
   output: Resource,
@@ -5243,7 +5242,7 @@ export const createRestApi: API.OperationMethod<
   CreateRestApiRequest,
   RestApi,
   CreateRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRestApiRequest,
   output: RestApi,
@@ -5274,7 +5273,7 @@ export const createStage: API.OperationMethod<
   CreateStageRequest,
   Stage,
   CreateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStageRequest,
   output: Stage,
@@ -5306,7 +5305,7 @@ export const createUsagePlan: API.OperationMethod<
   CreateUsagePlanRequest,
   UsagePlan,
   CreateUsagePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsagePlanRequest,
   output: UsagePlan,
@@ -5338,7 +5337,7 @@ export const createUsagePlanKey: API.OperationMethod<
   CreateUsagePlanKeyRequest,
   UsagePlanKey,
   CreateUsagePlanKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsagePlanKeyRequest,
   output: UsagePlanKey,
@@ -5369,7 +5368,7 @@ export const createVpcLink: API.OperationMethod<
   CreateVpcLinkRequest,
   VpcLink,
   CreateVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcLinkRequest,
   output: VpcLink,
@@ -5399,7 +5398,7 @@ export const deleteApiKey: API.OperationMethod<
   DeleteApiKeyRequest,
   DeleteApiKeyResponse,
   DeleteApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiKeyRequest,
   output: DeleteApiKeyResponse,
@@ -5429,7 +5428,7 @@ export const deleteAuthorizer: API.OperationMethod<
   DeleteAuthorizerRequest,
   DeleteAuthorizerResponse,
   DeleteAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuthorizerRequest,
   output: DeleteAuthorizerResponse,
@@ -5459,7 +5458,7 @@ export const deleteBasePathMapping: API.OperationMethod<
   DeleteBasePathMappingRequest,
   DeleteBasePathMappingResponse,
   DeleteBasePathMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBasePathMappingRequest,
   output: DeleteBasePathMappingResponse,
@@ -5489,7 +5488,7 @@ export const deleteClientCertificate: API.OperationMethod<
   DeleteClientCertificateRequest,
   DeleteClientCertificateResponse,
   DeleteClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClientCertificateRequest,
   output: DeleteClientCertificateResponse,
@@ -5520,7 +5519,7 @@ export const deleteDeployment: API.OperationMethod<
   DeleteDeploymentRequest,
   DeleteDeploymentResponse,
   DeleteDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentRequest,
   output: DeleteDeploymentResponse,
@@ -5551,7 +5550,7 @@ export const deleteDocumentationPart: API.OperationMethod<
   DeleteDocumentationPartRequest,
   DeleteDocumentationPartResponse,
   DeleteDocumentationPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentationPartRequest,
   output: DeleteDocumentationPartResponse,
@@ -5581,7 +5580,7 @@ export const deleteDocumentationVersion: API.OperationMethod<
   DeleteDocumentationVersionRequest,
   DeleteDocumentationVersionResponse,
   DeleteDocumentationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentationVersionRequest,
   output: DeleteDocumentationVersionResponse,
@@ -5611,7 +5610,7 @@ export const deleteDomainName: API.OperationMethod<
   DeleteDomainNameRequest,
   DeleteDomainNameResponse,
   DeleteDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainNameRequest,
   output: DeleteDomainNameResponse,
@@ -5643,7 +5642,7 @@ export const deleteDomainNameAccessAssociation: API.OperationMethod<
   DeleteDomainNameAccessAssociationRequest,
   DeleteDomainNameAccessAssociationResponse,
   DeleteDomainNameAccessAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainNameAccessAssociationRequest,
   output: DeleteDomainNameAccessAssociationResponse,
@@ -5673,7 +5672,7 @@ export const deleteGatewayResponse: API.OperationMethod<
   DeleteGatewayResponseRequest,
   DeleteGatewayResponseResponse,
   DeleteGatewayResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayResponseRequest,
   output: DeleteGatewayResponseResponse,
@@ -5703,7 +5702,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationRequest,
   DeleteIntegrationResponse,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationRequest,
   output: DeleteIntegrationResponse,
@@ -5733,7 +5732,7 @@ export const deleteIntegrationResponse: API.OperationMethod<
   DeleteIntegrationResponseRequest,
   DeleteIntegrationResponseResponse,
   DeleteIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationResponseRequest,
   output: DeleteIntegrationResponseResponse,
@@ -5762,7 +5761,7 @@ export const deleteMethod: API.OperationMethod<
   DeleteMethodRequest,
   DeleteMethodResponse,
   DeleteMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMethodRequest,
   output: DeleteMethodResponse,
@@ -5791,7 +5790,7 @@ export const deleteMethodResponse: API.OperationMethod<
   DeleteMethodResponseRequest,
   DeleteMethodResponseResponse,
   DeleteMethodResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMethodResponseRequest,
   output: DeleteMethodResponseResponse,
@@ -5821,7 +5820,7 @@ export const deleteModel: API.OperationMethod<
   DeleteModelRequest,
   DeleteModelResponse,
   DeleteModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelRequest,
   output: DeleteModelResponse,
@@ -5851,7 +5850,7 @@ export const deleteRequestValidator: API.OperationMethod<
   DeleteRequestValidatorRequest,
   DeleteRequestValidatorResponse,
   DeleteRequestValidatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRequestValidatorRequest,
   output: DeleteRequestValidatorResponse,
@@ -5881,7 +5880,7 @@ export const deleteResource: API.OperationMethod<
   DeleteResourceRequest,
   DeleteResourceResponse,
   DeleteResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceRequest,
   output: DeleteResourceResponse,
@@ -5911,7 +5910,7 @@ export const deleteRestApi: API.OperationMethod<
   DeleteRestApiRequest,
   DeleteRestApiResponse,
   DeleteRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRestApiRequest,
   output: DeleteRestApiResponse,
@@ -5942,7 +5941,7 @@ export const deleteStage: API.OperationMethod<
   DeleteStageRequest,
   DeleteStageResponse,
   DeleteStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStageRequest,
   output: DeleteStageResponse,
@@ -5973,7 +5972,7 @@ export const deleteUsagePlan: API.OperationMethod<
   DeleteUsagePlanRequest,
   DeleteUsagePlanResponse,
   DeleteUsagePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsagePlanRequest,
   output: DeleteUsagePlanResponse,
@@ -6003,7 +6002,7 @@ export const deleteUsagePlanKey: API.OperationMethod<
   DeleteUsagePlanKeyRequest,
   DeleteUsagePlanKeyResponse,
   DeleteUsagePlanKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsagePlanKeyRequest,
   output: DeleteUsagePlanKeyResponse,
@@ -6033,7 +6032,7 @@ export const deleteVpcLink: API.OperationMethod<
   DeleteVpcLinkRequest,
   DeleteVpcLinkResponse,
   DeleteVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcLinkRequest,
   output: DeleteVpcLinkResponse,
@@ -6064,7 +6063,7 @@ export const flushStageAuthorizersCache: API.OperationMethod<
   FlushStageAuthorizersCacheRequest,
   FlushStageAuthorizersCacheResponse,
   FlushStageAuthorizersCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FlushStageAuthorizersCacheRequest,
   output: FlushStageAuthorizersCacheResponse,
@@ -6096,7 +6095,7 @@ export const flushStageCache: API.OperationMethod<
   FlushStageCacheRequest,
   FlushStageCacheResponse,
   FlushStageCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FlushStageCacheRequest,
   output: FlushStageCacheResponse,
@@ -6127,7 +6126,7 @@ export const generateClientCertificate: API.OperationMethod<
   GenerateClientCertificateRequest,
   ClientCertificate,
   GenerateClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateClientCertificateRequest,
   output: ClientCertificate,
@@ -6156,7 +6155,7 @@ export const getAccount: API.OperationMethod<
   GetAccountRequest,
   Account,
   GetAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountRequest,
   output: Account,
@@ -6184,7 +6183,7 @@ export const getApiKey: API.OperationMethod<
   GetApiKeyRequest,
   ApiKey,
   GetApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiKeyRequest,
   output: ApiKey,
@@ -6212,7 +6211,7 @@ export const getApiKeys: API.PaginatedOperationMethod<
   GetApiKeysRequest,
   ApiKeys,
   GetApiKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApiKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetApiKeysRequest,
@@ -6247,7 +6246,7 @@ export const getAuthorizer: API.OperationMethod<
   GetAuthorizerRequest,
   Authorizer,
   GetAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizerRequest,
   output: Authorizer,
@@ -6275,7 +6274,7 @@ export const getAuthorizers: API.OperationMethod<
   GetAuthorizersRequest,
   Authorizers,
   GetAuthorizersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizersRequest,
   output: Authorizers,
@@ -6303,7 +6302,7 @@ export const getBasePathMapping: API.OperationMethod<
   GetBasePathMappingRequest,
   BasePathMapping,
   GetBasePathMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBasePathMappingRequest,
   output: BasePathMapping,
@@ -6331,7 +6330,7 @@ export const getBasePathMappings: API.PaginatedOperationMethod<
   GetBasePathMappingsRequest,
   BasePathMappings,
   GetBasePathMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BasePathMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBasePathMappingsRequest,
@@ -6366,7 +6365,7 @@ export const getClientCertificate: API.OperationMethod<
   GetClientCertificateRequest,
   ClientCertificate,
   GetClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClientCertificateRequest,
   output: ClientCertificate,
@@ -6394,7 +6393,7 @@ export const getClientCertificates: API.PaginatedOperationMethod<
   GetClientCertificatesRequest,
   ClientCertificates,
   GetClientCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientCertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetClientCertificatesRequest,
@@ -6430,7 +6429,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentRequest,
   Deployment,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentRequest,
   output: Deployment,
@@ -6460,7 +6459,7 @@ export const getDeployments: API.PaginatedOperationMethod<
   GetDeploymentsRequest,
   Deployments,
   GetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Deployment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDeploymentsRequest,
@@ -6496,7 +6495,7 @@ export const getDocumentationPart: API.OperationMethod<
   GetDocumentationPartRequest,
   DocumentationPart,
   GetDocumentationPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentationPartRequest,
   output: DocumentationPart,
@@ -6524,7 +6523,7 @@ export const getDocumentationParts: API.OperationMethod<
   GetDocumentationPartsRequest,
   DocumentationParts,
   GetDocumentationPartsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentationPartsRequest,
   output: DocumentationParts,
@@ -6551,7 +6550,7 @@ export const getDocumentationVersion: API.OperationMethod<
   GetDocumentationVersionRequest,
   DocumentationVersion,
   GetDocumentationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentationVersionRequest,
   output: DocumentationVersion,
@@ -6574,7 +6573,7 @@ export const getDocumentationVersions: API.OperationMethod<
   GetDocumentationVersionsRequest,
   DocumentationVersions,
   GetDocumentationVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentationVersionsRequest,
   output: DocumentationVersions,
@@ -6602,7 +6601,7 @@ export const getDomainName: API.OperationMethod<
   GetDomainNameRequest,
   DomainName,
   GetDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainNameRequest,
   output: DomainName,
@@ -6630,7 +6629,7 @@ export const getDomainNameAccessAssociations: API.OperationMethod<
   GetDomainNameAccessAssociationsRequest,
   DomainNameAccessAssociations,
   GetDomainNameAccessAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainNameAccessAssociationsRequest,
   output: DomainNameAccessAssociations,
@@ -6658,7 +6657,7 @@ export const getDomainNames: API.PaginatedOperationMethod<
   GetDomainNamesRequest,
   DomainNames,
   GetDomainNamesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDomainNamesRequest,
@@ -6695,7 +6694,7 @@ export const getExport: API.OperationMethod<
   GetExportRequest,
   ExportResponse,
   GetExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportRequest,
   output: ExportResponse,
@@ -6725,7 +6724,7 @@ export const getGatewayResponse: API.OperationMethod<
   GetGatewayResponseRequest,
   GatewayResponse,
   GetGatewayResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayResponseRequest,
   output: GatewayResponse,
@@ -6753,7 +6752,7 @@ export const getGatewayResponses: API.OperationMethod<
   GetGatewayResponsesRequest,
   GatewayResponses,
   GetGatewayResponsesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayResponsesRequest,
   output: GatewayResponses,
@@ -6781,7 +6780,7 @@ export const getIntegration: API.OperationMethod<
   GetIntegrationRequest,
   Integration,
   GetIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationRequest,
   output: Integration,
@@ -6809,7 +6808,7 @@ export const getIntegrationResponse: API.OperationMethod<
   GetIntegrationResponseRequest,
   IntegrationResponse,
   GetIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationResponseRequest,
   output: IntegrationResponse,
@@ -6836,7 +6835,7 @@ export const getMethod: API.OperationMethod<
   GetMethodRequest,
   Method,
   GetMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMethodRequest,
   output: Method,
@@ -6858,7 +6857,7 @@ export const getMethodResponse: API.OperationMethod<
   GetMethodResponseRequest,
   MethodResponse,
   GetMethodResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMethodResponseRequest,
   output: MethodResponse,
@@ -6881,7 +6880,7 @@ export const getModel: API.OperationMethod<
   GetModelRequest,
   Model,
   GetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelRequest,
   output: Model,
@@ -6909,7 +6908,7 @@ export const getModels: API.PaginatedOperationMethod<
   GetModelsRequest,
   Models,
   GetModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Model
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetModelsRequest,
@@ -6944,7 +6943,7 @@ export const getModelTemplate: API.OperationMethod<
   GetModelTemplateRequest,
   Template,
   GetModelTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelTemplateRequest,
   output: Template,
@@ -6972,7 +6971,7 @@ export const getRequestValidator: API.OperationMethod<
   GetRequestValidatorRequest,
   RequestValidator,
   GetRequestValidatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRequestValidatorRequest,
   output: RequestValidator,
@@ -7000,7 +6999,7 @@ export const getRequestValidators: API.OperationMethod<
   GetRequestValidatorsRequest,
   RequestValidators,
   GetRequestValidatorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRequestValidatorsRequest,
   output: RequestValidators,
@@ -7027,7 +7026,7 @@ export const getResource: API.OperationMethod<
   GetResourceRequest,
   Resource,
   GetResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceRequest,
   output: Resource,
@@ -7050,7 +7049,7 @@ export const getResources: API.PaginatedOperationMethod<
   GetResourcesRequest,
   Resources,
   GetResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Resource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcesRequest,
@@ -7085,7 +7084,7 @@ export const getRestApi: API.OperationMethod<
   GetRestApiRequest,
   RestApi,
   GetRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRestApiRequest,
   output: RestApi,
@@ -7113,7 +7112,7 @@ export const getRestApis: API.PaginatedOperationMethod<
   GetRestApisRequest,
   RestApis,
   GetRestApisError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestApi
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRestApisRequest,
@@ -7150,7 +7149,7 @@ export const getSdk: API.OperationMethod<
   GetSdkRequest,
   SdkResponse,
   GetSdkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSdkRequest,
   output: SdkResponse,
@@ -7180,7 +7179,7 @@ export const getSdkType: API.OperationMethod<
   GetSdkTypeRequest,
   SdkType,
   GetSdkTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSdkTypeRequest,
   output: SdkType,
@@ -7208,7 +7207,7 @@ export const getSdkTypes: API.OperationMethod<
   GetSdkTypesRequest,
   SdkTypes,
   GetSdkTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSdkTypesRequest,
   output: SdkTypes,
@@ -7238,7 +7237,7 @@ export const getStage: API.OperationMethod<
   GetStageRequest,
   Stage,
   GetStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStageRequest,
   output: Stage,
@@ -7270,7 +7269,7 @@ export const getStages: API.OperationMethod<
   GetStagesRequest,
   Stages,
   GetStagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStagesRequest,
   output: Stages,
@@ -7300,7 +7299,7 @@ export const getTags: API.OperationMethod<
   GetTagsRequest,
   Tags,
   GetTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagsRequest,
   output: Tags,
@@ -7328,7 +7327,7 @@ export const getUsage: API.PaginatedOperationMethod<
   GetUsageRequest,
   Usage,
   GetUsageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUsageRequest,
@@ -7363,7 +7362,7 @@ export const getUsagePlan: API.OperationMethod<
   GetUsagePlanRequest,
   UsagePlan,
   GetUsagePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsagePlanRequest,
   output: UsagePlan,
@@ -7391,7 +7390,7 @@ export const getUsagePlanKey: API.OperationMethod<
   GetUsagePlanKeyRequest,
   UsagePlanKey,
   GetUsagePlanKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsagePlanKeyRequest,
   output: UsagePlanKey,
@@ -7419,7 +7418,7 @@ export const getUsagePlanKeys: API.PaginatedOperationMethod<
   GetUsagePlanKeysRequest,
   UsagePlanKeys,
   GetUsagePlanKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsagePlanKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUsagePlanKeysRequest,
@@ -7454,7 +7453,7 @@ export const getUsagePlans: API.PaginatedOperationMethod<
   GetUsagePlansRequest,
   UsagePlans,
   GetUsagePlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsagePlan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUsagePlansRequest,
@@ -7489,7 +7488,7 @@ export const getVpcLink: API.OperationMethod<
   GetVpcLinkRequest,
   VpcLink,
   GetVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcLinkRequest,
   output: VpcLink,
@@ -7517,7 +7516,7 @@ export const getVpcLinks: API.PaginatedOperationMethod<
   GetVpcLinksRequest,
   VpcLinks,
   GetVpcLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcLink
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetVpcLinksRequest,
@@ -7554,7 +7553,7 @@ export const importApiKeys: API.OperationMethod<
   ImportApiKeysRequest,
   ApiKeyIds,
   ImportApiKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportApiKeysRequest,
   output: ApiKeyIds,
@@ -7586,7 +7585,7 @@ export const importDocumentationParts: API.OperationMethod<
   ImportDocumentationPartsRequest,
   DocumentationPartIds,
   ImportDocumentationPartsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportDocumentationPartsRequest,
   output: DocumentationPartIds,
@@ -7618,7 +7617,7 @@ export const importRestApi: API.OperationMethod<
   ImportRestApiRequest,
   RestApi,
   ImportRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportRestApiRequest,
   output: RestApi,
@@ -7650,7 +7649,7 @@ export const putGatewayResponse: API.OperationMethod<
   PutGatewayResponseRequest,
   GatewayResponse,
   PutGatewayResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGatewayResponseRequest,
   output: GatewayResponse,
@@ -7682,7 +7681,7 @@ export const putIntegration: API.OperationMethod<
   PutIntegrationRequest,
   Integration,
   PutIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIntegrationRequest,
   output: Integration,
@@ -7714,7 +7713,7 @@ export const putIntegrationResponse: API.OperationMethod<
   PutIntegrationResponseRequest,
   IntegrationResponse,
   PutIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIntegrationResponseRequest,
   output: IntegrationResponse,
@@ -7746,7 +7745,7 @@ export const putMethod: API.OperationMethod<
   PutMethodRequest,
   Method,
   PutMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMethodRequest,
   output: Method,
@@ -7778,7 +7777,7 @@ export const putMethodResponse: API.OperationMethod<
   PutMethodResponseRequest,
   MethodResponse,
   PutMethodResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMethodResponseRequest,
   output: MethodResponse,
@@ -7811,7 +7810,7 @@ export const putRestApi: API.OperationMethod<
   PutRestApiRequest,
   RestApi,
   PutRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRestApiRequest,
   output: RestApi,
@@ -7844,7 +7843,7 @@ export const rejectDomainNameAccessAssociation: API.OperationMethod<
   RejectDomainNameAccessAssociationRequest,
   RejectDomainNameAccessAssociationResponse,
   RejectDomainNameAccessAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectDomainNameAccessAssociationRequest,
   output: RejectDomainNameAccessAssociationResponse,
@@ -7875,7 +7874,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7905,7 +7904,7 @@ export const testInvokeAuthorizer: API.OperationMethod<
   TestInvokeAuthorizerRequest,
   TestInvokeAuthorizerResponse,
   TestInvokeAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestInvokeAuthorizerRequest,
   output: TestInvokeAuthorizerResponse,
@@ -7933,7 +7932,7 @@ export const testInvokeMethod: API.OperationMethod<
   TestInvokeMethodRequest,
   TestInvokeMethodResponse,
   TestInvokeMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestInvokeMethodRequest,
   output: TestInvokeMethodResponse,
@@ -7963,7 +7962,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7995,7 +7994,7 @@ export const updateAccount: API.OperationMethod<
   UpdateAccountRequest,
   Account,
   UpdateAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountRequest,
   output: Account,
@@ -8027,7 +8026,7 @@ export const updateApiKey: API.OperationMethod<
   UpdateApiKeyRequest,
   ApiKey,
   UpdateApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiKeyRequest,
   output: ApiKey,
@@ -8059,7 +8058,7 @@ export const updateAuthorizer: API.OperationMethod<
   UpdateAuthorizerRequest,
   Authorizer,
   UpdateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuthorizerRequest,
   output: Authorizer,
@@ -8091,7 +8090,7 @@ export const updateBasePathMapping: API.OperationMethod<
   UpdateBasePathMappingRequest,
   BasePathMapping,
   UpdateBasePathMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBasePathMappingRequest,
   output: BasePathMapping,
@@ -8123,7 +8122,7 @@ export const updateClientCertificate: API.OperationMethod<
   UpdateClientCertificateRequest,
   ClientCertificate,
   UpdateClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClientCertificateRequest,
   output: ClientCertificate,
@@ -8156,7 +8155,7 @@ export const updateDeployment: API.OperationMethod<
   UpdateDeploymentRequest,
   Deployment,
   UpdateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeploymentRequest,
   output: Deployment,
@@ -8189,7 +8188,7 @@ export const updateDocumentationPart: API.OperationMethod<
   UpdateDocumentationPartRequest,
   DocumentationPart,
   UpdateDocumentationPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentationPartRequest,
   output: DocumentationPart,
@@ -8221,7 +8220,7 @@ export const updateDocumentationVersion: API.OperationMethod<
   UpdateDocumentationVersionRequest,
   DocumentationVersion,
   UpdateDocumentationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentationVersionRequest,
   output: DocumentationVersion,
@@ -8253,7 +8252,7 @@ export const updateDomainName: API.OperationMethod<
   UpdateDomainNameRequest,
   DomainName,
   UpdateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainNameRequest,
   output: DomainName,
@@ -8285,7 +8284,7 @@ export const updateGatewayResponse: API.OperationMethod<
   UpdateGatewayResponseRequest,
   GatewayResponse,
   UpdateGatewayResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayResponseRequest,
   output: GatewayResponse,
@@ -8317,7 +8316,7 @@ export const updateIntegration: API.OperationMethod<
   UpdateIntegrationRequest,
   Integration,
   UpdateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationRequest,
   output: Integration,
@@ -8349,7 +8348,7 @@ export const updateIntegrationResponse: API.OperationMethod<
   UpdateIntegrationResponseRequest,
   IntegrationResponse,
   UpdateIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationResponseRequest,
   output: IntegrationResponse,
@@ -8380,7 +8379,7 @@ export const updateMethod: API.OperationMethod<
   UpdateMethodRequest,
   Method,
   UpdateMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMethodRequest,
   output: Method,
@@ -8411,7 +8410,7 @@ export const updateMethodResponse: API.OperationMethod<
   UpdateMethodResponseRequest,
   MethodResponse,
   UpdateMethodResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMethodResponseRequest,
   output: MethodResponse,
@@ -8443,7 +8442,7 @@ export const updateModel: API.OperationMethod<
   UpdateModelRequest,
   Model,
   UpdateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelRequest,
   output: Model,
@@ -8475,7 +8474,7 @@ export const updateRequestValidator: API.OperationMethod<
   UpdateRequestValidatorRequest,
   RequestValidator,
   UpdateRequestValidatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRequestValidatorRequest,
   output: RequestValidator,
@@ -8506,7 +8505,7 @@ export const updateResource: API.OperationMethod<
   UpdateResourceRequest,
   Resource,
   UpdateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceRequest,
   output: Resource,
@@ -8537,7 +8536,7 @@ export const updateRestApi: API.OperationMethod<
   UpdateRestApiRequest,
   RestApi,
   UpdateRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRestApiRequest,
   output: RestApi,
@@ -8569,7 +8568,7 @@ export const updateStage: API.OperationMethod<
   UpdateStageRequest,
   Stage,
   UpdateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStageRequest,
   output: Stage,
@@ -8601,7 +8600,7 @@ export const updateUsage: API.OperationMethod<
   UpdateUsageRequest,
   Usage,
   UpdateUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUsageRequest,
   output: Usage,
@@ -8633,7 +8632,7 @@ export const updateUsagePlan: API.OperationMethod<
   UpdateUsagePlanRequest,
   UsagePlan,
   UpdateUsagePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUsagePlanRequest,
   output: UsagePlan,
@@ -8665,7 +8664,7 @@ export const updateVpcLink: API.OperationMethod<
   UpdateVpcLinkRequest,
   VpcLink,
   UpdateVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcLinkRequest,
   output: VpcLink,

--- a/packages/aws/src/services/apigatewaymanagementapi.ts
+++ b/packages/aws/src/services/apigatewaymanagementapi.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ApiGatewayManagementApi",
   serviceShapeName: "ApiGatewayManagementApi",
@@ -222,7 +221,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -244,7 +243,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -267,7 +266,7 @@ export const postToConnection: API.OperationMethod<
   PostToConnectionRequest,
   PostToConnectionResponse,
   PostToConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostToConnectionRequest,
   output: PostToConnectionResponse,

--- a/packages/aws/src/services/apigatewayv2.ts
+++ b/packages/aws/src/services/apigatewayv2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ApiGatewayV2",
   serviceShapeName: "ApiGatewayV2",
@@ -7494,7 +7493,7 @@ export const createApi: API.OperationMethod<
   CreateApiRequest,
   CreateApiResponse,
   CreateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiRequest,
   output: CreateApiResponse,
@@ -7522,7 +7521,7 @@ export const createApiMapping: API.OperationMethod<
   CreateApiMappingRequest,
   CreateApiMappingResponse,
   CreateApiMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiMappingRequest,
   output: CreateApiMappingResponse,
@@ -7550,7 +7549,7 @@ export const createAuthorizer: API.OperationMethod<
   CreateAuthorizerRequest,
   CreateAuthorizerResponse,
   CreateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAuthorizerRequest,
   output: CreateAuthorizerResponse,
@@ -7578,7 +7577,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   CreateDeploymentResponse,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: CreateDeploymentResponse,
@@ -7607,7 +7606,7 @@ export const createDomainName: API.OperationMethod<
   CreateDomainNameRequest,
   CreateDomainNameResponse,
   CreateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainNameRequest,
   output: CreateDomainNameResponse,
@@ -7636,7 +7635,7 @@ export const createIntegration: API.OperationMethod<
   CreateIntegrationRequest,
   CreateIntegrationResult,
   CreateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationRequest,
   output: CreateIntegrationResult,
@@ -7664,7 +7663,7 @@ export const createIntegrationResponse: API.OperationMethod<
   CreateIntegrationResponseRequest,
   CreateIntegrationResponseResponse,
   CreateIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationResponseRequest,
   output: CreateIntegrationResponseResponse,
@@ -7692,7 +7691,7 @@ export const createModel: API.OperationMethod<
   CreateModelRequest,
   CreateModelResponse,
   CreateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelRequest,
   output: CreateModelResponse,
@@ -7719,7 +7718,7 @@ export const createPortal: API.OperationMethod<
   CreatePortalRequest,
   CreatePortalResponse,
   CreatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortalRequest,
   output: CreatePortalResponse,
@@ -7745,7 +7744,7 @@ export const createPortalProduct: API.OperationMethod<
   CreatePortalProductRequest,
   CreatePortalProductResponse,
   CreatePortalProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortalProductRequest,
   output: CreatePortalProductResponse,
@@ -7772,7 +7771,7 @@ export const createProductPage: API.OperationMethod<
   CreateProductPageRequest,
   CreateProductPageResponse,
   CreateProductPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProductPageRequest,
   output: CreateProductPageResponse,
@@ -7800,7 +7799,7 @@ export const createProductRestEndpointPage: API.OperationMethod<
   CreateProductRestEndpointPageRequest,
   CreateProductRestEndpointPageResponse,
   CreateProductRestEndpointPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProductRestEndpointPageRequest,
   output: CreateProductRestEndpointPageResponse,
@@ -7828,7 +7827,7 @@ export const createRoute: API.OperationMethod<
   CreateRouteRequest,
   CreateRouteResult,
   CreateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteRequest,
   output: CreateRouteResult,
@@ -7856,7 +7855,7 @@ export const createRouteResponse: API.OperationMethod<
   CreateRouteResponseRequest,
   CreateRouteResponseResponse,
   CreateRouteResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteResponseRequest,
   output: CreateRouteResponseResponse,
@@ -7884,7 +7883,7 @@ export const createRoutingRule: API.OperationMethod<
   CreateRoutingRuleRequest,
   CreateRoutingRuleResponse,
   CreateRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoutingRuleRequest,
   output: CreateRoutingRuleResponse,
@@ -7912,7 +7911,7 @@ export const createStage: API.OperationMethod<
   CreateStageRequest,
   CreateStageResponse,
   CreateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStageRequest,
   output: CreateStageResponse,
@@ -7938,7 +7937,7 @@ export const createVpcLink: API.OperationMethod<
   CreateVpcLinkRequest,
   CreateVpcLinkResponse,
   CreateVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcLinkRequest,
   output: CreateVpcLinkResponse,
@@ -7959,7 +7958,7 @@ export const deleteAccessLogSettings: API.OperationMethod<
   DeleteAccessLogSettingsRequest,
   DeleteAccessLogSettingsResponse,
   DeleteAccessLogSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessLogSettingsRequest,
   output: DeleteAccessLogSettingsResponse,
@@ -7980,7 +7979,7 @@ export const deleteApi: API.OperationMethod<
   DeleteApiRequest,
   DeleteApiResponse,
   DeleteApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiRequest,
   output: DeleteApiResponse,
@@ -8002,7 +8001,7 @@ export const deleteApiMapping: API.OperationMethod<
   DeleteApiMappingRequest,
   DeleteApiMappingResponse,
   DeleteApiMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiMappingRequest,
   output: DeleteApiMappingResponse,
@@ -8023,7 +8022,7 @@ export const deleteAuthorizer: API.OperationMethod<
   DeleteAuthorizerRequest,
   DeleteAuthorizerResponse,
   DeleteAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuthorizerRequest,
   output: DeleteAuthorizerResponse,
@@ -8044,7 +8043,7 @@ export const deleteCorsConfiguration: API.OperationMethod<
   DeleteCorsConfigurationRequest,
   DeleteCorsConfigurationResponse,
   DeleteCorsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCorsConfigurationRequest,
   output: DeleteCorsConfigurationResponse,
@@ -8065,7 +8064,7 @@ export const deleteDeployment: API.OperationMethod<
   DeleteDeploymentRequest,
   DeleteDeploymentResponse,
   DeleteDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentRequest,
   output: DeleteDeploymentResponse,
@@ -8086,7 +8085,7 @@ export const deleteDomainName: API.OperationMethod<
   DeleteDomainNameRequest,
   DeleteDomainNameResponse,
   DeleteDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainNameRequest,
   output: DeleteDomainNameResponse,
@@ -8107,7 +8106,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationRequest,
   DeleteIntegrationResponse,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationRequest,
   output: DeleteIntegrationResponse,
@@ -8128,7 +8127,7 @@ export const deleteIntegrationResponse: API.OperationMethod<
   DeleteIntegrationResponseRequest,
   DeleteIntegrationResponseResponse,
   DeleteIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationResponseRequest,
   output: DeleteIntegrationResponseResponse,
@@ -8149,7 +8148,7 @@ export const deleteModel: API.OperationMethod<
   DeleteModelRequest,
   DeleteModelResponse,
   DeleteModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelRequest,
   output: DeleteModelResponse,
@@ -8171,7 +8170,7 @@ export const deletePortal: API.OperationMethod<
   DeletePortalRequest,
   DeletePortalResponse,
   DeletePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortalRequest,
   output: DeletePortalResponse,
@@ -8198,7 +8197,7 @@ export const deletePortalProduct: API.OperationMethod<
   DeletePortalProductRequest,
   DeletePortalProductResponse,
   DeletePortalProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortalProductRequest,
   output: DeletePortalProductResponse,
@@ -8226,7 +8225,7 @@ export const deletePortalProductSharingPolicy: API.OperationMethod<
   DeletePortalProductSharingPolicyRequest,
   DeletePortalProductSharingPolicyResponse,
   DeletePortalProductSharingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortalProductSharingPolicyRequest,
   output: DeletePortalProductSharingPolicyResponse,
@@ -8254,7 +8253,7 @@ export const deleteProductPage: API.OperationMethod<
   DeleteProductPageRequest,
   DeleteProductPageResponse,
   DeleteProductPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProductPageRequest,
   output: DeleteProductPageResponse,
@@ -8282,7 +8281,7 @@ export const deleteProductRestEndpointPage: API.OperationMethod<
   DeleteProductRestEndpointPageRequest,
   DeleteProductRestEndpointPageResponse,
   DeleteProductRestEndpointPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProductRestEndpointPageRequest,
   output: DeleteProductRestEndpointPageResponse,
@@ -8308,7 +8307,7 @@ export const deleteRoute: API.OperationMethod<
   DeleteRouteRequest,
   DeleteRouteResponse,
   DeleteRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteRequest,
   output: DeleteRouteResponse,
@@ -8329,7 +8328,7 @@ export const deleteRouteRequestParameter: API.OperationMethod<
   DeleteRouteRequestParameterRequest,
   DeleteRouteRequestParameterResponse,
   DeleteRouteRequestParameterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteRequestParameterRequest,
   output: DeleteRouteRequestParameterResponse,
@@ -8350,7 +8349,7 @@ export const deleteRouteResponse: API.OperationMethod<
   DeleteRouteResponseRequest,
   DeleteRouteResponseResponse,
   DeleteRouteResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteResponseRequest,
   output: DeleteRouteResponseResponse,
@@ -8371,7 +8370,7 @@ export const deleteRouteSettings: API.OperationMethod<
   DeleteRouteSettingsRequest,
   DeleteRouteSettingsResponse,
   DeleteRouteSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteSettingsRequest,
   output: DeleteRouteSettingsResponse,
@@ -8393,7 +8392,7 @@ export const deleteRoutingRule: API.OperationMethod<
   DeleteRoutingRuleRequest,
   DeleteRoutingRuleResponse,
   DeleteRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoutingRuleRequest,
   output: DeleteRoutingRuleResponse,
@@ -8414,7 +8413,7 @@ export const deleteStage: API.OperationMethod<
   DeleteStageRequest,
   DeleteStageResponse,
   DeleteStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStageRequest,
   output: DeleteStageResponse,
@@ -8435,7 +8434,7 @@ export const deleteVpcLink: API.OperationMethod<
   DeleteVpcLinkRequest,
   DeleteVpcLinkResponse,
   DeleteVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcLinkRequest,
   output: DeleteVpcLinkResponse,
@@ -8459,7 +8458,7 @@ export const disablePortal: API.OperationMethod<
   DisablePortalRequest,
   DisablePortalResponse,
   DisablePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisablePortalRequest,
   output: DisablePortalResponse,
@@ -8487,7 +8486,7 @@ export const exportApi: API.OperationMethod<
   ExportApiRequest,
   ExportApiResponse,
   ExportApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportApiRequest,
   output: ExportApiResponse,
@@ -8508,7 +8507,7 @@ export const getApi: API.OperationMethod<
   GetApiRequest,
   GetApiResponse,
   GetApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiRequest,
   output: GetApiResponse,
@@ -8530,7 +8529,7 @@ export const getApiMapping: API.OperationMethod<
   GetApiMappingRequest,
   GetApiMappingResponse,
   GetApiMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiMappingRequest,
   output: GetApiMappingResponse,
@@ -8552,7 +8551,7 @@ export const getApiMappings: API.OperationMethod<
   GetApiMappingsRequest,
   GetApiMappingsResponse,
   GetApiMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiMappingsRequest,
   output: GetApiMappingsResponse,
@@ -8574,7 +8573,7 @@ export const getApis: API.OperationMethod<
   GetApisRequest,
   GetApisResponse,
   GetApisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApisRequest,
   output: GetApisResponse,
@@ -8595,7 +8594,7 @@ export const getAuthorizer: API.OperationMethod<
   GetAuthorizerRequest,
   GetAuthorizerResponse,
   GetAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizerRequest,
   output: GetAuthorizerResponse,
@@ -8617,7 +8616,7 @@ export const getAuthorizers: API.OperationMethod<
   GetAuthorizersRequest,
   GetAuthorizersResponse,
   GetAuthorizersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizersRequest,
   output: GetAuthorizersResponse,
@@ -8638,7 +8637,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentRequest,
   GetDeploymentResponse,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentRequest,
   output: GetDeploymentResponse,
@@ -8660,7 +8659,7 @@ export const getDeployments: API.OperationMethod<
   GetDeploymentsRequest,
   GetDeploymentsResponse,
   GetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentsRequest,
   output: GetDeploymentsResponse,
@@ -8681,7 +8680,7 @@ export const getDomainName: API.OperationMethod<
   GetDomainNameRequest,
   GetDomainNameResponse,
   GetDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainNameRequest,
   output: GetDomainNameResponse,
@@ -8703,7 +8702,7 @@ export const getDomainNames: API.OperationMethod<
   GetDomainNamesRequest,
   GetDomainNamesResponse,
   GetDomainNamesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainNamesRequest,
   output: GetDomainNamesResponse,
@@ -8724,7 +8723,7 @@ export const getIntegration: API.OperationMethod<
   GetIntegrationRequest,
   GetIntegrationResult,
   GetIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationRequest,
   output: GetIntegrationResult,
@@ -8745,7 +8744,7 @@ export const getIntegrationResponse: API.OperationMethod<
   GetIntegrationResponseRequest,
   GetIntegrationResponseResponse,
   GetIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationResponseRequest,
   output: GetIntegrationResponseResponse,
@@ -8767,7 +8766,7 @@ export const getIntegrationResponses: API.OperationMethod<
   GetIntegrationResponsesRequest,
   GetIntegrationResponsesResponse,
   GetIntegrationResponsesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationResponsesRequest,
   output: GetIntegrationResponsesResponse,
@@ -8789,7 +8788,7 @@ export const getIntegrations: API.OperationMethod<
   GetIntegrationsRequest,
   GetIntegrationsResponse,
   GetIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationsRequest,
   output: GetIntegrationsResponse,
@@ -8810,7 +8809,7 @@ export const getModel: API.OperationMethod<
   GetModelRequest,
   GetModelResponse,
   GetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelRequest,
   output: GetModelResponse,
@@ -8832,7 +8831,7 @@ export const getModels: API.OperationMethod<
   GetModelsRequest,
   GetModelsResponse,
   GetModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelsRequest,
   output: GetModelsResponse,
@@ -8853,7 +8852,7 @@ export const getModelTemplate: API.OperationMethod<
   GetModelTemplateRequest,
   GetModelTemplateResponse,
   GetModelTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelTemplateRequest,
   output: GetModelTemplateResponse,
@@ -8876,7 +8875,7 @@ export const getPortal: API.OperationMethod<
   GetPortalRequest,
   GetPortalResponse,
   GetPortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortalRequest,
   output: GetPortalResponse,
@@ -8904,7 +8903,7 @@ export const getPortalProduct: API.OperationMethod<
   GetPortalProductRequest,
   GetPortalProductResponse,
   GetPortalProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortalProductRequest,
   output: GetPortalProductResponse,
@@ -8932,7 +8931,7 @@ export const getPortalProductSharingPolicy: API.OperationMethod<
   GetPortalProductSharingPolicyRequest,
   GetPortalProductSharingPolicyResponse,
   GetPortalProductSharingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortalProductSharingPolicyRequest,
   output: GetPortalProductSharingPolicyResponse,
@@ -8960,7 +8959,7 @@ export const getProductPage: API.OperationMethod<
   GetProductPageRequest,
   GetProductPageResponse,
   GetProductPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProductPageRequest,
   output: GetProductPageResponse,
@@ -8988,7 +8987,7 @@ export const getProductRestEndpointPage: API.OperationMethod<
   GetProductRestEndpointPageRequest,
   GetProductRestEndpointPageResponse,
   GetProductRestEndpointPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProductRestEndpointPageRequest,
   output: GetProductRestEndpointPageResponse,
@@ -9014,7 +9013,7 @@ export const getRoute: API.OperationMethod<
   GetRouteRequest,
   GetRouteResult,
   GetRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteRequest,
   output: GetRouteResult,
@@ -9035,7 +9034,7 @@ export const getRouteResponse: API.OperationMethod<
   GetRouteResponseRequest,
   GetRouteResponseResponse,
   GetRouteResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteResponseRequest,
   output: GetRouteResponseResponse,
@@ -9057,7 +9056,7 @@ export const getRouteResponses: API.OperationMethod<
   GetRouteResponsesRequest,
   GetRouteResponsesResponse,
   GetRouteResponsesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteResponsesRequest,
   output: GetRouteResponsesResponse,
@@ -9079,7 +9078,7 @@ export const getRoutes: API.OperationMethod<
   GetRoutesRequest,
   GetRoutesResponse,
   GetRoutesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoutesRequest,
   output: GetRoutesResponse,
@@ -9101,7 +9100,7 @@ export const getRoutingRule: API.OperationMethod<
   GetRoutingRuleRequest,
   GetRoutingRuleResponse,
   GetRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoutingRuleRequest,
   output: GetRoutingRuleResponse,
@@ -9122,7 +9121,7 @@ export const getStage: API.OperationMethod<
   GetStageRequest,
   GetStageResponse,
   GetStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStageRequest,
   output: GetStageResponse,
@@ -9144,7 +9143,7 @@ export const getStages: API.OperationMethod<
   GetStagesRequest,
   GetStagesResponse,
   GetStagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStagesRequest,
   output: GetStagesResponse,
@@ -9167,7 +9166,7 @@ export const getTags: API.OperationMethod<
   GetTagsRequest,
   GetTagsResponse,
   GetTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagsRequest,
   output: GetTagsResponse,
@@ -9193,7 +9192,7 @@ export const getVpcLink: API.OperationMethod<
   GetVpcLinkRequest,
   GetVpcLinkResponse,
   GetVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcLinkRequest,
   output: GetVpcLinkResponse,
@@ -9214,7 +9213,7 @@ export const getVpcLinks: API.OperationMethod<
   GetVpcLinksRequest,
   GetVpcLinksResponse,
   GetVpcLinksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcLinksRequest,
   output: GetVpcLinksResponse,
@@ -9237,7 +9236,7 @@ export const importApi: API.OperationMethod<
   ImportApiRequest,
   ImportApiResponse,
   ImportApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportApiRequest,
   output: ImportApiResponse,
@@ -9264,7 +9263,7 @@ export const listPortalProducts: API.OperationMethod<
   ListPortalProductsRequest,
   ListPortalProductsResponse,
   ListPortalProductsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPortalProductsRequest,
   output: ListPortalProductsResponse,
@@ -9290,7 +9289,7 @@ export const listPortals: API.OperationMethod<
   ListPortalsRequest,
   ListPortalsResponse,
   ListPortalsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPortalsRequest,
   output: ListPortalsResponse,
@@ -9317,7 +9316,7 @@ export const listProductPages: API.OperationMethod<
   ListProductPagesRequest,
   ListProductPagesResponse,
   ListProductPagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProductPagesRequest,
   output: ListProductPagesResponse,
@@ -9345,7 +9344,7 @@ export const listProductRestEndpointPages: API.OperationMethod<
   ListProductRestEndpointPagesRequest,
   ListProductRestEndpointPagesResponse,
   ListProductRestEndpointPagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProductRestEndpointPagesRequest,
   output: ListProductRestEndpointPagesResponse,
@@ -9372,7 +9371,7 @@ export const listRoutingRules: API.PaginatedOperationMethod<
   ListRoutingRulesRequest,
   ListRoutingRulesResponse,
   ListRoutingRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RoutingRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingRulesRequest,
@@ -9403,7 +9402,7 @@ export const previewPortal: API.OperationMethod<
   PreviewPortalRequest,
   PreviewPortalResponse,
   PreviewPortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PreviewPortalRequest,
   output: PreviewPortalResponse,
@@ -9433,7 +9432,7 @@ export const publishPortal: API.OperationMethod<
   PublishPortalRequest,
   PublishPortalResponse,
   PublishPortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishPortalRequest,
   output: PublishPortalResponse,
@@ -9462,7 +9461,7 @@ export const putPortalProductSharingPolicy: API.OperationMethod<
   PutPortalProductSharingPolicyRequest,
   PutPortalProductSharingPolicyResponse,
   PutPortalProductSharingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPortalProductSharingPolicyRequest,
   output: PutPortalProductSharingPolicyResponse,
@@ -9490,7 +9489,7 @@ export const putRoutingRule: API.OperationMethod<
   PutRoutingRuleRequest,
   PutRoutingRuleResponse,
   PutRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRoutingRuleRequest,
   output: PutRoutingRuleResponse,
@@ -9518,7 +9517,7 @@ export const reimportApi: API.OperationMethod<
   ReimportApiRequest,
   ReimportApiResponse,
   ReimportApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReimportApiRequest,
   output: ReimportApiResponse,
@@ -9544,7 +9543,7 @@ export const resetAuthorizersCache: API.OperationMethod<
   ResetAuthorizersCacheRequest,
   ResetAuthorizersCacheResponse,
   ResetAuthorizersCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetAuthorizersCacheRequest,
   output: ResetAuthorizersCacheResponse,
@@ -9567,7 +9566,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -9595,7 +9594,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -9623,7 +9622,7 @@ export const updateApi: API.OperationMethod<
   UpdateApiRequest,
   UpdateApiResponse,
   UpdateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiRequest,
   output: UpdateApiResponse,
@@ -9651,7 +9650,7 @@ export const updateApiMapping: API.OperationMethod<
   UpdateApiMappingRequest,
   UpdateApiMappingResponse,
   UpdateApiMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiMappingRequest,
   output: UpdateApiMappingResponse,
@@ -9679,7 +9678,7 @@ export const updateAuthorizer: API.OperationMethod<
   UpdateAuthorizerRequest,
   UpdateAuthorizerResponse,
   UpdateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuthorizerRequest,
   output: UpdateAuthorizerResponse,
@@ -9707,7 +9706,7 @@ export const updateDeployment: API.OperationMethod<
   UpdateDeploymentRequest,
   UpdateDeploymentResponse,
   UpdateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeploymentRequest,
   output: UpdateDeploymentResponse,
@@ -9735,7 +9734,7 @@ export const updateDomainName: API.OperationMethod<
   UpdateDomainNameRequest,
   UpdateDomainNameResponse,
   UpdateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainNameRequest,
   output: UpdateDomainNameResponse,
@@ -9763,7 +9762,7 @@ export const updateIntegration: API.OperationMethod<
   UpdateIntegrationRequest,
   UpdateIntegrationResult,
   UpdateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationRequest,
   output: UpdateIntegrationResult,
@@ -9791,7 +9790,7 @@ export const updateIntegrationResponse: API.OperationMethod<
   UpdateIntegrationResponseRequest,
   UpdateIntegrationResponseResponse,
   UpdateIntegrationResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationResponseRequest,
   output: UpdateIntegrationResponseResponse,
@@ -9819,7 +9818,7 @@ export const updateModel: API.OperationMethod<
   UpdateModelRequest,
   UpdateModelResponse,
   UpdateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelRequest,
   output: UpdateModelResponse,
@@ -9848,7 +9847,7 @@ export const updatePortal: API.OperationMethod<
   UpdatePortalRequest,
   UpdatePortalResponse,
   UpdatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortalRequest,
   output: UpdatePortalResponse,
@@ -9877,7 +9876,7 @@ export const updatePortalProduct: API.OperationMethod<
   UpdatePortalProductRequest,
   UpdatePortalProductResponse,
   UpdatePortalProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortalProductRequest,
   output: UpdatePortalProductResponse,
@@ -9905,7 +9904,7 @@ export const updateProductPage: API.OperationMethod<
   UpdateProductPageRequest,
   UpdateProductPageResponse,
   UpdateProductPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProductPageRequest,
   output: UpdateProductPageResponse,
@@ -9933,7 +9932,7 @@ export const updateProductRestEndpointPage: API.OperationMethod<
   UpdateProductRestEndpointPageRequest,
   UpdateProductRestEndpointPageResponse,
   UpdateProductRestEndpointPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProductRestEndpointPageRequest,
   output: UpdateProductRestEndpointPageResponse,
@@ -9961,7 +9960,7 @@ export const updateRoute: API.OperationMethod<
   UpdateRouteRequest,
   UpdateRouteResult,
   UpdateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouteRequest,
   output: UpdateRouteResult,
@@ -9989,7 +9988,7 @@ export const updateRouteResponse: API.OperationMethod<
   UpdateRouteResponseRequest,
   UpdateRouteResponseResponse,
   UpdateRouteResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouteResponseRequest,
   output: UpdateRouteResponseResponse,
@@ -10017,7 +10016,7 @@ export const updateStage: API.OperationMethod<
   UpdateStageRequest,
   UpdateStageResponse,
   UpdateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStageRequest,
   output: UpdateStageResponse,
@@ -10044,7 +10043,7 @@ export const updateVpcLink: API.OperationMethod<
   UpdateVpcLinkRequest,
   UpdateVpcLinkResponse,
   UpdateVpcLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcLinkRequest,
   output: UpdateVpcLinkResponse,

--- a/packages/aws/src/services/app-mesh.ts
+++ b/packages/aws/src/services/app-mesh.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "App Mesh", serviceShapeName: "AppMesh" });
 const auth = T.AwsAuthSigv4({ name: "appmesh" });
 const ver = T.ServiceVersion("2019-01-25");
@@ -3497,7 +3496,7 @@ export const createGatewayRoute: API.OperationMethod<
   CreateGatewayRouteInput,
   CreateGatewayRouteOutput,
   CreateGatewayRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayRouteInput,
   output: CreateGatewayRouteOutput,
@@ -3540,7 +3539,7 @@ export const createMesh: API.OperationMethod<
   CreateMeshInput,
   CreateMeshOutput,
   CreateMeshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMeshInput,
   output: CreateMeshOutput,
@@ -3581,7 +3580,7 @@ export const createRoute: API.OperationMethod<
   CreateRouteInput,
   CreateRouteOutput,
   CreateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteInput,
   output: CreateRouteOutput,
@@ -3624,7 +3623,7 @@ export const createVirtualGateway: API.OperationMethod<
   CreateVirtualGatewayInput,
   CreateVirtualGatewayOutput,
   CreateVirtualGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualGatewayInput,
   output: CreateVirtualGatewayOutput,
@@ -3686,7 +3685,7 @@ export const createVirtualNode: API.OperationMethod<
   CreateVirtualNodeInput,
   CreateVirtualNodeOutput,
   CreateVirtualNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualNodeInput,
   output: CreateVirtualNodeOutput,
@@ -3730,7 +3729,7 @@ export const createVirtualRouter: API.OperationMethod<
   CreateVirtualRouterInput,
   CreateVirtualRouterOutput,
   CreateVirtualRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualRouterInput,
   output: CreateVirtualRouterOutput,
@@ -3774,7 +3773,7 @@ export const createVirtualService: API.OperationMethod<
   CreateVirtualServiceInput,
   CreateVirtualServiceOutput,
   CreateVirtualServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualServiceInput,
   output: CreateVirtualServiceOutput,
@@ -3809,7 +3808,7 @@ export const deleteGatewayRoute: API.OperationMethod<
   DeleteGatewayRouteInput,
   DeleteGatewayRouteOutput,
   DeleteGatewayRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayRouteInput,
   output: DeleteGatewayRouteOutput,
@@ -3846,7 +3845,7 @@ export const deleteMesh: API.OperationMethod<
   DeleteMeshInput,
   DeleteMeshOutput,
   DeleteMeshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMeshInput,
   output: DeleteMeshOutput,
@@ -3880,7 +3879,7 @@ export const deleteRoute: API.OperationMethod<
   DeleteRouteInput,
   DeleteRouteOutput,
   DeleteRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteInput,
   output: DeleteRouteOutput,
@@ -3915,7 +3914,7 @@ export const deleteVirtualGateway: API.OperationMethod<
   DeleteVirtualGatewayInput,
   DeleteVirtualGatewayOutput,
   DeleteVirtualGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualGatewayInput,
   output: DeleteVirtualGatewayOutput,
@@ -3952,7 +3951,7 @@ export const deleteVirtualNode: API.OperationMethod<
   DeleteVirtualNodeInput,
   DeleteVirtualNodeOutput,
   DeleteVirtualNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualNodeInput,
   output: DeleteVirtualNodeOutput,
@@ -3989,7 +3988,7 @@ export const deleteVirtualRouter: API.OperationMethod<
   DeleteVirtualRouterInput,
   DeleteVirtualRouterOutput,
   DeleteVirtualRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualRouterInput,
   output: DeleteVirtualRouterOutput,
@@ -4023,7 +4022,7 @@ export const deleteVirtualService: API.OperationMethod<
   DeleteVirtualServiceInput,
   DeleteVirtualServiceOutput,
   DeleteVirtualServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualServiceInput,
   output: DeleteVirtualServiceOutput,
@@ -4056,7 +4055,7 @@ export const describeGatewayRoute: API.OperationMethod<
   DescribeGatewayRouteInput,
   DescribeGatewayRouteOutput,
   DescribeGatewayRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayRouteInput,
   output: DescribeGatewayRouteOutput,
@@ -4088,7 +4087,7 @@ export const describeMesh: API.OperationMethod<
   DescribeMeshInput,
   DescribeMeshOutput,
   DescribeMeshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMeshInput,
   output: DescribeMeshOutput,
@@ -4120,7 +4119,7 @@ export const describeRoute: API.OperationMethod<
   DescribeRouteInput,
   DescribeRouteOutput,
   DescribeRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRouteInput,
   output: DescribeRouteOutput,
@@ -4152,7 +4151,7 @@ export const describeVirtualGateway: API.OperationMethod<
   DescribeVirtualGatewayInput,
   DescribeVirtualGatewayOutput,
   DescribeVirtualGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualGatewayInput,
   output: DescribeVirtualGatewayOutput,
@@ -4184,7 +4183,7 @@ export const describeVirtualNode: API.OperationMethod<
   DescribeVirtualNodeInput,
   DescribeVirtualNodeOutput,
   DescribeVirtualNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualNodeInput,
   output: DescribeVirtualNodeOutput,
@@ -4216,7 +4215,7 @@ export const describeVirtualRouter: API.OperationMethod<
   DescribeVirtualRouterInput,
   DescribeVirtualRouterOutput,
   DescribeVirtualRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualRouterInput,
   output: DescribeVirtualRouterOutput,
@@ -4248,7 +4247,7 @@ export const describeVirtualService: API.OperationMethod<
   DescribeVirtualServiceInput,
   DescribeVirtualServiceOutput,
   DescribeVirtualServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualServiceInput,
   output: DescribeVirtualServiceOutput,
@@ -4281,7 +4280,7 @@ export const listGatewayRoutes: API.PaginatedOperationMethod<
   ListGatewayRoutesInput,
   ListGatewayRoutesOutput,
   ListGatewayRoutesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewayRouteRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewayRoutesInput,
@@ -4320,7 +4319,7 @@ export const listMeshes: API.PaginatedOperationMethod<
   ListMeshesInput,
   ListMeshesOutput,
   ListMeshesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MeshRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMeshesInput,
@@ -4359,7 +4358,7 @@ export const listRoutes: API.PaginatedOperationMethod<
   ListRoutesInput,
   ListRoutesOutput,
   ListRoutesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutesInput,
@@ -4398,7 +4397,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -4437,7 +4436,7 @@ export const listVirtualGateways: API.PaginatedOperationMethod<
   ListVirtualGatewaysInput,
   ListVirtualGatewaysOutput,
   ListVirtualGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualGatewayRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualGatewaysInput,
@@ -4476,7 +4475,7 @@ export const listVirtualNodes: API.PaginatedOperationMethod<
   ListVirtualNodesInput,
   ListVirtualNodesOutput,
   ListVirtualNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualNodeRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualNodesInput,
@@ -4515,7 +4514,7 @@ export const listVirtualRouters: API.PaginatedOperationMethod<
   ListVirtualRoutersInput,
   ListVirtualRoutersOutput,
   ListVirtualRoutersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualRouterRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualRoutersInput,
@@ -4554,7 +4553,7 @@ export const listVirtualServices: API.PaginatedOperationMethod<
   ListVirtualServicesInput,
   ListVirtualServicesOutput,
   ListVirtualServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualServiceRef
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualServicesInput,
@@ -4597,7 +4596,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -4630,7 +4629,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -4665,7 +4664,7 @@ export const updateGatewayRoute: API.OperationMethod<
   UpdateGatewayRouteInput,
   UpdateGatewayRouteOutput,
   UpdateGatewayRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayRouteInput,
   output: UpdateGatewayRouteOutput,
@@ -4700,7 +4699,7 @@ export const updateMesh: API.OperationMethod<
   UpdateMeshInput,
   UpdateMeshOutput,
   UpdateMeshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMeshInput,
   output: UpdateMeshOutput,
@@ -4735,7 +4734,7 @@ export const updateRoute: API.OperationMethod<
   UpdateRouteInput,
   UpdateRouteOutput,
   UpdateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouteInput,
   output: UpdateRouteOutput,
@@ -4771,7 +4770,7 @@ export const updateVirtualGateway: API.OperationMethod<
   UpdateVirtualGatewayInput,
   UpdateVirtualGatewayOutput,
   UpdateVirtualGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVirtualGatewayInput,
   output: UpdateVirtualGatewayOutput,
@@ -4807,7 +4806,7 @@ export const updateVirtualNode: API.OperationMethod<
   UpdateVirtualNodeInput,
   UpdateVirtualNodeOutput,
   UpdateVirtualNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVirtualNodeInput,
   output: UpdateVirtualNodeOutput,
@@ -4843,7 +4842,7 @@ export const updateVirtualRouter: API.OperationMethod<
   UpdateVirtualRouterInput,
   UpdateVirtualRouterOutput,
   UpdateVirtualRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVirtualRouterInput,
   output: UpdateVirtualRouterOutput,
@@ -4879,7 +4878,7 @@ export const updateVirtualService: API.OperationMethod<
   UpdateVirtualServiceInput,
   UpdateVirtualServiceOutput,
   UpdateVirtualServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVirtualServiceInput,
   output: UpdateVirtualServiceOutput,

--- a/packages/aws/src/services/appconfig.ts
+++ b/packages/aws/src/services/appconfig.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AppConfig",
@@ -2939,7 +2938,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   Application,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: Application,
@@ -2994,7 +2993,7 @@ export const createConfigurationProfile: API.OperationMethod<
   CreateConfigurationProfileRequest,
   ConfigurationProfile,
   CreateConfigurationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationProfileRequest,
   output: ConfigurationProfile,
@@ -3024,7 +3023,7 @@ export const createDeploymentStrategy: API.OperationMethod<
   CreateDeploymentStrategyRequest,
   DeploymentStrategy,
   CreateDeploymentStrategyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentStrategyRequest,
   output: DeploymentStrategy,
@@ -3058,7 +3057,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   Environment,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: Environment,
@@ -3087,7 +3086,7 @@ export const createExperimentDefinition: API.OperationMethod<
   CreateExperimentDefinitionRequest,
   ExperimentDefinition,
   CreateExperimentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExperimentDefinitionRequest,
   output: ExperimentDefinition,
@@ -3136,7 +3135,7 @@ export const createExtension: API.OperationMethod<
   CreateExtensionRequest,
   Extension,
   CreateExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExtensionRequest,
   output: Extension,
@@ -3175,7 +3174,7 @@ export const createExtensionAssociation: API.OperationMethod<
   CreateExtensionAssociationRequest,
   ExtensionAssociation,
   CreateExtensionAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExtensionAssociationRequest,
   output: ExtensionAssociation,
@@ -3208,7 +3207,7 @@ export const createHostedConfigurationVersion: API.OperationMethod<
   CreateHostedConfigurationVersionRequest,
   HostedConfigurationVersion,
   CreateHostedConfigurationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHostedConfigurationVersionRequest,
   output: HostedConfigurationVersion,
@@ -3237,7 +3236,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -3268,7 +3267,7 @@ export const deleteConfigurationProfile: API.OperationMethod<
   DeleteConfigurationProfileRequest,
   DeleteConfigurationProfileResponse,
   DeleteConfigurationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationProfileRequest,
   output: DeleteConfigurationProfileResponse,
@@ -3295,7 +3294,7 @@ export const deleteDeploymentStrategy: API.OperationMethod<
   DeleteDeploymentStrategyRequest,
   DeleteDeploymentStrategyResponse,
   DeleteDeploymentStrategyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentStrategyRequest,
   output: DeleteDeploymentStrategyResponse,
@@ -3325,7 +3324,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -3353,7 +3352,7 @@ export const deleteExperimentDefinition: API.OperationMethod<
   DeleteExperimentDefinitionRequest,
   DeleteExperimentDefinitionResponse,
   DeleteExperimentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExperimentDefinitionRequest,
   output: DeleteExperimentDefinitionResponse,
@@ -3381,7 +3380,7 @@ export const deleteExtension: API.OperationMethod<
   DeleteExtensionRequest,
   DeleteExtensionResponse,
   DeleteExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExtensionRequest,
   output: DeleteExtensionResponse,
@@ -3408,7 +3407,7 @@ export const deleteExtensionAssociation: API.OperationMethod<
   DeleteExtensionAssociationRequest,
   DeleteExtensionAssociationResponse,
   DeleteExtensionAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExtensionAssociationRequest,
   output: DeleteExtensionAssociationResponse,
@@ -3435,7 +3434,7 @@ export const deleteHostedConfigurationVersion: API.OperationMethod<
   DeleteHostedConfigurationVersionRequest,
   DeleteHostedConfigurationVersionResponse,
   DeleteHostedConfigurationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHostedConfigurationVersionRequest,
   output: DeleteHostedConfigurationVersionResponse,
@@ -3461,7 +3460,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   AccountSettings,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: AccountSettings,
@@ -3483,7 +3482,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   Application,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: Application,
@@ -3517,7 +3516,7 @@ export const getConfiguration: API.OperationMethod<
   GetConfigurationRequest,
   Configuration,
   GetConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationRequest,
   output: Configuration,
@@ -3543,7 +3542,7 @@ export const getConfigurationProfile: API.OperationMethod<
   GetConfigurationProfileRequest,
   ConfigurationProfile,
   GetConfigurationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationProfileRequest,
   output: ConfigurationProfile,
@@ -3569,7 +3568,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentRequest,
   Deployment,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentRequest,
   output: Deployment,
@@ -3599,7 +3598,7 @@ export const getDeploymentStrategy: API.OperationMethod<
   GetDeploymentStrategyRequest,
   DeploymentStrategy,
   GetDeploymentStrategyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentStrategyRequest,
   output: DeploymentStrategy,
@@ -3630,7 +3629,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   Environment,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: Environment,
@@ -3656,7 +3655,7 @@ export const getExperimentDefinition: API.OperationMethod<
   GetExperimentDefinitionRequest,
   ExperimentDefinition,
   GetExperimentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExperimentDefinitionRequest,
   output: ExperimentDefinition,
@@ -3682,7 +3681,7 @@ export const getExperimentRun: API.OperationMethod<
   GetExperimentRunRequest,
   ExperimentRun,
   GetExperimentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExperimentRunRequest,
   output: ExperimentRun,
@@ -3708,7 +3707,7 @@ export const getExtension: API.OperationMethod<
   GetExtensionRequest,
   Extension,
   GetExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExtensionRequest,
   output: Extension,
@@ -3736,7 +3735,7 @@ export const getExtensionAssociation: API.OperationMethod<
   GetExtensionAssociationRequest,
   ExtensionAssociation,
   GetExtensionAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExtensionAssociationRequest,
   output: ExtensionAssociation,
@@ -3762,7 +3761,7 @@ export const getHostedConfigurationVersion: API.OperationMethod<
   GetHostedConfigurationVersionRequest,
   HostedConfigurationVersion,
   GetHostedConfigurationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostedConfigurationVersionRequest,
   output: HostedConfigurationVersion,
@@ -3787,7 +3786,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   Applications,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Application
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -3816,7 +3815,7 @@ export const listConfigurationProfiles: API.PaginatedOperationMethod<
   ListConfigurationProfilesRequest,
   ConfigurationProfiles,
   ListConfigurationProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationProfilesRequest,
@@ -3849,7 +3848,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsRequest,
   Deployments,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsRequest,
@@ -3881,7 +3880,7 @@ export const listDeploymentStrategies: API.PaginatedOperationMethod<
   ListDeploymentStrategiesRequest,
   DeploymentStrategies,
   ListDeploymentStrategiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentStrategy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentStrategiesRequest,
@@ -3910,7 +3909,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   Environments,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Environment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -3943,7 +3942,7 @@ export const listExperimentDefinitions: API.PaginatedOperationMethod<
   ListExperimentDefinitionsRequest,
   ExperimentDefinitions,
   ListExperimentDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentDefinitionsRequest,
@@ -3976,7 +3975,7 @@ export const listExperimentRunEvents: API.PaginatedOperationMethod<
   ListExperimentRunEventsRequest,
   ExperimentRunEvents,
   ListExperimentRunEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentRunEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentRunEventsRequest,
@@ -4009,7 +4008,7 @@ export const listExperimentRuns: API.PaginatedOperationMethod<
   ListExperimentRunsRequest,
   ExperimentRuns,
   ListExperimentRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentRunsRequest,
@@ -4043,7 +4042,7 @@ export const listExtensionAssociations: API.PaginatedOperationMethod<
   ListExtensionAssociationsRequest,
   ExtensionAssociations,
   ListExtensionAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExtensionAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExtensionAssociationsRequest,
@@ -4073,7 +4072,7 @@ export const listExtensions: API.PaginatedOperationMethod<
   ListExtensionsRequest,
   Extensions,
   ListExtensionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExtensionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExtensionsRequest,
@@ -4103,7 +4102,7 @@ export const listHostedConfigurationVersions: API.PaginatedOperationMethod<
   ListHostedConfigurationVersionsRequest,
   HostedConfigurationVersions,
   ListHostedConfigurationVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HostedConfigurationVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHostedConfigurationVersionsRequest,
@@ -4136,7 +4135,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ResourceTags,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ResourceTags,
@@ -4165,7 +4164,7 @@ export const startDeployment: API.OperationMethod<
   StartDeploymentRequest,
   Deployment,
   StartDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeploymentRequest,
   output: Deployment,
@@ -4193,7 +4192,7 @@ export const startExperimentRun: API.OperationMethod<
   StartExperimentRunRequest,
   ExperimentRun,
   StartExperimentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExperimentRunRequest,
   output: ExperimentRun,
@@ -4225,7 +4224,7 @@ export const stopDeployment: API.OperationMethod<
   StopDeploymentRequest,
   Deployment,
   StopDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDeploymentRequest,
   output: Deployment,
@@ -4251,7 +4250,7 @@ export const stopExperimentRun: API.OperationMethod<
   StopExperimentRunRequest,
   ExperimentRun,
   StopExperimentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopExperimentRunRequest,
   output: ExperimentRun,
@@ -4279,7 +4278,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4305,7 +4304,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4330,7 +4329,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsRequest,
   AccountSettings,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsRequest,
   output: AccountSettings,
@@ -4352,7 +4351,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   Application,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: Application,
@@ -4378,7 +4377,7 @@ export const updateConfigurationProfile: API.OperationMethod<
   UpdateConfigurationProfileRequest,
   ConfigurationProfile,
   UpdateConfigurationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationProfileRequest,
   output: ConfigurationProfile,
@@ -4404,7 +4403,7 @@ export const updateDeploymentStrategy: API.OperationMethod<
   UpdateDeploymentStrategyRequest,
   DeploymentStrategy,
   UpdateDeploymentStrategyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeploymentStrategyRequest,
   output: DeploymentStrategy,
@@ -4430,7 +4429,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentRequest,
   Environment,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentRequest,
   output: Environment,
@@ -4457,7 +4456,7 @@ export const updateExperimentDefinition: API.OperationMethod<
   UpdateExperimentDefinitionRequest,
   ExperimentDefinition,
   UpdateExperimentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExperimentDefinitionRequest,
   output: ExperimentDefinition,
@@ -4485,7 +4484,7 @@ export const updateExperimentRun: API.OperationMethod<
   UpdateExperimentRunRequest,
   ExperimentRun,
   UpdateExperimentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExperimentRunRequest,
   output: ExperimentRun,
@@ -4515,7 +4514,7 @@ export const updateExtension: API.OperationMethod<
   UpdateExtensionRequest,
   Extension,
   UpdateExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExtensionRequest,
   output: Extension,
@@ -4544,7 +4543,7 @@ export const updateExtensionAssociation: API.OperationMethod<
   UpdateExtensionAssociationRequest,
   ExtensionAssociation,
   UpdateExtensionAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExtensionAssociationRequest,
   output: ExtensionAssociation,
@@ -4570,7 +4569,7 @@ export const validateConfiguration: API.OperationMethod<
   ValidateConfigurationRequest,
   ValidateConfigurationResponse,
   ValidateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateConfigurationRequest,
   output: ValidateConfigurationResponse,

--- a/packages/aws/src/services/appconfigdata.ts
+++ b/packages/aws/src/services/appconfigdata.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "AppConfigData",
   serviceShapeName: "AppConfigData",
@@ -258,7 +257,7 @@ export const getLatestConfiguration: API.OperationMethod<
   GetLatestConfigurationRequest,
   GetLatestConfigurationResponse,
   GetLatestConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLatestConfigurationRequest,
   output: GetLatestConfigurationResponse,
@@ -289,7 +288,7 @@ export const startConfigurationSession: API.OperationMethod<
   StartConfigurationSessionRequest,
   StartConfigurationSessionResponse,
   StartConfigurationSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigurationSessionRequest,
   output: StartConfigurationSessionResponse,

--- a/packages/aws/src/services/appfabric.ts
+++ b/packages/aws/src/services/appfabric.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AppFabric",
@@ -1414,7 +1413,7 @@ export const batchGetUserAccessTasks: API.OperationMethod<
   BatchGetUserAccessTasksRequest,
   BatchGetUserAccessTasksResponse,
   BatchGetUserAccessTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetUserAccessTasksRequest,
   output: BatchGetUserAccessTasksResponse,
@@ -1445,7 +1444,7 @@ export const connectAppAuthorization: API.OperationMethod<
   ConnectAppAuthorizationRequest,
   ConnectAppAuthorizationResponse,
   ConnectAppAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConnectAppAuthorizationRequest,
   output: ConnectAppAuthorizationResponse,
@@ -1478,7 +1477,7 @@ export const createAppAuthorization: API.OperationMethod<
   CreateAppAuthorizationRequest,
   CreateAppAuthorizationResponse,
   CreateAppAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppAuthorizationRequest,
   output: CreateAppAuthorizationResponse,
@@ -1511,7 +1510,7 @@ export const createAppBundle: API.OperationMethod<
   CreateAppBundleRequest,
   CreateAppBundleResponse,
   CreateAppBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppBundleRequest,
   output: CreateAppBundleResponse,
@@ -1543,7 +1542,7 @@ export const createIngestion: API.OperationMethod<
   CreateIngestionRequest,
   CreateIngestionResponse,
   CreateIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIngestionRequest,
   output: CreateIngestionResponse,
@@ -1576,7 +1575,7 @@ export const createIngestionDestination: API.OperationMethod<
   CreateIngestionDestinationRequest,
   CreateIngestionDestinationResponse,
   CreateIngestionDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIngestionDestinationRequest,
   output: CreateIngestionDestinationResponse,
@@ -1608,7 +1607,7 @@ export const deleteAppAuthorization: API.OperationMethod<
   DeleteAppAuthorizationRequest,
   DeleteAppAuthorizationResponse,
   DeleteAppAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppAuthorizationRequest,
   output: DeleteAppAuthorizationResponse,
@@ -1639,7 +1638,7 @@ export const deleteAppBundle: API.OperationMethod<
   DeleteAppBundleRequest,
   DeleteAppBundleResponse,
   DeleteAppBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppBundleRequest,
   output: DeleteAppBundleResponse,
@@ -1670,7 +1669,7 @@ export const deleteIngestion: API.OperationMethod<
   DeleteIngestionRequest,
   DeleteIngestionResponse,
   DeleteIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIngestionRequest,
   output: DeleteIngestionResponse,
@@ -1705,7 +1704,7 @@ export const deleteIngestionDestination: API.OperationMethod<
   DeleteIngestionDestinationRequest,
   DeleteIngestionDestinationResponse,
   DeleteIngestionDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIngestionDestinationRequest,
   output: DeleteIngestionDestinationResponse,
@@ -1735,7 +1734,7 @@ export const getAppAuthorization: API.OperationMethod<
   GetAppAuthorizationRequest,
   GetAppAuthorizationResponse,
   GetAppAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppAuthorizationRequest,
   output: GetAppAuthorizationResponse,
@@ -1765,7 +1764,7 @@ export const getAppBundle: API.OperationMethod<
   GetAppBundleRequest,
   GetAppBundleResponse,
   GetAppBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppBundleRequest,
   output: GetAppBundleResponse,
@@ -1795,7 +1794,7 @@ export const getIngestion: API.OperationMethod<
   GetIngestionRequest,
   GetIngestionResponse,
   GetIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIngestionRequest,
   output: GetIngestionResponse,
@@ -1825,7 +1824,7 @@ export const getIngestionDestination: API.OperationMethod<
   GetIngestionDestinationRequest,
   GetIngestionDestinationResponse,
   GetIngestionDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIngestionDestinationRequest,
   output: GetIngestionDestinationResponse,
@@ -1855,7 +1854,7 @@ export const listAppAuthorizations: API.PaginatedOperationMethod<
   ListAppAuthorizationsRequest,
   ListAppAuthorizationsResponse,
   ListAppAuthorizationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppAuthorizationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppAuthorizationsRequest,
@@ -1891,7 +1890,7 @@ export const listAppBundles: API.PaginatedOperationMethod<
   ListAppBundlesRequest,
   ListAppBundlesResponse,
   ListAppBundlesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppBundleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppBundlesRequest,
@@ -1927,7 +1926,7 @@ export const listIngestionDestinations: API.PaginatedOperationMethod<
   ListIngestionDestinationsRequest,
   ListIngestionDestinationsResponse,
   ListIngestionDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IngestionDestinationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngestionDestinationsRequest,
@@ -1964,7 +1963,7 @@ export const listIngestions: API.PaginatedOperationMethod<
   ListIngestionsRequest,
   ListIngestionsResponse,
   ListIngestionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IngestionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngestionsRequest,
@@ -2001,7 +2000,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2032,7 +2031,7 @@ export const startIngestion: API.OperationMethod<
   StartIngestionRequest,
   StartIngestionResponse,
   StartIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartIngestionRequest,
   output: StartIngestionResponse,
@@ -2066,7 +2065,7 @@ export const startUserAccessTasks: API.OperationMethod<
   StartUserAccessTasksRequest,
   StartUserAccessTasksResponse,
   StartUserAccessTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartUserAccessTasksRequest,
   output: StartUserAccessTasksResponse,
@@ -2097,7 +2096,7 @@ export const stopIngestion: API.OperationMethod<
   StopIngestionRequest,
   StopIngestionResponse,
   StopIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopIngestionRequest,
   output: StopIngestionResponse,
@@ -2128,7 +2127,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2158,7 +2157,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2192,7 +2191,7 @@ export const updateAppAuthorization: API.OperationMethod<
   UpdateAppAuthorizationRequest,
   UpdateAppAuthorizationResponse,
   UpdateAppAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppAuthorizationRequest,
   output: UpdateAppAuthorizationResponse,
@@ -2225,7 +2224,7 @@ export const updateIngestionDestination: API.OperationMethod<
   UpdateIngestionDestinationRequest,
   UpdateIngestionDestinationResponse,
   UpdateIngestionDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIngestionDestinationRequest,
   output: UpdateIngestionDestinationResponse,

--- a/packages/aws/src/services/appflow.ts
+++ b/packages/aws/src/services/appflow.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Appflow",
@@ -3937,7 +3936,7 @@ export const cancelFlowExecutions: API.OperationMethod<
   CancelFlowExecutionsRequest,
   CancelFlowExecutionsResponse,
   CancelFlowExecutionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelFlowExecutionsRequest,
   output: CancelFlowExecutionsResponse,
@@ -3972,7 +3971,7 @@ export const createConnectorProfile: API.OperationMethod<
   CreateConnectorProfileRequest,
   CreateConnectorProfileResponse,
   CreateConnectorProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorProfileRequest,
   output: CreateConnectorProfileResponse,
@@ -4010,7 +4009,7 @@ export const createFlow: API.OperationMethod<
   CreateFlowRequest,
   CreateFlowResponse,
   CreateFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowRequest,
   output: CreateFlowResponse,
@@ -4041,7 +4040,7 @@ export const deleteConnectorProfile: API.OperationMethod<
   DeleteConnectorProfileRequest,
   DeleteConnectorProfileResponse,
   DeleteConnectorProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorProfileRequest,
   output: DeleteConnectorProfileResponse,
@@ -4068,7 +4067,7 @@ export const deleteFlow: API.OperationMethod<
   DeleteFlowRequest,
   DeleteFlowResponse,
   DeleteFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowRequest,
   output: DeleteFlowResponse,
@@ -4096,7 +4095,7 @@ export const describeConnector: API.OperationMethod<
   DescribeConnectorRequest,
   DescribeConnectorResponse,
   DescribeConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectorRequest,
   output: DescribeConnectorResponse,
@@ -4125,7 +4124,7 @@ export const describeConnectorEntity: API.OperationMethod<
   DescribeConnectorEntityRequest,
   DescribeConnectorEntityResponse,
   DescribeConnectorEntityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectorEntityRequest,
   output: DescribeConnectorEntityResponse,
@@ -4157,7 +4156,7 @@ export const describeConnectorProfiles: API.PaginatedOperationMethod<
   DescribeConnectorProfilesRequest,
   DescribeConnectorProfilesResponse,
   DescribeConnectorProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConnectorProfilesRequest,
@@ -4187,7 +4186,7 @@ export const describeConnectors: API.PaginatedOperationMethod<
   DescribeConnectorsRequest,
   DescribeConnectorsResponse,
   DescribeConnectorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConnectorsRequest,
@@ -4214,7 +4213,7 @@ export const describeFlow: API.OperationMethod<
   DescribeFlowRequest,
   DescribeFlowResponse,
   DescribeFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowRequest,
   output: DescribeFlowResponse,
@@ -4236,7 +4235,7 @@ export const describeFlowExecutionRecords: API.PaginatedOperationMethod<
   DescribeFlowExecutionRecordsRequest,
   DescribeFlowExecutionRecordsResponse,
   DescribeFlowExecutionRecordsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFlowExecutionRecordsRequest,
@@ -4273,7 +4272,7 @@ export const listConnectorEntities: API.OperationMethod<
   ListConnectorEntitiesRequest,
   ListConnectorEntitiesResponse,
   ListConnectorEntitiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectorEntitiesRequest,
   output: ListConnectorEntitiesResponse,
@@ -4302,7 +4301,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -4329,7 +4328,7 @@ export const listFlows: API.PaginatedOperationMethod<
   ListFlowsRequest,
   ListFlowsResponse,
   ListFlowsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowsRequest,
@@ -4357,7 +4356,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4391,7 +4390,7 @@ export const registerConnector: API.OperationMethod<
   RegisterConnectorRequest,
   RegisterConnectorResponse,
   RegisterConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterConnectorRequest,
   output: RegisterConnectorResponse,
@@ -4431,7 +4430,7 @@ export const resetConnectorMetadataCache: API.OperationMethod<
   ResetConnectorMetadataCacheRequest,
   ResetConnectorMetadataCacheResponse,
   ResetConnectorMetadataCacheError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetConnectorMetadataCacheRequest,
   output: ResetConnectorMetadataCacheResponse,
@@ -4460,7 +4459,7 @@ export const startFlow: API.OperationMethod<
   StartFlowRequest,
   StartFlowResponse,
   StartFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlowRequest,
   output: StartFlowResponse,
@@ -4490,7 +4489,7 @@ export const stopFlow: API.OperationMethod<
   StopFlowRequest,
   StopFlowResponse,
   StopFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFlowRequest,
   output: StopFlowResponse,
@@ -4517,7 +4516,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4544,7 +4543,7 @@ export const unregisterConnector: API.OperationMethod<
   UnregisterConnectorRequest,
   UnregisterConnectorResponse,
   UnregisterConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnregisterConnectorRequest,
   output: UnregisterConnectorResponse,
@@ -4570,7 +4569,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4599,7 +4598,7 @@ export const updateConnectorProfile: API.OperationMethod<
   UpdateConnectorProfileRequest,
   UpdateConnectorProfileResponse,
   UpdateConnectorProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorProfileRequest,
   output: UpdateConnectorProfileResponse,
@@ -4639,7 +4638,7 @@ export const updateConnectorRegistration: API.OperationMethod<
   UpdateConnectorRegistrationRequest,
   UpdateConnectorRegistrationResponse,
   UpdateConnectorRegistrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorRegistrationRequest,
   output: UpdateConnectorRegistrationResponse,
@@ -4676,7 +4675,7 @@ export const updateFlow: API.OperationMethod<
   UpdateFlowRequest,
   UpdateFlowResponse,
   UpdateFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowRequest,
   output: UpdateFlowResponse,

--- a/packages/aws/src/services/appintegrations.ts
+++ b/packages/aws/src/services/appintegrations.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "AppIntegrations",
   serviceShapeName: "AmazonAppIntegrationService",
@@ -1386,7 +1385,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1425,7 +1424,7 @@ export const createDataIntegration: API.OperationMethod<
   CreateDataIntegrationRequest,
   CreateDataIntegrationResponse,
   CreateDataIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataIntegrationRequest,
   output: CreateDataIntegrationResponse,
@@ -1459,7 +1458,7 @@ export const createDataIntegrationAssociation: API.OperationMethod<
   CreateDataIntegrationAssociationRequest,
   CreateDataIntegrationAssociationResponse,
   CreateDataIntegrationAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataIntegrationAssociationRequest,
   output: CreateDataIntegrationAssociationResponse,
@@ -1496,7 +1495,7 @@ export const createEventIntegration: API.OperationMethod<
   CreateEventIntegrationRequest,
   CreateEventIntegrationResponse,
   CreateEventIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventIntegrationRequest,
   output: CreateEventIntegrationResponse,
@@ -1530,7 +1529,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1568,7 +1567,7 @@ export const deleteDataIntegration: API.OperationMethod<
   DeleteDataIntegrationRequest,
   DeleteDataIntegrationResponse,
   DeleteDataIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataIntegrationRequest,
   output: DeleteDataIntegrationResponse,
@@ -1601,7 +1600,7 @@ export const deleteEventIntegration: API.OperationMethod<
   DeleteEventIntegrationRequest,
   DeleteEventIntegrationResponse,
   DeleteEventIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventIntegrationRequest,
   output: DeleteEventIntegrationResponse,
@@ -1633,7 +1632,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -1669,7 +1668,7 @@ export const getDataIntegration: API.OperationMethod<
   GetDataIntegrationRequest,
   GetDataIntegrationResponse,
   GetDataIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataIntegrationRequest,
   output: GetDataIntegrationResponse,
@@ -1701,7 +1700,7 @@ export const getEventIntegration: API.OperationMethod<
   GetEventIntegrationRequest,
   GetEventIntegrationResponse,
   GetEventIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventIntegrationRequest,
   output: GetEventIntegrationResponse,
@@ -1733,7 +1732,7 @@ export const listApplicationAssociations: API.PaginatedOperationMethod<
   ListApplicationAssociationsRequest,
   ListApplicationAssociationsResponse,
   ListApplicationAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationAssociationsRequest,
@@ -1771,7 +1770,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -1813,7 +1812,7 @@ export const listDataIntegrationAssociations: API.PaginatedOperationMethod<
   ListDataIntegrationAssociationsRequest,
   ListDataIntegrationAssociationsResponse,
   ListDataIntegrationAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataIntegrationAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIntegrationAssociationsRequest,
@@ -1855,7 +1854,7 @@ export const listDataIntegrations: API.PaginatedOperationMethod<
   ListDataIntegrationsRequest,
   ListDataIntegrationsResponse,
   ListDataIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataIntegrationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIntegrationsRequest,
@@ -1893,7 +1892,7 @@ export const listEventIntegrationAssociations: API.PaginatedOperationMethod<
   ListEventIntegrationAssociationsRequest,
   ListEventIntegrationAssociationsResponse,
   ListEventIntegrationAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventIntegrationAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventIntegrationAssociationsRequest,
@@ -1931,7 +1930,7 @@ export const listEventIntegrations: API.PaginatedOperationMethod<
   ListEventIntegrationsRequest,
   ListEventIntegrationsResponse,
   ListEventIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventIntegration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventIntegrationsRequest,
@@ -1968,7 +1967,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1998,7 +1997,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2028,7 +2027,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2060,7 +2059,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -2097,7 +2096,7 @@ export const updateDataIntegration: API.OperationMethod<
   UpdateDataIntegrationRequest,
   UpdateDataIntegrationResponse,
   UpdateDataIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataIntegrationRequest,
   output: UpdateDataIntegrationResponse,
@@ -2131,7 +2130,7 @@ export const updateDataIntegrationAssociation: API.OperationMethod<
   UpdateDataIntegrationAssociationRequest,
   UpdateDataIntegrationAssociationResponse,
   UpdateDataIntegrationAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataIntegrationAssociationRequest,
   output: UpdateDataIntegrationAssociationResponse,
@@ -2163,7 +2162,7 @@ export const updateEventIntegration: API.OperationMethod<
   UpdateEventIntegrationRequest,
   UpdateEventIntegrationResponse,
   UpdateEventIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventIntegrationRequest,
   output: UpdateEventIntegrationResponse,

--- a/packages/aws/src/services/application-auto-scaling.ts
+++ b/packages/aws/src/services/application-auto-scaling.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Application Auto Scaling",
   serviceShapeName: "AnyScaleFrontendService",
@@ -1346,7 +1345,7 @@ export const deleteScalingPolicy: API.OperationMethod<
   DeleteScalingPolicyRequest,
   DeleteScalingPolicyResponse,
   DeleteScalingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScalingPolicyRequest,
   output: DeleteScalingPolicyResponse,
@@ -1376,7 +1375,7 @@ export const deleteScheduledAction: API.OperationMethod<
   DeleteScheduledActionRequest,
   DeleteScheduledActionResponse,
   DeleteScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledActionRequest,
   output: DeleteScheduledActionResponse,
@@ -1408,7 +1407,7 @@ export const deregisterScalableTarget: API.OperationMethod<
   DeregisterScalableTargetRequest,
   DeregisterScalableTargetResponse,
   DeregisterScalableTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterScalableTargetRequest,
   output: DeregisterScalableTargetResponse,
@@ -1439,7 +1438,7 @@ export const describeScalableTargets: API.PaginatedOperationMethod<
   DescribeScalableTargetsRequest,
   DescribeScalableTargetsResponse,
   DescribeScalableTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScalableTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScalableTargetsRequest,
@@ -1480,7 +1479,7 @@ export const describeScalingActivities: API.PaginatedOperationMethod<
   DescribeScalingActivitiesRequest,
   DescribeScalingActivitiesResponse,
   DescribeScalingActivitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScalingActivity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScalingActivitiesRequest,
@@ -1521,7 +1520,7 @@ export const describeScalingPolicies: API.PaginatedOperationMethod<
   DescribeScalingPoliciesRequest,
   DescribeScalingPoliciesResponse,
   DescribeScalingPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScalingPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScalingPoliciesRequest,
@@ -1562,7 +1561,7 @@ export const describeScheduledActions: API.PaginatedOperationMethod<
   DescribeScheduledActionsRequest,
   DescribeScheduledActionsResponse,
   DescribeScheduledActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduledActionsRequest,
@@ -1604,7 +1603,7 @@ export const getPredictiveScalingForecast: API.OperationMethod<
   GetPredictiveScalingForecastRequest,
   GetPredictiveScalingForecastResponse,
   GetPredictiveScalingForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPredictiveScalingForecastRequest,
   output: GetPredictiveScalingForecastResponse,
@@ -1629,7 +1628,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1682,7 +1681,7 @@ export const putScalingPolicy: API.OperationMethod<
   PutScalingPolicyRequest,
   PutScalingPolicyResponse,
   PutScalingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutScalingPolicyRequest,
   output: PutScalingPolicyResponse,
@@ -1730,7 +1729,7 @@ export const putScheduledAction: API.OperationMethod<
   PutScheduledActionRequest,
   PutScheduledActionResponse,
   PutScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutScheduledActionRequest,
   output: PutScheduledActionResponse,
@@ -1795,7 +1794,7 @@ export const registerScalableTarget: API.OperationMethod<
   RegisterScalableTargetRequest,
   RegisterScalableTargetResponse,
   RegisterScalableTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterScalableTargetRequest,
   output: RegisterScalableTargetResponse,
@@ -1838,7 +1837,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1864,7 +1863,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/application-discovery-service.ts
+++ b/packages/aws/src/services/application-discovery-service.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://ec2.amazon.com/awsposiedon/V2015_11_01/");
 const svc = T.AwsApiService({
   sdkId: "Application Discovery Service",
@@ -1781,7 +1780,7 @@ export const associateConfigurationItemsToApplication: API.OperationMethod<
   AssociateConfigurationItemsToApplicationRequest,
   AssociateConfigurationItemsToApplicationResponse,
   AssociateConfigurationItemsToApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateConfigurationItemsToApplicationRequest,
   output: AssociateConfigurationItemsToApplicationResponse,
@@ -1812,7 +1811,7 @@ export const batchDeleteAgents: API.OperationMethod<
   BatchDeleteAgentsRequest,
   BatchDeleteAgentsResponse,
   BatchDeleteAgentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteAgentsRequest,
   output: BatchDeleteAgentsResponse,
@@ -1848,7 +1847,7 @@ export const batchDeleteImportData: API.OperationMethod<
   BatchDeleteImportDataRequest,
   BatchDeleteImportDataResponse,
   BatchDeleteImportDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteImportDataRequest,
   output: BatchDeleteImportDataResponse,
@@ -1878,7 +1877,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1912,7 +1911,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResponse,
@@ -1944,7 +1943,7 @@ export const deleteApplications: API.OperationMethod<
   DeleteApplicationsRequest,
   DeleteApplicationsResponse,
   DeleteApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationsRequest,
   output: DeleteApplicationsResponse,
@@ -1976,7 +1975,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResponse,
@@ -2009,7 +2008,7 @@ export const describeAgents: API.PaginatedOperationMethod<
   DescribeAgentsRequest,
   DescribeAgentsResponse,
   DescribeAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAgentsRequest,
@@ -2045,7 +2044,7 @@ export const describeBatchDeleteConfigurationTask: API.OperationMethod<
   DescribeBatchDeleteConfigurationTaskRequest,
   DescribeBatchDeleteConfigurationTaskResponse,
   DescribeBatchDeleteConfigurationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBatchDeleteConfigurationTaskRequest,
   output: DescribeBatchDeleteConfigurationTaskResponse,
@@ -2092,7 +2091,7 @@ export const describeConfigurations: API.OperationMethod<
   DescribeConfigurationsRequest,
   DescribeConfigurationsResponse,
   DescribeConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationsRequest,
   output: DescribeConfigurationsResponse,
@@ -2126,7 +2125,7 @@ export const describeContinuousExports: API.PaginatedOperationMethod<
   DescribeContinuousExportsRequest,
   DescribeContinuousExportsResponse,
   DescribeContinuousExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContinuousExportDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeContinuousExportsRequest,
@@ -2166,7 +2165,7 @@ export const describeExportConfigurations: API.PaginatedOperationMethod<
   DescribeExportConfigurationsRequest,
   DescribeExportConfigurationsResponse,
   DescribeExportConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeExportConfigurationsRequest,
@@ -2205,7 +2204,7 @@ export const describeExportTasks: API.PaginatedOperationMethod<
   DescribeExportTasksRequest,
   DescribeExportTasksResponse,
   DescribeExportTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeExportTasksRequest,
@@ -2243,7 +2242,7 @@ export const describeImportTasks: API.PaginatedOperationMethod<
   DescribeImportTasksRequest,
   DescribeImportTasksResponse,
   DescribeImportTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImportTasksRequest,
@@ -2293,7 +2292,7 @@ export const describeTags: API.PaginatedOperationMethod<
   DescribeTagsRequest,
   DescribeTagsResponse,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationTag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTagsRequest,
@@ -2331,7 +2330,7 @@ export const disassociateConfigurationItemsFromApplication: API.OperationMethod<
   DisassociateConfigurationItemsFromApplicationRequest,
   DisassociateConfigurationItemsFromApplicationResponse,
   DisassociateConfigurationItemsFromApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateConfigurationItemsFromApplicationRequest,
   output: DisassociateConfigurationItemsFromApplicationResponse,
@@ -2368,7 +2367,7 @@ export const exportConfigurations: API.OperationMethod<
   ExportConfigurationsRequest,
   ExportConfigurationsResponse,
   ExportConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportConfigurationsRequest,
   output: ExportConfigurationsResponse,
@@ -2402,7 +2401,7 @@ export const getDiscoverySummary: API.OperationMethod<
   GetDiscoverySummaryRequest,
   GetDiscoverySummaryResponse,
   GetDiscoverySummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDiscoverySummaryRequest,
   output: GetDiscoverySummaryResponse,
@@ -2435,7 +2434,7 @@ export const listConfigurations: API.PaginatedOperationMethod<
   ListConfigurationsRequest,
   ListConfigurationsResponse,
   ListConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   { [key: string]: string | undefined }
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationsRequest,
@@ -2474,7 +2473,7 @@ export const listServerNeighbors: API.OperationMethod<
   ListServerNeighborsRequest,
   ListServerNeighborsResponse,
   ListServerNeighborsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListServerNeighborsRequest,
   output: ListServerNeighborsResponse,
@@ -2507,7 +2506,7 @@ export const startBatchDeleteConfigurationTask: API.OperationMethod<
   StartBatchDeleteConfigurationTaskRequest,
   StartBatchDeleteConfigurationTaskResponse,
   StartBatchDeleteConfigurationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBatchDeleteConfigurationTaskRequest,
   output: StartBatchDeleteConfigurationTaskResponse,
@@ -2542,7 +2541,7 @@ export const startContinuousExport: API.OperationMethod<
   StartContinuousExportRequest,
   StartContinuousExportResponse,
   StartContinuousExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContinuousExportRequest,
   output: StartContinuousExportResponse,
@@ -2575,7 +2574,7 @@ export const startDataCollectionByAgentIds: API.OperationMethod<
   StartDataCollectionByAgentIdsRequest,
   StartDataCollectionByAgentIdsResponse,
   StartDataCollectionByAgentIdsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataCollectionByAgentIdsRequest,
   output: StartDataCollectionByAgentIdsResponse,
@@ -2629,7 +2628,7 @@ export const startExportTask: API.OperationMethod<
   StartExportTaskRequest,
   StartExportTaskResponse,
   StartExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExportTaskRequest,
   output: StartExportTaskResponse,
@@ -2688,7 +2687,7 @@ export const startImportTask: API.OperationMethod<
   StartImportTaskRequest,
   StartImportTaskResponse,
   StartImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportTaskRequest,
   output: StartImportTaskResponse,
@@ -2722,7 +2721,7 @@ export const stopContinuousExport: API.OperationMethod<
   StopContinuousExportRequest,
   StopContinuousExportResponse,
   StopContinuousExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopContinuousExportRequest,
   output: StopContinuousExportResponse,
@@ -2755,7 +2754,7 @@ export const stopDataCollectionByAgentIds: API.OperationMethod<
   StopDataCollectionByAgentIdsRequest,
   StopDataCollectionByAgentIdsResponse,
   StopDataCollectionByAgentIdsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDataCollectionByAgentIdsRequest,
   output: StopDataCollectionByAgentIdsResponse,
@@ -2785,7 +2784,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,

--- a/packages/aws/src/services/application-insights.ts
+++ b/packages/aws/src/services/application-insights.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Application Insights",
   serviceShapeName: "EC2WindowsBarleyService",
@@ -1584,7 +1583,7 @@ export const addWorkload: API.OperationMethod<
   AddWorkloadRequest,
   AddWorkloadResponse,
   AddWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddWorkloadRequest,
   output: AddWorkloadResponse,
@@ -1614,7 +1613,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1644,7 +1643,7 @@ export const createComponent: API.OperationMethod<
   CreateComponentRequest,
   CreateComponentResponse,
   CreateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentRequest,
   output: CreateComponentResponse,
@@ -1672,7 +1671,7 @@ export const createLogPattern: API.OperationMethod<
   CreateLogPatternRequest,
   CreateLogPatternResponse,
   CreateLogPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogPatternRequest,
   output: CreateLogPatternResponse,
@@ -1701,7 +1700,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1730,7 +1729,7 @@ export const deleteComponent: API.OperationMethod<
   DeleteComponentRequest,
   DeleteComponentResponse,
   DeleteComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentRequest,
   output: DeleteComponentResponse,
@@ -1757,7 +1756,7 @@ export const deleteLogPattern: API.OperationMethod<
   DeleteLogPatternRequest,
   DeleteLogPatternResponse,
   DeleteLogPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLogPatternRequest,
   output: DeleteLogPatternResponse,
@@ -1784,7 +1783,7 @@ export const describeApplication: API.OperationMethod<
   DescribeApplicationRequest,
   DescribeApplicationResponse,
   DescribeApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationRequest,
   output: DescribeApplicationResponse,
@@ -1811,7 +1810,7 @@ export const describeComponent: API.OperationMethod<
   DescribeComponentRequest,
   DescribeComponentResponse,
   DescribeComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComponentRequest,
   output: DescribeComponentResponse,
@@ -1837,7 +1836,7 @@ export const describeComponentConfiguration: API.OperationMethod<
   DescribeComponentConfigurationRequest,
   DescribeComponentConfigurationResponse,
   DescribeComponentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComponentConfigurationRequest,
   output: DescribeComponentConfigurationResponse,
@@ -1863,7 +1862,7 @@ export const describeComponentConfigurationRecommendation: API.OperationMethod<
   DescribeComponentConfigurationRecommendationRequest,
   DescribeComponentConfigurationRecommendationResponse,
   DescribeComponentConfigurationRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComponentConfigurationRecommendationRequest,
   output: DescribeComponentConfigurationRecommendationResponse,
@@ -1889,7 +1888,7 @@ export const describeLogPattern: API.OperationMethod<
   DescribeLogPatternRequest,
   DescribeLogPatternResponse,
   DescribeLogPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLogPatternRequest,
   output: DescribeLogPatternResponse,
@@ -1915,7 +1914,7 @@ export const describeObservation: API.OperationMethod<
   DescribeObservationRequest,
   DescribeObservationResponse,
   DescribeObservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeObservationRequest,
   output: DescribeObservationResponse,
@@ -1941,7 +1940,7 @@ export const describeProblem: API.OperationMethod<
   DescribeProblemRequest,
   DescribeProblemResponse,
   DescribeProblemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProblemRequest,
   output: DescribeProblemResponse,
@@ -1967,7 +1966,7 @@ export const describeProblemObservations: API.OperationMethod<
   DescribeProblemObservationsRequest,
   DescribeProblemObservationsResponse,
   DescribeProblemObservationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProblemObservationsRequest,
   output: DescribeProblemObservationsResponse,
@@ -1993,7 +1992,7 @@ export const describeWorkload: API.OperationMethod<
   DescribeWorkloadRequest,
   DescribeWorkloadResponse,
   DescribeWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkloadRequest,
   output: DescribeWorkloadResponse,
@@ -2018,7 +2017,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -2046,7 +2045,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsRequest,
   ListComponentsResponse,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsRequest,
@@ -2086,7 +2085,7 @@ export const listConfigurationHistory: API.PaginatedOperationMethod<
   ListConfigurationHistoryRequest,
   ListConfigurationHistoryResponse,
   ListConfigurationHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationHistoryRequest,
@@ -2118,7 +2117,7 @@ export const listLogPatterns: API.PaginatedOperationMethod<
   ListLogPatternsRequest,
   ListLogPatternsResponse,
   ListLogPatternsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogPatternsRequest,
@@ -2150,7 +2149,7 @@ export const listLogPatternSets: API.PaginatedOperationMethod<
   ListLogPatternSetsRequest,
   ListLogPatternSetsResponse,
   ListLogPatternSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogPatternSetsRequest,
@@ -2182,7 +2181,7 @@ export const listProblems: API.PaginatedOperationMethod<
   ListProblemsRequest,
   ListProblemsResponse,
   ListProblemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProblemsRequest,
@@ -2218,7 +2217,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2240,7 +2239,7 @@ export const listWorkloads: API.PaginatedOperationMethod<
   ListWorkloadsRequest,
   ListWorkloadsResponse,
   ListWorkloadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadsRequest,
@@ -2272,7 +2271,7 @@ export const removeWorkload: API.OperationMethod<
   RemoveWorkloadRequest,
   RemoveWorkloadResponse,
   RemoveWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveWorkloadRequest,
   output: RemoveWorkloadResponse,
@@ -2306,7 +2305,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2331,7 +2330,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2353,7 +2352,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -2381,7 +2380,7 @@ export const updateComponent: API.OperationMethod<
   UpdateComponentRequest,
   UpdateComponentResponse,
   UpdateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComponentRequest,
   output: UpdateComponentResponse,
@@ -2411,7 +2410,7 @@ export const updateComponentConfiguration: API.OperationMethod<
   UpdateComponentConfigurationRequest,
   UpdateComponentConfigurationResponse,
   UpdateComponentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComponentConfigurationRequest,
   output: UpdateComponentConfigurationResponse,
@@ -2439,7 +2438,7 @@ export const updateLogPattern: API.OperationMethod<
   UpdateLogPatternRequest,
   UpdateLogPatternResponse,
   UpdateLogPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLogPatternRequest,
   output: UpdateLogPatternResponse,
@@ -2467,7 +2466,7 @@ export const updateProblem: API.OperationMethod<
   UpdateProblemRequest,
   UpdateProblemResponse,
   UpdateProblemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProblemRequest,
   output: UpdateProblemResponse,
@@ -2493,7 +2492,7 @@ export const updateWorkload: API.OperationMethod<
   UpdateWorkloadRequest,
   UpdateWorkloadResponse,
   UpdateWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkloadRequest,
   output: UpdateWorkloadResponse,

--- a/packages/aws/src/services/application-signals.ts
+++ b/packages/aws/src/services/application-signals.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Application Signals",
   serviceShapeName: "ApplicationSignals",
@@ -2716,7 +2715,7 @@ export const batchDeleteInstrumentationConfigurations: API.OperationMethod<
   BatchDeleteInstrumentationConfigurationsRequest,
   BatchDeleteInstrumentationConfigurationsResponse,
   BatchDeleteInstrumentationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteInstrumentationConfigurationsRequest,
   output: BatchDeleteInstrumentationConfigurationsResponse,
@@ -2743,7 +2742,7 @@ export const batchGetServiceLevelObjectiveBudgetReport: API.OperationMethod<
   BatchGetServiceLevelObjectiveBudgetReportInput,
   BatchGetServiceLevelObjectiveBudgetReportOutput,
   BatchGetServiceLevelObjectiveBudgetReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetServiceLevelObjectiveBudgetReportInput,
   output: BatchGetServiceLevelObjectiveBudgetReportOutput,
@@ -2765,7 +2764,7 @@ export const batchUpdateExclusionWindows: API.OperationMethod<
   BatchUpdateExclusionWindowsInput,
   BatchUpdateExclusionWindowsOutput,
   BatchUpdateExclusionWindowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateExclusionWindowsInput,
   output: BatchUpdateExclusionWindowsOutput,
@@ -2792,7 +2791,7 @@ export const createInstrumentationConfiguration: API.OperationMethod<
   CreateInstrumentationConfigurationRequest,
   CreateInstrumentationConfigurationResponse,
   CreateInstrumentationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstrumentationConfigurationRequest,
   output: CreateInstrumentationConfigurationResponse,
@@ -2863,7 +2862,7 @@ export const createServiceLevelObjective: API.OperationMethod<
   CreateServiceLevelObjectiveInput,
   CreateServiceLevelObjectiveOutput,
   CreateServiceLevelObjectiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceLevelObjectiveInput,
   output: CreateServiceLevelObjectiveOutput,
@@ -2891,7 +2890,7 @@ export const deleteGroupingConfiguration: API.OperationMethod<
   DeleteGroupingConfigurationRequest,
   DeleteGroupingConfigurationOutput,
   DeleteGroupingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupingConfigurationRequest,
   output: DeleteGroupingConfigurationOutput,
@@ -2913,7 +2912,7 @@ export const deleteInstrumentationConfiguration: API.OperationMethod<
   DeleteInstrumentationConfigurationRequest,
   DeleteInstrumentationConfigurationResponse,
   DeleteInstrumentationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstrumentationConfigurationRequest,
   output: DeleteInstrumentationConfigurationResponse,
@@ -2935,7 +2934,7 @@ export const deleteServiceLevelObjective: API.OperationMethod<
   DeleteServiceLevelObjectiveInput,
   DeleteServiceLevelObjectiveOutput,
   DeleteServiceLevelObjectiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceLevelObjectiveInput,
   output: DeleteServiceLevelObjectiveOutput,
@@ -2957,7 +2956,7 @@ export const getInstrumentationConfiguration: API.OperationMethod<
   GetInstrumentationConfigurationRequest,
   GetInstrumentationConfigurationResponse,
   GetInstrumentationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstrumentationConfigurationRequest,
   output: GetInstrumentationConfigurationResponse,
@@ -2981,7 +2980,7 @@ export const getInstrumentationConfigurationStatus: API.PaginatedOperationMethod
   GetInstrumentationConfigurationStatusRequest,
   GetInstrumentationConfigurationStatusResponse,
   GetInstrumentationConfigurationStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstrumentationStatusEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInstrumentationConfigurationStatusRequest,
@@ -3009,7 +3008,7 @@ export const getService: API.OperationMethod<
   GetServiceInput,
   GetServiceOutput,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceInput,
   output: GetServiceOutput,
@@ -3031,7 +3030,7 @@ export const getServiceLevelObjective: API.OperationMethod<
   GetServiceLevelObjectiveInput,
   GetServiceLevelObjectiveOutput,
   GetServiceLevelObjectiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceLevelObjectiveInput,
   output: GetServiceLevelObjectiveOutput,
@@ -3052,7 +3051,7 @@ export const listAuditFindings: API.OperationMethod<
   ListAuditFindingsInput,
   ListAuditFindingsOutput,
   ListAuditFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAuditFindingsInput,
   output: ListAuditFindingsOutput,
@@ -3073,7 +3072,7 @@ export const listEntityEvents: API.PaginatedOperationMethod<
   ListEntityEventsInput,
   ListEntityEventsOutput,
   ListEntityEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChangeEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntityEventsInput,
@@ -3102,7 +3101,7 @@ export const listGroupingAttributeDefinitions: API.OperationMethod<
   ListGroupingAttributeDefinitionsInput,
   ListGroupingAttributeDefinitionsOutput,
   ListGroupingAttributeDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGroupingAttributeDefinitionsInput,
   output: ListGroupingAttributeDefinitionsOutput,
@@ -3126,7 +3125,7 @@ export const listInstrumentationConfigurations: API.PaginatedOperationMethod<
   ListInstrumentationConfigurationsRequest,
   InstrumentationConfigurationsPage,
   ListInstrumentationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstrumentationConfigurationWithoutServiceEnv
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstrumentationConfigurationsRequest,
@@ -3154,7 +3153,7 @@ export const listServiceDependencies: API.PaginatedOperationMethod<
   ListServiceDependenciesInput,
   ListServiceDependenciesOutput,
   ListServiceDependenciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceDependency
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceDependenciesInput,
@@ -3182,7 +3181,7 @@ export const listServiceDependents: API.PaginatedOperationMethod<
   ListServiceDependentsInput,
   ListServiceDependentsOutput,
   ListServiceDependentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceDependent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceDependentsInput,
@@ -3211,7 +3210,7 @@ export const listServiceLevelObjectiveExclusionWindows: API.PaginatedOperationMe
   ListServiceLevelObjectiveExclusionWindowsInput,
   ListServiceLevelObjectiveExclusionWindowsOutput,
   ListServiceLevelObjectiveExclusionWindowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExclusionWindow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceLevelObjectiveExclusionWindowsInput,
@@ -3239,7 +3238,7 @@ export const listServiceLevelObjectives: API.PaginatedOperationMethod<
   ListServiceLevelObjectivesInput,
   ListServiceLevelObjectivesOutput,
   ListServiceLevelObjectivesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceLevelObjectiveSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceLevelObjectivesInput,
@@ -3267,7 +3266,7 @@ export const listServiceOperations: API.PaginatedOperationMethod<
   ListServiceOperationsInput,
   ListServiceOperationsOutput,
   ListServiceOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceOperation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceOperationsInput,
@@ -3295,7 +3294,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesInput,
   ListServicesOutput,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesInput,
@@ -3323,7 +3322,7 @@ export const listServiceStates: API.PaginatedOperationMethod<
   ListServiceStatesInput,
   ListServiceStatesOutput,
   ListServiceStatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceState
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceStatesInput,
@@ -3351,7 +3350,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3373,7 +3372,7 @@ export const putGroupingConfiguration: API.OperationMethod<
   PutGroupingConfigurationInput,
   PutGroupingConfigurationOutput,
   PutGroupingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGroupingConfigurationInput,
   output: PutGroupingConfigurationOutput,
@@ -3396,7 +3395,7 @@ export const reportInstrumentationConfigurationStatus: API.OperationMethod<
   ReportInstrumentationConfigurationStatusRequest,
   ReportInstrumentationConfigurationStatusResponse,
   ReportInstrumentationConfigurationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReportInstrumentationConfigurationStatusRequest,
   output: ReportInstrumentationConfigurationStatusResponse,
@@ -3436,7 +3435,7 @@ export const startDiscovery: API.OperationMethod<
   StartDiscoveryInput,
   StartDiscoveryOutput,
   StartDiscoveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDiscoveryInput,
   output: StartDiscoveryOutput,
@@ -3466,7 +3465,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3491,7 +3490,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3515,7 +3514,7 @@ export const updateServiceLevelObjective: API.OperationMethod<
   UpdateServiceLevelObjectiveInput,
   UpdateServiceLevelObjectiveOutput,
   UpdateServiceLevelObjectiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceLevelObjectiveInput,
   output: UpdateServiceLevelObjectiveOutput,

--- a/packages/aws/src/services/applicationcostprofiler.ts
+++ b/packages/aws/src/services/applicationcostprofiler.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ApplicationCostProfiler",
   serviceShapeName: "AWSApplicationCostProfiler",
@@ -387,7 +386,7 @@ export const deleteReportDefinition: API.OperationMethod<
   DeleteReportDefinitionRequest,
   DeleteReportDefinitionResult,
   DeleteReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReportDefinitionRequest,
   output: DeleteReportDefinitionResult,
@@ -415,7 +414,7 @@ export const getReportDefinition: API.OperationMethod<
   GetReportDefinitionRequest,
   GetReportDefinitionResult,
   GetReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReportDefinitionRequest,
   output: GetReportDefinitionResult,
@@ -447,7 +446,7 @@ export const importApplicationUsage: API.OperationMethod<
   ImportApplicationUsageRequest,
   ImportApplicationUsageResult,
   ImportApplicationUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportApplicationUsageRequest,
   output: ImportApplicationUsageResult,
@@ -477,7 +476,7 @@ export const listReportDefinitions: API.PaginatedOperationMethod<
   ListReportDefinitionsRequest,
   ListReportDefinitionsResult,
   ListReportDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReportDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportDefinitionsRequest,
@@ -513,7 +512,7 @@ export const putReportDefinition: API.OperationMethod<
   PutReportDefinitionRequest,
   PutReportDefinitionResult,
   PutReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutReportDefinitionRequest,
   output: PutReportDefinitionResult,
@@ -542,7 +541,7 @@ export const updateReportDefinition: API.OperationMethod<
   UpdateReportDefinitionRequest,
   UpdateReportDefinitionResult,
   UpdateReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReportDefinitionRequest,
   output: UpdateReportDefinitionResult,

--- a/packages/aws/src/services/apprunner.ts
+++ b/packages/aws/src/services/apprunner.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://apprunner.amazonaws.com/doc/2020-05-15/");
 const svc = T.AwsApiService({
@@ -2124,7 +2123,7 @@ export const associateCustomDomain: API.OperationMethod<
   AssociateCustomDomainRequest,
   AssociateCustomDomainResponse,
   AssociateCustomDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCustomDomainRequest,
   output: AssociateCustomDomainResponse,
@@ -2161,7 +2160,7 @@ export const createAutoScalingConfiguration: API.OperationMethod<
   CreateAutoScalingConfigurationRequest,
   CreateAutoScalingConfigurationResponse,
   CreateAutoScalingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutoScalingConfigurationRequest,
   output: CreateAutoScalingConfigurationResponse,
@@ -2192,7 +2191,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -2228,7 +2227,7 @@ export const createObservabilityConfiguration: API.OperationMethod<
   CreateObservabilityConfigurationRequest,
   CreateObservabilityConfigurationResponse,
   CreateObservabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateObservabilityConfigurationRequest,
   output: CreateObservabilityConfigurationResponse,
@@ -2256,7 +2255,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -2283,7 +2282,7 @@ export const createVpcConnector: API.OperationMethod<
   CreateVpcConnectorRequest,
   CreateVpcConnectorResponse,
   CreateVpcConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcConnectorRequest,
   output: CreateVpcConnectorResponse,
@@ -2310,7 +2309,7 @@ export const createVpcIngressConnection: API.OperationMethod<
   CreateVpcIngressConnectionRequest,
   CreateVpcIngressConnectionResponse,
   CreateVpcIngressConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcIngressConnectionRequest,
   output: CreateVpcIngressConnectionResponse,
@@ -2339,7 +2338,7 @@ export const deleteAutoScalingConfiguration: API.OperationMethod<
   DeleteAutoScalingConfigurationRequest,
   DeleteAutoScalingConfigurationResponse,
   DeleteAutoScalingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutoScalingConfigurationRequest,
   output: DeleteAutoScalingConfigurationResponse,
@@ -2366,7 +2365,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -2393,7 +2392,7 @@ export const deleteObservabilityConfiguration: API.OperationMethod<
   DeleteObservabilityConfigurationRequest,
   DeleteObservabilityConfigurationResponse,
   DeleteObservabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObservabilityConfigurationRequest,
   output: DeleteObservabilityConfigurationResponse,
@@ -2425,7 +2424,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -2453,7 +2452,7 @@ export const deleteVpcConnector: API.OperationMethod<
   DeleteVpcConnectorRequest,
   DeleteVpcConnectorResponse,
   DeleteVpcConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcConnectorRequest,
   output: DeleteVpcConnectorResponse,
@@ -2488,7 +2487,7 @@ export const deleteVpcIngressConnection: API.OperationMethod<
   DeleteVpcIngressConnectionRequest,
   DeleteVpcIngressConnectionResponse,
   DeleteVpcIngressConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcIngressConnectionRequest,
   output: DeleteVpcIngressConnectionResponse,
@@ -2515,7 +2514,7 @@ export const describeAutoScalingConfiguration: API.OperationMethod<
   DescribeAutoScalingConfigurationRequest,
   DescribeAutoScalingConfigurationResponse,
   DescribeAutoScalingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutoScalingConfigurationRequest,
   output: DescribeAutoScalingConfigurationResponse,
@@ -2541,7 +2540,7 @@ export const describeCustomDomains: API.PaginatedOperationMethod<
   DescribeCustomDomainsRequest,
   DescribeCustomDomainsResponse,
   DescribeCustomDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCustomDomainsRequest,
@@ -2573,7 +2572,7 @@ export const describeObservabilityConfiguration: API.OperationMethod<
   DescribeObservabilityConfigurationRequest,
   DescribeObservabilityConfigurationResponse,
   DescribeObservabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeObservabilityConfigurationRequest,
   output: DescribeObservabilityConfigurationResponse,
@@ -2599,7 +2598,7 @@ export const describeService: API.OperationMethod<
   DescribeServiceRequest,
   DescribeServiceResponse,
   DescribeServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceRequest,
   output: DescribeServiceResponse,
@@ -2625,7 +2624,7 @@ export const describeVpcConnector: API.OperationMethod<
   DescribeVpcConnectorRequest,
   DescribeVpcConnectorResponse,
   DescribeVpcConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcConnectorRequest,
   output: DescribeVpcConnectorResponse,
@@ -2651,7 +2650,7 @@ export const describeVpcIngressConnection: API.OperationMethod<
   DescribeVpcIngressConnectionRequest,
   DescribeVpcIngressConnectionResponse,
   DescribeVpcIngressConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcIngressConnectionRequest,
   output: DescribeVpcIngressConnectionResponse,
@@ -2682,7 +2681,7 @@ export const disassociateCustomDomain: API.OperationMethod<
   DisassociateCustomDomainRequest,
   DisassociateCustomDomainResponse,
   DisassociateCustomDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCustomDomainRequest,
   output: DisassociateCustomDomainResponse,
@@ -2713,7 +2712,7 @@ export const listAutoScalingConfigurations: API.PaginatedOperationMethod<
   ListAutoScalingConfigurationsRequest,
   ListAutoScalingConfigurationsResponse,
   ListAutoScalingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutoScalingConfigurationsRequest,
@@ -2740,7 +2739,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsRequest,
   ListConnectionsResponse,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsRequest,
@@ -2772,7 +2771,7 @@ export const listObservabilityConfigurations: API.PaginatedOperationMethod<
   ListObservabilityConfigurationsRequest,
   ListObservabilityConfigurationsResponse,
   ListObservabilityConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObservabilityConfigurationsRequest,
@@ -2803,7 +2802,7 @@ export const listOperations: API.PaginatedOperationMethod<
   ListOperationsRequest,
   ListOperationsResponse,
   ListOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOperationsRequest,
@@ -2834,7 +2833,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -2862,7 +2861,7 @@ export const listServicesForAutoScalingConfiguration: API.PaginatedOperationMeth
   ListServicesForAutoScalingConfigurationRequest,
   ListServicesForAutoScalingConfigurationResponse,
   ListServicesForAutoScalingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesForAutoScalingConfigurationRequest,
@@ -2895,7 +2894,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2921,7 +2920,7 @@ export const listVpcConnectors: API.PaginatedOperationMethod<
   ListVpcConnectorsRequest,
   ListVpcConnectorsResponse,
   ListVpcConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVpcConnectorsRequest,
@@ -2948,7 +2947,7 @@ export const listVpcIngressConnections: API.PaginatedOperationMethod<
   ListVpcIngressConnectionsRequest,
   ListVpcIngressConnectionsResponse,
   ListVpcIngressConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVpcIngressConnectionsRequest,
@@ -2981,7 +2980,7 @@ export const pauseService: API.OperationMethod<
   PauseServiceRequest,
   PauseServiceResponse,
   PauseServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseServiceRequest,
   output: PauseServiceResponse,
@@ -3012,7 +3011,7 @@ export const resumeService: API.OperationMethod<
   ResumeServiceRequest,
   ResumeServiceResponse,
   ResumeServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeServiceRequest,
   output: ResumeServiceResponse,
@@ -3046,7 +3045,7 @@ export const startDeployment: API.OperationMethod<
   StartDeploymentRequest,
   StartDeploymentResponse,
   StartDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeploymentRequest,
   output: StartDeploymentResponse,
@@ -3073,7 +3072,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3101,7 +3100,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3129,7 +3128,7 @@ export const updateDefaultAutoScalingConfiguration: API.OperationMethod<
   UpdateDefaultAutoScalingConfigurationRequest,
   UpdateDefaultAutoScalingConfigurationResponse,
   UpdateDefaultAutoScalingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDefaultAutoScalingConfigurationRequest,
   output: UpdateDefaultAutoScalingConfigurationResponse,
@@ -3163,7 +3162,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceRequest,
   UpdateServiceResponse,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceRequest,
   output: UpdateServiceResponse,
@@ -3197,7 +3196,7 @@ export const updateVpcIngressConnection: API.OperationMethod<
   UpdateVpcIngressConnectionRequest,
   UpdateVpcIngressConnectionResponse,
   UpdateVpcIngressConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcIngressConnectionRequest,
   output: UpdateVpcIngressConnectionResponse,

--- a/packages/aws/src/services/appstream.ts
+++ b/packages/aws/src/services/appstream.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AppStream",
@@ -4333,7 +4332,7 @@ export const associateAppBlockBuilderAppBlock: API.OperationMethod<
   AssociateAppBlockBuilderAppBlockRequest,
   AssociateAppBlockBuilderAppBlockResult,
   AssociateAppBlockBuilderAppBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAppBlockBuilderAppBlockRequest,
   output: AssociateAppBlockBuilderAppBlockResult,
@@ -4363,7 +4362,7 @@ export const associateApplicationFleet: API.OperationMethod<
   AssociateApplicationFleetRequest,
   AssociateApplicationFleetResult,
   AssociateApplicationFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApplicationFleetRequest,
   output: AssociateApplicationFleetResult,
@@ -4392,7 +4391,7 @@ export const associateApplicationToEntitlement: API.OperationMethod<
   AssociateApplicationToEntitlementRequest,
   AssociateApplicationToEntitlementResult,
   AssociateApplicationToEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApplicationToEntitlementRequest,
   output: AssociateApplicationToEntitlementResult,
@@ -4422,7 +4421,7 @@ export const associateFleet: API.OperationMethod<
   AssociateFleetRequest,
   AssociateFleetResult,
   AssociateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFleetRequest,
   output: AssociateFleetResult,
@@ -4453,7 +4452,7 @@ export const associateSoftwareToImageBuilder: API.OperationMethod<
   AssociateSoftwareToImageBuilderRequest,
   AssociateSoftwareToImageBuilderResult,
   AssociateSoftwareToImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSoftwareToImageBuilderRequest,
   output: AssociateSoftwareToImageBuilderResult,
@@ -4480,7 +4479,7 @@ export const batchAssociateUserStack: API.OperationMethod<
   BatchAssociateUserStackRequest,
   BatchAssociateUserStackResult,
   BatchAssociateUserStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateUserStackRequest,
   output: BatchAssociateUserStackResult,
@@ -4504,7 +4503,7 @@ export const batchDisassociateUserStack: API.OperationMethod<
   BatchDisassociateUserStackRequest,
   BatchDisassociateUserStackResult,
   BatchDisassociateUserStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateUserStackRequest,
   output: BatchDisassociateUserStackResult,
@@ -4532,7 +4531,7 @@ export const copyImage: API.OperationMethod<
   CopyImageRequest,
   CopyImageResponse,
   CopyImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyImageRequest,
   output: CopyImageResponse,
@@ -4570,7 +4569,7 @@ export const createAppBlock: API.OperationMethod<
   CreateAppBlockRequest,
   CreateAppBlockResult,
   CreateAppBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppBlockRequest,
   output: CreateAppBlockResult,
@@ -4604,7 +4603,7 @@ export const createAppBlockBuilder: API.OperationMethod<
   CreateAppBlockBuilderRequest,
   CreateAppBlockBuilderResult,
   CreateAppBlockBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppBlockBuilderRequest,
   output: CreateAppBlockBuilderResult,
@@ -4636,7 +4635,7 @@ export const createAppBlockBuilderStreamingURL: API.OperationMethod<
   CreateAppBlockBuilderStreamingURLRequest,
   CreateAppBlockBuilderStreamingURLResult,
   CreateAppBlockBuilderStreamingURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppBlockBuilderStreamingURLRequest,
   output: CreateAppBlockBuilderStreamingURLResult,
@@ -4668,7 +4667,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResult,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResult,
@@ -4699,7 +4698,7 @@ export const createDirectoryConfig: API.OperationMethod<
   CreateDirectoryConfigRequest,
   CreateDirectoryConfigResult,
   CreateDirectoryConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectoryConfigRequest,
   output: CreateDirectoryConfigResult,
@@ -4734,7 +4733,7 @@ export const createEntitlement: API.OperationMethod<
   CreateEntitlementRequest,
   CreateEntitlementResult,
   CreateEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEntitlementRequest,
   output: CreateEntitlementResult,
@@ -4765,7 +4764,7 @@ export const createExportImageTask: API.OperationMethod<
   CreateExportImageTaskRequest,
   CreateExportImageTaskResult,
   CreateExportImageTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportImageTaskRequest,
   output: CreateExportImageTaskResult,
@@ -4803,7 +4802,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetRequest,
   CreateFleetResult,
   CreateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetRequest,
   output: CreateFleetResult,
@@ -4847,7 +4846,7 @@ export const createImageBuilder: API.OperationMethod<
   CreateImageBuilderRequest,
   CreateImageBuilderResult,
   CreateImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageBuilderRequest,
   output: CreateImageBuilderResult,
@@ -4880,7 +4879,7 @@ export const createImageBuilderStreamingURL: API.OperationMethod<
   CreateImageBuilderStreamingURLRequest,
   CreateImageBuilderStreamingURLResult,
   CreateImageBuilderStreamingURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageBuilderStreamingURLRequest,
   output: CreateImageBuilderStreamingURLResult,
@@ -4908,7 +4907,7 @@ export const createImportedImage: API.OperationMethod<
   CreateImportedImageRequest,
   CreateImportedImageResult,
   CreateImportedImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImportedImageRequest,
   output: CreateImportedImageResult,
@@ -4945,7 +4944,7 @@ export const createStack: API.OperationMethod<
   CreateStackRequest,
   CreateStackResult,
   CreateStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStackRequest,
   output: CreateStackResult,
@@ -4977,7 +4976,7 @@ export const createStreamingURL: API.OperationMethod<
   CreateStreamingURLRequest,
   CreateStreamingURLResult,
   CreateStreamingURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamingURLRequest,
   output: CreateStreamingURLResult,
@@ -5007,7 +5006,7 @@ export const createThemeForStack: API.OperationMethod<
   CreateThemeForStackRequest,
   CreateThemeForStackResult,
   CreateThemeForStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThemeForStackRequest,
   output: CreateThemeForStackResult,
@@ -5043,7 +5042,7 @@ export const createUpdatedImage: API.OperationMethod<
   CreateUpdatedImageRequest,
   CreateUpdatedImageResult,
   CreateUpdatedImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUpdatedImageRequest,
   output: CreateUpdatedImageResult,
@@ -5073,7 +5072,7 @@ export const createUsageReportSubscription: API.OperationMethod<
   CreateUsageReportSubscriptionRequest,
   CreateUsageReportSubscriptionResult,
   CreateUsageReportSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsageReportSubscriptionRequest,
   output: CreateUsageReportSubscriptionResult,
@@ -5101,7 +5100,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResult,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResult,
@@ -5129,7 +5128,7 @@ export const deleteAppBlock: API.OperationMethod<
   DeleteAppBlockRequest,
   DeleteAppBlockResult,
   DeleteAppBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppBlockRequest,
   output: DeleteAppBlockResult,
@@ -5159,7 +5158,7 @@ export const deleteAppBlockBuilder: API.OperationMethod<
   DeleteAppBlockBuilderRequest,
   DeleteAppBlockBuilderResult,
   DeleteAppBlockBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppBlockBuilderRequest,
   output: DeleteAppBlockBuilderResult,
@@ -5187,7 +5186,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResult,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResult,
@@ -5213,7 +5212,7 @@ export const deleteDirectoryConfig: API.OperationMethod<
   DeleteDirectoryConfigRequest,
   DeleteDirectoryConfigResult,
   DeleteDirectoryConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectoryConfigRequest,
   output: DeleteDirectoryConfigResult,
@@ -5236,7 +5235,7 @@ export const deleteEntitlement: API.OperationMethod<
   DeleteEntitlementRequest,
   DeleteEntitlementResult,
   DeleteEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEntitlementRequest,
   output: DeleteEntitlementResult,
@@ -5263,7 +5262,7 @@ export const deleteFleet: API.OperationMethod<
   DeleteFleetRequest,
   DeleteFleetResult,
   DeleteFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetRequest,
   output: DeleteFleetResult,
@@ -5291,7 +5290,7 @@ export const deleteImage: API.OperationMethod<
   DeleteImageRequest,
   DeleteImageResult,
   DeleteImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageRequest,
   output: DeleteImageResult,
@@ -5318,7 +5317,7 @@ export const deleteImageBuilder: API.OperationMethod<
   DeleteImageBuilderRequest,
   DeleteImageBuilderResult,
   DeleteImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageBuilderRequest,
   output: DeleteImageBuilderResult,
@@ -5343,7 +5342,7 @@ export const deleteImagePermissions: API.OperationMethod<
   DeleteImagePermissionsRequest,
   DeleteImagePermissionsResult,
   DeleteImagePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImagePermissionsRequest,
   output: DeleteImagePermissionsResult,
@@ -5366,7 +5365,7 @@ export const deleteStack: API.OperationMethod<
   DeleteStackRequest,
   DeleteStackResult,
   DeleteStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStackRequest,
   output: DeleteStackResult,
@@ -5393,7 +5392,7 @@ export const deleteThemeForStack: API.OperationMethod<
   DeleteThemeForStackRequest,
   DeleteThemeForStackResult,
   DeleteThemeForStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThemeForStackRequest,
   output: DeleteThemeForStackResult,
@@ -5418,7 +5417,7 @@ export const deleteUsageReportSubscription: API.OperationMethod<
   DeleteUsageReportSubscriptionRequest,
   DeleteUsageReportSubscriptionResult,
   DeleteUsageReportSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsageReportSubscriptionRequest,
   output: DeleteUsageReportSubscriptionResult,
@@ -5436,7 +5435,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResult,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResult,
@@ -5457,7 +5456,7 @@ export const describeAppBlockBuilderAppBlockAssociations: API.PaginatedOperation
   DescribeAppBlockBuilderAppBlockAssociationsRequest,
   DescribeAppBlockBuilderAppBlockAssociationsResult,
   DescribeAppBlockBuilderAppBlockAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAppBlockBuilderAppBlockAssociationsRequest,
@@ -5487,7 +5486,7 @@ export const describeAppBlockBuilders: API.PaginatedOperationMethod<
   DescribeAppBlockBuildersRequest,
   DescribeAppBlockBuildersResult,
   DescribeAppBlockBuildersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAppBlockBuildersRequest,
@@ -5514,7 +5513,7 @@ export const describeAppBlocks: API.OperationMethod<
   DescribeAppBlocksRequest,
   DescribeAppBlocksResult,
   DescribeAppBlocksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppBlocksRequest,
   output: DescribeAppBlocksResult,
@@ -5535,7 +5534,7 @@ export const describeApplicationFleetAssociations: API.OperationMethod<
   DescribeApplicationFleetAssociationsRequest,
   DescribeApplicationFleetAssociationsResult,
   DescribeApplicationFleetAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationFleetAssociationsRequest,
   output: DescribeApplicationFleetAssociationsResult,
@@ -5559,7 +5558,7 @@ export const describeApplications: API.OperationMethod<
   DescribeApplicationsRequest,
   DescribeApplicationsResult,
   DescribeApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationsRequest,
   output: DescribeApplicationsResult,
@@ -5581,7 +5580,7 @@ export const describeAppLicenseUsage: API.OperationMethod<
   DescribeAppLicenseUsageRequest,
   DescribeAppLicenseUsageResult,
   DescribeAppLicenseUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppLicenseUsageRequest,
   output: DescribeAppLicenseUsageResult,
@@ -5607,7 +5606,7 @@ export const describeDirectoryConfigs: API.OperationMethod<
   DescribeDirectoryConfigsRequest,
   DescribeDirectoryConfigsResult,
   DescribeDirectoryConfigsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectoryConfigsRequest,
   output: DescribeDirectoryConfigsResult,
@@ -5629,7 +5628,7 @@ export const describeEntitlements: API.OperationMethod<
   DescribeEntitlementsRequest,
   DescribeEntitlementsResult,
   DescribeEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntitlementsRequest,
   output: DescribeEntitlementsResult,
@@ -5651,7 +5650,7 @@ export const describeFleets: API.OperationMethod<
   DescribeFleetsRequest,
   DescribeFleetsResult,
   DescribeFleetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetsRequest,
   output: DescribeFleetsResult,
@@ -5671,7 +5670,7 @@ export const describeImageBuilders: API.OperationMethod<
   DescribeImageBuildersRequest,
   DescribeImageBuildersResult,
   DescribeImageBuildersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageBuildersRequest,
   output: DescribeImageBuildersResult,
@@ -5691,7 +5690,7 @@ export const describeImagePermissions: API.PaginatedOperationMethod<
   DescribeImagePermissionsRequest,
   DescribeImagePermissionsResult,
   DescribeImagePermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImagePermissionsRequest,
@@ -5718,7 +5717,7 @@ export const describeImages: API.PaginatedOperationMethod<
   DescribeImagesRequest,
   DescribeImagesResult,
   DescribeImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImagesRequest,
@@ -5746,7 +5745,7 @@ export const describeSessions: API.OperationMethod<
   DescribeSessionsRequest,
   DescribeSessionsResult,
   DescribeSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSessionsRequest,
   output: DescribeSessionsResult,
@@ -5767,7 +5766,7 @@ export const describeSoftwareAssociations: API.OperationMethod<
   DescribeSoftwareAssociationsRequest,
   DescribeSoftwareAssociationsResult,
   DescribeSoftwareAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSoftwareAssociationsRequest,
   output: DescribeSoftwareAssociationsResult,
@@ -5785,7 +5784,7 @@ export const describeStacks: API.OperationMethod<
   DescribeStacksRequest,
   DescribeStacksResult,
   DescribeStacksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStacksRequest,
   output: DescribeStacksResult,
@@ -5806,7 +5805,7 @@ export const describeThemeForStack: API.OperationMethod<
   DescribeThemeForStackRequest,
   DescribeThemeForStackResult,
   DescribeThemeForStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThemeForStackRequest,
   output: DescribeThemeForStackResult,
@@ -5827,7 +5826,7 @@ export const describeUsageReportSubscriptions: API.OperationMethod<
   DescribeUsageReportSubscriptionsRequest,
   DescribeUsageReportSubscriptionsResult,
   DescribeUsageReportSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUsageReportSubscriptionsRequest,
   output: DescribeUsageReportSubscriptionsResult,
@@ -5849,7 +5848,7 @@ export const describeUsers: API.OperationMethod<
   DescribeUsersRequest,
   DescribeUsersResult,
   DescribeUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUsersRequest,
   output: DescribeUsersResult,
@@ -5878,7 +5877,7 @@ export const describeUserStackAssociations: API.OperationMethod<
   DescribeUserStackAssociationsRequest,
   DescribeUserStackAssociationsResult,
   DescribeUserStackAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserStackAssociationsRequest,
   output: DescribeUserStackAssociationsResult,
@@ -5899,7 +5898,7 @@ export const disableUser: API.OperationMethod<
   DisableUserRequest,
   DisableUserResult,
   DisableUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableUserRequest,
   output: DisableUserResult,
@@ -5922,7 +5921,7 @@ export const disassociateAppBlockBuilderAppBlock: API.OperationMethod<
   DisassociateAppBlockBuilderAppBlockRequest,
   DisassociateAppBlockBuilderAppBlockResult,
   DisassociateAppBlockBuilderAppBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAppBlockBuilderAppBlockRequest,
   output: DisassociateAppBlockBuilderAppBlockResult,
@@ -5949,7 +5948,7 @@ export const disassociateApplicationFleet: API.OperationMethod<
   DisassociateApplicationFleetRequest,
   DisassociateApplicationFleetResult,
   DisassociateApplicationFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApplicationFleetRequest,
   output: DisassociateApplicationFleetResult,
@@ -5975,7 +5974,7 @@ export const disassociateApplicationFromEntitlement: API.OperationMethod<
   DisassociateApplicationFromEntitlementRequest,
   DisassociateApplicationFromEntitlementResult,
   DisassociateApplicationFromEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApplicationFromEntitlementRequest,
   output: DisassociateApplicationFromEntitlementResult,
@@ -6002,7 +6001,7 @@ export const disassociateFleet: API.OperationMethod<
   DisassociateFleetRequest,
   DisassociateFleetResult,
   DisassociateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFleetRequest,
   output: DisassociateFleetResult,
@@ -6030,7 +6029,7 @@ export const disassociateSoftwareFromImageBuilder: API.OperationMethod<
   DisassociateSoftwareFromImageBuilderRequest,
   DisassociateSoftwareFromImageBuilderResult,
   DisassociateSoftwareFromImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSoftwareFromImageBuilderRequest,
   output: DisassociateSoftwareFromImageBuilderResult,
@@ -6057,7 +6056,7 @@ export const drainSessionInstance: API.OperationMethod<
   DrainSessionInstanceRequest,
   DrainSessionInstanceResult,
   DrainSessionInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DrainSessionInstanceRequest,
   output: DrainSessionInstanceResult,
@@ -6082,7 +6081,7 @@ export const enableUser: API.OperationMethod<
   EnableUserRequest,
   EnableUserResult,
   EnableUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableUserRequest,
   output: EnableUserResult,
@@ -6100,7 +6099,7 @@ export const expireSession: API.OperationMethod<
   ExpireSessionRequest,
   ExpireSessionResult,
   ExpireSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExpireSessionRequest,
   output: ExpireSessionResult,
@@ -6121,7 +6120,7 @@ export const getExportImageTask: API.OperationMethod<
   GetExportImageTaskRequest,
   GetExportImageTaskResult,
   GetExportImageTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportImageTaskRequest,
   output: GetExportImageTaskResult,
@@ -6139,7 +6138,7 @@ export const listAssociatedFleets: API.OperationMethod<
   ListAssociatedFleetsRequest,
   ListAssociatedFleetsResult,
   ListAssociatedFleetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAssociatedFleetsRequest,
   output: ListAssociatedFleetsResult,
@@ -6157,7 +6156,7 @@ export const listAssociatedStacks: API.OperationMethod<
   ListAssociatedStacksRequest,
   ListAssociatedStacksResult,
   ListAssociatedStacksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAssociatedStacksRequest,
   output: ListAssociatedStacksResult,
@@ -6179,7 +6178,7 @@ export const listEntitledApplications: API.OperationMethod<
   ListEntitledApplicationsRequest,
   ListEntitledApplicationsResult,
   ListEntitledApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEntitledApplicationsRequest,
   output: ListEntitledApplicationsResult,
@@ -6203,7 +6202,7 @@ export const listExportImageTasks: API.OperationMethod<
   ListExportImageTasksRequest,
   ListExportImageTasksResult,
   ListExportImageTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListExportImageTasksRequest,
   output: ListExportImageTasksResult,
@@ -6223,7 +6222,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6255,7 +6254,7 @@ export const startAppBlockBuilder: API.OperationMethod<
   StartAppBlockBuilderRequest,
   StartAppBlockBuilderResult,
   StartAppBlockBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAppBlockBuilderRequest,
   output: StartAppBlockBuilderResult,
@@ -6290,7 +6289,7 @@ export const startFleet: API.OperationMethod<
   StartFleetRequest,
   StartFleetResult,
   StartFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFleetRequest,
   output: StartFleetResult,
@@ -6323,7 +6322,7 @@ export const startImageBuilder: API.OperationMethod<
   StartImageBuilderRequest,
   StartImageBuilderResult,
   StartImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImageBuilderRequest,
   output: StartImageBuilderResult,
@@ -6351,7 +6350,7 @@ export const startSoftwareDeploymentToImageBuilder: API.OperationMethod<
   StartSoftwareDeploymentToImageBuilderRequest,
   StartSoftwareDeploymentToImageBuilderResult,
   StartSoftwareDeploymentToImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSoftwareDeploymentToImageBuilderRequest,
   output: StartSoftwareDeploymentToImageBuilderResult,
@@ -6380,7 +6379,7 @@ export const stopAppBlockBuilder: API.OperationMethod<
   StopAppBlockBuilderRequest,
   StopAppBlockBuilderResult,
   StopAppBlockBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAppBlockBuilderRequest,
   output: StopAppBlockBuilderResult,
@@ -6405,7 +6404,7 @@ export const stopFleet: API.OperationMethod<
   StopFleetRequest,
   StopFleetResult,
   StopFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFleetRequest,
   output: StopFleetResult,
@@ -6427,7 +6426,7 @@ export const stopImageBuilder: API.OperationMethod<
   StopImageBuilderRequest,
   StopImageBuilderResult,
   StopImageBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopImageBuilderRequest,
   output: StopImageBuilderResult,
@@ -6461,7 +6460,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6487,7 +6486,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6521,7 +6520,7 @@ export const updateAppBlockBuilder: API.OperationMethod<
   UpdateAppBlockBuilderRequest,
   UpdateAppBlockBuilderResult,
   UpdateAppBlockBuilderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppBlockBuilderRequest,
   output: UpdateAppBlockBuilderResult,
@@ -6554,7 +6553,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResult,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResult,
@@ -6583,7 +6582,7 @@ export const updateDirectoryConfig: API.OperationMethod<
   UpdateDirectoryConfigRequest,
   UpdateDirectoryConfigResult,
   UpdateDirectoryConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectoryConfigRequest,
   output: UpdateDirectoryConfigResult,
@@ -6613,7 +6612,7 @@ export const updateEntitlement: API.OperationMethod<
   UpdateEntitlementRequest,
   UpdateEntitlementResult,
   UpdateEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEntitlementRequest,
   output: UpdateEntitlementResult,
@@ -6670,7 +6669,7 @@ export const updateFleet: API.OperationMethod<
   UpdateFleetRequest,
   UpdateFleetResult,
   UpdateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetRequest,
   output: UpdateFleetResult,
@@ -6704,7 +6703,7 @@ export const updateImagePermissions: API.OperationMethod<
   UpdateImagePermissionsRequest,
   UpdateImagePermissionsResult,
   UpdateImagePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImagePermissionsRequest,
   output: UpdateImagePermissionsResult,
@@ -6736,7 +6735,7 @@ export const updateStack: API.OperationMethod<
   UpdateStackRequest,
   UpdateStackResult,
   UpdateStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStackRequest,
   output: UpdateStackResult,
@@ -6771,7 +6770,7 @@ export const updateThemeForStack: API.OperationMethod<
   UpdateThemeForStackRequest,
   UpdateThemeForStackResult,
   UpdateThemeForStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThemeForStackRequest,
   output: UpdateThemeForStackResult,

--- a/packages/aws/src/services/appsync.ts
+++ b/packages/aws/src/services/appsync.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://appsync.amazonaws.com");
 const svc = T.AwsApiService({
   sdkId: "AppSync",
@@ -3967,7 +3966,7 @@ export const associateApi: API.OperationMethod<
   AssociateApiRequest,
   AssociateApiResponse,
   AssociateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApiRequest,
   output: AssociateApiResponse,
@@ -3998,7 +3997,7 @@ export const associateMergedGraphqlApi: API.OperationMethod<
   AssociateMergedGraphqlApiRequest,
   AssociateMergedGraphqlApiResponse,
   AssociateMergedGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMergedGraphqlApiRequest,
   output: AssociateMergedGraphqlApiResponse,
@@ -4031,7 +4030,7 @@ export const associateSourceGraphqlApi: API.OperationMethod<
   AssociateSourceGraphqlApiRequest,
   AssociateSourceGraphqlApiResponse,
   AssociateSourceGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceGraphqlApiRequest,
   output: AssociateSourceGraphqlApiResponse,
@@ -4064,7 +4063,7 @@ export const createApi: API.OperationMethod<
   CreateApiRequest,
   CreateApiResponse,
   CreateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiRequest,
   output: CreateApiResponse,
@@ -4094,7 +4093,7 @@ export const createApiCache: API.OperationMethod<
   CreateApiCacheRequest,
   CreateApiCacheResponse,
   CreateApiCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiCacheRequest,
   output: CreateApiCacheResponse,
@@ -4126,7 +4125,7 @@ export const createApiKey: API.OperationMethod<
   CreateApiKeyRequest,
   CreateApiKeyResponse,
   CreateApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiKeyRequest,
   output: CreateApiKeyResponse,
@@ -4160,7 +4159,7 @@ export const createChannelNamespace: API.OperationMethod<
   CreateChannelNamespaceRequest,
   CreateChannelNamespaceResponse,
   CreateChannelNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelNamespaceRequest,
   output: CreateChannelNamespaceResponse,
@@ -4192,7 +4191,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceRequest,
   CreateDataSourceResponse,
   CreateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceRequest,
   output: CreateDataSourceResponse,
@@ -4220,7 +4219,7 @@ export const createDomainName: API.OperationMethod<
   CreateDomainNameRequest,
   CreateDomainNameResponse,
   CreateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainNameRequest,
   output: CreateDomainNameResponse,
@@ -4251,7 +4250,7 @@ export const createFunction: API.OperationMethod<
   CreateFunctionRequest,
   CreateFunctionResponse,
   CreateFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionRequest,
   output: CreateFunctionResponse,
@@ -4282,7 +4281,7 @@ export const createGraphqlApi: API.OperationMethod<
   CreateGraphqlApiRequest,
   CreateGraphqlApiResponse,
   CreateGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGraphqlApiRequest,
   output: CreateGraphqlApiResponse,
@@ -4316,7 +4315,7 @@ export const createResolver: API.OperationMethod<
   CreateResolverRequest,
   CreateResolverResponse,
   CreateResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResolverRequest,
   output: CreateResolverResponse,
@@ -4346,7 +4345,7 @@ export const createType: API.OperationMethod<
   CreateTypeRequest,
   CreateTypeResponse,
   CreateTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTypeRequest,
   output: CreateTypeResponse,
@@ -4377,7 +4376,7 @@ export const deleteApi: API.OperationMethod<
   DeleteApiRequest,
   DeleteApiResponse,
   DeleteApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiRequest,
   output: DeleteApiResponse,
@@ -4408,7 +4407,7 @@ export const deleteApiCache: API.OperationMethod<
   DeleteApiCacheRequest,
   DeleteApiCacheResponse,
   DeleteApiCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiCacheRequest,
   output: DeleteApiCacheResponse,
@@ -4437,7 +4436,7 @@ export const deleteApiKey: API.OperationMethod<
   DeleteApiKeyRequest,
   DeleteApiKeyResponse,
   DeleteApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiKeyRequest,
   output: DeleteApiKeyResponse,
@@ -4467,7 +4466,7 @@ export const deleteChannelNamespace: API.OperationMethod<
   DeleteChannelNamespaceRequest,
   DeleteChannelNamespaceResponse,
   DeleteChannelNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelNamespaceRequest,
   output: DeleteChannelNamespaceResponse,
@@ -4498,7 +4497,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -4528,7 +4527,7 @@ export const deleteDomainName: API.OperationMethod<
   DeleteDomainNameRequest,
   DeleteDomainNameResponse,
   DeleteDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainNameRequest,
   output: DeleteDomainNameResponse,
@@ -4558,7 +4557,7 @@ export const deleteFunction: API.OperationMethod<
   DeleteFunctionRequest,
   DeleteFunctionResponse,
   DeleteFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionRequest,
   output: DeleteFunctionResponse,
@@ -4589,7 +4588,7 @@ export const deleteGraphqlApi: API.OperationMethod<
   DeleteGraphqlApiRequest,
   DeleteGraphqlApiResponse,
   DeleteGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGraphqlApiRequest,
   output: DeleteGraphqlApiResponse,
@@ -4620,7 +4619,7 @@ export const deleteResolver: API.OperationMethod<
   DeleteResolverRequest,
   DeleteResolverResponse,
   DeleteResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResolverRequest,
   output: DeleteResolverResponse,
@@ -4650,7 +4649,7 @@ export const deleteType: API.OperationMethod<
   DeleteTypeRequest,
   DeleteTypeResponse,
   DeleteTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTypeRequest,
   output: DeleteTypeResponse,
@@ -4680,7 +4679,7 @@ export const disassociateApi: API.OperationMethod<
   DisassociateApiRequest,
   DisassociateApiResponse,
   DisassociateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApiRequest,
   output: DisassociateApiResponse,
@@ -4711,7 +4710,7 @@ export const disassociateMergedGraphqlApi: API.OperationMethod<
   DisassociateMergedGraphqlApiRequest,
   DisassociateMergedGraphqlApiResponse,
   DisassociateMergedGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMergedGraphqlApiRequest,
   output: DisassociateMergedGraphqlApiResponse,
@@ -4742,7 +4741,7 @@ export const disassociateSourceGraphqlApi: API.OperationMethod<
   DisassociateSourceGraphqlApiRequest,
   DisassociateSourceGraphqlApiResponse,
   DisassociateSourceGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSourceGraphqlApiRequest,
   output: DisassociateSourceGraphqlApiResponse,
@@ -4775,7 +4774,7 @@ export const evaluateCode: API.OperationMethod<
   EvaluateCodeRequest,
   EvaluateCodeResponse,
   EvaluateCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluateCodeRequest,
   output: EvaluateCodeResponse,
@@ -4809,7 +4808,7 @@ export const evaluateMappingTemplate: API.OperationMethod<
   EvaluateMappingTemplateRequest,
   EvaluateMappingTemplateResponse,
   EvaluateMappingTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluateMappingTemplateRequest,
   output: EvaluateMappingTemplateResponse,
@@ -4837,7 +4836,7 @@ export const flushApiCache: API.OperationMethod<
   FlushApiCacheRequest,
   FlushApiCacheResponse,
   FlushApiCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FlushApiCacheRequest,
   output: FlushApiCacheResponse,
@@ -4867,7 +4866,7 @@ export const getApi: API.OperationMethod<
   GetApiRequest,
   GetApiResponse,
   GetApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiRequest,
   output: GetApiResponse,
@@ -4896,7 +4895,7 @@ export const getApiAssociation: API.OperationMethod<
   GetApiAssociationRequest,
   GetApiAssociationResponse,
   GetApiAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiAssociationRequest,
   output: GetApiAssociationResponse,
@@ -4925,7 +4924,7 @@ export const getApiCache: API.OperationMethod<
   GetApiCacheRequest,
   GetApiCacheResponse,
   GetApiCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiCacheRequest,
   output: GetApiCacheResponse,
@@ -4955,7 +4954,7 @@ export const getChannelNamespace: API.OperationMethod<
   GetChannelNamespaceRequest,
   GetChannelNamespaceResponse,
   GetChannelNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelNamespaceRequest,
   output: GetChannelNamespaceResponse,
@@ -4985,7 +4984,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceRequest,
   GetDataSourceResponse,
   GetDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceRequest,
   output: GetDataSourceResponse,
@@ -5015,7 +5014,7 @@ export const getDataSourceIntrospection: API.OperationMethod<
   GetDataSourceIntrospectionRequest,
   GetDataSourceIntrospectionResponse,
   GetDataSourceIntrospectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceIntrospectionRequest,
   output: GetDataSourceIntrospectionResponse,
@@ -5038,7 +5037,7 @@ export const getDomainName: API.OperationMethod<
   GetDomainNameRequest,
   GetDomainNameResponse,
   GetDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainNameRequest,
   output: GetDomainNameResponse,
@@ -5065,7 +5064,7 @@ export const getFunction: API.OperationMethod<
   GetFunctionRequest,
   GetFunctionResponse,
   GetFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionRequest,
   output: GetFunctionResponse,
@@ -5093,7 +5092,7 @@ export const getGraphqlApi: API.OperationMethod<
   GetGraphqlApiRequest,
   GetGraphqlApiResponse,
   GetGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGraphqlApiRequest,
   output: GetGraphqlApiResponse,
@@ -5124,7 +5123,7 @@ export const getGraphqlApiEnvironmentVariables: API.OperationMethod<
   GetGraphqlApiEnvironmentVariablesRequest,
   GetGraphqlApiEnvironmentVariablesResponse,
   GetGraphqlApiEnvironmentVariablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGraphqlApiEnvironmentVariablesRequest,
   output: GetGraphqlApiEnvironmentVariablesResponse,
@@ -5153,7 +5152,7 @@ export const getIntrospectionSchema: API.OperationMethod<
   GetIntrospectionSchemaRequest,
   GetIntrospectionSchemaResponse,
   GetIntrospectionSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntrospectionSchemaRequest,
   output: GetIntrospectionSchemaResponse,
@@ -5180,7 +5179,7 @@ export const getResolver: API.OperationMethod<
   GetResolverRequest,
   GetResolverResponse,
   GetResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverRequest,
   output: GetResolverResponse,
@@ -5207,7 +5206,7 @@ export const getSchemaCreationStatus: API.OperationMethod<
   GetSchemaCreationStatusRequest,
   GetSchemaCreationStatusResponse,
   GetSchemaCreationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaCreationStatusRequest,
   output: GetSchemaCreationStatusResponse,
@@ -5235,7 +5234,7 @@ export const getSourceApiAssociation: API.OperationMethod<
   GetSourceApiAssociationRequest,
   GetSourceApiAssociationResponse,
   GetSourceApiAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSourceApiAssociationRequest,
   output: GetSourceApiAssociationResponse,
@@ -5264,7 +5263,7 @@ export const getType: API.OperationMethod<
   GetTypeRequest,
   GetTypeResponse,
   GetTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTypeRequest,
   output: GetTypeResponse,
@@ -5298,7 +5297,7 @@ export const listApiKeys: API.PaginatedOperationMethod<
   ListApiKeysRequest,
   ListApiKeysResponse,
   ListApiKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApiKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApiKeysRequest,
@@ -5335,7 +5334,7 @@ export const listApis: API.PaginatedOperationMethod<
   ListApisRequest,
   ListApisResponse,
   ListApisError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Api
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApisRequest,
@@ -5372,7 +5371,7 @@ export const listChannelNamespaces: API.PaginatedOperationMethod<
   ListChannelNamespacesRequest,
   ListChannelNamespacesResponse,
   ListChannelNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelNamespace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelNamespacesRequest,
@@ -5407,7 +5406,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesRequest,
@@ -5441,7 +5440,7 @@ export const listDomainNames: API.PaginatedOperationMethod<
   ListDomainNamesRequest,
   ListDomainNamesResponse,
   ListDomainNamesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainNameConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainNamesRequest,
@@ -5475,7 +5474,7 @@ export const listFunctions: API.PaginatedOperationMethod<
   ListFunctionsRequest,
   ListFunctionsResponse,
   ListFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionsRequest,
@@ -5509,7 +5508,7 @@ export const listGraphqlApis: API.PaginatedOperationMethod<
   ListGraphqlApisRequest,
   ListGraphqlApisResponse,
   ListGraphqlApisError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GraphqlApi
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGraphqlApisRequest,
@@ -5543,7 +5542,7 @@ export const listResolvers: API.PaginatedOperationMethod<
   ListResolversRequest,
   ListResolversResponse,
   ListResolversError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Resolver
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolversRequest,
@@ -5578,7 +5577,7 @@ export const listResolversByFunction: API.PaginatedOperationMethod<
   ListResolversByFunctionRequest,
   ListResolversByFunctionResponse,
   ListResolversByFunctionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Resolver
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolversByFunctionRequest,
@@ -5613,7 +5612,7 @@ export const listSourceApiAssociations: API.PaginatedOperationMethod<
   ListSourceApiAssociationsRequest,
   ListSourceApiAssociationsResponse,
   ListSourceApiAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceApiAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceApiAssociationsRequest,
@@ -5650,7 +5649,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5681,7 +5680,7 @@ export const listTypes: API.PaginatedOperationMethod<
   ListTypesRequest,
   ListTypesResponse,
   ListTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Type
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypesRequest,
@@ -5718,7 +5717,7 @@ export const listTypesByAssociation: API.PaginatedOperationMethod<
   ListTypesByAssociationRequest,
   ListTypesByAssociationResponse,
   ListTypesByAssociationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Type
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypesByAssociationRequest,
@@ -5792,7 +5791,7 @@ export const putGraphqlApiEnvironmentVariables: API.OperationMethod<
   PutGraphqlApiEnvironmentVariablesRequest,
   PutGraphqlApiEnvironmentVariablesResponse,
   PutGraphqlApiEnvironmentVariablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGraphqlApiEnvironmentVariablesRequest,
   output: PutGraphqlApiEnvironmentVariablesResponse,
@@ -5823,7 +5822,7 @@ export const startDataSourceIntrospection: API.OperationMethod<
   StartDataSourceIntrospectionRequest,
   StartDataSourceIntrospectionResponse,
   StartDataSourceIntrospectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataSourceIntrospectionRequest,
   output: StartDataSourceIntrospectionResponse,
@@ -5855,7 +5854,7 @@ export const startSchemaCreation: API.OperationMethod<
   StartSchemaCreationRequest,
   StartSchemaCreationResponse,
   StartSchemaCreationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSchemaCreationRequest,
   output: StartSchemaCreationResponse,
@@ -5886,7 +5885,7 @@ export const startSchemaMerge: API.OperationMethod<
   StartSchemaMergeRequest,
   StartSchemaMergeResponse,
   StartSchemaMergeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSchemaMergeRequest,
   output: StartSchemaMergeResponse,
@@ -5917,7 +5916,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5949,7 +5948,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5981,7 +5980,7 @@ export const updateApi: API.OperationMethod<
   UpdateApiRequest,
   UpdateApiResponse,
   UpdateApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiRequest,
   output: UpdateApiResponse,
@@ -6012,7 +6011,7 @@ export const updateApiCache: API.OperationMethod<
   UpdateApiCacheRequest,
   UpdateApiCacheResponse,
   UpdateApiCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiCacheRequest,
   output: UpdateApiCacheResponse,
@@ -6043,7 +6042,7 @@ export const updateApiKey: API.OperationMethod<
   UpdateApiKeyRequest,
   UpdateApiKeyResponse,
   UpdateApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiKeyRequest,
   output: UpdateApiKeyResponse,
@@ -6075,7 +6074,7 @@ export const updateChannelNamespace: API.OperationMethod<
   UpdateChannelNamespaceRequest,
   UpdateChannelNamespaceResponse,
   UpdateChannelNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelNamespaceRequest,
   output: UpdateChannelNamespaceResponse,
@@ -6106,7 +6105,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -6136,7 +6135,7 @@ export const updateDomainName: API.OperationMethod<
   UpdateDomainNameRequest,
   UpdateDomainNameResponse,
   UpdateDomainNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainNameRequest,
   output: UpdateDomainNameResponse,
@@ -6166,7 +6165,7 @@ export const updateFunction: API.OperationMethod<
   UpdateFunctionRequest,
   UpdateFunctionResponse,
   UpdateFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionRequest,
   output: UpdateFunctionResponse,
@@ -6197,7 +6196,7 @@ export const updateGraphqlApi: API.OperationMethod<
   UpdateGraphqlApiRequest,
   UpdateGraphqlApiResponse,
   UpdateGraphqlApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGraphqlApiRequest,
   output: UpdateGraphqlApiResponse,
@@ -6228,7 +6227,7 @@ export const updateResolver: API.OperationMethod<
   UpdateResolverRequest,
   UpdateResolverResponse,
   UpdateResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverRequest,
   output: UpdateResolverResponse,
@@ -6258,7 +6257,7 @@ export const updateSourceApiAssociation: API.OperationMethod<
   UpdateSourceApiAssociationRequest,
   UpdateSourceApiAssociationResponse,
   UpdateSourceApiAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSourceApiAssociationRequest,
   output: UpdateSourceApiAssociationResponse,
@@ -6288,7 +6287,7 @@ export const updateType: API.OperationMethod<
   UpdateTypeRequest,
   UpdateTypeResponse,
   UpdateTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTypeRequest,
   output: UpdateTypeResponse,

--- a/packages/aws/src/services/arc-region-switch.ts
+++ b/packages/aws/src/services/arc-region-switch.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ARC Region switch",
   serviceShapeName: "ArcRegionSwitch",
@@ -2367,7 +2366,7 @@ export const approvePlanExecutionStep: API.OperationMethod<
   ApprovePlanExecutionStepRequest,
   ApprovePlanExecutionStepResponse,
   ApprovePlanExecutionStepError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApprovePlanExecutionStepRequest,
   output: ApprovePlanExecutionStepResponse,
@@ -2390,7 +2389,7 @@ export const cancelPlanExecution: API.OperationMethod<
   CancelPlanExecutionRequest,
   CancelPlanExecutionResponse,
   CancelPlanExecutionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelPlanExecutionRequest,
   output: CancelPlanExecutionResponse,
@@ -2410,7 +2409,7 @@ export const createPlan: API.OperationMethod<
   CreatePlanRequest,
   CreatePlanResponse,
   CreatePlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlanRequest,
   output: CreatePlanResponse,
@@ -2433,7 +2432,7 @@ export const deletePlan: API.OperationMethod<
   DeletePlanRequest,
   DeletePlanResponse,
   DeletePlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlanRequest,
   output: DeletePlanResponse,
@@ -2451,7 +2450,7 @@ export const getPlan: API.OperationMethod<
   GetPlanRequest,
   GetPlanResponse,
   GetPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlanRequest,
   output: GetPlanResponse,
@@ -2472,7 +2471,7 @@ export const getPlanEvaluationStatus: API.PaginatedOperationMethod<
   GetPlanEvaluationStatusRequest,
   GetPlanEvaluationStatusResponse,
   GetPlanEvaluationStatusError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceWarning
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPlanEvaluationStatusRequest,
@@ -2500,7 +2499,7 @@ export const getPlanExecution: API.PaginatedOperationMethod<
   GetPlanExecutionRequest,
   GetPlanExecutionResponse,
   GetPlanExecutionError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StepState
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPlanExecutionRequest,
@@ -2528,7 +2527,7 @@ export const getPlanInRegion: API.OperationMethod<
   GetPlanInRegionRequest,
   GetPlanInRegionResponse,
   GetPlanInRegionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlanInRegionRequest,
   output: GetPlanInRegionResponse,
@@ -2549,7 +2548,7 @@ export const listPlanExecutionEvents: API.PaginatedOperationMethod<
   ListPlanExecutionEventsRequest,
   ListPlanExecutionEventsResponse,
   ListPlanExecutionEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExecutionEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlanExecutionEventsRequest,
@@ -2577,7 +2576,7 @@ export const listPlanExecutions: API.PaginatedOperationMethod<
   ListPlanExecutionsRequest,
   ListPlanExecutionsResponse,
   ListPlanExecutionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AbbreviatedExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlanExecutionsRequest,
@@ -2602,7 +2601,7 @@ export const listPlans: API.PaginatedOperationMethod<
   ListPlansRequest,
   ListPlansResponse,
   ListPlansError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AbbreviatedPlan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlansRequest,
@@ -2627,7 +2626,7 @@ export const listPlansInRegion: API.PaginatedOperationMethod<
   ListPlansInRegionRequest,
   ListPlansInRegionResponse,
   ListPlansInRegionError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AbbreviatedPlan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlansInRegionRequest,
@@ -2657,7 +2656,7 @@ export const listRoute53HealthChecks: API.PaginatedOperationMethod<
   ListRoute53HealthChecksRequest,
   ListRoute53HealthChecksResponse,
   ListRoute53HealthChecksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Route53HealthCheck
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoute53HealthChecksRequest,
@@ -2692,7 +2691,7 @@ export const listRoute53HealthChecksInRegion: API.PaginatedOperationMethod<
   ListRoute53HealthChecksInRegionRequest,
   ListRoute53HealthChecksInRegionResponse,
   ListRoute53HealthChecksInRegionError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Route53HealthCheck
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoute53HealthChecksInRegionRequest,
@@ -2725,7 +2724,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2750,7 +2749,7 @@ export const startPlanExecution: API.OperationMethod<
   StartPlanExecutionRequest,
   StartPlanExecutionResponse,
   StartPlanExecutionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPlanExecutionRequest,
   output: StartPlanExecutionResponse,
@@ -2776,7 +2775,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2797,7 +2796,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2815,7 +2814,7 @@ export const updatePlan: API.OperationMethod<
   UpdatePlanRequest,
   UpdatePlanResponse,
   UpdatePlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePlanRequest,
   output: UpdatePlanResponse,
@@ -2837,7 +2836,7 @@ export const updatePlanExecution: API.OperationMethod<
   UpdatePlanExecutionRequest,
   UpdatePlanExecutionResponse,
   UpdatePlanExecutionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePlanExecutionRequest,
   output: UpdatePlanExecutionResponse,
@@ -2862,7 +2861,7 @@ export const updatePlanExecutionStep: API.OperationMethod<
   UpdatePlanExecutionStepRequest,
   UpdatePlanExecutionStepResponse,
   UpdatePlanExecutionStepError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePlanExecutionStepRequest,
   output: UpdatePlanExecutionStepResponse,

--- a/packages/aws/src/services/arc-zonal-shift.ts
+++ b/packages/aws/src/services/arc-zonal-shift.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ARC Zonal Shift",
   serviceShapeName: "PercDataPlane",
@@ -943,7 +942,7 @@ export const cancelPracticeRun: API.OperationMethod<
   CancelPracticeRunRequest,
   CancelPracticeRunResponse,
   CancelPracticeRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelPracticeRunRequest,
   output: CancelPracticeRunResponse,
@@ -977,7 +976,7 @@ export const cancelZonalShift: API.OperationMethod<
   CancelZonalShiftRequest,
   ZonalShift,
   CancelZonalShiftError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelZonalShiftRequest,
   output: ZonalShift,
@@ -1013,7 +1012,7 @@ export const createPracticeRunConfiguration: API.OperationMethod<
   CreatePracticeRunConfigurationRequest,
   CreatePracticeRunConfigurationResponse,
   CreatePracticeRunConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePracticeRunConfigurationRequest,
   output: CreatePracticeRunConfigurationResponse,
@@ -1045,7 +1044,7 @@ export const deletePracticeRunConfiguration: API.OperationMethod<
   DeletePracticeRunConfigurationRequest,
   DeletePracticeRunConfigurationResponse,
   DeletePracticeRunConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePracticeRunConfigurationRequest,
   output: DeletePracticeRunConfigurationResponse,
@@ -1074,7 +1073,7 @@ export const getAutoshiftObserverNotificationStatus: API.OperationMethod<
   GetAutoshiftObserverNotificationStatusRequest,
   GetAutoshiftObserverNotificationStatusResponse,
   GetAutoshiftObserverNotificationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoshiftObserverNotificationStatusRequest,
   output: GetAutoshiftObserverNotificationStatusResponse,
@@ -1098,7 +1097,7 @@ export const getManagedResource: API.OperationMethod<
   GetManagedResourceRequest,
   GetManagedResourceResponse,
   GetManagedResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedResourceRequest,
   output: GetManagedResourceResponse,
@@ -1127,7 +1126,7 @@ export const listAutoshifts: API.PaginatedOperationMethod<
   ListAutoshiftsRequest,
   ListAutoshiftsResponse,
   ListAutoshiftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutoshiftSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutoshiftsRequest,
@@ -1162,7 +1161,7 @@ export const listManagedResources: API.PaginatedOperationMethod<
   ListManagedResourcesRequest,
   ListManagedResourcesResponse,
   ListManagedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedResourcesRequest,
@@ -1199,7 +1198,7 @@ export const listZonalShifts: API.PaginatedOperationMethod<
   ListZonalShiftsRequest,
   ListZonalShiftsResponse,
   ListZonalShiftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ZonalShiftSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListZonalShiftsRequest,
@@ -1238,7 +1237,7 @@ export const startPracticeRun: API.OperationMethod<
   StartPracticeRunRequest,
   StartPracticeRunResponse,
   StartPracticeRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPracticeRunRequest,
   output: StartPracticeRunResponse,
@@ -1284,7 +1283,7 @@ export const startZonalShift: API.OperationMethod<
   StartZonalShiftRequest,
   ZonalShift,
   StartZonalShiftError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartZonalShiftRequest,
   output: ZonalShift,
@@ -1318,7 +1317,7 @@ export const updateAutoshiftObserverNotificationStatus: API.OperationMethod<
   UpdateAutoshiftObserverNotificationStatusRequest,
   UpdateAutoshiftObserverNotificationStatusResponse,
   UpdateAutoshiftObserverNotificationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutoshiftObserverNotificationStatusRequest,
   output: UpdateAutoshiftObserverNotificationStatusResponse,
@@ -1348,7 +1347,7 @@ export const updatePracticeRunConfiguration: API.OperationMethod<
   UpdatePracticeRunConfigurationRequest,
   UpdatePracticeRunConfigurationResponse,
   UpdatePracticeRunConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePracticeRunConfigurationRequest,
   output: UpdatePracticeRunConfigurationResponse,
@@ -1382,7 +1381,7 @@ export const updateZonalAutoshiftConfiguration: API.OperationMethod<
   UpdateZonalAutoshiftConfigurationRequest,
   UpdateZonalAutoshiftConfigurationResponse,
   UpdateZonalAutoshiftConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateZonalAutoshiftConfigurationRequest,
   output: UpdateZonalAutoshiftConfigurationResponse,
@@ -1414,7 +1413,7 @@ export const updateZonalShift: API.OperationMethod<
   UpdateZonalShiftRequest,
   ZonalShift,
   UpdateZonalShiftError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateZonalShiftRequest,
   output: ZonalShift,

--- a/packages/aws/src/services/artifact.ts
+++ b/packages/aws/src/services/artifact.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Artifact",
   serviceShapeName: "Artifact",
@@ -635,7 +634,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsResponse,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsResponse,
@@ -669,7 +668,7 @@ export const getReport: API.OperationMethod<
   GetReportRequest,
   GetReportResponse,
   GetReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReportRequest,
   output: GetReportResponse,
@@ -702,7 +701,7 @@ export const getReportMetadata: API.OperationMethod<
   GetReportMetadataRequest,
   GetReportMetadataResponse,
   GetReportMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReportMetadataRequest,
   output: GetReportMetadataResponse,
@@ -735,7 +734,7 @@ export const getTermForReport: API.OperationMethod<
   GetTermForReportRequest,
   GetTermForReportResponse,
   GetTermForReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTermForReportRequest,
   output: GetTermForReportResponse,
@@ -766,7 +765,7 @@ export const listCustomerAgreements: API.PaginatedOperationMethod<
   ListCustomerAgreementsRequest,
   ListCustomerAgreementsResponse,
   ListCustomerAgreementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomerAgreementSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomerAgreementsRequest,
@@ -803,7 +802,7 @@ export const listReports: API.PaginatedOperationMethod<
   ListReportsRequest,
   ListReportsResponse,
   ListReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportsRequest,
@@ -842,7 +841,7 @@ export const listReportVersions: API.PaginatedOperationMethod<
   ListReportVersionsRequest,
   ListReportVersionsResponse,
   ListReportVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportVersionsRequest,
@@ -882,7 +881,7 @@ export const putAccountSettings: API.OperationMethod<
   PutAccountSettingsRequest,
   PutAccountSettingsResponse,
   PutAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSettingsRequest,
   output: PutAccountSettingsResponse,

--- a/packages/aws/src/services/athena.ts
+++ b/packages/aws/src/services/athena.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Athena",
   serviceShapeName: "AmazonAthena",
@@ -3284,7 +3283,7 @@ export const batchGetNamedQuery: API.OperationMethod<
   BatchGetNamedQueryInput,
   BatchGetNamedQueryOutput,
   BatchGetNamedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetNamedQueryInput,
   output: BatchGetNamedQueryOutput,
@@ -3309,7 +3308,7 @@ export const batchGetPreparedStatement: API.OperationMethod<
   BatchGetPreparedStatementInput,
   BatchGetPreparedStatementOutput,
   BatchGetPreparedStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPreparedStatementInput,
   output: BatchGetPreparedStatementOutput,
@@ -3335,7 +3334,7 @@ export const batchGetQueryExecution: API.OperationMethod<
   BatchGetQueryExecutionInput,
   BatchGetQueryExecutionOutput,
   BatchGetQueryExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetQueryExecutionInput,
   output: BatchGetQueryExecutionOutput,
@@ -3359,7 +3358,7 @@ export const cancelCapacityReservation: API.OperationMethod<
   CancelCapacityReservationInput,
   CancelCapacityReservationOutput,
   CancelCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCapacityReservationInput,
   output: CancelCapacityReservationOutput,
@@ -3381,7 +3380,7 @@ export const createCapacityReservation: API.OperationMethod<
   CreateCapacityReservationInput,
   CreateCapacityReservationOutput,
   CreateCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityReservationInput,
   output: CreateCapacityReservationOutput,
@@ -3418,7 +3417,7 @@ export const createDataCatalog: API.OperationMethod<
   CreateDataCatalogInput,
   CreateDataCatalogOutput,
   CreateDataCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataCatalogInput,
   output: CreateDataCatalogOutput,
@@ -3440,7 +3439,7 @@ export const createNamedQuery: API.OperationMethod<
   CreateNamedQueryInput,
   CreateNamedQueryOutput,
   CreateNamedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNamedQueryInput,
   output: CreateNamedQueryOutput,
@@ -3464,7 +3463,7 @@ export const createNotebook: API.OperationMethod<
   CreateNotebookInput,
   CreateNotebookOutput,
   CreateNotebookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotebookInput,
   output: CreateNotebookOutput,
@@ -3489,7 +3488,7 @@ export const createPreparedStatement: API.OperationMethod<
   CreatePreparedStatementInput,
   CreatePreparedStatementOutput,
   CreatePreparedStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePreparedStatementInput,
   output: CreatePreparedStatementOutput,
@@ -3515,7 +3514,7 @@ export const createPresignedNotebookUrl: API.OperationMethod<
   CreatePresignedNotebookUrlRequest,
   CreatePresignedNotebookUrlResponse,
   CreatePresignedNotebookUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedNotebookUrlRequest,
   output: CreatePresignedNotebookUrlResponse,
@@ -3541,7 +3540,7 @@ export const createWorkGroup: API.OperationMethod<
   CreateWorkGroupInput,
   CreateWorkGroupOutput,
   CreateWorkGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkGroupInput,
   output: CreateWorkGroupOutput,
@@ -3566,7 +3565,7 @@ export const deleteCapacityReservation: API.OperationMethod<
   DeleteCapacityReservationInput,
   DeleteCapacityReservationOutput,
   DeleteCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapacityReservationInput,
   output: DeleteCapacityReservationOutput,
@@ -3588,7 +3587,7 @@ export const deleteDataCatalog: API.OperationMethod<
   DeleteDataCatalogInput,
   DeleteDataCatalogOutput,
   DeleteDataCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataCatalogInput,
   output: DeleteDataCatalogOutput,
@@ -3615,7 +3614,7 @@ export const deleteNamedQuery: API.OperationMethod<
   DeleteNamedQueryInput,
   DeleteNamedQueryOutput,
   DeleteNamedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamedQueryInput,
   output: DeleteNamedQueryOutput,
@@ -3641,7 +3640,7 @@ export const deleteNotebook: API.OperationMethod<
   DeleteNotebookInput,
   DeleteNotebookOutput,
   DeleteNotebookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotebookInput,
   output: DeleteNotebookOutput,
@@ -3669,7 +3668,7 @@ export const deletePreparedStatement: API.OperationMethod<
   DeletePreparedStatementInput,
   DeletePreparedStatementOutput,
   DeletePreparedStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePreparedStatementInput,
   output: DeletePreparedStatementOutput,
@@ -3696,7 +3695,7 @@ export const deleteWorkGroup: API.OperationMethod<
   DeleteWorkGroupInput,
   DeleteWorkGroupOutput,
   DeleteWorkGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkGroupInput,
   output: DeleteWorkGroupOutput,
@@ -3718,7 +3717,7 @@ export const exportNotebook: API.OperationMethod<
   ExportNotebookInput,
   ExportNotebookOutput,
   ExportNotebookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportNotebookInput,
   output: ExportNotebookOutput,
@@ -3744,7 +3743,7 @@ export const getCalculationExecution: API.OperationMethod<
   GetCalculationExecutionRequest,
   GetCalculationExecutionResponse,
   GetCalculationExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalculationExecutionRequest,
   output: GetCalculationExecutionResponse,
@@ -3770,7 +3769,7 @@ export const getCalculationExecutionCode: API.OperationMethod<
   GetCalculationExecutionCodeRequest,
   GetCalculationExecutionCodeResponse,
   GetCalculationExecutionCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalculationExecutionCodeRequest,
   output: GetCalculationExecutionCodeResponse,
@@ -3796,7 +3795,7 @@ export const getCalculationExecutionStatus: API.OperationMethod<
   GetCalculationExecutionStatusRequest,
   GetCalculationExecutionStatusResponse,
   GetCalculationExecutionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalculationExecutionStatusRequest,
   output: GetCalculationExecutionStatusResponse,
@@ -3822,7 +3821,7 @@ export const getCapacityAssignmentConfiguration: API.OperationMethod<
   GetCapacityAssignmentConfigurationInput,
   GetCapacityAssignmentConfigurationOutput,
   GetCapacityAssignmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityAssignmentConfigurationInput,
   output: GetCapacityAssignmentConfigurationOutput,
@@ -3843,7 +3842,7 @@ export const getCapacityReservation: API.OperationMethod<
   GetCapacityReservationInput,
   GetCapacityReservationOutput,
   GetCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityReservationInput,
   output: GetCapacityReservationOutput,
@@ -3865,7 +3864,7 @@ export const getDatabase: API.OperationMethod<
   GetDatabaseInput,
   GetDatabaseOutput,
   GetDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatabaseInput,
   output: GetDatabaseOutput,
@@ -3887,7 +3886,7 @@ export const getDataCatalog: API.OperationMethod<
   GetDataCatalogInput,
   GetDataCatalogOutput,
   GetDataCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataCatalogInput,
   output: GetDataCatalogOutput,
@@ -3914,7 +3913,7 @@ export const getNamedQuery: API.OperationMethod<
   GetNamedQueryInput,
   GetNamedQueryOutput,
   GetNamedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNamedQueryInput,
   output: GetNamedQueryOutput,
@@ -3940,7 +3939,7 @@ export const getNotebookMetadata: API.OperationMethod<
   GetNotebookMetadataInput,
   GetNotebookMetadataOutput,
   GetNotebookMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotebookMetadataInput,
   output: GetNotebookMetadataOutput,
@@ -3968,7 +3967,7 @@ export const getPreparedStatement: API.OperationMethod<
   GetPreparedStatementInput,
   GetPreparedStatementOutput,
   GetPreparedStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPreparedStatementInput,
   output: GetPreparedStatementOutput,
@@ -3996,7 +3995,7 @@ export const getQueryExecution: API.OperationMethod<
   GetQueryExecutionInput,
   GetQueryExecutionOutput,
   GetQueryExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryExecutionInput,
   output: GetQueryExecutionOutput,
@@ -4033,7 +4032,7 @@ export const getQueryResults: API.PaginatedOperationMethod<
   GetQueryResultsInput,
   GetQueryResultsOutput,
   GetQueryResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsInput,
@@ -4070,7 +4069,7 @@ export const getQueryRuntimeStatistics: API.OperationMethod<
   GetQueryRuntimeStatisticsInput,
   GetQueryRuntimeStatisticsOutput,
   GetQueryRuntimeStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryRuntimeStatisticsInput,
   output: GetQueryRuntimeStatisticsOutput,
@@ -4092,7 +4091,7 @@ export const getResourceDashboard: API.OperationMethod<
   GetResourceDashboardRequest,
   GetResourceDashboardResponse,
   GetResourceDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceDashboardRequest,
   output: GetResourceDashboardResponse,
@@ -4119,7 +4118,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -4145,7 +4144,7 @@ export const getSessionEndpoint: API.OperationMethod<
   GetSessionEndpointRequest,
   GetSessionEndpointResponse,
   GetSessionEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionEndpointRequest,
   output: GetSessionEndpointResponse,
@@ -4171,7 +4170,7 @@ export const getSessionStatus: API.OperationMethod<
   GetSessionStatusRequest,
   GetSessionStatusResponse,
   GetSessionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionStatusRequest,
   output: GetSessionStatusResponse,
@@ -4197,7 +4196,7 @@ export const getTableMetadata: API.OperationMethod<
   GetTableMetadataInput,
   GetTableMetadataOutput,
   GetTableMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableMetadataInput,
   output: GetTableMetadataOutput,
@@ -4219,7 +4218,7 @@ export const getWorkGroup: API.OperationMethod<
   GetWorkGroupInput,
   GetWorkGroupOutput,
   GetWorkGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkGroupInput,
   output: GetWorkGroupOutput,
@@ -4246,7 +4245,7 @@ export const importNotebook: API.OperationMethod<
   ImportNotebookInput,
   ImportNotebookOutput,
   ImportNotebookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportNotebookInput,
   output: ImportNotebookOutput,
@@ -4273,7 +4272,7 @@ export const listApplicationDPUSizes: API.PaginatedOperationMethod<
   ListApplicationDPUSizesInput,
   ListApplicationDPUSizesOutput,
   ListApplicationDPUSizesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationDPUSizesInput,
@@ -4306,7 +4305,7 @@ export const listCalculationExecutions: API.PaginatedOperationMethod<
   ListCalculationExecutionsRequest,
   ListCalculationExecutionsResponse,
   ListCalculationExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCalculationExecutionsRequest,
@@ -4337,7 +4336,7 @@ export const listCapacityReservations: API.PaginatedOperationMethod<
   ListCapacityReservationsInput,
   ListCapacityReservationsOutput,
   ListCapacityReservationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCapacityReservationsInput,
@@ -4365,7 +4364,7 @@ export const listDatabases: API.PaginatedOperationMethod<
   ListDatabasesInput,
   ListDatabasesOutput,
   ListDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Database
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatabasesInput,
@@ -4396,7 +4395,7 @@ export const listDataCatalogs: API.PaginatedOperationMethod<
   ListDataCatalogsInput,
   ListDataCatalogsOutput,
   ListDataCatalogsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataCatalogSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataCatalogsInput,
@@ -4425,7 +4424,7 @@ export const listEngineVersions: API.PaginatedOperationMethod<
   ListEngineVersionsInput,
   ListEngineVersionsOutput,
   ListEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngineVersionsInput,
@@ -4455,7 +4454,7 @@ export const listExecutors: API.PaginatedOperationMethod<
   ListExecutorsRequest,
   ListExecutorsResponse,
   ListExecutorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutorsRequest,
@@ -4488,7 +4487,7 @@ export const listNamedQueries: API.PaginatedOperationMethod<
   ListNamedQueriesInput,
   ListNamedQueriesOutput,
   ListNamedQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNamedQueriesInput,
@@ -4516,7 +4515,7 @@ export const listNotebookMetadata: API.OperationMethod<
   ListNotebookMetadataInput,
   ListNotebookMetadataOutput,
   ListNotebookMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListNotebookMetadataInput,
   output: ListNotebookMetadataOutput,
@@ -4545,7 +4544,7 @@ export const listNotebookSessions: API.OperationMethod<
   ListNotebookSessionsRequest,
   ListNotebookSessionsResponse,
   ListNotebookSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListNotebookSessionsRequest,
   output: ListNotebookSessionsResponse,
@@ -4570,7 +4569,7 @@ export const listPreparedStatements: API.PaginatedOperationMethod<
   ListPreparedStatementsInput,
   ListPreparedStatementsOutput,
   ListPreparedStatementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPreparedStatementsInput,
@@ -4600,7 +4599,7 @@ export const listQueryExecutions: API.PaginatedOperationMethod<
   ListQueryExecutionsInput,
   ListQueryExecutionsOutput,
   ListQueryExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueryExecutionsInput,
@@ -4631,7 +4630,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -4663,7 +4662,7 @@ export const listTableMetadata: API.PaginatedOperationMethod<
   ListTableMetadataInput,
   ListTableMetadataOutput,
   ListTableMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTableMetadataInput,
@@ -4692,7 +4691,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -4724,7 +4723,7 @@ export const listWorkGroups: API.PaginatedOperationMethod<
   ListWorkGroupsInput,
   ListWorkGroupsOutput,
   ListWorkGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkGroupsInput,
@@ -4753,7 +4752,7 @@ export const putCapacityAssignmentConfiguration: API.OperationMethod<
   PutCapacityAssignmentConfigurationInput,
   PutCapacityAssignmentConfigurationOutput,
   PutCapacityAssignmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCapacityAssignmentConfigurationInput,
   output: PutCapacityAssignmentConfigurationOutput,
@@ -4781,7 +4780,7 @@ export const startCalculationExecution: API.OperationMethod<
   StartCalculationExecutionRequest,
   StartCalculationExecutionResponse,
   StartCalculationExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCalculationExecutionRequest,
   output: StartCalculationExecutionResponse,
@@ -4812,7 +4811,7 @@ export const startQueryExecution: API.OperationMethod<
   StartQueryExecutionInput,
   StartQueryExecutionOutput,
   StartQueryExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryExecutionInput,
   output: StartQueryExecutionOutput,
@@ -4841,7 +4840,7 @@ export const startSession: API.OperationMethod<
   StartSessionRequest,
   StartSessionResponse,
   StartSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionRequest,
   output: StartSessionResponse,
@@ -4877,7 +4876,7 @@ export const stopCalculationExecution: API.OperationMethod<
   StopCalculationExecutionRequest,
   StopCalculationExecutionResponse,
   StopCalculationExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCalculationExecutionRequest,
   output: StopCalculationExecutionResponse,
@@ -4903,7 +4902,7 @@ export const stopQueryExecution: API.OperationMethod<
   StopQueryExecutionInput,
   StopQueryExecutionOutput,
   StopQueryExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryExecutionInput,
   output: StopQueryExecutionOutput,
@@ -4935,7 +4934,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -4965,7 +4964,7 @@ export const terminateSession: API.OperationMethod<
   TerminateSessionRequest,
   TerminateSessionResponse,
   TerminateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateSessionRequest,
   output: TerminateSessionResponse,
@@ -4991,7 +4990,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -5017,7 +5016,7 @@ export const updateCapacityReservation: API.OperationMethod<
   UpdateCapacityReservationInput,
   UpdateCapacityReservationOutput,
   UpdateCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapacityReservationInput,
   output: UpdateCapacityReservationOutput,
@@ -5039,7 +5038,7 @@ export const updateDataCatalog: API.OperationMethod<
   UpdateDataCatalogInput,
   UpdateDataCatalogOutput,
   UpdateDataCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataCatalogInput,
   output: UpdateDataCatalogOutput,
@@ -5066,7 +5065,7 @@ export const updateNamedQuery: API.OperationMethod<
   UpdateNamedQueryInput,
   UpdateNamedQueryOutput,
   UpdateNamedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNamedQueryInput,
   output: UpdateNamedQueryOutput,
@@ -5092,7 +5091,7 @@ export const updateNotebook: API.OperationMethod<
   UpdateNotebookInput,
   UpdateNotebookOutput,
   UpdateNotebookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotebookInput,
   output: UpdateNotebookOutput,
@@ -5118,7 +5117,7 @@ export const updateNotebookMetadata: API.OperationMethod<
   UpdateNotebookMetadataInput,
   UpdateNotebookMetadataOutput,
   UpdateNotebookMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotebookMetadataInput,
   output: UpdateNotebookMetadataOutput,
@@ -5144,7 +5143,7 @@ export const updatePreparedStatement: API.OperationMethod<
   UpdatePreparedStatementInput,
   UpdatePreparedStatementOutput,
   UpdatePreparedStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePreparedStatementInput,
   output: UpdatePreparedStatementOutput,
@@ -5171,7 +5170,7 @@ export const updateWorkGroup: API.OperationMethod<
   UpdateWorkGroupInput,
   UpdateWorkGroupOutput,
   UpdateWorkGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkGroupInput,
   output: UpdateWorkGroupOutput,

--- a/packages/aws/src/services/auditmanager.ts
+++ b/packages/aws/src/services/auditmanager.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "AuditManager",
@@ -3589,7 +3588,7 @@ export const associateAssessmentReportEvidenceFolder: API.OperationMethod<
   AssociateAssessmentReportEvidenceFolderRequest,
   AssociateAssessmentReportEvidenceFolderResponse,
   AssociateAssessmentReportEvidenceFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAssessmentReportEvidenceFolderRequest,
   output: AssociateAssessmentReportEvidenceFolderResponse,
@@ -3618,7 +3617,7 @@ export const batchAssociateAssessmentReportEvidence: API.OperationMethod<
   BatchAssociateAssessmentReportEvidenceRequest,
   BatchAssociateAssessmentReportEvidenceResponse,
   BatchAssociateAssessmentReportEvidenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateAssessmentReportEvidenceRequest,
   output: BatchAssociateAssessmentReportEvidenceResponse,
@@ -3646,7 +3645,7 @@ export const batchCreateDelegationByAssessment: API.OperationMethod<
   BatchCreateDelegationByAssessmentRequest,
   BatchCreateDelegationByAssessmentResponse,
   BatchCreateDelegationByAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateDelegationByAssessmentRequest,
   output: BatchCreateDelegationByAssessmentResponse,
@@ -3674,7 +3673,7 @@ export const batchDeleteDelegationByAssessment: API.OperationMethod<
   BatchDeleteDelegationByAssessmentRequest,
   BatchDeleteDelegationByAssessmentResponse,
   BatchDeleteDelegationByAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDelegationByAssessmentRequest,
   output: BatchDeleteDelegationByAssessmentResponse,
@@ -3702,7 +3701,7 @@ export const batchDisassociateAssessmentReportEvidence: API.OperationMethod<
   BatchDisassociateAssessmentReportEvidenceRequest,
   BatchDisassociateAssessmentReportEvidenceResponse,
   BatchDisassociateAssessmentReportEvidenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateAssessmentReportEvidenceRequest,
   output: BatchDisassociateAssessmentReportEvidenceResponse,
@@ -3750,7 +3749,7 @@ export const batchImportEvidenceToAssessmentControl: API.OperationMethod<
   BatchImportEvidenceToAssessmentControlRequest,
   BatchImportEvidenceToAssessmentControlResponse,
   BatchImportEvidenceToAssessmentControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchImportEvidenceToAssessmentControlRequest,
   output: BatchImportEvidenceToAssessmentControlResponse,
@@ -3781,7 +3780,7 @@ export const createAssessment: API.OperationMethod<
   CreateAssessmentRequest,
   CreateAssessmentResponse,
   CreateAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssessmentRequest,
   output: CreateAssessmentResponse,
@@ -3812,7 +3811,7 @@ export const createAssessmentFramework: API.OperationMethod<
   CreateAssessmentFrameworkRequest,
   CreateAssessmentFrameworkResponse,
   CreateAssessmentFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssessmentFrameworkRequest,
   output: CreateAssessmentFrameworkResponse,
@@ -3841,7 +3840,7 @@ export const createAssessmentReport: API.OperationMethod<
   CreateAssessmentReportRequest,
   CreateAssessmentReportResponse,
   CreateAssessmentReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssessmentReportRequest,
   output: CreateAssessmentReportResponse,
@@ -3870,7 +3869,7 @@ export const createControl: API.OperationMethod<
   CreateControlRequest,
   CreateControlResponse,
   CreateControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateControlRequest,
   output: CreateControlResponse,
@@ -3899,7 +3898,7 @@ export const deleteAssessment: API.OperationMethod<
   DeleteAssessmentRequest,
   DeleteAssessmentResponse,
   DeleteAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentRequest,
   output: DeleteAssessmentResponse,
@@ -3927,7 +3926,7 @@ export const deleteAssessmentFramework: API.OperationMethod<
   DeleteAssessmentFrameworkRequest,
   DeleteAssessmentFrameworkResponse,
   DeleteAssessmentFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentFrameworkRequest,
   output: DeleteAssessmentFrameworkResponse,
@@ -3955,7 +3954,7 @@ export const deleteAssessmentFrameworkShare: API.OperationMethod<
   DeleteAssessmentFrameworkShareRequest,
   DeleteAssessmentFrameworkShareResponse,
   DeleteAssessmentFrameworkShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentFrameworkShareRequest,
   output: DeleteAssessmentFrameworkShareResponse,
@@ -4003,7 +4002,7 @@ export const deleteAssessmentReport: API.OperationMethod<
   DeleteAssessmentReportRequest,
   DeleteAssessmentReportResponse,
   DeleteAssessmentReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentReportRequest,
   output: DeleteAssessmentReportResponse,
@@ -4036,7 +4035,7 @@ export const deleteControl: API.OperationMethod<
   DeleteControlRequest,
   DeleteControlResponse,
   DeleteControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteControlRequest,
   output: DeleteControlResponse,
@@ -4072,7 +4071,7 @@ export const deregisterAccount: API.OperationMethod<
   DeregisterAccountRequest,
   DeregisterAccountResponse,
   DeregisterAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterAccountRequest,
   output: DeregisterAccountResponse,
@@ -4152,7 +4151,7 @@ export const deregisterOrganizationAdminAccount: API.OperationMethod<
   DeregisterOrganizationAdminAccountRequest,
   DeregisterOrganizationAdminAccountResponse,
   DeregisterOrganizationAdminAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterOrganizationAdminAccountRequest,
   output: DeregisterOrganizationAdminAccountResponse,
@@ -4180,7 +4179,7 @@ export const disassociateAssessmentReportEvidenceFolder: API.OperationMethod<
   DisassociateAssessmentReportEvidenceFolderRequest,
   DisassociateAssessmentReportEvidenceFolderResponse,
   DisassociateAssessmentReportEvidenceFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAssessmentReportEvidenceFolderRequest,
   output: DisassociateAssessmentReportEvidenceFolderResponse,
@@ -4203,7 +4202,7 @@ export const getAccountStatus: API.OperationMethod<
   GetAccountStatusRequest,
   GetAccountStatusResponse,
   GetAccountStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountStatusRequest,
   output: GetAccountStatusResponse,
@@ -4226,7 +4225,7 @@ export const getAssessment: API.OperationMethod<
   GetAssessmentRequest,
   GetAssessmentResponse,
   GetAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssessmentRequest,
   output: GetAssessmentResponse,
@@ -4254,7 +4253,7 @@ export const getAssessmentFramework: API.OperationMethod<
   GetAssessmentFrameworkRequest,
   GetAssessmentFrameworkResponse,
   GetAssessmentFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssessmentFrameworkRequest,
   output: GetAssessmentFrameworkResponse,
@@ -4282,7 +4281,7 @@ export const getAssessmentReportUrl: API.OperationMethod<
   GetAssessmentReportUrlRequest,
   GetAssessmentReportUrlResponse,
   GetAssessmentReportUrlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssessmentReportUrlRequest,
   output: GetAssessmentReportUrlResponse,
@@ -4310,7 +4309,7 @@ export const getChangeLogs: API.PaginatedOperationMethod<
   GetChangeLogsRequest,
   GetChangeLogsResponse,
   GetChangeLogsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetChangeLogsRequest,
@@ -4344,7 +4343,7 @@ export const getControl: API.OperationMethod<
   GetControlRequest,
   GetControlResponse,
   GetControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetControlRequest,
   output: GetControlResponse,
@@ -4371,7 +4370,7 @@ export const getDelegations: API.PaginatedOperationMethod<
   GetDelegationsRequest,
   GetDelegationsResponse,
   GetDelegationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDelegationsRequest,
@@ -4400,7 +4399,7 @@ export const getEvidence: API.OperationMethod<
   GetEvidenceRequest,
   GetEvidenceResponse,
   GetEvidenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvidenceRequest,
   output: GetEvidenceResponse,
@@ -4428,7 +4427,7 @@ export const getEvidenceByEvidenceFolder: API.PaginatedOperationMethod<
   GetEvidenceByEvidenceFolderRequest,
   GetEvidenceByEvidenceFolderResponse,
   GetEvidenceByEvidenceFolderError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEvidenceByEvidenceFolderRequest,
@@ -4475,7 +4474,7 @@ export const getEvidenceFileUploadUrl: API.OperationMethod<
   GetEvidenceFileUploadUrlRequest,
   GetEvidenceFileUploadUrlResponse,
   GetEvidenceFileUploadUrlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvidenceFileUploadUrlRequest,
   output: GetEvidenceFileUploadUrlResponse,
@@ -4503,7 +4502,7 @@ export const getEvidenceFolder: API.OperationMethod<
   GetEvidenceFolderRequest,
   GetEvidenceFolderResponse,
   GetEvidenceFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvidenceFolderRequest,
   output: GetEvidenceFolderResponse,
@@ -4531,7 +4530,7 @@ export const getEvidenceFoldersByAssessment: API.PaginatedOperationMethod<
   GetEvidenceFoldersByAssessmentRequest,
   GetEvidenceFoldersByAssessmentResponse,
   GetEvidenceFoldersByAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEvidenceFoldersByAssessmentRequest,
@@ -4566,7 +4565,7 @@ export const getEvidenceFoldersByAssessmentControl: API.PaginatedOperationMethod
   GetEvidenceFoldersByAssessmentControlRequest,
   GetEvidenceFoldersByAssessmentControlResponse,
   GetEvidenceFoldersByAssessmentControlError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEvidenceFoldersByAssessmentControlRequest,
@@ -4598,7 +4597,7 @@ export const getInsights: API.OperationMethod<
   GetInsightsRequest,
   GetInsightsResponse,
   GetInsightsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightsRequest,
   output: GetInsightsResponse,
@@ -4621,7 +4620,7 @@ export const getInsightsByAssessment: API.OperationMethod<
   GetInsightsByAssessmentRequest,
   GetInsightsByAssessmentResponse,
   GetInsightsByAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightsByAssessmentRequest,
   output: GetInsightsByAssessmentResponse,
@@ -4650,7 +4649,7 @@ export const getOrganizationAdminAccount: API.OperationMethod<
   GetOrganizationAdminAccountRequest,
   GetOrganizationAdminAccountResponse,
   GetOrganizationAdminAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrganizationAdminAccountRequest,
   output: GetOrganizationAdminAccountResponse,
@@ -4688,7 +4687,7 @@ export const getServicesInScope: API.OperationMethod<
   GetServicesInScopeRequest,
   GetServicesInScopeResponse,
   GetServicesInScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServicesInScopeRequest,
   output: GetServicesInScopeResponse,
@@ -4709,7 +4708,7 @@ export const getSettings: API.OperationMethod<
   GetSettingsRequest,
   GetSettingsResponse,
   GetSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSettingsRequest,
   output: GetSettingsResponse,
@@ -4738,7 +4737,7 @@ export const listAssessmentControlInsightsByControlDomain: API.PaginatedOperatio
   ListAssessmentControlInsightsByControlDomainRequest,
   ListAssessmentControlInsightsByControlDomainResponse,
   ListAssessmentControlInsightsByControlDomainError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentControlInsightsByControlDomainRequest,
@@ -4772,7 +4771,7 @@ export const listAssessmentFrameworks: API.PaginatedOperationMethod<
   ListAssessmentFrameworksRequest,
   ListAssessmentFrameworksResponse,
   ListAssessmentFrameworksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentFrameworksRequest,
@@ -4800,7 +4799,7 @@ export const listAssessmentFrameworkShareRequests: API.PaginatedOperationMethod<
   ListAssessmentFrameworkShareRequestsRequest,
   ListAssessmentFrameworkShareRequestsResponse,
   ListAssessmentFrameworkShareRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentFrameworkShareRequestsRequest,
@@ -4828,7 +4827,7 @@ export const listAssessmentReports: API.PaginatedOperationMethod<
   ListAssessmentReportsRequest,
   ListAssessmentReportsResponse,
   ListAssessmentReportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentReportsRequest,
@@ -4856,7 +4855,7 @@ export const listAssessments: API.PaginatedOperationMethod<
   ListAssessmentsRequest,
   ListAssessmentsResponse,
   ListAssessmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentsRequest,
@@ -4898,7 +4897,7 @@ export const listControlDomainInsights: API.PaginatedOperationMethod<
   ListControlDomainInsightsRequest,
   ListControlDomainInsightsResponse,
   ListControlDomainInsightsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlDomainInsightsRequest,
@@ -4944,7 +4943,7 @@ export const listControlDomainInsightsByAssessment: API.PaginatedOperationMethod
   ListControlDomainInsightsByAssessmentRequest,
   ListControlDomainInsightsByAssessmentResponse,
   ListControlDomainInsightsByAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlDomainInsightsByAssessmentRequest,
@@ -4984,7 +4983,7 @@ export const listControlInsightsByControlDomain: API.PaginatedOperationMethod<
   ListControlInsightsByControlDomainRequest,
   ListControlInsightsByControlDomainResponse,
   ListControlInsightsByControlDomainError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlInsightsByControlDomainRequest,
@@ -5017,7 +5016,7 @@ export const listControls: API.PaginatedOperationMethod<
   ListControlsRequest,
   ListControlsResponse,
   ListControlsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlsRequest,
@@ -5046,7 +5045,7 @@ export const listKeywordsForDataSource: API.PaginatedOperationMethod<
   ListKeywordsForDataSourceRequest,
   ListKeywordsForDataSourceResponse,
   ListKeywordsForDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeywordsForDataSourceRequest,
@@ -5074,7 +5073,7 @@ export const listNotifications: API.PaginatedOperationMethod<
   ListNotificationsRequest,
   ListNotificationsResponse,
   ListNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationsRequest,
@@ -5102,7 +5101,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5131,7 +5130,7 @@ export const registerAccount: API.OperationMethod<
   RegisterAccountRequest,
   RegisterAccountResponse,
   RegisterAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAccountRequest,
   output: RegisterAccountResponse,
@@ -5163,7 +5162,7 @@ export const registerOrganizationAdminAccount: API.OperationMethod<
   RegisterOrganizationAdminAccountRequest,
   RegisterOrganizationAdminAccountResponse,
   RegisterOrganizationAdminAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOrganizationAdminAccountRequest,
   output: RegisterOrganizationAdminAccountResponse,
@@ -5226,7 +5225,7 @@ export const startAssessmentFrameworkShare: API.OperationMethod<
   StartAssessmentFrameworkShareRequest,
   StartAssessmentFrameworkShareResponse,
   StartAssessmentFrameworkShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssessmentFrameworkShareRequest,
   output: StartAssessmentFrameworkShareResponse,
@@ -5253,7 +5252,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5279,7 +5278,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5308,7 +5307,7 @@ export const updateAssessment: API.OperationMethod<
   UpdateAssessmentRequest,
   UpdateAssessmentResponse,
   UpdateAssessmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentRequest,
   output: UpdateAssessmentResponse,
@@ -5338,7 +5337,7 @@ export const updateAssessmentControl: API.OperationMethod<
   UpdateAssessmentControlRequest,
   UpdateAssessmentControlResponse,
   UpdateAssessmentControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentControlRequest,
   output: UpdateAssessmentControlResponse,
@@ -5366,7 +5365,7 @@ export const updateAssessmentControlSetStatus: API.OperationMethod<
   UpdateAssessmentControlSetStatusRequest,
   UpdateAssessmentControlSetStatusResponse,
   UpdateAssessmentControlSetStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentControlSetStatusRequest,
   output: UpdateAssessmentControlSetStatusResponse,
@@ -5395,7 +5394,7 @@ export const updateAssessmentFramework: API.OperationMethod<
   UpdateAssessmentFrameworkRequest,
   UpdateAssessmentFrameworkResponse,
   UpdateAssessmentFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentFrameworkRequest,
   output: UpdateAssessmentFrameworkResponse,
@@ -5425,7 +5424,7 @@ export const updateAssessmentFrameworkShare: API.OperationMethod<
   UpdateAssessmentFrameworkShareRequest,
   UpdateAssessmentFrameworkShareResponse,
   UpdateAssessmentFrameworkShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentFrameworkShareRequest,
   output: UpdateAssessmentFrameworkShareResponse,
@@ -5455,7 +5454,7 @@ export const updateAssessmentStatus: API.OperationMethod<
   UpdateAssessmentStatusRequest,
   UpdateAssessmentStatusResponse,
   UpdateAssessmentStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentStatusRequest,
   output: UpdateAssessmentStatusResponse,
@@ -5484,7 +5483,7 @@ export const updateControl: API.OperationMethod<
   UpdateControlRequest,
   UpdateControlResponse,
   UpdateControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateControlRequest,
   output: UpdateControlResponse,
@@ -5511,7 +5510,7 @@ export const updateSettings: API.OperationMethod<
   UpdateSettingsRequest,
   UpdateSettingsResponse,
   UpdateSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSettingsRequest,
   output: UpdateSettingsResponse,
@@ -5534,7 +5533,7 @@ export const validateAssessmentReportIntegrity: API.OperationMethod<
   ValidateAssessmentReportIntegrityRequest,
   ValidateAssessmentReportIntegrityResponse,
   ValidateAssessmentReportIntegrityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateAssessmentReportIntegrityRequest,
   output: ValidateAssessmentReportIntegrityResponse,

--- a/packages/aws/src/services/auto-scaling-plans.ts
+++ b/packages/aws/src/services/auto-scaling-plans.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Auto Scaling Plans",
   serviceShapeName: "AnyScaleScalingPlannerFrontendService",
@@ -712,7 +711,7 @@ export const createScalingPlan: API.OperationMethod<
   CreateScalingPlanRequest,
   CreateScalingPlanResponse,
   CreateScalingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScalingPlanRequest,
   output: CreateScalingPlanResponse,
@@ -746,7 +745,7 @@ export const deleteScalingPlan: API.OperationMethod<
   DeleteScalingPlanRequest,
   DeleteScalingPlanResponse,
   DeleteScalingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScalingPlanRequest,
   output: DeleteScalingPlanResponse,
@@ -774,7 +773,7 @@ export const describeScalingPlanResources: API.OperationMethod<
   DescribeScalingPlanResourcesRequest,
   DescribeScalingPlanResourcesResponse,
   DescribeScalingPlanResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScalingPlanResourcesRequest,
   output: DescribeScalingPlanResourcesResponse,
@@ -802,7 +801,7 @@ export const describeScalingPlans: API.OperationMethod<
   DescribeScalingPlansRequest,
   DescribeScalingPlansResponse,
   DescribeScalingPlansError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScalingPlansRequest,
   output: DescribeScalingPlansResponse,
@@ -832,7 +831,7 @@ export const getScalingPlanResourceForecastData: API.OperationMethod<
   GetScalingPlanResourceForecastDataRequest,
   GetScalingPlanResourceForecastDataResponse,
   GetScalingPlanResourceForecastDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScalingPlanResourceForecastDataRequest,
   output: GetScalingPlanResourceForecastDataResponse,
@@ -858,7 +857,7 @@ export const updateScalingPlan: API.OperationMethod<
   UpdateScalingPlanRequest,
   UpdateScalingPlanResponse,
   UpdateScalingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScalingPlanRequest,
   output: UpdateScalingPlanResponse,

--- a/packages/aws/src/services/auto-scaling.ts
+++ b/packages/aws/src/services/auto-scaling.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://autoscaling.amazonaws.com/doc/2011-01-01/");
 const svc = T.AwsApiService({
   sdkId: "Auto Scaling",
@@ -4719,7 +4718,7 @@ export const attachInstances: API.OperationMethod<
   AttachInstancesQuery,
   AttachInstancesResponse,
   AttachInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachInstancesQuery,
   output: AttachInstancesResponse,
@@ -4760,7 +4759,7 @@ export const attachLoadBalancers: API.OperationMethod<
   AttachLoadBalancersType,
   AttachLoadBalancersResultType,
   AttachLoadBalancersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachLoadBalancersType,
   output: AttachLoadBalancersResultType,
@@ -4814,7 +4813,7 @@ export const attachLoadBalancerTargetGroups: API.OperationMethod<
   AttachLoadBalancerTargetGroupsType,
   AttachLoadBalancerTargetGroupsResultType,
   AttachLoadBalancerTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachLoadBalancerTargetGroupsType,
   output: AttachLoadBalancerTargetGroupsResultType,
@@ -4860,7 +4859,7 @@ export const attachTrafficSources: API.OperationMethod<
   AttachTrafficSourcesType,
   AttachTrafficSourcesResultType,
   AttachTrafficSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachTrafficSourcesType,
   output: AttachTrafficSourcesResultType,
@@ -4884,7 +4883,7 @@ export const batchDeleteScheduledAction: API.OperationMethod<
   BatchDeleteScheduledActionType,
   BatchDeleteScheduledActionAnswer,
   BatchDeleteScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteScheduledActionType,
   output: BatchDeleteScheduledActionAnswer,
@@ -4906,7 +4905,7 @@ export const batchPutScheduledUpdateGroupAction: API.OperationMethod<
   BatchPutScheduledUpdateGroupActionType,
   BatchPutScheduledUpdateGroupActionAnswer,
   BatchPutScheduledUpdateGroupActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutScheduledUpdateGroupActionType,
   output: BatchPutScheduledUpdateGroupActionAnswer,
@@ -4937,7 +4936,7 @@ export const cancelInstanceRefresh: API.OperationMethod<
   CancelInstanceRefreshType,
   CancelInstanceRefreshAnswer,
   CancelInstanceRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelInstanceRefreshType,
   output: CancelInstanceRefreshAnswer,
@@ -4990,7 +4989,7 @@ export const completeLifecycleAction: API.OperationMethod<
   CompleteLifecycleActionType,
   CompleteLifecycleActionAnswer,
   CompleteLifecycleActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteLifecycleActionType,
   output: CompleteLifecycleActionAnswer,
@@ -5029,7 +5028,7 @@ export const createAutoScalingGroup: API.OperationMethod<
   CreateAutoScalingGroupType,
   CreateAutoScalingGroupResponse,
   CreateAutoScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutoScalingGroupType,
   output: CreateAutoScalingGroupResponse,
@@ -5069,7 +5068,7 @@ export const createLaunchConfiguration: API.OperationMethod<
   CreateLaunchConfigurationType,
   CreateLaunchConfigurationResponse,
   CreateLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLaunchConfigurationType,
   output: CreateLaunchConfigurationResponse,
@@ -5098,7 +5097,7 @@ export const createOrUpdateTags: API.OperationMethod<
   CreateOrUpdateTagsType,
   CreateOrUpdateTagsResponse,
   CreateOrUpdateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOrUpdateTagsType,
   output: CreateOrUpdateTagsResponse,
@@ -5146,7 +5145,7 @@ export const deleteAutoScalingGroup: API.OperationMethod<
   DeleteAutoScalingGroupType,
   DeleteAutoScalingGroupResponse,
   DeleteAutoScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutoScalingGroupType,
   output: DeleteAutoScalingGroupResponse,
@@ -5174,7 +5173,7 @@ export const deleteLaunchConfiguration: API.OperationMethod<
   LaunchConfigurationNameType,
   DeleteLaunchConfigurationResponse,
   DeleteLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LaunchConfigurationNameType,
   output: DeleteLaunchConfigurationResponse,
@@ -5199,7 +5198,7 @@ export const deleteLifecycleHook: API.OperationMethod<
   DeleteLifecycleHookType,
   DeleteLifecycleHookAnswer,
   DeleteLifecycleHookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecycleHookType,
   output: DeleteLifecycleHookAnswer,
@@ -5219,7 +5218,7 @@ export const deleteNotificationConfiguration: API.OperationMethod<
   DeleteNotificationConfigurationType,
   DeleteNotificationConfigurationResponse,
   DeleteNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationConfigurationType,
   output: DeleteNotificationConfigurationResponse,
@@ -5247,7 +5246,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyType,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyType,
   output: DeletePolicyResponse,
@@ -5268,7 +5267,7 @@ export const deleteScheduledAction: API.OperationMethod<
   DeleteScheduledActionType,
   DeleteScheduledActionResponse,
   DeleteScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledActionType,
   output: DeleteScheduledActionResponse,
@@ -5289,7 +5288,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsType,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsType,
   output: DeleteTagsResponse,
@@ -5315,7 +5314,7 @@ export const deleteWarmPool: API.OperationMethod<
   DeleteWarmPoolType,
   DeleteWarmPoolAnswer,
   DeleteWarmPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWarmPoolType,
   output: DeleteWarmPoolAnswer,
@@ -5343,7 +5342,7 @@ export const describeAccountLimits: API.OperationMethod<
   DescribeAccountLimitsRequest,
   DescribeAccountLimitsAnswer,
   DescribeAccountLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountLimitsRequest,
   output: DescribeAccountLimitsAnswer,
@@ -5372,7 +5371,7 @@ export const describeAdjustmentTypes: API.OperationMethod<
   DescribeAdjustmentTypesRequest,
   DescribeAdjustmentTypesAnswer,
   DescribeAdjustmentTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAdjustmentTypesRequest,
   output: DescribeAdjustmentTypesAnswer,
@@ -5402,7 +5401,7 @@ export const describeAutoScalingGroups: API.PaginatedOperationMethod<
   AutoScalingGroupNamesType,
   AutoScalingGroupsType,
   DescribeAutoScalingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutoScalingGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: AutoScalingGroupNamesType,
@@ -5430,7 +5429,7 @@ export const describeAutoScalingInstances: API.PaginatedOperationMethod<
   DescribeAutoScalingInstancesType,
   AutoScalingInstancesType,
   DescribeAutoScalingInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutoScalingInstanceDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAutoScalingInstancesType,
@@ -5457,7 +5456,7 @@ export const describeAutoScalingNotificationTypes: API.OperationMethod<
   DescribeAutoScalingNotificationTypesRequest,
   DescribeAutoScalingNotificationTypesAnswer,
   DescribeAutoScalingNotificationTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutoScalingNotificationTypesRequest,
   output: DescribeAutoScalingNotificationTypesAnswer,
@@ -5490,7 +5489,7 @@ export const describeInstanceRefreshes: API.PaginatedOperationMethod<
   DescribeInstanceRefreshesType,
   DescribeInstanceRefreshesAnswer,
   DescribeInstanceRefreshesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceRefreshesType,
@@ -5517,7 +5516,7 @@ export const describeLaunchConfigurations: API.PaginatedOperationMethod<
   LaunchConfigurationNamesType,
   LaunchConfigurationsType,
   DescribeLaunchConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: LaunchConfigurationNamesType,
@@ -5545,7 +5544,7 @@ export const describeLifecycleHooks: API.OperationMethod<
   DescribeLifecycleHooksType,
   DescribeLifecycleHooksAnswer,
   DescribeLifecycleHooksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLifecycleHooksType,
   output: DescribeLifecycleHooksAnswer,
@@ -5571,7 +5570,7 @@ export const describeLifecycleHookTypes: API.OperationMethod<
   DescribeLifecycleHookTypesRequest,
   DescribeLifecycleHookTypesAnswer,
   DescribeLifecycleHookTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLifecycleHookTypesRequest,
   output: DescribeLifecycleHookTypesAnswer,
@@ -5625,7 +5624,7 @@ export const describeLoadBalancers: API.PaginatedOperationMethod<
   DescribeLoadBalancersRequest,
   DescribeLoadBalancersResponse,
   DescribeLoadBalancersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLoadBalancersRequest,
@@ -5685,7 +5684,7 @@ export const describeLoadBalancerTargetGroups: API.PaginatedOperationMethod<
   DescribeLoadBalancerTargetGroupsRequest,
   DescribeLoadBalancerTargetGroupsResponse,
   DescribeLoadBalancerTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLoadBalancerTargetGroupsRequest,
@@ -5711,7 +5710,7 @@ export const describeMetricCollectionTypes: API.OperationMethod<
   DescribeMetricCollectionTypesRequest,
   DescribeMetricCollectionTypesAnswer,
   DescribeMetricCollectionTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMetricCollectionTypesRequest,
   output: DescribeMetricCollectionTypesAnswer,
@@ -5733,7 +5732,7 @@ export const describeNotificationConfigurations: API.PaginatedOperationMethod<
   DescribeNotificationConfigurationsType,
   DescribeNotificationConfigurationsAnswer,
   DescribeNotificationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNotificationConfigurationsType,
@@ -5762,7 +5761,7 @@ export const describePolicies: API.PaginatedOperationMethod<
   DescribePoliciesType,
   PoliciesType,
   DescribePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScalingPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePoliciesType,
@@ -5800,7 +5799,7 @@ export const describeScalingActivities: API.PaginatedOperationMethod<
   DescribeScalingActivitiesType,
   ActivitiesType,
   DescribeScalingActivitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Activity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScalingActivitiesType,
@@ -5828,7 +5827,7 @@ export const describeScalingProcessTypes: API.OperationMethod<
   DescribeScalingProcessTypesRequest,
   ProcessesType,
   DescribeScalingProcessTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScalingProcessTypesRequest,
   output: ProcessesType,
@@ -5854,7 +5853,7 @@ export const describeScheduledActions: API.PaginatedOperationMethod<
   DescribeScheduledActionsType,
   ScheduledActionsType,
   DescribeScheduledActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledUpdateGroupAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduledActionsType,
@@ -5893,7 +5892,7 @@ export const describeTags: API.PaginatedOperationMethod<
   DescribeTagsType,
   TagsType,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTagsType,
@@ -5924,7 +5923,7 @@ export const describeTerminationPolicyTypes: API.OperationMethod<
   DescribeTerminationPolicyTypesRequest,
   DescribeTerminationPolicyTypesAnswer,
   DescribeTerminationPolicyTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTerminationPolicyTypesRequest,
   output: DescribeTerminationPolicyTypesAnswer,
@@ -5951,7 +5950,7 @@ export const describeTrafficSources: API.PaginatedOperationMethod<
   DescribeTrafficSourcesRequest,
   DescribeTrafficSourcesResponse,
   DescribeTrafficSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrafficSourcesRequest,
@@ -5982,7 +5981,7 @@ export const describeWarmPool: API.PaginatedOperationMethod<
   DescribeWarmPoolType,
   DescribeWarmPoolAnswer,
   DescribeWarmPoolError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Instance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeWarmPoolType,
@@ -6020,7 +6019,7 @@ export const detachInstances: API.OperationMethod<
   DetachInstancesQuery,
   DetachInstancesAnswer,
   DetachInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachInstancesQuery,
   output: DetachInstancesAnswer,
@@ -6053,7 +6052,7 @@ export const detachLoadBalancers: API.OperationMethod<
   DetachLoadBalancersType,
   DetachLoadBalancersResultType,
   DetachLoadBalancersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachLoadBalancersType,
   output: DetachLoadBalancersResultType,
@@ -6090,7 +6089,7 @@ export const detachLoadBalancerTargetGroups: API.OperationMethod<
   DetachLoadBalancerTargetGroupsType,
   DetachLoadBalancerTargetGroupsResultType,
   DetachLoadBalancerTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachLoadBalancerTargetGroupsType,
   output: DetachLoadBalancerTargetGroupsResultType,
@@ -6114,7 +6113,7 @@ export const detachTrafficSources: API.OperationMethod<
   DetachTrafficSourcesType,
   DetachTrafficSourcesResultType,
   DetachTrafficSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachTrafficSourcesType,
   output: DetachTrafficSourcesResultType,
@@ -6134,7 +6133,7 @@ export const disableMetricsCollection: API.OperationMethod<
   DisableMetricsCollectionQuery,
   DisableMetricsCollectionResponse,
   DisableMetricsCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableMetricsCollectionQuery,
   output: DisableMetricsCollectionResponse,
@@ -6160,7 +6159,7 @@ export const enableMetricsCollection: API.OperationMethod<
   EnableMetricsCollectionQuery,
   EnableMetricsCollectionResponse,
   EnableMetricsCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableMetricsCollectionQuery,
   output: EnableMetricsCollectionResponse,
@@ -6190,7 +6189,7 @@ export const enterStandby: API.OperationMethod<
   EnterStandbyQuery,
   EnterStandbyAnswer,
   EnterStandbyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnterStandbyQuery,
   output: EnterStandbyAnswer,
@@ -6212,7 +6211,7 @@ export const executePolicy: API.OperationMethod<
   ExecutePolicyType,
   ExecutePolicyResponse,
   ExecutePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecutePolicyType,
   output: ExecutePolicyResponse,
@@ -6237,7 +6236,7 @@ export const exitStandby: API.OperationMethod<
   ExitStandbyQuery,
   ExitStandbyAnswer,
   ExitStandbyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExitStandbyQuery,
   output: ExitStandbyAnswer,
@@ -6268,7 +6267,7 @@ export const getPredictiveScalingForecast: API.OperationMethod<
   GetPredictiveScalingForecastType,
   GetPredictiveScalingForecastAnswer,
   GetPredictiveScalingForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPredictiveScalingForecastType,
   output: GetPredictiveScalingForecastAnswer,
@@ -6290,7 +6289,7 @@ export const launchInstances: API.OperationMethod<
   LaunchInstancesRequest,
   LaunchInstancesResult,
   LaunchInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LaunchInstancesRequest,
   output: LaunchInstancesResult,
@@ -6350,7 +6349,7 @@ export const putLifecycleHook: API.OperationMethod<
   PutLifecycleHookType,
   PutLifecycleHookAnswer,
   PutLifecycleHookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLifecycleHookType,
   output: PutLifecycleHookAnswer,
@@ -6387,7 +6386,7 @@ export const putNotificationConfiguration: API.OperationMethod<
   PutNotificationConfigurationType,
   PutNotificationConfigurationResponse,
   PutNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutNotificationConfigurationType,
   output: PutNotificationConfigurationResponse,
@@ -6426,7 +6425,7 @@ export const putScalingPolicy: API.OperationMethod<
   PutScalingPolicyType,
   PolicyARNType,
   PutScalingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutScalingPolicyType,
   output: PolicyARNType,
@@ -6464,7 +6463,7 @@ export const putScheduledUpdateGroupAction: API.OperationMethod<
   PutScheduledUpdateGroupActionType,
   PutScheduledUpdateGroupActionResponse,
   PutScheduledUpdateGroupActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutScheduledUpdateGroupActionType,
   output: PutScheduledUpdateGroupActionResponse,
@@ -6503,7 +6502,7 @@ export const putWarmPool: API.OperationMethod<
   PutWarmPoolType,
   PutWarmPoolAnswer,
   PutWarmPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutWarmPoolType,
   output: PutWarmPoolAnswer,
@@ -6556,7 +6555,7 @@ export const recordLifecycleActionHeartbeat: API.OperationMethod<
   RecordLifecycleActionHeartbeatType,
   RecordLifecycleActionHeartbeatAnswer,
   RecordLifecycleActionHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecordLifecycleActionHeartbeatType,
   output: RecordLifecycleActionHeartbeatAnswer,
@@ -6581,7 +6580,7 @@ export const resumeProcesses: API.OperationMethod<
   ScalingProcessQuery,
   ResumeProcessesResponse,
   ResumeProcessesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalingProcessQuery,
   output: ResumeProcessesResponse,
@@ -6625,7 +6624,7 @@ export const rollbackInstanceRefresh: API.OperationMethod<
   RollbackInstanceRefreshType,
   RollbackInstanceRefreshAnswer,
   RollbackInstanceRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackInstanceRefreshType,
   output: RollbackInstanceRefreshAnswer,
@@ -6658,7 +6657,7 @@ export const setDesiredCapacity: API.OperationMethod<
   SetDesiredCapacityType,
   SetDesiredCapacityResponse,
   SetDesiredCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDesiredCapacityType,
   output: SetDesiredCapacityResponse,
@@ -6680,7 +6679,7 @@ export const setInstanceHealth: API.OperationMethod<
   SetInstanceHealthQuery,
   SetInstanceHealthResponse,
   SetInstanceHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetInstanceHealthQuery,
   output: SetInstanceHealthResponse,
@@ -6709,7 +6708,7 @@ export const setInstanceProtection: API.OperationMethod<
   SetInstanceProtectionQuery,
   SetInstanceProtectionAnswer,
   SetInstanceProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetInstanceProtectionQuery,
   output: SetInstanceProtectionAnswer,
@@ -6757,7 +6756,7 @@ export const startInstanceRefresh: API.OperationMethod<
   StartInstanceRefreshType,
   StartInstanceRefreshAnswer,
   StartInstanceRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInstanceRefreshType,
   output: StartInstanceRefreshAnswer,
@@ -6790,7 +6789,7 @@ export const suspendProcesses: API.OperationMethod<
   ScalingProcessQuery,
   SuspendProcessesResponse,
   SuspendProcessesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalingProcessQuery,
   output: SuspendProcessesResponse,
@@ -6826,7 +6825,7 @@ export const terminateInstanceInAutoScalingGroup: API.OperationMethod<
   TerminateInstanceInAutoScalingGroupType,
   ActivityType,
   TerminateInstanceInAutoScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateInstanceInAutoScalingGroupType,
   output: ActivityType,
@@ -6888,7 +6887,7 @@ export const updateAutoScalingGroup: API.OperationMethod<
   UpdateAutoScalingGroupType,
   UpdateAutoScalingGroupResponse,
   UpdateAutoScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutoScalingGroupType,
   output: UpdateAutoScalingGroupResponse,

--- a/packages/aws/src/services/b2bi.ts
+++ b/packages/aws/src/services/b2bi.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "b2bi", serviceShapeName: "B2BI" });
 const auth = T.AwsAuthSigv4({ name: "b2bi" });
@@ -2352,7 +2351,7 @@ export const createCapability: API.OperationMethod<
   CreateCapabilityRequest,
   CreateCapabilityResponse,
   CreateCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapabilityRequest,
   output: CreateCapabilityResponse,
@@ -2386,7 +2385,7 @@ export const createPartnership: API.OperationMethod<
   CreatePartnershipRequest,
   CreatePartnershipResponse,
   CreatePartnershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnershipRequest,
   output: CreatePartnershipResponse,
@@ -2420,7 +2419,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileRequest,
   CreateProfileResponse,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileRequest,
   output: CreateProfileResponse,
@@ -2457,7 +2456,7 @@ export const createStarterMappingTemplate: API.OperationMethod<
   CreateStarterMappingTemplateRequest,
   CreateStarterMappingTemplateResponse,
   CreateStarterMappingTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStarterMappingTemplateRequest,
   output: CreateStarterMappingTemplateResponse,
@@ -2500,7 +2499,7 @@ export const createTransformer: API.OperationMethod<
   CreateTransformerRequest,
   CreateTransformerResponse,
   CreateTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransformerRequest,
   output: CreateTransformerResponse,
@@ -2533,7 +2532,7 @@ export const deleteCapability: API.OperationMethod<
   DeleteCapabilityRequest,
   DeleteCapabilityResponse,
   DeleteCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapabilityRequest,
   output: DeleteCapabilityResponse,
@@ -2565,7 +2564,7 @@ export const deletePartnership: API.OperationMethod<
   DeletePartnershipRequest,
   DeletePartnershipResponse,
   DeletePartnershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartnershipRequest,
   output: DeletePartnershipResponse,
@@ -2597,7 +2596,7 @@ export const deleteProfile: API.OperationMethod<
   DeleteProfileRequest,
   DeleteProfileResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileRequest,
   output: DeleteProfileResponse,
@@ -2629,7 +2628,7 @@ export const deleteTransformer: API.OperationMethod<
   DeleteTransformerRequest,
   DeleteTransformerResponse,
   DeleteTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransformerRequest,
   output: DeleteTransformerResponse,
@@ -2669,7 +2668,7 @@ export const generateMapping: API.OperationMethod<
   GenerateMappingRequest,
   GenerateMappingResponse,
   GenerateMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMappingRequest,
   output: GenerateMappingResponse,
@@ -2698,7 +2697,7 @@ export const getCapability: API.OperationMethod<
   GetCapabilityRequest,
   GetCapabilityResponse,
   GetCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapabilityRequest,
   output: GetCapabilityResponse,
@@ -2728,7 +2727,7 @@ export const getPartnership: API.OperationMethod<
   GetPartnershipRequest,
   GetPartnershipResponse,
   GetPartnershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPartnershipRequest,
   output: GetPartnershipResponse,
@@ -2758,7 +2757,7 @@ export const getProfile: API.OperationMethod<
   GetProfileRequest,
   GetProfileResponse,
   GetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileRequest,
   output: GetProfileResponse,
@@ -2788,7 +2787,7 @@ export const getTransformer: API.OperationMethod<
   GetTransformerRequest,
   GetTransformerResponse,
   GetTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransformerRequest,
   output: GetTransformerResponse,
@@ -2820,7 +2819,7 @@ export const getTransformerJob: API.OperationMethod<
   GetTransformerJobRequest,
   GetTransformerJobResponse,
   GetTransformerJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransformerJobRequest,
   output: GetTransformerJobResponse,
@@ -2849,7 +2848,7 @@ export const listCapabilities: API.PaginatedOperationMethod<
   ListCapabilitiesRequest,
   ListCapabilitiesResponse,
   ListCapabilitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapabilitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCapabilitiesRequest,
@@ -2885,7 +2884,7 @@ export const listPartnerships: API.PaginatedOperationMethod<
   ListPartnershipsRequest,
   ListPartnershipsResponse,
   ListPartnershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PartnershipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPartnershipsRequest,
@@ -2921,7 +2920,7 @@ export const listProfiles: API.PaginatedOperationMethod<
   ListProfilesRequest,
   ListProfilesResponse,
   ListProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilesRequest,
@@ -2955,7 +2954,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2982,7 +2981,7 @@ export const listTransformers: API.PaginatedOperationMethod<
   ListTransformersRequest,
   ListTransformersResponse,
   ListTransformersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransformerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTransformersRequest,
@@ -3023,7 +3022,7 @@ export const startTransformerJob: API.OperationMethod<
   StartTransformerJobRequest,
   StartTransformerJobResponse,
   StartTransformerJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTransformerJobRequest,
   output: StartTransformerJobResponse,
@@ -3055,7 +3054,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3084,7 +3083,7 @@ export const testConversion: API.OperationMethod<
   TestConversionRequest,
   TestConversionResponse,
   TestConversionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestConversionRequest,
   output: TestConversionResponse,
@@ -3114,7 +3113,7 @@ export const testMapping: API.OperationMethod<
   TestMappingRequest,
   TestMappingResponse,
   TestMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestMappingRequest,
   output: TestMappingResponse,
@@ -3144,7 +3143,7 @@ export const testParsing: API.OperationMethod<
   TestParsingRequest,
   TestParsingResponse,
   TestParsingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestParsingRequest,
   output: TestParsingResponse,
@@ -3172,7 +3171,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3202,7 +3201,7 @@ export const updateCapability: API.OperationMethod<
   UpdateCapabilityRequest,
   UpdateCapabilityResponse,
   UpdateCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapabilityRequest,
   output: UpdateCapabilityResponse,
@@ -3236,7 +3235,7 @@ export const updatePartnership: API.OperationMethod<
   UpdatePartnershipRequest,
   UpdatePartnershipResponse,
   UpdatePartnershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePartnershipRequest,
   output: UpdatePartnershipResponse,
@@ -3270,7 +3269,7 @@ export const updateProfile: API.OperationMethod<
   UpdateProfileRequest,
   UpdateProfileResponse,
   UpdateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileRequest,
   output: UpdateProfileResponse,
@@ -3304,7 +3303,7 @@ export const updateTransformer: API.OperationMethod<
   UpdateTransformerRequest,
   UpdateTransformerResponse,
   UpdateTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTransformerRequest,
   output: UpdateTransformerResponse,

--- a/packages/aws/src/services/backup-gateway.ts
+++ b/packages/aws/src/services/backup-gateway.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Backup Gateway",
@@ -923,7 +922,7 @@ export const associateGatewayToServer: API.OperationMethod<
   AssociateGatewayToServerInput,
   AssociateGatewayToServerOutput,
   AssociateGatewayToServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateGatewayToServerInput,
   output: AssociateGatewayToServerOutput,
@@ -942,7 +941,7 @@ export const createGateway: API.OperationMethod<
   CreateGatewayInput,
   CreateGatewayOutput,
   CreateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayInput,
   output: CreateGatewayOutput,
@@ -960,7 +959,7 @@ export const deleteGateway: API.OperationMethod<
   DeleteGatewayInput,
   DeleteGatewayOutput,
   DeleteGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayInput,
   output: DeleteGatewayOutput,
@@ -982,7 +981,7 @@ export const deleteHypervisor: API.OperationMethod<
   DeleteHypervisorInput,
   DeleteHypervisorOutput,
   DeleteHypervisorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHypervisorInput,
   output: DeleteHypervisorOutput,
@@ -1004,7 +1003,7 @@ export const disassociateGatewayFromServer: API.OperationMethod<
   DisassociateGatewayFromServerInput,
   DisassociateGatewayFromServerOutput,
   DisassociateGatewayFromServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateGatewayFromServerInput,
   output: DisassociateGatewayFromServerOutput,
@@ -1027,7 +1026,7 @@ export const getBandwidthRateLimitSchedule: API.OperationMethod<
   GetBandwidthRateLimitScheduleInput,
   GetBandwidthRateLimitScheduleOutput,
   GetBandwidthRateLimitScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBandwidthRateLimitScheduleInput,
   output: GetBandwidthRateLimitScheduleOutput,
@@ -1046,7 +1045,7 @@ export const getGateway: API.OperationMethod<
   GetGatewayInput,
   GetGatewayOutput,
   GetGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayInput,
   output: GetGatewayOutput,
@@ -1066,7 +1065,7 @@ export const getHypervisor: API.OperationMethod<
   GetHypervisorInput,
   GetHypervisorOutput,
   GetHypervisorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHypervisorInput,
   output: GetHypervisorOutput,
@@ -1088,7 +1087,7 @@ export const getHypervisorPropertyMappings: API.OperationMethod<
   GetHypervisorPropertyMappingsInput,
   GetHypervisorPropertyMappingsOutput,
   GetHypervisorPropertyMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHypervisorPropertyMappingsInput,
   output: GetHypervisorPropertyMappingsOutput,
@@ -1106,7 +1105,7 @@ export const getVirtualMachine: API.OperationMethod<
   GetVirtualMachineInput,
   GetVirtualMachineOutput,
   GetVirtualMachineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVirtualMachineInput,
   output: GetVirtualMachineOutput,
@@ -1127,7 +1126,7 @@ export const importHypervisorConfiguration: API.OperationMethod<
   ImportHypervisorConfigurationInput,
   ImportHypervisorConfigurationOutput,
   ImportHypervisorConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportHypervisorConfigurationInput,
   output: ImportHypervisorConfigurationOutput,
@@ -1145,7 +1144,7 @@ export const listGateways: API.PaginatedOperationMethod<
   ListGatewaysInput,
   ListGatewaysOutput,
   ListGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Gateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewaysInput,
@@ -1170,7 +1169,7 @@ export const listHypervisors: API.PaginatedOperationMethod<
   ListHypervisorsInput,
   ListHypervisorsOutput,
   ListHypervisorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Hypervisor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHypervisorsInput,
@@ -1196,7 +1195,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1214,7 +1213,7 @@ export const listVirtualMachines: API.PaginatedOperationMethod<
   ListVirtualMachinesInput,
   ListVirtualMachinesOutput,
   ListVirtualMachinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualMachine
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualMachinesInput,
@@ -1244,7 +1243,7 @@ export const putBandwidthRateLimitSchedule: API.OperationMethod<
   PutBandwidthRateLimitScheduleInput,
   PutBandwidthRateLimitScheduleOutput,
   PutBandwidthRateLimitScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBandwidthRateLimitScheduleInput,
   output: PutBandwidthRateLimitScheduleOutput,
@@ -1268,7 +1267,7 @@ export const putHypervisorPropertyMappings: API.OperationMethod<
   PutHypervisorPropertyMappingsInput,
   PutHypervisorPropertyMappingsOutput,
   PutHypervisorPropertyMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutHypervisorPropertyMappingsInput,
   output: PutHypervisorPropertyMappingsOutput,
@@ -1289,7 +1288,7 @@ export const putMaintenanceStartTime: API.OperationMethod<
   PutMaintenanceStartTimeInput,
   PutMaintenanceStartTimeOutput,
   PutMaintenanceStartTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMaintenanceStartTimeInput,
   output: PutMaintenanceStartTimeOutput,
@@ -1310,7 +1309,7 @@ export const startVirtualMachinesMetadataSync: API.OperationMethod<
   StartVirtualMachinesMetadataSyncInput,
   StartVirtualMachinesMetadataSyncOutput,
   StartVirtualMachinesMetadataSyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVirtualMachinesMetadataSyncInput,
   output: StartVirtualMachinesMetadataSyncOutput,
@@ -1328,7 +1327,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1350,7 +1349,7 @@ export const testHypervisorConfiguration: API.OperationMethod<
   TestHypervisorConfigurationInput,
   TestHypervisorConfigurationOutput,
   TestHypervisorConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestHypervisorConfigurationInput,
   output: TestHypervisorConfigurationOutput,
@@ -1368,7 +1367,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1390,7 +1389,7 @@ export const updateGatewayInformation: API.OperationMethod<
   UpdateGatewayInformationInput,
   UpdateGatewayInformationOutput,
   UpdateGatewayInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayInformationInput,
   output: UpdateGatewayInformationOutput,
@@ -1415,7 +1414,7 @@ export const updateGatewaySoftwareNow: API.OperationMethod<
   UpdateGatewaySoftwareNowInput,
   UpdateGatewaySoftwareNowOutput,
   UpdateGatewaySoftwareNowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewaySoftwareNowInput,
   output: UpdateGatewaySoftwareNowOutput,
@@ -1439,7 +1438,7 @@ export const updateHypervisor: API.OperationMethod<
   UpdateHypervisorInput,
   UpdateHypervisorOutput,
   UpdateHypervisorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHypervisorInput,
   output: UpdateHypervisorOutput,

--- a/packages/aws/src/services/backup.ts
+++ b/packages/aws/src/services/backup.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Backup",
@@ -6490,7 +6489,7 @@ export const associateBackupVaultMpaApprovalTeam: API.OperationMethod<
   AssociateBackupVaultMpaApprovalTeamInput,
   AssociateBackupVaultMpaApprovalTeamResponse,
   AssociateBackupVaultMpaApprovalTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateBackupVaultMpaApprovalTeamInput,
   output: AssociateBackupVaultMpaApprovalTeamResponse,
@@ -6521,7 +6520,7 @@ export const cancelLegalHold: API.OperationMethod<
   CancelLegalHoldInput,
   CancelLegalHoldOutput,
   CancelLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelLegalHoldInput,
   output: CancelLegalHoldOutput,
@@ -6556,7 +6555,7 @@ export const createBackupPlan: API.OperationMethod<
   CreateBackupPlanInput,
   CreateBackupPlanOutput,
   CreateBackupPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackupPlanInput,
   output: CreateBackupPlanOutput,
@@ -6587,7 +6586,7 @@ export const createBackupSelection: API.OperationMethod<
   CreateBackupSelectionInput,
   CreateBackupSelectionOutput,
   CreateBackupSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackupSelectionInput,
   output: CreateBackupSelectionOutput,
@@ -6622,7 +6621,7 @@ export const createBackupVault: API.OperationMethod<
   CreateBackupVaultInput,
   CreateBackupVaultOutput,
   CreateBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackupVaultInput,
   output: CreateBackupVaultOutput,
@@ -6655,7 +6654,7 @@ export const createFramework: API.OperationMethod<
   CreateFrameworkInput,
   CreateFrameworkOutput,
   CreateFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFrameworkInput,
   output: CreateFrameworkOutput,
@@ -6687,7 +6686,7 @@ export const createLegalHold: API.OperationMethod<
   CreateLegalHoldInput,
   CreateLegalHoldOutput,
   CreateLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLegalHoldInput,
   output: CreateLegalHoldOutput,
@@ -6724,7 +6723,7 @@ export const createLogicallyAirGappedBackupVault: API.OperationMethod<
   CreateLogicallyAirGappedBackupVaultInput,
   CreateLogicallyAirGappedBackupVaultOutput,
   CreateLogicallyAirGappedBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogicallyAirGappedBackupVaultInput,
   output: CreateLogicallyAirGappedBackupVaultOutput,
@@ -6759,7 +6758,7 @@ export const createReportPlan: API.OperationMethod<
   CreateReportPlanInput,
   CreateReportPlanOutput,
   CreateReportPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReportPlanInput,
   output: CreateReportPlanOutput,
@@ -6791,7 +6790,7 @@ export const createRestoreAccessBackupVault: API.OperationMethod<
   CreateRestoreAccessBackupVaultInput,
   CreateRestoreAccessBackupVaultOutput,
   CreateRestoreAccessBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRestoreAccessBackupVaultInput,
   output: CreateRestoreAccessBackupVaultOutput,
@@ -6828,7 +6827,7 @@ export const createRestoreTestingPlan: API.OperationMethod<
   CreateRestoreTestingPlanInput,
   CreateRestoreTestingPlanOutput,
   CreateRestoreTestingPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRestoreTestingPlanInput,
   output: CreateRestoreTestingPlanOutput,
@@ -6879,7 +6878,7 @@ export const createRestoreTestingSelection: API.OperationMethod<
   CreateRestoreTestingSelectionInput,
   CreateRestoreTestingSelectionOutput,
   CreateRestoreTestingSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRestoreTestingSelectionInput,
   output: CreateRestoreTestingSelectionOutput,
@@ -6915,7 +6914,7 @@ export const createTieringConfiguration: API.OperationMethod<
   CreateTieringConfigurationInput,
   CreateTieringConfigurationOutput,
   CreateTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTieringConfigurationInput,
   output: CreateTieringConfigurationOutput,
@@ -6948,7 +6947,7 @@ export const deleteBackupPlan: API.OperationMethod<
   DeleteBackupPlanInput,
   DeleteBackupPlanOutput,
   DeleteBackupPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupPlanInput,
   output: DeleteBackupPlanOutput,
@@ -6978,7 +6977,7 @@ export const deleteBackupSelection: API.OperationMethod<
   DeleteBackupSelectionInput,
   DeleteBackupSelectionResponse,
   DeleteBackupSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupSelectionInput,
   output: DeleteBackupSelectionResponse,
@@ -7008,7 +7007,7 @@ export const deleteBackupVault: API.OperationMethod<
   DeleteBackupVaultInput,
   DeleteBackupVaultResponse,
   DeleteBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupVaultInput,
   output: DeleteBackupVaultResponse,
@@ -7037,7 +7036,7 @@ export const deleteBackupVaultAccessPolicy: API.OperationMethod<
   DeleteBackupVaultAccessPolicyInput,
   DeleteBackupVaultAccessPolicyResponse,
   DeleteBackupVaultAccessPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupVaultAccessPolicyInput,
   output: DeleteBackupVaultAccessPolicyResponse,
@@ -7072,7 +7071,7 @@ export const deleteBackupVaultLockConfiguration: API.OperationMethod<
   DeleteBackupVaultLockConfigurationInput,
   DeleteBackupVaultLockConfigurationResponse,
   DeleteBackupVaultLockConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupVaultLockConfigurationInput,
   output: DeleteBackupVaultLockConfigurationResponse,
@@ -7101,7 +7100,7 @@ export const deleteBackupVaultNotifications: API.OperationMethod<
   DeleteBackupVaultNotificationsInput,
   DeleteBackupVaultNotificationsResponse,
   DeleteBackupVaultNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupVaultNotificationsInput,
   output: DeleteBackupVaultNotificationsResponse,
@@ -7130,7 +7129,7 @@ export const deleteFramework: API.OperationMethod<
   DeleteFrameworkInput,
   DeleteFrameworkResponse,
   DeleteFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFrameworkInput,
   output: DeleteFrameworkResponse,
@@ -7176,7 +7175,7 @@ export const deleteRecoveryPoint: API.OperationMethod<
   DeleteRecoveryPointInput,
   DeleteRecoveryPointResponse,
   DeleteRecoveryPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecoveryPointInput,
   output: DeleteRecoveryPointResponse,
@@ -7207,7 +7206,7 @@ export const deleteReportPlan: API.OperationMethod<
   DeleteReportPlanInput,
   DeleteReportPlanResponse,
   DeleteReportPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReportPlanInput,
   output: DeleteReportPlanResponse,
@@ -7237,7 +7236,7 @@ export const deleteRestoreTestingPlan: API.OperationMethod<
   DeleteRestoreTestingPlanInput,
   DeleteRestoreTestingPlanResponse,
   DeleteRestoreTestingPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRestoreTestingPlanInput,
   output: DeleteRestoreTestingPlanResponse,
@@ -7262,7 +7261,7 @@ export const deleteRestoreTestingSelection: API.OperationMethod<
   DeleteRestoreTestingSelectionInput,
   DeleteRestoreTestingSelectionResponse,
   DeleteRestoreTestingSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRestoreTestingSelectionInput,
   output: DeleteRestoreTestingSelectionResponse,
@@ -7285,7 +7284,7 @@ export const deleteTieringConfiguration: API.OperationMethod<
   DeleteTieringConfigurationInput,
   DeleteTieringConfigurationOutput,
   DeleteTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTieringConfigurationInput,
   output: DeleteTieringConfigurationOutput,
@@ -7314,7 +7313,7 @@ export const describeBackupJob: API.OperationMethod<
   DescribeBackupJobInput,
   DescribeBackupJobOutput,
   DescribeBackupJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBackupJobInput,
   output: DescribeBackupJobOutput,
@@ -7343,7 +7342,7 @@ export const describeBackupVault: API.OperationMethod<
   DescribeBackupVaultInput,
   DescribeBackupVaultOutput,
   DescribeBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBackupVaultInput,
   output: DescribeBackupVaultOutput,
@@ -7371,7 +7370,7 @@ export const describeCopyJob: API.OperationMethod<
   DescribeCopyJobInput,
   DescribeCopyJobOutput,
   DescribeCopyJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCopyJobInput,
   output: DescribeCopyJobOutput,
@@ -7399,7 +7398,7 @@ export const describeFramework: API.OperationMethod<
   DescribeFrameworkInput,
   DescribeFrameworkOutput,
   DescribeFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFrameworkInput,
   output: DescribeFrameworkOutput,
@@ -7425,7 +7424,7 @@ export const describeGlobalSettings: API.OperationMethod<
   DescribeGlobalSettingsInput,
   DescribeGlobalSettingsOutput,
   DescribeGlobalSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGlobalSettingsInput,
   output: DescribeGlobalSettingsOutput,
@@ -7450,7 +7449,7 @@ export const describeProtectedResource: API.OperationMethod<
   DescribeProtectedResourceInput,
   DescribeProtectedResourceOutput,
   DescribeProtectedResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProtectedResourceInput,
   output: DescribeProtectedResourceOutput,
@@ -7479,7 +7478,7 @@ export const describeRecoveryPoint: API.OperationMethod<
   DescribeRecoveryPointInput,
   DescribeRecoveryPointOutput,
   DescribeRecoveryPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecoveryPointInput,
   output: DescribeRecoveryPointOutput,
@@ -7508,7 +7507,7 @@ export const describeRegionSettings: API.OperationMethod<
   DescribeRegionSettingsInput,
   DescribeRegionSettingsOutput,
   DescribeRegionSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRegionSettingsInput,
   output: DescribeRegionSettingsOutput,
@@ -7531,7 +7530,7 @@ export const describeReportJob: API.OperationMethod<
   DescribeReportJobInput,
   DescribeReportJobOutput,
   DescribeReportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReportJobInput,
   output: DescribeReportJobOutput,
@@ -7558,7 +7557,7 @@ export const describeReportPlan: API.OperationMethod<
   DescribeReportPlanInput,
   DescribeReportPlanOutput,
   DescribeReportPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReportPlanInput,
   output: DescribeReportPlanOutput,
@@ -7587,7 +7586,7 @@ export const describeRestoreJob: API.OperationMethod<
   DescribeRestoreJobInput,
   DescribeRestoreJobOutput,
   DescribeRestoreJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRestoreJobInput,
   output: DescribeRestoreJobOutput,
@@ -7616,7 +7615,7 @@ export const describeScanJob: API.OperationMethod<
   DescribeScanJobInput,
   DescribeScanJobOutput,
   DescribeScanJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScanJobInput,
   output: DescribeScanJobOutput,
@@ -7645,7 +7644,7 @@ export const disassociateBackupVaultMpaApprovalTeam: API.OperationMethod<
   DisassociateBackupVaultMpaApprovalTeamInput,
   DisassociateBackupVaultMpaApprovalTeamResponse,
   DisassociateBackupVaultMpaApprovalTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateBackupVaultMpaApprovalTeamInput,
   output: DisassociateBackupVaultMpaApprovalTeamResponse,
@@ -7680,7 +7679,7 @@ export const disassociateRecoveryPoint: API.OperationMethod<
   DisassociateRecoveryPointInput,
   DisassociateRecoveryPointResponse,
   DisassociateRecoveryPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRecoveryPointInput,
   output: DisassociateRecoveryPointResponse,
@@ -7712,7 +7711,7 @@ export const disassociateRecoveryPointFromParent: API.OperationMethod<
   DisassociateRecoveryPointFromParentInput,
   DisassociateRecoveryPointFromParentResponse,
   DisassociateRecoveryPointFromParentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRecoveryPointFromParentInput,
   output: DisassociateRecoveryPointFromParentResponse,
@@ -7741,7 +7740,7 @@ export const exportBackupPlanTemplate: API.OperationMethod<
   ExportBackupPlanTemplateInput,
   ExportBackupPlanTemplateOutput,
   ExportBackupPlanTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportBackupPlanTemplateInput,
   output: ExportBackupPlanTemplateOutput,
@@ -7770,7 +7769,7 @@ export const getBackupPlan: API.OperationMethod<
   GetBackupPlanInput,
   GetBackupPlanOutput,
   GetBackupPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupPlanInput,
   output: GetBackupPlanOutput,
@@ -7799,7 +7798,7 @@ export const getBackupPlanFromJSON: API.OperationMethod<
   GetBackupPlanFromJSONInput,
   GetBackupPlanFromJSONOutput,
   GetBackupPlanFromJSONError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupPlanFromJSONInput,
   output: GetBackupPlanFromJSONOutput,
@@ -7828,7 +7827,7 @@ export const getBackupPlanFromTemplate: API.OperationMethod<
   GetBackupPlanFromTemplateInput,
   GetBackupPlanFromTemplateOutput,
   GetBackupPlanFromTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupPlanFromTemplateInput,
   output: GetBackupPlanFromTemplateOutput,
@@ -7857,7 +7856,7 @@ export const getBackupSelection: API.OperationMethod<
   GetBackupSelectionInput,
   GetBackupSelectionOutput,
   GetBackupSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupSelectionInput,
   output: GetBackupSelectionOutput,
@@ -7886,7 +7885,7 @@ export const getBackupVaultAccessPolicy: API.OperationMethod<
   GetBackupVaultAccessPolicyInput,
   GetBackupVaultAccessPolicyOutput,
   GetBackupVaultAccessPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupVaultAccessPolicyInput,
   output: GetBackupVaultAccessPolicyOutput,
@@ -7914,7 +7913,7 @@ export const getBackupVaultNotifications: API.OperationMethod<
   GetBackupVaultNotificationsInput,
   GetBackupVaultNotificationsOutput,
   GetBackupVaultNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBackupVaultNotificationsInput,
   output: GetBackupVaultNotificationsOutput,
@@ -7943,7 +7942,7 @@ export const getLegalHold: API.OperationMethod<
   GetLegalHoldInput,
   GetLegalHoldOutput,
   GetLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLegalHoldInput,
   output: GetLegalHoldOutput,
@@ -7971,7 +7970,7 @@ export const getPITRMalwareScanResults: API.OperationMethod<
   GetPITRMalwareScanResultsInput,
   GetPITRMalwareScanResultsOutput,
   GetPITRMalwareScanResultsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPITRMalwareScanResultsInput,
   output: GetPITRMalwareScanResultsOutput,
@@ -8000,7 +7999,7 @@ export const getRecoveryPointIndexDetails: API.OperationMethod<
   GetRecoveryPointIndexDetailsInput,
   GetRecoveryPointIndexDetailsOutput,
   GetRecoveryPointIndexDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecoveryPointIndexDetailsInput,
   output: GetRecoveryPointIndexDetailsOutput,
@@ -8028,7 +8027,7 @@ export const getRecoveryPointRestoreMetadata: API.OperationMethod<
   GetRecoveryPointRestoreMetadataInput,
   GetRecoveryPointRestoreMetadataOutput,
   GetRecoveryPointRestoreMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecoveryPointRestoreMetadataInput,
   output: GetRecoveryPointRestoreMetadataOutput,
@@ -8056,7 +8055,7 @@ export const getRestoreJobMetadata: API.OperationMethod<
   GetRestoreJobMetadataInput,
   GetRestoreJobMetadataOutput,
   GetRestoreJobMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRestoreJobMetadataInput,
   output: GetRestoreJobMetadataOutput,
@@ -8087,7 +8086,7 @@ export const getRestoreTestingInferredMetadata: API.OperationMethod<
   GetRestoreTestingInferredMetadataInput,
   GetRestoreTestingInferredMetadataOutput,
   GetRestoreTestingInferredMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRestoreTestingInferredMetadataInput,
   output: GetRestoreTestingInferredMetadataOutput,
@@ -8115,7 +8114,7 @@ export const getRestoreTestingPlan: API.OperationMethod<
   GetRestoreTestingPlanInput,
   GetRestoreTestingPlanOutput,
   GetRestoreTestingPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRestoreTestingPlanInput,
   output: GetRestoreTestingPlanOutput,
@@ -8137,7 +8136,7 @@ export const getRestoreTestingSelection: API.OperationMethod<
   GetRestoreTestingSelectionInput,
   GetRestoreTestingSelectionOutput,
   GetRestoreTestingSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRestoreTestingSelectionInput,
   output: GetRestoreTestingSelectionOutput,
@@ -8157,7 +8156,7 @@ export const getSupportedResourceTypes: API.OperationMethod<
   GetSupportedResourceTypesRequest,
   GetSupportedResourceTypesOutput,
   GetSupportedResourceTypesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSupportedResourceTypesRequest,
   output: GetSupportedResourceTypesOutput,
@@ -8182,7 +8181,7 @@ export const getTieringConfiguration: API.OperationMethod<
   GetTieringConfigurationInput,
   GetTieringConfigurationOutput,
   GetTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTieringConfigurationInput,
   output: GetTieringConfigurationOutput,
@@ -8209,7 +8208,7 @@ export const listBackupJobs: API.PaginatedOperationMethod<
   ListBackupJobsInput,
   ListBackupJobsOutput,
   ListBackupJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupJobsInput,
@@ -8245,7 +8244,7 @@ export const listBackupJobSummaries: API.PaginatedOperationMethod<
   ListBackupJobSummariesInput,
   ListBackupJobSummariesOutput,
   ListBackupJobSummariesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupJobSummariesInput,
@@ -8274,7 +8273,7 @@ export const listBackupPlans: API.PaginatedOperationMethod<
   ListBackupPlansInput,
   ListBackupPlansOutput,
   ListBackupPlansError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupPlansListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupPlansInput,
@@ -8309,7 +8308,7 @@ export const listBackupPlanTemplates: API.PaginatedOperationMethod<
   ListBackupPlanTemplatesInput,
   ListBackupPlanTemplatesOutput,
   ListBackupPlanTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupPlanTemplatesListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupPlanTemplatesInput,
@@ -8345,7 +8344,7 @@ export const listBackupPlanVersions: API.PaginatedOperationMethod<
   ListBackupPlanVersionsInput,
   ListBackupPlanVersionsOutput,
   ListBackupPlanVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupPlansListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupPlanVersionsInput,
@@ -8381,7 +8380,7 @@ export const listBackupSelections: API.PaginatedOperationMethod<
   ListBackupSelectionsInput,
   ListBackupSelectionsOutput,
   ListBackupSelectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupSelectionsListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupSelectionsInput,
@@ -8417,7 +8416,7 @@ export const listBackupVaults: API.PaginatedOperationMethod<
   ListBackupVaultsInput,
   ListBackupVaultsOutput,
   ListBackupVaultsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BackupVaultListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBackupVaultsInput,
@@ -8450,7 +8449,7 @@ export const listCopyJobs: API.PaginatedOperationMethod<
   ListCopyJobsInput,
   ListCopyJobsOutput,
   ListCopyJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CopyJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCopyJobsInput,
@@ -8486,7 +8485,7 @@ export const listCopyJobSummaries: API.PaginatedOperationMethod<
   ListCopyJobSummariesInput,
   ListCopyJobSummariesOutput,
   ListCopyJobSummariesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCopyJobSummariesInput,
@@ -8513,7 +8512,7 @@ export const listFrameworks: API.PaginatedOperationMethod<
   ListFrameworksInput,
   ListFrameworksOutput,
   ListFrameworksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFrameworksInput,
@@ -8546,7 +8545,7 @@ export const listIndexedRecoveryPoints: API.PaginatedOperationMethod<
   ListIndexedRecoveryPointsInput,
   ListIndexedRecoveryPointsOutput,
   ListIndexedRecoveryPointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IndexedRecoveryPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndexedRecoveryPointsInput,
@@ -8578,7 +8577,7 @@ export const listLegalHolds: API.PaginatedOperationMethod<
   ListLegalHoldsInput,
   ListLegalHoldsOutput,
   ListLegalHoldsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LegalHold
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLegalHoldsInput,
@@ -8608,7 +8607,7 @@ export const listProtectedResources: API.PaginatedOperationMethod<
   ListProtectedResourcesInput,
   ListProtectedResourcesOutput,
   ListProtectedResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectedResourcesInput,
@@ -8637,7 +8636,7 @@ export const listProtectedResourcesByBackupVault: API.PaginatedOperationMethod<
   ListProtectedResourcesByBackupVaultInput,
   ListProtectedResourcesByBackupVaultOutput,
   ListProtectedResourcesByBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectedResourcesByBackupVaultInput,
@@ -8671,7 +8670,7 @@ export const listRecoveryPointsByBackupVault: API.PaginatedOperationMethod<
   ListRecoveryPointsByBackupVaultInput,
   ListRecoveryPointsByBackupVaultOutput,
   ListRecoveryPointsByBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryPointByBackupVault
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecoveryPointsByBackupVaultInput,
@@ -8706,7 +8705,7 @@ export const listRecoveryPointsByLegalHold: API.PaginatedOperationMethod<
   ListRecoveryPointsByLegalHoldInput,
   ListRecoveryPointsByLegalHoldOutput,
   ListRecoveryPointsByLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryPointMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecoveryPointsByLegalHoldInput,
@@ -8744,7 +8743,7 @@ export const listRecoveryPointsByResource: API.PaginatedOperationMethod<
   ListRecoveryPointsByResourceInput,
   ListRecoveryPointsByResourceOutput,
   ListRecoveryPointsByResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryPointByResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecoveryPointsByResourceInput,
@@ -8778,7 +8777,7 @@ export const listReportJobs: API.PaginatedOperationMethod<
   ListReportJobsInput,
   ListReportJobsOutput,
   ListReportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportJobsInput,
@@ -8810,7 +8809,7 @@ export const listReportPlans: API.PaginatedOperationMethod<
   ListReportPlansInput,
   ListReportPlansOutput,
   ListReportPlansError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportPlansInput,
@@ -8839,7 +8838,7 @@ export const listRestoreAccessBackupVaults: API.PaginatedOperationMethod<
   ListRestoreAccessBackupVaultsInput,
   ListRestoreAccessBackupVaultsOutput,
   ListRestoreAccessBackupVaultsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestoreAccessBackupVaultListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreAccessBackupVaultsInput,
@@ -8875,7 +8874,7 @@ export const listRestoreJobs: API.PaginatedOperationMethod<
   ListRestoreJobsInput,
   ListRestoreJobsOutput,
   ListRestoreJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestoreJobsListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreJobsInput,
@@ -8915,7 +8914,7 @@ export const listRestoreJobsByProtectedResource: API.PaginatedOperationMethod<
   ListRestoreJobsByProtectedResourceInput,
   ListRestoreJobsByProtectedResourceOutput,
   ListRestoreJobsByProtectedResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestoreJobsListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreJobsByProtectedResourceInput,
@@ -8956,7 +8955,7 @@ export const listRestoreJobSummaries: API.PaginatedOperationMethod<
   ListRestoreJobSummariesInput,
   ListRestoreJobSummariesOutput,
   ListRestoreJobSummariesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreJobSummariesInput,
@@ -8983,7 +8982,7 @@ export const listRestoreTestingPlans: API.PaginatedOperationMethod<
   ListRestoreTestingPlansInput,
   ListRestoreTestingPlansOutput,
   ListRestoreTestingPlansError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestoreTestingPlanForList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreTestingPlansInput,
@@ -9013,7 +9012,7 @@ export const listRestoreTestingSelections: API.PaginatedOperationMethod<
   ListRestoreTestingSelectionsInput,
   ListRestoreTestingSelectionsOutput,
   ListRestoreTestingSelectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RestoreTestingSelectionForList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRestoreTestingSelectionsInput,
@@ -9045,7 +9044,7 @@ export const listScanJobs: API.PaginatedOperationMethod<
   ListScanJobsInput,
   ListScanJobsOutput,
   ListScanJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScanJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScanJobsInput,
@@ -9073,7 +9072,7 @@ export const listScanJobSummaries: API.PaginatedOperationMethod<
   ListScanJobSummariesInput,
   ListScanJobSummariesOutput,
   ListScanJobSummariesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScanJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScanJobSummariesInput,
@@ -9117,7 +9116,7 @@ export const listTags: API.PaginatedOperationMethod<
   ListTagsInput,
   ListTagsOutput,
   ListTagsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsInput,
@@ -9149,7 +9148,7 @@ export const listTieringConfigurations: API.PaginatedOperationMethod<
   ListTieringConfigurationsInput,
   ListTieringConfigurationsOutput,
   ListTieringConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TieringConfigurationsListMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTieringConfigurationsInput,
@@ -9181,7 +9180,7 @@ export const putBackupVaultAccessPolicy: API.OperationMethod<
   PutBackupVaultAccessPolicyInput,
   PutBackupVaultAccessPolicyResponse,
   PutBackupVaultAccessPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBackupVaultAccessPolicyInput,
   output: PutBackupVaultAccessPolicyResponse,
@@ -9222,7 +9221,7 @@ export const putBackupVaultLockConfiguration: API.OperationMethod<
   PutBackupVaultLockConfigurationInput,
   PutBackupVaultLockConfigurationResponse,
   PutBackupVaultLockConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBackupVaultLockConfigurationInput,
   output: PutBackupVaultLockConfigurationResponse,
@@ -9251,7 +9250,7 @@ export const putBackupVaultNotifications: API.OperationMethod<
   PutBackupVaultNotificationsInput,
   PutBackupVaultNotificationsResponse,
   PutBackupVaultNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBackupVaultNotificationsInput,
   output: PutBackupVaultNotificationsResponse,
@@ -9284,7 +9283,7 @@ export const putRestoreValidationResult: API.OperationMethod<
   PutRestoreValidationResultInput,
   PutRestoreValidationResultResponse,
   PutRestoreValidationResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRestoreValidationResultInput,
   output: PutRestoreValidationResultResponse,
@@ -9314,7 +9313,7 @@ export const revokeRestoreAccessBackupVault: API.OperationMethod<
   RevokeRestoreAccessBackupVaultInput,
   RevokeRestoreAccessBackupVaultResponse,
   RevokeRestoreAccessBackupVaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeRestoreAccessBackupVaultInput,
   output: RevokeRestoreAccessBackupVaultResponse,
@@ -9345,7 +9344,7 @@ export const startBackupJob: API.OperationMethod<
   StartBackupJobInput,
   StartBackupJobOutput,
   StartBackupJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBackupJobInput,
   output: StartBackupJobOutput,
@@ -9383,7 +9382,7 @@ export const startCopyJob: API.OperationMethod<
   StartCopyJobInput,
   StartCopyJobOutput,
   StartCopyJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCopyJobInput,
   output: StartCopyJobOutput,
@@ -9413,7 +9412,7 @@ export const startReportJob: API.OperationMethod<
   StartReportJobInput,
   StartReportJobOutput,
   StartReportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReportJobInput,
   output: StartReportJobOutput,
@@ -9442,7 +9441,7 @@ export const startRestoreJob: API.OperationMethod<
   StartRestoreJobInput,
   StartRestoreJobOutput,
   StartRestoreJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRestoreJobInput,
   output: StartRestoreJobOutput,
@@ -9473,7 +9472,7 @@ export const startScanJob: API.OperationMethod<
   StartScanJobInput,
   StartScanJobOutput,
   StartScanJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartScanJobInput,
   output: StartScanJobOutput,
@@ -9524,7 +9523,7 @@ export const stopBackupJob: API.OperationMethod<
   StopBackupJobInput,
   StopBackupJobResponse,
   StopBackupJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBackupJobInput,
   output: StopBackupJobResponse,
@@ -9554,7 +9553,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -9588,7 +9587,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -9616,7 +9615,7 @@ export const updateBackupPlan: API.OperationMethod<
   UpdateBackupPlanInput,
   UpdateBackupPlanOutput,
   UpdateBackupPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBackupPlanInput,
   output: UpdateBackupPlanOutput,
@@ -9647,7 +9646,7 @@ export const updateFramework: API.OperationMethod<
   UpdateFrameworkInput,
   UpdateFrameworkOutput,
   UpdateFrameworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFrameworkInput,
   output: UpdateFrameworkOutput,
@@ -9678,7 +9677,7 @@ export const updateGlobalSettings: API.OperationMethod<
   UpdateGlobalSettingsInput,
   UpdateGlobalSettingsResponse,
   UpdateGlobalSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalSettingsInput,
   output: UpdateGlobalSettingsResponse,
@@ -9709,7 +9708,7 @@ export const updateRecoveryPointIndexSettings: API.OperationMethod<
   UpdateRecoveryPointIndexSettingsInput,
   UpdateRecoveryPointIndexSettingsOutput,
   UpdateRecoveryPointIndexSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecoveryPointIndexSettingsInput,
   output: UpdateRecoveryPointIndexSettingsOutput,
@@ -9757,7 +9756,7 @@ export const updateRecoveryPointLifecycle: API.OperationMethod<
   UpdateRecoveryPointLifecycleInput,
   UpdateRecoveryPointLifecycleOutput,
   UpdateRecoveryPointLifecycleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecoveryPointLifecycleInput,
   output: UpdateRecoveryPointLifecycleOutput,
@@ -9789,7 +9788,7 @@ export const updateRegionSettings: API.OperationMethod<
   UpdateRegionSettingsInput,
   UpdateRegionSettingsResponse,
   UpdateRegionSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegionSettingsInput,
   output: UpdateRegionSettingsResponse,
@@ -9817,7 +9816,7 @@ export const updateReportPlan: API.OperationMethod<
   UpdateReportPlanInput,
   UpdateReportPlanOutput,
   UpdateReportPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReportPlanInput,
   output: UpdateReportPlanOutput,
@@ -9861,7 +9860,7 @@ export const updateRestoreTestingPlan: API.OperationMethod<
   UpdateRestoreTestingPlanInput,
   UpdateRestoreTestingPlanOutput,
   UpdateRestoreTestingPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRestoreTestingPlanInput,
   output: UpdateRestoreTestingPlanOutput,
@@ -9896,7 +9895,7 @@ export const updateRestoreTestingSelection: API.OperationMethod<
   UpdateRestoreTestingSelectionInput,
   UpdateRestoreTestingSelectionOutput,
   UpdateRestoreTestingSelectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRestoreTestingSelectionInput,
   output: UpdateRestoreTestingSelectionOutput,
@@ -9938,7 +9937,7 @@ export const updateTieringConfiguration: API.OperationMethod<
   UpdateTieringConfigurationInput,
   UpdateTieringConfigurationOutput,
   UpdateTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTieringConfigurationInput,
   output: UpdateTieringConfigurationOutput,

--- a/packages/aws/src/services/backupsearch.ts
+++ b/packages/aws/src/services/backupsearch.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "BackupSearch",
@@ -871,7 +870,7 @@ export const getSearchJob: API.OperationMethod<
   GetSearchJobInput,
   GetSearchJobOutput,
   GetSearchJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSearchJobInput,
   output: GetSearchJobOutput,
@@ -895,7 +894,7 @@ export const getSearchResultExportJob: API.OperationMethod<
   GetSearchResultExportJobInput,
   GetSearchResultExportJobOutput,
   GetSearchResultExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSearchResultExportJobInput,
   output: GetSearchResultExportJobOutput,
@@ -919,7 +918,7 @@ export const listSearchJobBackups: API.PaginatedOperationMethod<
   ListSearchJobBackupsInput,
   ListSearchJobBackupsOutput,
   ListSearchJobBackupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchJobBackupsResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSearchJobBackupsInput,
@@ -946,7 +945,7 @@ export const listSearchJobResults: API.PaginatedOperationMethod<
   ListSearchJobResultsInput,
   ListSearchJobResultsOutput,
   ListSearchJobResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSearchJobResultsInput,
@@ -971,7 +970,7 @@ export const listSearchJobs: API.PaginatedOperationMethod<
   ListSearchJobsInput,
   ListSearchJobsOutput,
   ListSearchJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSearchJobsInput,
@@ -999,7 +998,7 @@ export const listSearchResultExportJobs: API.PaginatedOperationMethod<
   ListSearchResultExportJobsInput,
   ListSearchResultExportJobsOutput,
   ListSearchResultExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSearchResultExportJobsInput,
@@ -1024,7 +1023,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1048,7 +1047,7 @@ export const startSearchJob: API.OperationMethod<
   StartSearchJobInput,
   StartSearchJobOutput,
   StartSearchJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSearchJobInput,
   output: StartSearchJobOutput,
@@ -1074,7 +1073,7 @@ export const startSearchResultExportJob: API.OperationMethod<
   StartSearchResultExportJobInput,
   StartSearchResultExportJobOutput,
   StartSearchResultExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSearchResultExportJobInput,
   output: StartSearchResultExportJobOutput,
@@ -1101,7 +1100,7 @@ export const stopSearchJob: API.OperationMethod<
   StopSearchJobInput,
   StopSearchJobOutput,
   StopSearchJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSearchJobInput,
   output: StopSearchJobOutput,
@@ -1119,7 +1118,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1137,7 +1136,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/batch.ts
+++ b/packages/aws/src/services/batch.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://batch.amazonaws.com/doc/2016-08-10/");
 const svc = T.AwsApiService({
   sdkId: "Batch",
@@ -4997,7 +4996,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -5043,7 +5042,7 @@ export const createComputeEnvironment: API.OperationMethod<
   CreateComputeEnvironmentRequest,
   CreateComputeEnvironmentResponse,
   CreateComputeEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComputeEnvironmentRequest,
   output: CreateComputeEnvironmentResponse,
@@ -5064,7 +5063,7 @@ export const createConsumableResource: API.OperationMethod<
   CreateConsumableResourceRequest,
   CreateConsumableResourceResponse,
   CreateConsumableResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConsumableResourceRequest,
   output: CreateConsumableResourceResponse,
@@ -5094,7 +5093,7 @@ export const createJobQueue: API.OperationMethod<
   CreateJobQueueRequest,
   CreateJobQueueResponse,
   CreateJobQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobQueueRequest,
   output: CreateJobQueueResponse,
@@ -5120,7 +5119,7 @@ export const createQuotaShare: API.OperationMethod<
   CreateQuotaShareRequest,
   CreateQuotaShareResponse,
   CreateQuotaShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuotaShareRequest,
   output: CreateQuotaShareResponse,
@@ -5141,7 +5140,7 @@ export const createSchedulingPolicy: API.OperationMethod<
   CreateSchedulingPolicyRequest,
   CreateSchedulingPolicyResponse,
   CreateSchedulingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchedulingPolicyRequest,
   output: CreateSchedulingPolicyResponse,
@@ -5162,7 +5161,7 @@ export const createServiceEnvironment: API.OperationMethod<
   CreateServiceEnvironmentRequest,
   CreateServiceEnvironmentResponse,
   CreateServiceEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceEnvironmentRequest,
   output: CreateServiceEnvironmentResponse,
@@ -5193,7 +5192,7 @@ export const deleteComputeEnvironment: API.OperationMethod<
   DeleteComputeEnvironmentRequest,
   DeleteComputeEnvironmentResponse,
   DeleteComputeEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComputeEnvironmentRequest,
   output: DeleteComputeEnvironmentResponse,
@@ -5220,7 +5219,7 @@ export const deleteConsumableResource: API.OperationMethod<
   DeleteConsumableResourceRequest,
   DeleteConsumableResourceResponse,
   DeleteConsumableResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConsumableResourceRequest,
   output: DeleteConsumableResourceResponse,
@@ -5248,7 +5247,7 @@ export const deleteJobQueue: API.OperationMethod<
   DeleteJobQueueRequest,
   DeleteJobQueueResponse,
   DeleteJobQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobQueueRequest,
   output: DeleteJobQueueResponse,
@@ -5276,7 +5275,7 @@ export const deleteQuotaShare: API.OperationMethod<
   DeleteQuotaShareRequest,
   DeleteQuotaShareResponse,
   DeleteQuotaShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuotaShareRequest,
   output: DeleteQuotaShareResponse,
@@ -5299,7 +5298,7 @@ export const deleteSchedulingPolicy: API.OperationMethod<
   DeleteSchedulingPolicyRequest,
   DeleteSchedulingPolicyResponse,
   DeleteSchedulingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchedulingPolicyRequest,
   output: DeleteSchedulingPolicyResponse,
@@ -5320,7 +5319,7 @@ export const deleteServiceEnvironment: API.OperationMethod<
   DeleteServiceEnvironmentRequest,
   DeleteServiceEnvironmentResponse,
   DeleteServiceEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceEnvironmentRequest,
   output: DeleteServiceEnvironmentResponse,
@@ -5342,7 +5341,7 @@ export const deregisterJobDefinition: API.OperationMethod<
   DeregisterJobDefinitionRequest,
   DeregisterJobDefinitionResponse,
   DeregisterJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterJobDefinitionRequest,
   output: DeregisterJobDefinitionResponse,
@@ -5367,7 +5366,7 @@ export const describeComputeEnvironments: API.PaginatedOperationMethod<
   DescribeComputeEnvironmentsRequest,
   DescribeComputeEnvironmentsResponse,
   DescribeComputeEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputeEnvironmentDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeComputeEnvironmentsRequest,
@@ -5395,7 +5394,7 @@ export const describeConsumableResource: API.OperationMethod<
   DescribeConsumableResourceRequest,
   DescribeConsumableResourceResponse,
   DescribeConsumableResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConsumableResourceRequest,
   output: DescribeConsumableResourceResponse,
@@ -5417,7 +5416,7 @@ export const describeJobDefinitions: API.PaginatedOperationMethod<
   DescribeJobDefinitionsRequest,
   DescribeJobDefinitionsResponse,
   DescribeJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobDefinitionsRequest,
@@ -5445,7 +5444,7 @@ export const describeJobQueues: API.PaginatedOperationMethod<
   DescribeJobQueuesRequest,
   DescribeJobQueuesResponse,
   DescribeJobQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobQueueDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobQueuesRequest,
@@ -5473,7 +5472,7 @@ export const describeJobs: API.OperationMethod<
   DescribeJobsRequest,
   DescribeJobsResponse,
   DescribeJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobsRequest,
   output: DescribeJobsResponse,
@@ -5494,7 +5493,7 @@ export const describeQuotaShare: API.OperationMethod<
   DescribeQuotaShareRequest,
   DescribeQuotaShareResponse,
   DescribeQuotaShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQuotaShareRequest,
   output: DescribeQuotaShareResponse,
@@ -5515,7 +5514,7 @@ export const describeSchedulingPolicies: API.OperationMethod<
   DescribeSchedulingPoliciesRequest,
   DescribeSchedulingPoliciesResponse,
   DescribeSchedulingPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSchedulingPoliciesRequest,
   output: DescribeSchedulingPoliciesResponse,
@@ -5536,7 +5535,7 @@ export const describeServiceEnvironments: API.PaginatedOperationMethod<
   DescribeServiceEnvironmentsRequest,
   DescribeServiceEnvironmentsResponse,
   DescribeServiceEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceEnvironmentDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServiceEnvironmentsRequest,
@@ -5564,7 +5563,7 @@ export const describeServiceJob: API.OperationMethod<
   DescribeServiceJobRequest,
   DescribeServiceJobResponse,
   DescribeServiceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceJobRequest,
   output: DescribeServiceJobResponse,
@@ -5588,7 +5587,7 @@ export const getJobQueueSnapshot: API.OperationMethod<
   GetJobQueueSnapshotRequest,
   GetJobQueueSnapshotResponse,
   GetJobQueueSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobQueueSnapshotRequest,
   output: GetJobQueueSnapshotResponse,
@@ -5609,7 +5608,7 @@ export const listConsumableResources: API.PaginatedOperationMethod<
   ListConsumableResourcesRequest,
   ListConsumableResourcesResponse,
   ListConsumableResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConsumableResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConsumableResourcesRequest,
@@ -5642,7 +5641,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -5670,7 +5669,7 @@ export const listJobsByConsumableResource: API.PaginatedOperationMethod<
   ListJobsByConsumableResourceRequest,
   ListJobsByConsumableResourceResponse,
   ListJobsByConsumableResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListJobsByConsumableResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsByConsumableResourceRequest,
@@ -5698,7 +5697,7 @@ export const listQuotaShares: API.PaginatedOperationMethod<
   ListQuotaSharesRequest,
   ListQuotaSharesResponse,
   ListQuotaSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuotaShareDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuotaSharesRequest,
@@ -5726,7 +5725,7 @@ export const listSchedulingPolicies: API.PaginatedOperationMethod<
   ListSchedulingPoliciesRequest,
   ListSchedulingPoliciesResponse,
   ListSchedulingPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchedulingPolicyListingDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchedulingPoliciesRequest,
@@ -5754,7 +5753,7 @@ export const listServiceJobs: API.PaginatedOperationMethod<
   ListServiceJobsRequest,
   ListServiceJobsResponse,
   ListServiceJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceJobsRequest,
@@ -5783,7 +5782,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5804,7 +5803,7 @@ export const registerJobDefinition: API.OperationMethod<
   RegisterJobDefinitionRequest,
   RegisterJobDefinitionResponse,
   RegisterJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterJobDefinitionRequest,
   output: RegisterJobDefinitionResponse,
@@ -5834,7 +5833,7 @@ export const submitJob: API.OperationMethod<
   SubmitJobRequest,
   SubmitJobResponse,
   SubmitJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitJobRequest,
   output: SubmitJobResponse,
@@ -5855,7 +5854,7 @@ export const submitServiceJob: API.OperationMethod<
   SubmitServiceJobRequest,
   SubmitServiceJobResponse,
   SubmitServiceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitServiceJobRequest,
   output: SubmitServiceJobResponse,
@@ -5877,7 +5876,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5901,7 +5900,7 @@ export const terminateJob: API.OperationMethod<
   TerminateJobRequest,
   TerminateJobResponse,
   TerminateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateJobRequest,
   output: TerminateJobResponse,
@@ -5922,7 +5921,7 @@ export const terminateServiceJob: API.OperationMethod<
   TerminateServiceJobRequest,
   TerminateServiceJobResponse,
   TerminateServiceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateServiceJobRequest,
   output: TerminateServiceJobResponse,
@@ -5943,7 +5942,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5966,7 +5965,7 @@ export const updateComputeEnvironment: API.OperationMethod<
   UpdateComputeEnvironmentRequest,
   UpdateComputeEnvironmentResponse,
   UpdateComputeEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComputeEnvironmentRequest,
   output: UpdateComputeEnvironmentResponse,
@@ -5992,7 +5991,7 @@ export const updateConsumableResource: API.OperationMethod<
   UpdateConsumableResourceRequest,
   UpdateConsumableResourceResponse,
   UpdateConsumableResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConsumableResourceRequest,
   output: UpdateConsumableResourceResponse,
@@ -6015,7 +6014,7 @@ export const updateJobQueue: API.OperationMethod<
   UpdateJobQueueRequest,
   UpdateJobQueueResponse,
   UpdateJobQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobQueueRequest,
   output: UpdateJobQueueResponse,
@@ -6041,7 +6040,7 @@ export const updateQuotaShare: API.OperationMethod<
   UpdateQuotaShareRequest,
   UpdateQuotaShareResponse,
   UpdateQuotaShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuotaShareRequest,
   output: UpdateQuotaShareResponse,
@@ -6062,7 +6061,7 @@ export const updateSchedulingPolicy: API.OperationMethod<
   UpdateSchedulingPolicyRequest,
   UpdateSchedulingPolicyResponse,
   UpdateSchedulingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSchedulingPolicyRequest,
   output: UpdateSchedulingPolicyResponse,
@@ -6083,7 +6082,7 @@ export const updateServiceEnvironment: API.OperationMethod<
   UpdateServiceEnvironmentRequest,
   UpdateServiceEnvironmentResponse,
   UpdateServiceEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceEnvironmentRequest,
   output: UpdateServiceEnvironmentResponse,
@@ -6104,7 +6103,7 @@ export const updateServiceJob: API.OperationMethod<
   UpdateServiceJobRequest,
   UpdateServiceJobResponse,
   UpdateServiceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceJobRequest,
   output: UpdateServiceJobResponse,

--- a/packages/aws/src/services/bcm-dashboards.ts
+++ b/packages/aws/src/services/bcm-dashboards.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "BCM Dashboards",
   serviceShapeName: "AWSBCMDashboardsService",
@@ -1033,7 +1032,7 @@ export const createDashboard: API.OperationMethod<
   CreateDashboardRequest,
   CreateDashboardResponse,
   CreateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDashboardRequest,
   output: CreateDashboardResponse,
@@ -1064,7 +1063,7 @@ export const createScheduledReport: API.OperationMethod<
   CreateScheduledReportRequest,
   CreateScheduledReportResponse,
   CreateScheduledReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledReportRequest,
   output: CreateScheduledReportResponse,
@@ -1094,7 +1093,7 @@ export const deleteDashboard: API.OperationMethod<
   DeleteDashboardRequest,
   DeleteDashboardResponse,
   DeleteDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDashboardRequest,
   output: DeleteDashboardResponse,
@@ -1123,7 +1122,7 @@ export const deleteScheduledReport: API.OperationMethod<
   DeleteScheduledReportRequest,
   DeleteScheduledReportResponse,
   DeleteScheduledReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledReportRequest,
   output: DeleteScheduledReportResponse,
@@ -1156,7 +1155,7 @@ export const executeScheduledReport: API.OperationMethod<
   ExecuteScheduledReportRequest,
   ExecuteScheduledReportResponse,
   ExecuteScheduledReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteScheduledReportRequest,
   output: ExecuteScheduledReportResponse,
@@ -1187,7 +1186,7 @@ export const getDashboard: API.OperationMethod<
   GetDashboardRequest,
   GetDashboardResponse,
   GetDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardRequest,
   output: GetDashboardResponse,
@@ -1217,7 +1216,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1247,7 +1246,7 @@ export const getScheduledReport: API.OperationMethod<
   GetScheduledReportRequest,
   GetScheduledReportResponse,
   GetScheduledReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScheduledReportRequest,
   output: GetScheduledReportResponse,
@@ -1276,7 +1275,7 @@ export const listDashboards: API.PaginatedOperationMethod<
   ListDashboardsRequest,
   ListDashboardsResponse,
   ListDashboardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDashboardsRequest,
@@ -1311,7 +1310,7 @@ export const listScheduledReports: API.PaginatedOperationMethod<
   ListScheduledReportsRequest,
   ListScheduledReportsResponse,
   ListScheduledReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledReportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledReportsRequest,
@@ -1346,7 +1345,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1374,7 +1373,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1402,7 +1401,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1431,7 +1430,7 @@ export const updateDashboard: API.OperationMethod<
   UpdateDashboardRequest,
   UpdateDashboardResponse,
   UpdateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardRequest,
   output: UpdateDashboardResponse,
@@ -1462,7 +1461,7 @@ export const updateScheduledReport: API.OperationMethod<
   UpdateScheduledReportRequest,
   UpdateScheduledReportResponse,
   UpdateScheduledReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledReportRequest,
   output: UpdateScheduledReportResponse,

--- a/packages/aws/src/services/bcm-data-exports.ts
+++ b/packages/aws/src/services/bcm-data-exports.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "BCM Data Exports",
   serviceShapeName: "AWSBillingAndCostManagementDataExports",
@@ -760,7 +759,7 @@ export const createExport: API.OperationMethod<
   CreateExportRequest,
   CreateExportResponse,
   CreateExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportRequest,
   output: CreateExportResponse,
@@ -789,7 +788,7 @@ export const deleteExport: API.OperationMethod<
   DeleteExportRequest,
   DeleteExportResponse,
   DeleteExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExportRequest,
   output: DeleteExportResponse,
@@ -817,7 +816,7 @@ export const getExecution: API.OperationMethod<
   GetExecutionRequest,
   GetExecutionResponse,
   GetExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExecutionRequest,
   output: GetExecutionResponse,
@@ -845,7 +844,7 @@ export const getExport: API.OperationMethod<
   GetExportRequest,
   GetExportResponse,
   GetExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportRequest,
   output: GetExportResponse,
@@ -872,7 +871,7 @@ export const getTable: API.OperationMethod<
   GetTableRequest,
   GetTableResponse,
   GetTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRequest,
   output: GetTableResponse,
@@ -895,7 +894,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsRequest,
   ListExecutionsResponse,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExecutionReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsRequest,
@@ -929,7 +928,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsRequest,
   ListExportsResponse,
   ListExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsRequest,
@@ -958,7 +957,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesRequest,
   ListTablesResponse,
   ListTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Table
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesRequest,
@@ -989,7 +988,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1019,7 +1018,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1049,7 +1048,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1078,7 +1077,7 @@ export const updateExport: API.OperationMethod<
   UpdateExportRequest,
   UpdateExportResponse,
   UpdateExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExportRequest,
   output: UpdateExportResponse,

--- a/packages/aws/src/services/bcm-pricing-calculator.ts
+++ b/packages/aws/src/services/bcm-pricing-calculator.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "BCM Pricing Calculator",
   serviceShapeName: "AWSBCMPricingCalculator",
@@ -2526,7 +2525,7 @@ export const batchCreateBillScenarioCommitmentModification: API.OperationMethod<
   BatchCreateBillScenarioCommitmentModificationRequest,
   BatchCreateBillScenarioCommitmentModificationResponse,
   BatchCreateBillScenarioCommitmentModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateBillScenarioCommitmentModificationRequest,
   output: BatchCreateBillScenarioCommitmentModificationResponse,
@@ -2555,7 +2554,7 @@ export const batchCreateBillScenarioUsageModification: API.OperationMethod<
   BatchCreateBillScenarioUsageModificationRequest,
   BatchCreateBillScenarioUsageModificationResponse,
   BatchCreateBillScenarioUsageModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateBillScenarioUsageModificationRequest,
   output: BatchCreateBillScenarioUsageModificationResponse,
@@ -2585,7 +2584,7 @@ export const batchCreateWorkloadEstimateUsage: API.OperationMethod<
   BatchCreateWorkloadEstimateUsageRequest,
   BatchCreateWorkloadEstimateUsageResponse,
   BatchCreateWorkloadEstimateUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateWorkloadEstimateUsageRequest,
   output: BatchCreateWorkloadEstimateUsageResponse,
@@ -2614,7 +2613,7 @@ export const batchDeleteBillScenarioCommitmentModification: API.OperationMethod<
   BatchDeleteBillScenarioCommitmentModificationRequest,
   BatchDeleteBillScenarioCommitmentModificationResponse,
   BatchDeleteBillScenarioCommitmentModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteBillScenarioCommitmentModificationRequest,
   output: BatchDeleteBillScenarioCommitmentModificationResponse,
@@ -2643,7 +2642,7 @@ export const batchDeleteBillScenarioUsageModification: API.OperationMethod<
   BatchDeleteBillScenarioUsageModificationRequest,
   BatchDeleteBillScenarioUsageModificationResponse,
   BatchDeleteBillScenarioUsageModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteBillScenarioUsageModificationRequest,
   output: BatchDeleteBillScenarioUsageModificationResponse,
@@ -2672,7 +2671,7 @@ export const batchDeleteWorkloadEstimateUsage: API.OperationMethod<
   BatchDeleteWorkloadEstimateUsageRequest,
   BatchDeleteWorkloadEstimateUsageResponse,
   BatchDeleteWorkloadEstimateUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteWorkloadEstimateUsageRequest,
   output: BatchDeleteWorkloadEstimateUsageResponse,
@@ -2700,7 +2699,7 @@ export const batchUpdateBillScenarioCommitmentModification: API.OperationMethod<
   BatchUpdateBillScenarioCommitmentModificationRequest,
   BatchUpdateBillScenarioCommitmentModificationResponse,
   BatchUpdateBillScenarioCommitmentModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateBillScenarioCommitmentModificationRequest,
   output: BatchUpdateBillScenarioCommitmentModificationResponse,
@@ -2729,7 +2728,7 @@ export const batchUpdateBillScenarioUsageModification: API.OperationMethod<
   BatchUpdateBillScenarioUsageModificationRequest,
   BatchUpdateBillScenarioUsageModificationResponse,
   BatchUpdateBillScenarioUsageModificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateBillScenarioUsageModificationRequest,
   output: BatchUpdateBillScenarioUsageModificationResponse,
@@ -2758,7 +2757,7 @@ export const batchUpdateWorkloadEstimateUsage: API.OperationMethod<
   BatchUpdateWorkloadEstimateUsageRequest,
   BatchUpdateWorkloadEstimateUsageResponse,
   BatchUpdateWorkloadEstimateUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateWorkloadEstimateUsageRequest,
   output: BatchUpdateWorkloadEstimateUsageResponse,
@@ -2784,7 +2783,7 @@ export const createBillEstimate: API.OperationMethod<
   CreateBillEstimateRequest,
   CreateBillEstimateResponse,
   CreateBillEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillEstimateRequest,
   output: CreateBillEstimateResponse,
@@ -2810,7 +2809,7 @@ export const createBillScenario: API.OperationMethod<
   CreateBillScenarioRequest,
   CreateBillScenarioResponse,
   CreateBillScenarioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillScenarioRequest,
   output: CreateBillScenarioResponse,
@@ -2836,7 +2835,7 @@ export const createWorkloadEstimate: API.OperationMethod<
   CreateWorkloadEstimateRequest,
   CreateWorkloadEstimateResponse,
   CreateWorkloadEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkloadEstimateRequest,
   output: CreateWorkloadEstimateResponse,
@@ -2861,7 +2860,7 @@ export const deleteBillEstimate: API.OperationMethod<
   DeleteBillEstimateRequest,
   DeleteBillEstimateResponse,
   DeleteBillEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBillEstimateRequest,
   output: DeleteBillEstimateResponse,
@@ -2882,7 +2881,7 @@ export const deleteBillScenario: API.OperationMethod<
   DeleteBillScenarioRequest,
   DeleteBillScenarioResponse,
   DeleteBillScenarioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBillScenarioRequest,
   output: DeleteBillScenarioResponse,
@@ -2902,7 +2901,7 @@ export const deleteWorkloadEstimate: API.OperationMethod<
   DeleteWorkloadEstimateRequest,
   DeleteWorkloadEstimateResponse,
   DeleteWorkloadEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkloadEstimateRequest,
   output: DeleteWorkloadEstimateResponse,
@@ -2923,7 +2922,7 @@ export const getBillEstimate: API.OperationMethod<
   GetBillEstimateRequest,
   GetBillEstimateResponse,
   GetBillEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBillEstimateRequest,
   output: GetBillEstimateResponse,
@@ -2944,7 +2943,7 @@ export const getBillScenario: API.OperationMethod<
   GetBillScenarioRequest,
   GetBillScenarioResponse,
   GetBillScenarioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBillScenarioRequest,
   output: GetBillScenarioResponse,
@@ -2962,7 +2961,7 @@ export const getPreferences: API.OperationMethod<
   GetPreferencesRequest,
   GetPreferencesResponse,
   GetPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPreferencesRequest,
   output: GetPreferencesResponse,
@@ -2983,7 +2982,7 @@ export const getWorkloadEstimate: API.OperationMethod<
   GetWorkloadEstimateRequest,
   GetWorkloadEstimateResponse,
   GetWorkloadEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadEstimateRequest,
   output: GetWorkloadEstimateResponse,
@@ -3004,7 +3003,7 @@ export const listBillEstimateCommitments: API.PaginatedOperationMethod<
   ListBillEstimateCommitmentsRequest,
   ListBillEstimateCommitmentsResponse,
   ListBillEstimateCommitmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillEstimateCommitmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillEstimateCommitmentsRequest,
@@ -3032,7 +3031,7 @@ export const listBillEstimateInputCommitmentModifications: API.PaginatedOperatio
   ListBillEstimateInputCommitmentModificationsRequest,
   ListBillEstimateInputCommitmentModificationsResponse,
   ListBillEstimateInputCommitmentModificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillEstimateInputCommitmentModificationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillEstimateInputCommitmentModificationsRequest,
@@ -3060,7 +3059,7 @@ export const listBillEstimateInputUsageModifications: API.PaginatedOperationMeth
   ListBillEstimateInputUsageModificationsRequest,
   ListBillEstimateInputUsageModificationsResponse,
   ListBillEstimateInputUsageModificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillEstimateInputUsageModificationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillEstimateInputUsageModificationsRequest,
@@ -3088,7 +3087,7 @@ export const listBillEstimateLineItems: API.PaginatedOperationMethod<
   ListBillEstimateLineItemsRequest,
   ListBillEstimateLineItemsResponse,
   ListBillEstimateLineItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillEstimateLineItemSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillEstimateLineItemsRequest,
@@ -3113,7 +3112,7 @@ export const listBillEstimates: API.PaginatedOperationMethod<
   ListBillEstimatesRequest,
   ListBillEstimatesResponse,
   ListBillEstimatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillEstimateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillEstimatesRequest,
@@ -3141,7 +3140,7 @@ export const listBillScenarioCommitmentModifications: API.PaginatedOperationMeth
   ListBillScenarioCommitmentModificationsRequest,
   ListBillScenarioCommitmentModificationsResponse,
   ListBillScenarioCommitmentModificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillScenarioCommitmentModificationItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillScenarioCommitmentModificationsRequest,
@@ -3166,7 +3165,7 @@ export const listBillScenarios: API.PaginatedOperationMethod<
   ListBillScenariosRequest,
   ListBillScenariosResponse,
   ListBillScenariosError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillScenarioSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillScenariosRequest,
@@ -3194,7 +3193,7 @@ export const listBillScenarioUsageModifications: API.PaginatedOperationMethod<
   ListBillScenarioUsageModificationsRequest,
   ListBillScenarioUsageModificationsResponse,
   ListBillScenarioUsageModificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillScenarioUsageModificationItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillScenarioUsageModificationsRequest,
@@ -3219,7 +3218,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3239,7 +3238,7 @@ export const listWorkloadEstimates: API.PaginatedOperationMethod<
   ListWorkloadEstimatesRequest,
   ListWorkloadEstimatesResponse,
   ListWorkloadEstimatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadEstimateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadEstimatesRequest,
@@ -3267,7 +3266,7 @@ export const listWorkloadEstimateUsage: API.PaginatedOperationMethod<
   ListWorkloadEstimateUsageRequest,
   ListWorkloadEstimateUsageResponse,
   ListWorkloadEstimateUsageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadEstimateUsageItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadEstimateUsageRequest,
@@ -3295,7 +3294,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3313,7 +3312,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3335,7 +3334,7 @@ export const updateBillEstimate: API.OperationMethod<
   UpdateBillEstimateRequest,
   UpdateBillEstimateResponse,
   UpdateBillEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBillEstimateRequest,
   output: UpdateBillEstimateResponse,
@@ -3361,7 +3360,7 @@ export const updateBillScenario: API.OperationMethod<
   UpdateBillScenarioRequest,
   UpdateBillScenarioResponse,
   UpdateBillScenarioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBillScenarioRequest,
   output: UpdateBillScenarioResponse,
@@ -3386,7 +3385,7 @@ export const updatePreferences: API.OperationMethod<
   UpdatePreferencesRequest,
   UpdatePreferencesResponse,
   UpdatePreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePreferencesRequest,
   output: UpdatePreferencesResponse,
@@ -3408,7 +3407,7 @@ export const updateWorkloadEstimate: API.OperationMethod<
   UpdateWorkloadEstimateRequest,
   UpdateWorkloadEstimateResponse,
   UpdateWorkloadEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkloadEstimateRequest,
   output: UpdateWorkloadEstimateResponse,

--- a/packages/aws/src/services/bcm-recommended-actions.ts
+++ b/packages/aws/src/services/bcm-recommended-actions.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "BCM Recommended Actions",
   serviceShapeName: "AWSBillingAndCostManagementRecommendedActions",
@@ -286,7 +285,7 @@ export const listRecommendedActions: API.PaginatedOperationMethod<
   ListRecommendedActionsRequest,
   ListRecommendedActionsResponse,
   ListRecommendedActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendedAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendedActionsRequest,

--- a/packages/aws/src/services/bedrock-agent-runtime.ts
+++ b/packages/aws/src/services/bedrock-agent-runtime.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock Agent Runtime",
@@ -7288,7 +7287,7 @@ export const agenticRetrieveStream: API.OperationMethod<
   AgenticRetrieveStreamRequest,
   AgenticRetrieveStreamResponse,
   AgenticRetrieveStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AgenticRetrieveStreamRequest,
   output: AgenticRetrieveStreamResponse,
@@ -7332,7 +7331,7 @@ export const createInvocation: API.OperationMethod<
   CreateInvocationRequest,
   CreateInvocationResponse,
   CreateInvocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvocationRequest,
   output: CreateInvocationResponse,
@@ -7379,7 +7378,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionResponse,
   CreateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionResponse,
@@ -7414,7 +7413,7 @@ export const deleteAgentMemory: API.OperationMethod<
   DeleteAgentMemoryRequest,
   DeleteAgentMemoryResponse,
   DeleteAgentMemoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentMemoryRequest,
   output: DeleteAgentMemoryResponse,
@@ -7449,7 +7448,7 @@ export const deleteSession: API.OperationMethod<
   DeleteSessionRequest,
   DeleteSessionResponse,
   DeleteSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSessionRequest,
   output: DeleteSessionResponse,
@@ -7481,7 +7480,7 @@ export const endSession: API.OperationMethod<
   EndSessionRequest,
   EndSessionResponse,
   EndSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EndSessionRequest,
   output: EndSessionResponse,
@@ -7516,7 +7515,7 @@ export const generateQuery: API.OperationMethod<
   GenerateQueryRequest,
   GenerateQueryResponse,
   GenerateQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateQueryRequest,
   output: GenerateQueryResponse,
@@ -7554,7 +7553,7 @@ export const getAgentMemory: API.PaginatedOperationMethod<
   GetAgentMemoryRequest,
   GetAgentMemoryResponse,
   GetAgentMemoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Memory
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAgentMemoryRequest,
@@ -7595,7 +7594,7 @@ export const getDocumentContent: API.OperationMethod<
   GetDocumentContentRequest,
   GetDocumentContentResponse,
   GetDocumentContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentContentRequest,
   output: GetDocumentContentResponse,
@@ -7627,7 +7626,7 @@ export const getExecutionFlowSnapshot: API.OperationMethod<
   GetExecutionFlowSnapshotRequest,
   GetExecutionFlowSnapshotResponse,
   GetExecutionFlowSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExecutionFlowSnapshotRequest,
   output: GetExecutionFlowSnapshotResponse,
@@ -7657,7 +7656,7 @@ export const getFlowExecution: API.OperationMethod<
   GetFlowExecutionRequest,
   GetFlowExecutionResponse,
   GetFlowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowExecutionRequest,
   output: GetFlowExecutionResponse,
@@ -7687,7 +7686,7 @@ export const getInvocationStep: API.OperationMethod<
   GetInvocationStepRequest,
   GetInvocationStepResponse,
   GetInvocationStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvocationStepRequest,
   output: GetInvocationStepResponse,
@@ -7717,7 +7716,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -7772,7 +7771,7 @@ export const invokeAgent: API.OperationMethod<
   InvokeAgentRequest,
   InvokeAgentResponse,
   InvokeAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeAgentRequest,
   output: InvokeAgentResponse,
@@ -7813,7 +7812,7 @@ export const invokeFlow: API.OperationMethod<
   InvokeFlowRequest,
   InvokeFlowResponse,
   InvokeFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeFlowRequest,
   output: InvokeFlowResponse,
@@ -7861,7 +7860,7 @@ export const invokeInlineAgent: API.OperationMethod<
   InvokeInlineAgentRequest,
   InvokeInlineAgentResponse,
   InvokeInlineAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeInlineAgentRequest,
   output: InvokeInlineAgentResponse,
@@ -7897,7 +7896,7 @@ export const listFlowExecutionEvents: API.PaginatedOperationMethod<
   ListFlowExecutionEventsRequest,
   ListFlowExecutionEventsResponse,
   ListFlowExecutionEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowExecutionEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowExecutionEventsRequest,
@@ -7936,7 +7935,7 @@ export const listFlowExecutions: API.PaginatedOperationMethod<
   ListFlowExecutionsRequest,
   ListFlowExecutionsResponse,
   ListFlowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowExecutionsRequest,
@@ -7973,7 +7972,7 @@ export const listInvocations: API.PaginatedOperationMethod<
   ListInvocationsRequest,
   ListInvocationsResponse,
   ListInvocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvocationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvocationsRequest,
@@ -8010,7 +8009,7 @@ export const listInvocationSteps: API.PaginatedOperationMethod<
   ListInvocationStepsRequest,
   ListInvocationStepsResponse,
   ListInvocationStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvocationStepSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvocationStepsRequest,
@@ -8046,7 +8045,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -8082,7 +8081,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8113,7 +8112,7 @@ export const optimizePrompt: API.OperationMethod<
   OptimizePromptRequest,
   OptimizePromptResponse,
   OptimizePromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OptimizePromptRequest,
   output: OptimizePromptResponse,
@@ -8156,7 +8155,7 @@ export const putInvocationStep: API.OperationMethod<
   PutInvocationStepRequest,
   PutInvocationStepResponse,
   PutInvocationStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInvocationStepRequest,
   output: PutInvocationStepResponse,
@@ -8192,7 +8191,7 @@ export const rerank: API.PaginatedOperationMethod<
   RerankRequest,
   RerankResponse,
   RerankError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RerankResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: RerankRequest,
@@ -8236,7 +8235,7 @@ export const retrieve: API.PaginatedOperationMethod<
   RetrieveRequest,
   RetrieveResponse,
   RetrieveError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseRetrievalResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: RetrieveRequest,
@@ -8282,7 +8281,7 @@ export const retrieveAndGenerate: API.OperationMethod<
   RetrieveAndGenerateRequest,
   RetrieveAndGenerateResponse,
   RetrieveAndGenerateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveAndGenerateRequest,
   output: RetrieveAndGenerateResponse,
@@ -8326,7 +8325,7 @@ export const retrieveAndGenerateStream: API.OperationMethod<
   RetrieveAndGenerateStreamRequest,
   RetrieveAndGenerateStreamResponse,
   RetrieveAndGenerateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveAndGenerateStreamRequest,
   output: RetrieveAndGenerateStreamResponse,
@@ -8368,7 +8367,7 @@ export const startFlowExecution: API.OperationMethod<
   StartFlowExecutionRequest,
   StartFlowExecutionResponse,
   StartFlowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlowExecutionRequest,
   output: StartFlowExecutionResponse,
@@ -8405,7 +8404,7 @@ export const stopFlowExecution: API.OperationMethod<
   StopFlowExecutionRequest,
   StopFlowExecutionResponse,
   StopFlowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFlowExecutionRequest,
   output: StopFlowExecutionResponse,
@@ -8439,7 +8438,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8470,7 +8469,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8501,7 +8500,7 @@ export const updateSession: API.OperationMethod<
   UpdateSessionRequest,
   UpdateSessionResponse,
   UpdateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSessionRequest,
   output: UpdateSessionResponse,

--- a/packages/aws/src/services/bedrock-agent.ts
+++ b/packages/aws/src/services/bedrock-agent.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock Agent",
@@ -8451,7 +8450,7 @@ export const associateAgentCollaborator: API.OperationMethod<
   AssociateAgentCollaboratorRequest,
   AssociateAgentCollaboratorResponse,
   AssociateAgentCollaboratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAgentCollaboratorRequest,
   output: AssociateAgentCollaboratorResponse,
@@ -8485,7 +8484,7 @@ export const associateAgentKnowledgeBase: API.OperationMethod<
   AssociateAgentKnowledgeBaseRequest,
   AssociateAgentKnowledgeBaseResponse,
   AssociateAgentKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAgentKnowledgeBaseRequest,
   output: AssociateAgentKnowledgeBaseResponse,
@@ -8534,7 +8533,7 @@ export const createAgent: API.OperationMethod<
   CreateAgentRequest,
   CreateAgentResponse,
   CreateAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentRequest,
   output: CreateAgentResponse,
@@ -8573,7 +8572,7 @@ export const createAgentActionGroup: API.OperationMethod<
   CreateAgentActionGroupRequest,
   CreateAgentActionGroupResponse,
   CreateAgentActionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentActionGroupRequest,
   output: CreateAgentActionGroupResponse,
@@ -8607,7 +8606,7 @@ export const createAgentAlias: API.OperationMethod<
   CreateAgentAliasRequest,
   CreateAgentAliasResponse,
   CreateAgentAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentAliasRequest,
   output: CreateAgentAliasResponse,
@@ -8643,7 +8642,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceRequest,
   CreateDataSourceResponse,
   CreateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceRequest,
   output: CreateDataSourceResponse,
@@ -8676,7 +8675,7 @@ export const createFlow: API.OperationMethod<
   CreateFlowRequest,
   CreateFlowResponse,
   CreateFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowRequest,
   output: CreateFlowResponse,
@@ -8709,7 +8708,7 @@ export const createFlowAlias: API.OperationMethod<
   CreateFlowAliasRequest,
   CreateFlowAliasResponse,
   CreateFlowAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowAliasRequest,
   output: CreateFlowAliasResponse,
@@ -8743,7 +8742,7 @@ export const createFlowVersion: API.OperationMethod<
   CreateFlowVersionRequest,
   CreateFlowVersionResponse,
   CreateFlowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowVersionRequest,
   output: CreateFlowVersionResponse,
@@ -8796,7 +8795,7 @@ export const createKnowledgeBase: API.OperationMethod<
   CreateKnowledgeBaseRequest,
   CreateKnowledgeBaseResponse,
   CreateKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKnowledgeBaseRequest,
   output: CreateKnowledgeBaseResponse,
@@ -8828,7 +8827,7 @@ export const createPrompt: API.OperationMethod<
   CreatePromptRequest,
   CreatePromptResponse,
   CreatePromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePromptRequest,
   output: CreatePromptResponse,
@@ -8861,7 +8860,7 @@ export const createPromptVersion: API.OperationMethod<
   CreatePromptVersionRequest,
   CreatePromptVersionResponse,
   CreatePromptVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePromptVersionRequest,
   output: CreatePromptVersionResponse,
@@ -8894,7 +8893,7 @@ export const deleteAgent: API.OperationMethod<
   DeleteAgentRequest,
   DeleteAgentResponse,
   DeleteAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentRequest,
   output: DeleteAgentResponse,
@@ -8926,7 +8925,7 @@ export const deleteAgentActionGroup: API.OperationMethod<
   DeleteAgentActionGroupRequest,
   DeleteAgentActionGroupResponse,
   DeleteAgentActionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentActionGroupRequest,
   output: DeleteAgentActionGroupResponse,
@@ -8957,7 +8956,7 @@ export const deleteAgentAlias: API.OperationMethod<
   DeleteAgentAliasRequest,
   DeleteAgentAliasResponse,
   DeleteAgentAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentAliasRequest,
   output: DeleteAgentAliasResponse,
@@ -8988,7 +8987,7 @@ export const deleteAgentVersion: API.OperationMethod<
   DeleteAgentVersionRequest,
   DeleteAgentVersionResponse,
   DeleteAgentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentVersionRequest,
   output: DeleteAgentVersionResponse,
@@ -9020,7 +9019,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -9052,7 +9051,7 @@ export const deleteFlow: API.OperationMethod<
   DeleteFlowRequest,
   DeleteFlowResponse,
   DeleteFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowRequest,
   output: DeleteFlowResponse,
@@ -9084,7 +9083,7 @@ export const deleteFlowAlias: API.OperationMethod<
   DeleteFlowAliasRequest,
   DeleteFlowAliasResponse,
   DeleteFlowAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowAliasRequest,
   output: DeleteFlowAliasResponse,
@@ -9116,7 +9115,7 @@ export const deleteFlowVersion: API.OperationMethod<
   DeleteFlowVersionRequest,
   DeleteFlowVersionResponse,
   DeleteFlowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowVersionRequest,
   output: DeleteFlowVersionResponse,
@@ -9148,7 +9147,7 @@ export const deleteKnowledgeBase: API.OperationMethod<
   DeleteKnowledgeBaseRequest,
   DeleteKnowledgeBaseResponse,
   DeleteKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnowledgeBaseRequest,
   output: DeleteKnowledgeBaseResponse,
@@ -9180,7 +9179,7 @@ export const deleteKnowledgeBaseDocuments: API.OperationMethod<
   DeleteKnowledgeBaseDocumentsRequest,
   DeleteKnowledgeBaseDocumentsResponse,
   DeleteKnowledgeBaseDocumentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnowledgeBaseDocumentsRequest,
   output: DeleteKnowledgeBaseDocumentsResponse,
@@ -9212,7 +9211,7 @@ export const deletePrompt: API.OperationMethod<
   DeletePromptRequest,
   DeletePromptResponse,
   DeletePromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePromptRequest,
   output: DeletePromptResponse,
@@ -9244,7 +9243,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -9276,7 +9275,7 @@ export const disassociateAgentCollaborator: API.OperationMethod<
   DisassociateAgentCollaboratorRequest,
   DisassociateAgentCollaboratorResponse,
   DisassociateAgentCollaboratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAgentCollaboratorRequest,
   output: DisassociateAgentCollaboratorResponse,
@@ -9308,7 +9307,7 @@ export const disassociateAgentKnowledgeBase: API.OperationMethod<
   DisassociateAgentKnowledgeBaseRequest,
   DisassociateAgentKnowledgeBaseResponse,
   DisassociateAgentKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAgentKnowledgeBaseRequest,
   output: DisassociateAgentKnowledgeBaseResponse,
@@ -9339,7 +9338,7 @@ export const getAgent: API.OperationMethod<
   GetAgentRequest,
   GetAgentResponse,
   GetAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentRequest,
   output: GetAgentResponse,
@@ -9369,7 +9368,7 @@ export const getAgentActionGroup: API.OperationMethod<
   GetAgentActionGroupRequest,
   GetAgentActionGroupResponse,
   GetAgentActionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentActionGroupRequest,
   output: GetAgentActionGroupResponse,
@@ -9399,7 +9398,7 @@ export const getAgentAlias: API.OperationMethod<
   GetAgentAliasRequest,
   GetAgentAliasResponse,
   GetAgentAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentAliasRequest,
   output: GetAgentAliasResponse,
@@ -9429,7 +9428,7 @@ export const getAgentCollaborator: API.OperationMethod<
   GetAgentCollaboratorRequest,
   GetAgentCollaboratorResponse,
   GetAgentCollaboratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentCollaboratorRequest,
   output: GetAgentCollaboratorResponse,
@@ -9459,7 +9458,7 @@ export const getAgentKnowledgeBase: API.OperationMethod<
   GetAgentKnowledgeBaseRequest,
   GetAgentKnowledgeBaseResponse,
   GetAgentKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentKnowledgeBaseRequest,
   output: GetAgentKnowledgeBaseResponse,
@@ -9489,7 +9488,7 @@ export const getAgentVersion: API.OperationMethod<
   GetAgentVersionRequest,
   GetAgentVersionResponse,
   GetAgentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentVersionRequest,
   output: GetAgentVersionResponse,
@@ -9519,7 +9518,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceRequest,
   GetDataSourceResponse,
   GetDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceRequest,
   output: GetDataSourceResponse,
@@ -9549,7 +9548,7 @@ export const getFlow: API.OperationMethod<
   GetFlowRequest,
   GetFlowResponse,
   GetFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowRequest,
   output: GetFlowResponse,
@@ -9579,7 +9578,7 @@ export const getFlowAlias: API.OperationMethod<
   GetFlowAliasRequest,
   GetFlowAliasResponse,
   GetFlowAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowAliasRequest,
   output: GetFlowAliasResponse,
@@ -9609,7 +9608,7 @@ export const getFlowVersion: API.OperationMethod<
   GetFlowVersionRequest,
   GetFlowVersionResponse,
   GetFlowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowVersionRequest,
   output: GetFlowVersionResponse,
@@ -9639,7 +9638,7 @@ export const getIngestionJob: API.OperationMethod<
   GetIngestionJobRequest,
   GetIngestionJobResponse,
   GetIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIngestionJobRequest,
   output: GetIngestionJobResponse,
@@ -9669,7 +9668,7 @@ export const getKnowledgeBase: API.OperationMethod<
   GetKnowledgeBaseRequest,
   GetKnowledgeBaseResponse,
   GetKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKnowledgeBaseRequest,
   output: GetKnowledgeBaseResponse,
@@ -9700,7 +9699,7 @@ export const getKnowledgeBaseDocuments: API.OperationMethod<
   GetKnowledgeBaseDocumentsRequest,
   GetKnowledgeBaseDocumentsResponse,
   GetKnowledgeBaseDocumentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKnowledgeBaseDocumentsRequest,
   output: GetKnowledgeBaseDocumentsResponse,
@@ -9731,7 +9730,7 @@ export const getPrompt: API.OperationMethod<
   GetPromptRequest,
   GetPromptResponse,
   GetPromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPromptRequest,
   output: GetPromptResponse,
@@ -9761,7 +9760,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -9792,7 +9791,7 @@ export const ingestKnowledgeBaseDocuments: API.OperationMethod<
   IngestKnowledgeBaseDocumentsRequest,
   IngestKnowledgeBaseDocumentsResponse,
   IngestKnowledgeBaseDocumentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IngestKnowledgeBaseDocumentsRequest,
   output: IngestKnowledgeBaseDocumentsResponse,
@@ -9823,7 +9822,7 @@ export const listAgentActionGroups: API.PaginatedOperationMethod<
   ListAgentActionGroupsRequest,
   ListAgentActionGroupsResponse,
   ListAgentActionGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentActionGroupsRequest,
@@ -9860,7 +9859,7 @@ export const listAgentAliases: API.PaginatedOperationMethod<
   ListAgentAliasesRequest,
   ListAgentAliasesResponse,
   ListAgentAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentAliasSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentAliasesRequest,
@@ -9897,7 +9896,7 @@ export const listAgentCollaborators: API.PaginatedOperationMethod<
   ListAgentCollaboratorsRequest,
   ListAgentCollaboratorsResponse,
   ListAgentCollaboratorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentCollaboratorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentCollaboratorsRequest,
@@ -9934,7 +9933,7 @@ export const listAgentKnowledgeBases: API.PaginatedOperationMethod<
   ListAgentKnowledgeBasesRequest,
   ListAgentKnowledgeBasesResponse,
   ListAgentKnowledgeBasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentKnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentKnowledgeBasesRequest,
@@ -9970,7 +9969,7 @@ export const listAgents: API.PaginatedOperationMethod<
   ListAgentsRequest,
   ListAgentsResponse,
   ListAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentsRequest,
@@ -10006,7 +10005,7 @@ export const listAgentVersions: API.PaginatedOperationMethod<
   ListAgentVersionsRequest,
   ListAgentVersionsResponse,
   ListAgentVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentVersionsRequest,
@@ -10043,7 +10042,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesRequest,
@@ -10080,7 +10079,7 @@ export const listFlowAliases: API.PaginatedOperationMethod<
   ListFlowAliasesRequest,
   ListFlowAliasesResponse,
   ListFlowAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowAliasSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowAliasesRequest,
@@ -10116,7 +10115,7 @@ export const listFlows: API.PaginatedOperationMethod<
   ListFlowsRequest,
   ListFlowsResponse,
   ListFlowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowsRequest,
@@ -10152,7 +10151,7 @@ export const listFlowVersions: API.PaginatedOperationMethod<
   ListFlowVersionsRequest,
   ListFlowVersionsResponse,
   ListFlowVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowVersionsRequest,
@@ -10189,7 +10188,7 @@ export const listIngestionJobs: API.PaginatedOperationMethod<
   ListIngestionJobsRequest,
   ListIngestionJobsResponse,
   ListIngestionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IngestionJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngestionJobsRequest,
@@ -10227,7 +10226,7 @@ export const listKnowledgeBaseDocuments: API.PaginatedOperationMethod<
   ListKnowledgeBaseDocumentsRequest,
   ListKnowledgeBaseDocumentsResponse,
   ListKnowledgeBaseDocumentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseDocumentDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKnowledgeBaseDocumentsRequest,
@@ -10264,7 +10263,7 @@ export const listKnowledgeBases: API.PaginatedOperationMethod<
   ListKnowledgeBasesRequest,
   ListKnowledgeBasesResponse,
   ListKnowledgeBasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKnowledgeBasesRequest,
@@ -10300,7 +10299,7 @@ export const listPrompts: API.PaginatedOperationMethod<
   ListPromptsRequest,
   ListPromptsResponse,
   ListPromptsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PromptSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPromptsRequest,
@@ -10337,7 +10336,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -10369,7 +10368,7 @@ export const prepareAgent: API.OperationMethod<
   PrepareAgentRequest,
   PrepareAgentResponse,
   PrepareAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PrepareAgentRequest,
   output: PrepareAgentResponse,
@@ -10403,7 +10402,7 @@ export const prepareFlow: API.OperationMethod<
   PrepareFlowRequest,
   PrepareFlowResponse,
   PrepareFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PrepareFlowRequest,
   output: PrepareFlowResponse,
@@ -10436,7 +10435,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -10469,7 +10468,7 @@ export const startIngestionJob: API.OperationMethod<
   StartIngestionJobRequest,
   StartIngestionJobResponse,
   StartIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartIngestionJobRequest,
   output: StartIngestionJobResponse,
@@ -10502,7 +10501,7 @@ export const stopIngestionJob: API.OperationMethod<
   StopIngestionJobRequest,
   StopIngestionJobResponse,
   StopIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopIngestionJobRequest,
   output: StopIngestionJobResponse,
@@ -10534,7 +10533,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10565,7 +10564,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10597,7 +10596,7 @@ export const updateAgent: API.OperationMethod<
   UpdateAgentRequest,
   UpdateAgentResponse,
   UpdateAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentRequest,
   output: UpdateAgentResponse,
@@ -10631,7 +10630,7 @@ export const updateAgentActionGroup: API.OperationMethod<
   UpdateAgentActionGroupRequest,
   UpdateAgentActionGroupResponse,
   UpdateAgentActionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentActionGroupRequest,
   output: UpdateAgentActionGroupResponse,
@@ -10665,7 +10664,7 @@ export const updateAgentAlias: API.OperationMethod<
   UpdateAgentAliasRequest,
   UpdateAgentAliasResponse,
   UpdateAgentAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentAliasRequest,
   output: UpdateAgentAliasResponse,
@@ -10699,7 +10698,7 @@ export const updateAgentCollaborator: API.OperationMethod<
   UpdateAgentCollaboratorRequest,
   UpdateAgentCollaboratorResponse,
   UpdateAgentCollaboratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentCollaboratorRequest,
   output: UpdateAgentCollaboratorResponse,
@@ -10732,7 +10731,7 @@ export const updateAgentKnowledgeBase: API.OperationMethod<
   UpdateAgentKnowledgeBaseRequest,
   UpdateAgentKnowledgeBaseResponse,
   UpdateAgentKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentKnowledgeBaseRequest,
   output: UpdateAgentKnowledgeBaseResponse,
@@ -10766,7 +10765,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -10799,7 +10798,7 @@ export const updateFlow: API.OperationMethod<
   UpdateFlowRequest,
   UpdateFlowResponse,
   UpdateFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowRequest,
   output: UpdateFlowResponse,
@@ -10833,7 +10832,7 @@ export const updateFlowAlias: API.OperationMethod<
   UpdateFlowAliasRequest,
   UpdateFlowAliasResponse,
   UpdateFlowAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowAliasRequest,
   output: UpdateFlowAliasResponse,
@@ -10876,7 +10875,7 @@ export const updateKnowledgeBase: API.OperationMethod<
   UpdateKnowledgeBaseRequest,
   UpdateKnowledgeBaseResponse,
   UpdateKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKnowledgeBaseRequest,
   output: UpdateKnowledgeBaseResponse,
@@ -10909,7 +10908,7 @@ export const updatePrompt: API.OperationMethod<
   UpdatePromptRequest,
   UpdatePromptResponse,
   UpdatePromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePromptRequest,
   output: UpdatePromptResponse,
@@ -10940,7 +10939,7 @@ export const validateFlowDefinition: API.OperationMethod<
   ValidateFlowDefinitionRequest,
   ValidateFlowDefinitionResponse,
   ValidateFlowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateFlowDefinitionRequest,
   output: ValidateFlowDefinitionResponse,

--- a/packages/aws/src/services/bedrock-agentcore-control.ts
+++ b/packages/aws/src/services/bedrock-agentcore-control.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock AgentCore Control",
@@ -13180,7 +13179,7 @@ export const addDatasetExamples: API.OperationMethod<
   AddDatasetExamplesRequest,
   AddDatasetExamplesResponse,
   AddDatasetExamplesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddDatasetExamplesRequest,
   output: AddDatasetExamplesResponse,
@@ -13213,7 +13212,7 @@ export const createAgentRuntime: API.OperationMethod<
   CreateAgentRuntimeRequest,
   CreateAgentRuntimeResponse,
   CreateAgentRuntimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentRuntimeRequest,
   output: CreateAgentRuntimeResponse,
@@ -13246,7 +13245,7 @@ export const createAgentRuntimeEndpoint: API.OperationMethod<
   CreateAgentRuntimeEndpointRequest,
   CreateAgentRuntimeEndpointResponse,
   CreateAgentRuntimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentRuntimeEndpointRequest,
   output: CreateAgentRuntimeEndpointResponse,
@@ -13284,7 +13283,7 @@ export const createApiKeyCredentialProvider: API.OperationMethod<
   CreateApiKeyCredentialProviderRequest,
   CreateApiKeyCredentialProviderResponse,
   CreateApiKeyCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiKeyCredentialProviderRequest,
   output: CreateApiKeyCredentialProviderResponse,
@@ -13321,7 +13320,7 @@ export const createBrowser: API.OperationMethod<
   CreateBrowserRequest,
   CreateBrowserResponse,
   CreateBrowserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBrowserRequest,
   output: CreateBrowserResponse,
@@ -13353,7 +13352,7 @@ export const createBrowserProfile: API.OperationMethod<
   CreateBrowserProfileRequest,
   CreateBrowserProfileResponse,
   CreateBrowserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBrowserProfileRequest,
   output: CreateBrowserProfileResponse,
@@ -13385,7 +13384,7 @@ export const createCodeInterpreter: API.OperationMethod<
   CreateCodeInterpreterRequest,
   CreateCodeInterpreterResponse,
   CreateCodeInterpreterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeInterpreterRequest,
   output: CreateCodeInterpreterResponse,
@@ -13417,7 +13416,7 @@ export const createConfigurationBundle: API.OperationMethod<
   CreateConfigurationBundleRequest,
   CreateConfigurationBundleResponse,
   CreateConfigurationBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationBundleRequest,
   output: CreateConfigurationBundleResponse,
@@ -13449,7 +13448,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -13482,7 +13481,7 @@ export const createDatasetVersion: API.OperationMethod<
   CreateDatasetVersionRequest,
   CreateDatasetVersionResponse,
   CreateDatasetVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetVersionRequest,
   output: CreateDatasetVersionResponse,
@@ -13515,7 +13514,7 @@ export const createEvaluator: API.OperationMethod<
   CreateEvaluatorRequest,
   CreateEvaluatorResponse,
   CreateEvaluatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEvaluatorRequest,
   output: CreateEvaluatorResponse,
@@ -13549,7 +13548,7 @@ export const createGateway: API.OperationMethod<
   CreateGatewayRequest,
   CreateGatewayResponse,
   CreateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayRequest,
   output: CreateGatewayResponse,
@@ -13582,7 +13581,7 @@ export const createGatewayRule: API.OperationMethod<
   CreateGatewayRuleRequest,
   CreateGatewayRuleResponse,
   CreateGatewayRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayRuleRequest,
   output: CreateGatewayRuleResponse,
@@ -13616,7 +13615,7 @@ export const createGatewayTarget: API.OperationMethod<
   CreateGatewayTargetRequest,
   CreateGatewayTargetResponse,
   CreateGatewayTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayTargetRequest,
   output: CreateGatewayTargetResponse,
@@ -13649,7 +13648,7 @@ export const createHarness: API.OperationMethod<
   CreateHarnessRequest,
   CreateHarnessResponse,
   CreateHarnessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHarnessRequest,
   output: CreateHarnessResponse,
@@ -13682,7 +13681,7 @@ export const createHarnessEndpoint: API.OperationMethod<
   CreateHarnessEndpointRequest,
   CreateHarnessEndpointResponse,
   CreateHarnessEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHarnessEndpointRequest,
   output: CreateHarnessEndpointResponse,
@@ -13716,7 +13715,7 @@ export const createMemory: API.OperationMethod<
   CreateMemoryInput,
   CreateMemoryOutput,
   CreateMemoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMemoryInput,
   output: CreateMemoryOutput,
@@ -13754,7 +13753,7 @@ export const createOauth2CredentialProvider: API.OperationMethod<
   CreateOauth2CredentialProviderRequest,
   CreateOauth2CredentialProviderResponse,
   CreateOauth2CredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOauth2CredentialProviderRequest,
   output: CreateOauth2CredentialProviderResponse,
@@ -13791,7 +13790,7 @@ export const createOnlineEvaluationConfig: API.OperationMethod<
   CreateOnlineEvaluationConfigRequest,
   CreateOnlineEvaluationConfigResponse,
   CreateOnlineEvaluationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOnlineEvaluationConfigRequest,
   output: CreateOnlineEvaluationConfigResponse,
@@ -13824,7 +13823,7 @@ export const createPaymentConnector: API.OperationMethod<
   CreatePaymentConnectorRequest,
   CreatePaymentConnectorResponse,
   CreatePaymentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePaymentConnectorRequest,
   output: CreatePaymentConnectorResponse,
@@ -13862,7 +13861,7 @@ export const createPaymentCredentialProvider: API.OperationMethod<
   CreatePaymentCredentialProviderRequest,
   CreatePaymentCredentialProviderResponse,
   CreatePaymentCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePaymentCredentialProviderRequest,
   output: CreatePaymentCredentialProviderResponse,
@@ -13901,7 +13900,7 @@ export const createPaymentManager: API.OperationMethod<
   CreatePaymentManagerRequest,
   CreatePaymentManagerResponse,
   CreatePaymentManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePaymentManagerRequest,
   output: CreatePaymentManagerResponse,
@@ -13934,7 +13933,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyRequest,
   CreatePolicyResponse,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyRequest,
   output: CreatePolicyResponse,
@@ -13967,7 +13966,7 @@ export const createPolicyEngine: API.OperationMethod<
   CreatePolicyEngineRequest,
   CreatePolicyEngineResponse,
   CreatePolicyEngineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyEngineRequest,
   output: CreatePolicyEngineResponse,
@@ -14001,7 +14000,7 @@ export const createRegistry: API.OperationMethod<
   CreateRegistryRequest,
   CreateRegistryResponse,
   CreateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistryRequest,
   output: CreateRegistryResponse,
@@ -14036,7 +14035,7 @@ export const createRegistryRecord: API.OperationMethod<
   CreateRegistryRecordRequest,
   CreateRegistryRecordResponse,
   CreateRegistryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistryRecordRequest,
   output: CreateRegistryRecordResponse,
@@ -14069,7 +14068,7 @@ export const createWorkloadIdentity: API.OperationMethod<
   CreateWorkloadIdentityRequest,
   CreateWorkloadIdentityResponse,
   CreateWorkloadIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkloadIdentityRequest,
   output: CreateWorkloadIdentityResponse,
@@ -14100,7 +14099,7 @@ export const deleteAgentRuntime: API.OperationMethod<
   DeleteAgentRuntimeRequest,
   DeleteAgentRuntimeResponse,
   DeleteAgentRuntimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentRuntimeRequest,
   output: DeleteAgentRuntimeResponse,
@@ -14130,7 +14129,7 @@ export const deleteAgentRuntimeEndpoint: API.OperationMethod<
   DeleteAgentRuntimeEndpointRequest,
   DeleteAgentRuntimeEndpointResponse,
   DeleteAgentRuntimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentRuntimeEndpointRequest,
   output: DeleteAgentRuntimeEndpointResponse,
@@ -14161,7 +14160,7 @@ export const deleteApiKeyCredentialProvider: API.OperationMethod<
   DeleteApiKeyCredentialProviderRequest,
   DeleteApiKeyCredentialProviderResponse,
   DeleteApiKeyCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiKeyCredentialProviderRequest,
   output: DeleteApiKeyCredentialProviderResponse,
@@ -14194,7 +14193,7 @@ export const deleteBrowser: API.OperationMethod<
   DeleteBrowserRequest,
   DeleteBrowserResponse,
   DeleteBrowserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrowserRequest,
   output: DeleteBrowserResponse,
@@ -14227,7 +14226,7 @@ export const deleteBrowserProfile: API.OperationMethod<
   DeleteBrowserProfileRequest,
   DeleteBrowserProfileResponse,
   DeleteBrowserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrowserProfileRequest,
   output: DeleteBrowserProfileResponse,
@@ -14260,7 +14259,7 @@ export const deleteCodeInterpreter: API.OperationMethod<
   DeleteCodeInterpreterRequest,
   DeleteCodeInterpreterResponse,
   DeleteCodeInterpreterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCodeInterpreterRequest,
   output: DeleteCodeInterpreterResponse,
@@ -14293,7 +14292,7 @@ export const deleteConfigurationBundle: API.OperationMethod<
   DeleteConfigurationBundleRequest,
   DeleteConfigurationBundleResponse,
   DeleteConfigurationBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationBundleRequest,
   output: DeleteConfigurationBundleResponse,
@@ -14325,7 +14324,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -14357,7 +14356,7 @@ export const deleteDatasetExamples: API.OperationMethod<
   DeleteDatasetExamplesRequest,
   DeleteDatasetExamplesResponse,
   DeleteDatasetExamplesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetExamplesRequest,
   output: DeleteDatasetExamplesResponse,
@@ -14389,7 +14388,7 @@ export const deleteEvaluator: API.OperationMethod<
   DeleteEvaluatorRequest,
   DeleteEvaluatorResponse,
   DeleteEvaluatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEvaluatorRequest,
   output: DeleteEvaluatorResponse,
@@ -14421,7 +14420,7 @@ export const deleteGateway: API.OperationMethod<
   DeleteGatewayRequest,
   DeleteGatewayResponse,
   DeleteGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayRequest,
   output: DeleteGatewayResponse,
@@ -14453,7 +14452,7 @@ export const deleteGatewayRule: API.OperationMethod<
   DeleteGatewayRuleRequest,
   DeleteGatewayRuleResponse,
   DeleteGatewayRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayRuleRequest,
   output: DeleteGatewayRuleResponse,
@@ -14487,7 +14486,7 @@ export const deleteGatewayTarget: API.OperationMethod<
   DeleteGatewayTargetRequest,
   DeleteGatewayTargetResponse,
   DeleteGatewayTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayTargetRequest,
   output: DeleteGatewayTargetResponse,
@@ -14519,7 +14518,7 @@ export const deleteHarness: API.OperationMethod<
   DeleteHarnessRequest,
   DeleteHarnessResponse,
   DeleteHarnessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHarnessRequest,
   output: DeleteHarnessResponse,
@@ -14551,7 +14550,7 @@ export const deleteHarnessEndpoint: API.OperationMethod<
   DeleteHarnessEndpointRequest,
   DeleteHarnessEndpointResponse,
   DeleteHarnessEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHarnessEndpointRequest,
   output: DeleteHarnessEndpointResponse,
@@ -14583,7 +14582,7 @@ export const deleteMemory: API.OperationMethod<
   DeleteMemoryInput,
   DeleteMemoryOutput,
   DeleteMemoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMemoryInput,
   output: DeleteMemoryOutput,
@@ -14616,7 +14615,7 @@ export const deleteOauth2CredentialProvider: API.OperationMethod<
   DeleteOauth2CredentialProviderRequest,
   DeleteOauth2CredentialProviderResponse,
   DeleteOauth2CredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOauth2CredentialProviderRequest,
   output: DeleteOauth2CredentialProviderResponse,
@@ -14649,7 +14648,7 @@ export const deleteOnlineEvaluationConfig: API.OperationMethod<
   DeleteOnlineEvaluationConfigRequest,
   DeleteOnlineEvaluationConfigResponse,
   DeleteOnlineEvaluationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOnlineEvaluationConfigRequest,
   output: DeleteOnlineEvaluationConfigResponse,
@@ -14680,7 +14679,7 @@ export const deletePaymentConnector: API.OperationMethod<
   DeletePaymentConnectorRequest,
   DeletePaymentConnectorResponse,
   DeletePaymentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePaymentConnectorRequest,
   output: DeletePaymentConnectorResponse,
@@ -14711,7 +14710,7 @@ export const deletePaymentCredentialProvider: API.OperationMethod<
   DeletePaymentCredentialProviderRequest,
   DeletePaymentCredentialProviderResponse,
   DeletePaymentCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePaymentCredentialProviderRequest,
   output: DeletePaymentCredentialProviderResponse,
@@ -14742,7 +14741,7 @@ export const deletePaymentManager: API.OperationMethod<
   DeletePaymentManagerRequest,
   DeletePaymentManagerResponse,
   DeletePaymentManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePaymentManagerRequest,
   output: DeletePaymentManagerResponse,
@@ -14773,7 +14772,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -14805,7 +14804,7 @@ export const deletePolicyEngine: API.OperationMethod<
   DeletePolicyEngineRequest,
   DeletePolicyEngineResponse,
   DeletePolicyEngineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyEngineRequest,
   output: DeletePolicyEngineResponse,
@@ -14837,7 +14836,7 @@ export const deleteRegistry: API.OperationMethod<
   DeleteRegistryRequest,
   DeleteRegistryResponse,
   DeleteRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistryRequest,
   output: DeleteRegistryResponse,
@@ -14869,7 +14868,7 @@ export const deleteRegistryRecord: API.OperationMethod<
   DeleteRegistryRecordRequest,
   DeleteRegistryRecordResponse,
   DeleteRegistryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistryRecordRequest,
   output: DeleteRegistryRecordResponse,
@@ -14902,7 +14901,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -14933,7 +14932,7 @@ export const deleteWorkloadIdentity: API.OperationMethod<
   DeleteWorkloadIdentityRequest,
   DeleteWorkloadIdentityResponse,
   DeleteWorkloadIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkloadIdentityRequest,
   output: DeleteWorkloadIdentityResponse,
@@ -14964,7 +14963,7 @@ export const getAgentRuntime: API.OperationMethod<
   GetAgentRuntimeRequest,
   GetAgentRuntimeResponse,
   GetAgentRuntimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentRuntimeRequest,
   output: GetAgentRuntimeResponse,
@@ -14994,7 +14993,7 @@ export const getAgentRuntimeEndpoint: API.OperationMethod<
   GetAgentRuntimeEndpointRequest,
   GetAgentRuntimeEndpointResponse,
   GetAgentRuntimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentRuntimeEndpointRequest,
   output: GetAgentRuntimeEndpointResponse,
@@ -15026,7 +15025,7 @@ export const getApiKeyCredentialProvider: API.OperationMethod<
   GetApiKeyCredentialProviderRequest,
   GetApiKeyCredentialProviderResponse,
   GetApiKeyCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApiKeyCredentialProviderRequest,
   output: GetApiKeyCredentialProviderResponse,
@@ -15058,7 +15057,7 @@ export const getBrowser: API.OperationMethod<
   GetBrowserRequest,
   GetBrowserResponse,
   GetBrowserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBrowserRequest,
   output: GetBrowserResponse,
@@ -15088,7 +15087,7 @@ export const getBrowserProfile: API.OperationMethod<
   GetBrowserProfileRequest,
   GetBrowserProfileResponse,
   GetBrowserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBrowserProfileRequest,
   output: GetBrowserProfileResponse,
@@ -15118,7 +15117,7 @@ export const getCodeInterpreter: API.OperationMethod<
   GetCodeInterpreterRequest,
   GetCodeInterpreterResponse,
   GetCodeInterpreterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeInterpreterRequest,
   output: GetCodeInterpreterResponse,
@@ -15148,7 +15147,7 @@ export const getConfigurationBundle: API.OperationMethod<
   GetConfigurationBundleRequest,
   GetConfigurationBundleResponse,
   GetConfigurationBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationBundleRequest,
   output: GetConfigurationBundleResponse,
@@ -15178,7 +15177,7 @@ export const getConfigurationBundleVersion: API.OperationMethod<
   GetConfigurationBundleVersionRequest,
   GetConfigurationBundleVersionResponse,
   GetConfigurationBundleVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationBundleVersionRequest,
   output: GetConfigurationBundleVersionResponse,
@@ -15209,7 +15208,7 @@ export const getDataset: API.OperationMethod<
   GetDatasetRequest,
   GetDatasetResponse,
   GetDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatasetRequest,
   output: GetDatasetResponse,
@@ -15240,7 +15239,7 @@ export const getEvaluator: API.OperationMethod<
   GetEvaluatorRequest,
   GetEvaluatorResponse,
   GetEvaluatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvaluatorRequest,
   output: GetEvaluatorResponse,
@@ -15270,7 +15269,7 @@ export const getGateway: API.OperationMethod<
   GetGatewayRequest,
   GetGatewayResponse,
   GetGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayRequest,
   output: GetGatewayResponse,
@@ -15300,7 +15299,7 @@ export const getGatewayRule: API.OperationMethod<
   GetGatewayRuleRequest,
   GetGatewayRuleResponse,
   GetGatewayRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayRuleRequest,
   output: GetGatewayRuleResponse,
@@ -15330,7 +15329,7 @@ export const getGatewayTarget: API.OperationMethod<
   GetGatewayTargetRequest,
   GetGatewayTargetResponse,
   GetGatewayTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGatewayTargetRequest,
   output: GetGatewayTargetResponse,
@@ -15360,7 +15359,7 @@ export const getHarness: API.OperationMethod<
   GetHarnessRequest,
   GetHarnessResponse,
   GetHarnessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHarnessRequest,
   output: GetHarnessResponse,
@@ -15390,7 +15389,7 @@ export const getHarnessEndpoint: API.OperationMethod<
   GetHarnessEndpointRequest,
   GetHarnessEndpointResponse,
   GetHarnessEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHarnessEndpointRequest,
   output: GetHarnessEndpointResponse,
@@ -15420,7 +15419,7 @@ export const getMemory: API.OperationMethod<
   GetMemoryInput,
   GetMemoryOutput,
   GetMemoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemoryInput,
   output: GetMemoryOutput,
@@ -15452,7 +15451,7 @@ export const getOauth2CredentialProvider: API.OperationMethod<
   GetOauth2CredentialProviderRequest,
   GetOauth2CredentialProviderResponse,
   GetOauth2CredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOauth2CredentialProviderRequest,
   output: GetOauth2CredentialProviderResponse,
@@ -15484,7 +15483,7 @@ export const getOnlineEvaluationConfig: API.OperationMethod<
   GetOnlineEvaluationConfigRequest,
   GetOnlineEvaluationConfigResponse,
   GetOnlineEvaluationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOnlineEvaluationConfigRequest,
   output: GetOnlineEvaluationConfigResponse,
@@ -15514,7 +15513,7 @@ export const getPaymentConnector: API.OperationMethod<
   GetPaymentConnectorRequest,
   GetPaymentConnectorResponse,
   GetPaymentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentConnectorRequest,
   output: GetPaymentConnectorResponse,
@@ -15546,7 +15545,7 @@ export const getPaymentCredentialProvider: API.OperationMethod<
   GetPaymentCredentialProviderRequest,
   GetPaymentCredentialProviderResponse,
   GetPaymentCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentCredentialProviderRequest,
   output: GetPaymentCredentialProviderResponse,
@@ -15578,7 +15577,7 @@ export const getPaymentManager: API.OperationMethod<
   GetPaymentManagerRequest,
   GetPaymentManagerResponse,
   GetPaymentManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentManagerRequest,
   output: GetPaymentManagerResponse,
@@ -15608,7 +15607,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -15638,7 +15637,7 @@ export const getPolicyEngine: API.OperationMethod<
   GetPolicyEngineRequest,
   GetPolicyEngineResponse,
   GetPolicyEngineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyEngineRequest,
   output: GetPolicyEngineResponse,
@@ -15668,7 +15667,7 @@ export const getPolicyEngineSummary: API.OperationMethod<
   GetPolicyEngineSummaryRequest,
   GetPolicyEngineSummaryResponse,
   GetPolicyEngineSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyEngineSummaryRequest,
   output: GetPolicyEngineSummaryResponse,
@@ -15698,7 +15697,7 @@ export const getPolicyGeneration: API.OperationMethod<
   GetPolicyGenerationRequest,
   GetPolicyGenerationResponse,
   GetPolicyGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyGenerationRequest,
   output: GetPolicyGenerationResponse,
@@ -15728,7 +15727,7 @@ export const getPolicyGenerationSummary: API.OperationMethod<
   GetPolicyGenerationSummaryRequest,
   GetPolicyGenerationSummaryResponse,
   GetPolicyGenerationSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyGenerationSummaryRequest,
   output: GetPolicyGenerationSummaryResponse,
@@ -15758,7 +15757,7 @@ export const getPolicySummary: API.OperationMethod<
   GetPolicySummaryRequest,
   GetPolicySummaryResponse,
   GetPolicySummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicySummaryRequest,
   output: GetPolicySummaryResponse,
@@ -15788,7 +15787,7 @@ export const getRegistry: API.OperationMethod<
   GetRegistryRequest,
   GetRegistryResponse,
   GetRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryRequest,
   output: GetRegistryResponse,
@@ -15819,7 +15818,7 @@ export const getRegistryRecord: API.OperationMethod<
   GetRegistryRecordRequest,
   GetRegistryRecordResponse,
   GetRegistryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryRecordRequest,
   output: GetRegistryRecordResponse,
@@ -15852,7 +15851,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -15883,7 +15882,7 @@ export const getTokenVault: API.OperationMethod<
   GetTokenVaultRequest,
   GetTokenVaultResponse,
   GetTokenVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTokenVaultRequest,
   output: GetTokenVaultResponse,
@@ -15915,7 +15914,7 @@ export const getWorkloadIdentity: API.OperationMethod<
   GetWorkloadIdentityRequest,
   GetWorkloadIdentityResponse,
   GetWorkloadIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadIdentityRequest,
   output: GetWorkloadIdentityResponse,
@@ -15945,7 +15944,7 @@ export const listAgentRuntimeEndpoints: API.PaginatedOperationMethod<
   ListAgentRuntimeEndpointsRequest,
   ListAgentRuntimeEndpointsResponse,
   ListAgentRuntimeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentRuntimeEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentRuntimeEndpointsRequest,
@@ -15980,7 +15979,7 @@ export const listAgentRuntimes: API.PaginatedOperationMethod<
   ListAgentRuntimesRequest,
   ListAgentRuntimesResponse,
   ListAgentRuntimesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentRuntime
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentRuntimesRequest,
@@ -16016,7 +16015,7 @@ export const listAgentRuntimeVersions: API.PaginatedOperationMethod<
   ListAgentRuntimeVersionsRequest,
   ListAgentRuntimeVersionsResponse,
   ListAgentRuntimeVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentRuntime
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentRuntimeVersionsRequest,
@@ -16054,7 +16053,7 @@ export const listApiKeyCredentialProviders: API.PaginatedOperationMethod<
   ListApiKeyCredentialProvidersRequest,
   ListApiKeyCredentialProvidersResponse,
   ListApiKeyCredentialProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApiKeyCredentialProviderItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApiKeyCredentialProvidersRequest,
@@ -16091,7 +16090,7 @@ export const listBrowserProfiles: API.PaginatedOperationMethod<
   ListBrowserProfilesRequest,
   ListBrowserProfilesResponse,
   ListBrowserProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BrowserProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBrowserProfilesRequest,
@@ -16126,7 +16125,7 @@ export const listBrowsers: API.PaginatedOperationMethod<
   ListBrowsersRequest,
   ListBrowsersResponse,
   ListBrowsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BrowserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBrowsersRequest,
@@ -16161,7 +16160,7 @@ export const listCodeInterpreters: API.PaginatedOperationMethod<
   ListCodeInterpretersRequest,
   ListCodeInterpretersResponse,
   ListCodeInterpretersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeInterpreterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeInterpretersRequest,
@@ -16196,7 +16195,7 @@ export const listConfigurationBundles: API.PaginatedOperationMethod<
   ListConfigurationBundlesRequest,
   ListConfigurationBundlesResponse,
   ListConfigurationBundlesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationBundleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationBundlesRequest,
@@ -16232,7 +16231,7 @@ export const listConfigurationBundleVersions: API.PaginatedOperationMethod<
   ListConfigurationBundleVersionsRequest,
   ListConfigurationBundleVersionsResponse,
   ListConfigurationBundleVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationBundleVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationBundleVersionsRequest,
@@ -16270,7 +16269,7 @@ export const listDatasetExamples: API.PaginatedOperationMethod<
   ListDatasetExamplesRequest,
   ListDatasetExamplesResponse,
   ListDatasetExamplesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetExamplesRequest,
@@ -16307,7 +16306,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -16343,7 +16342,7 @@ export const listDatasetVersions: API.PaginatedOperationMethod<
   ListDatasetVersionsRequest,
   ListDatasetVersionsResponse,
   ListDatasetVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetVersionsRequest,
@@ -16379,7 +16378,7 @@ export const listEvaluators: API.PaginatedOperationMethod<
   ListEvaluatorsRequest,
   ListEvaluatorsResponse,
   ListEvaluatorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluatorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEvaluatorsRequest,
@@ -16415,7 +16414,7 @@ export const listGatewayRules: API.PaginatedOperationMethod<
   ListGatewayRulesRequest,
   ListGatewayRulesResponse,
   ListGatewayRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewayRuleDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewayRulesRequest,
@@ -16451,7 +16450,7 @@ export const listGateways: API.PaginatedOperationMethod<
   ListGatewaysRequest,
   ListGatewaysResponse,
   ListGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewaySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewaysRequest,
@@ -16487,7 +16486,7 @@ export const listGatewayTargets: API.PaginatedOperationMethod<
   ListGatewayTargetsRequest,
   ListGatewayTargetsResponse,
   ListGatewayTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewayTargetsRequest,
@@ -16524,7 +16523,7 @@ export const listHarnessEndpoints: API.PaginatedOperationMethod<
   ListHarnessEndpointsRequest,
   ListHarnessEndpointsResponse,
   ListHarnessEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HarnessEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHarnessEndpointsRequest,
@@ -16560,7 +16559,7 @@ export const listHarnesses: API.PaginatedOperationMethod<
   ListHarnessesRequest,
   ListHarnessesResponse,
   ListHarnessesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HarnessSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHarnessesRequest,
@@ -16596,7 +16595,7 @@ export const listHarnessVersions: API.PaginatedOperationMethod<
   ListHarnessVersionsRequest,
   ListHarnessVersionsResponse,
   ListHarnessVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HarnessVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHarnessVersionsRequest,
@@ -16633,7 +16632,7 @@ export const listMemories: API.PaginatedOperationMethod<
   ListMemoriesInput,
   ListMemoriesOutput,
   ListMemoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMemoriesInput,
@@ -16671,7 +16670,7 @@ export const listOauth2CredentialProviders: API.PaginatedOperationMethod<
   ListOauth2CredentialProvidersRequest,
   ListOauth2CredentialProvidersResponse,
   ListOauth2CredentialProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Oauth2CredentialProviderItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOauth2CredentialProvidersRequest,
@@ -16708,7 +16707,7 @@ export const listOnlineEvaluationConfigs: API.PaginatedOperationMethod<
   ListOnlineEvaluationConfigsRequest,
   ListOnlineEvaluationConfigsResponse,
   ListOnlineEvaluationConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OnlineEvaluationConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOnlineEvaluationConfigsRequest,
@@ -16743,7 +16742,7 @@ export const listPaymentConnectors: API.PaginatedOperationMethod<
   ListPaymentConnectorsRequest,
   ListPaymentConnectorsResponse,
   ListPaymentConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPaymentConnectorsRequest,
@@ -16780,7 +16779,7 @@ export const listPaymentCredentialProviders: API.PaginatedOperationMethod<
   ListPaymentCredentialProvidersRequest,
   ListPaymentCredentialProvidersResponse,
   ListPaymentCredentialProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentCredentialProviderItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPaymentCredentialProvidersRequest,
@@ -16817,7 +16816,7 @@ export const listPaymentManagers: API.PaginatedOperationMethod<
   ListPaymentManagersRequest,
   ListPaymentManagersResponse,
   ListPaymentManagersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentManagerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPaymentManagersRequest,
@@ -16853,7 +16852,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -16889,7 +16888,7 @@ export const listPolicyEngines: API.PaginatedOperationMethod<
   ListPolicyEnginesRequest,
   ListPolicyEnginesResponse,
   ListPolicyEnginesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyEngine
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyEnginesRequest,
@@ -16924,7 +16923,7 @@ export const listPolicyEngineSummaries: API.PaginatedOperationMethod<
   ListPolicyEngineSummariesRequest,
   ListPolicyEngineSummariesResponse,
   ListPolicyEngineSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyEngineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyEngineSummariesRequest,
@@ -16960,7 +16959,7 @@ export const listPolicyGenerationAssets: API.PaginatedOperationMethod<
   ListPolicyGenerationAssetsRequest,
   ListPolicyGenerationAssetsResponse,
   ListPolicyGenerationAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyGenerationAsset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyGenerationAssetsRequest,
@@ -16997,7 +16996,7 @@ export const listPolicyGenerations: API.PaginatedOperationMethod<
   ListPolicyGenerationsRequest,
   ListPolicyGenerationsResponse,
   ListPolicyGenerationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyGeneration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyGenerationsRequest,
@@ -17034,7 +17033,7 @@ export const listPolicyGenerationSummaries: API.PaginatedOperationMethod<
   ListPolicyGenerationSummariesRequest,
   ListPolicyGenerationSummariesResponse,
   ListPolicyGenerationSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyGenerationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyGenerationSummariesRequest,
@@ -17071,7 +17070,7 @@ export const listPolicySummaries: API.PaginatedOperationMethod<
   ListPolicySummariesRequest,
   ListPolicySummariesResponse,
   ListPolicySummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicySummariesRequest,
@@ -17107,7 +17106,7 @@ export const listRegistries: API.PaginatedOperationMethod<
   ListRegistriesRequest,
   ListRegistriesResponse,
   ListRegistriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegistriesRequest,
@@ -17144,7 +17143,7 @@ export const listRegistryRecords: API.PaginatedOperationMethod<
   ListRegistryRecordsRequest,
   ListRegistryRecordsResponse,
   ListRegistryRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistryRecordSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegistryRecordsRequest,
@@ -17184,7 +17183,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -17215,7 +17214,7 @@ export const listWorkloadIdentities: API.PaginatedOperationMethod<
   ListWorkloadIdentitiesRequest,
   ListWorkloadIdentitiesResponse,
   ListWorkloadIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadIdentityType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadIdentitiesRequest,
@@ -17255,7 +17254,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -17287,7 +17286,7 @@ export const setTokenVaultCMK: API.OperationMethod<
   SetTokenVaultCMKRequest,
   SetTokenVaultCMKResponse,
   SetTokenVaultCMKError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTokenVaultCMKRequest,
   output: SetTokenVaultCMKResponse,
@@ -17321,7 +17320,7 @@ export const startPolicyGeneration: API.OperationMethod<
   StartPolicyGenerationRequest,
   StartPolicyGenerationResponse,
   StartPolicyGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPolicyGenerationRequest,
   output: StartPolicyGenerationResponse,
@@ -17354,7 +17353,7 @@ export const submitRegistryRecordForApproval: API.OperationMethod<
   SubmitRegistryRecordForApprovalRequest,
   SubmitRegistryRecordForApprovalResponse,
   SubmitRegistryRecordForApprovalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitRegistryRecordForApprovalRequest,
   output: SubmitRegistryRecordForApprovalResponse,
@@ -17391,7 +17390,7 @@ export const synchronizeGatewayTargets: API.OperationMethod<
   SynchronizeGatewayTargetsRequest,
   SynchronizeGatewayTargetsResponse,
   SynchronizeGatewayTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SynchronizeGatewayTargetsRequest,
   output: SynchronizeGatewayTargetsResponse,
@@ -17426,7 +17425,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -17459,7 +17458,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -17491,7 +17490,7 @@ export const updateAgentRuntime: API.OperationMethod<
   UpdateAgentRuntimeRequest,
   UpdateAgentRuntimeResponse,
   UpdateAgentRuntimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentRuntimeRequest,
   output: UpdateAgentRuntimeResponse,
@@ -17525,7 +17524,7 @@ export const updateAgentRuntimeEndpoint: API.OperationMethod<
   UpdateAgentRuntimeEndpointRequest,
   UpdateAgentRuntimeEndpointResponse,
   UpdateAgentRuntimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentRuntimeEndpointRequest,
   output: UpdateAgentRuntimeEndpointResponse,
@@ -17562,7 +17561,7 @@ export const updateApiKeyCredentialProvider: API.OperationMethod<
   UpdateApiKeyCredentialProviderRequest,
   UpdateApiKeyCredentialProviderResponse,
   UpdateApiKeyCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiKeyCredentialProviderRequest,
   output: UpdateApiKeyCredentialProviderResponse,
@@ -17598,7 +17597,7 @@ export const updateConfigurationBundle: API.OperationMethod<
   UpdateConfigurationBundleRequest,
   UpdateConfigurationBundleResponse,
   UpdateConfigurationBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationBundleRequest,
   output: UpdateConfigurationBundleResponse,
@@ -17630,7 +17629,7 @@ export const updateDataset: API.OperationMethod<
   UpdateDatasetRequest,
   UpdateDatasetResponse,
   UpdateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetRequest,
   output: UpdateDatasetResponse,
@@ -17663,7 +17662,7 @@ export const updateDatasetExamples: API.OperationMethod<
   UpdateDatasetExamplesRequest,
   UpdateDatasetExamplesResponse,
   UpdateDatasetExamplesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetExamplesRequest,
   output: UpdateDatasetExamplesResponse,
@@ -17697,7 +17696,7 @@ export const updateEvaluator: API.OperationMethod<
   UpdateEvaluatorRequest,
   UpdateEvaluatorResponse,
   UpdateEvaluatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEvaluatorRequest,
   output: UpdateEvaluatorResponse,
@@ -17731,7 +17730,7 @@ export const updateGateway: API.OperationMethod<
   UpdateGatewayRequest,
   UpdateGatewayResponse,
   UpdateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayRequest,
   output: UpdateGatewayResponse,
@@ -17764,7 +17763,7 @@ export const updateGatewayRule: API.OperationMethod<
   UpdateGatewayRuleRequest,
   UpdateGatewayRuleResponse,
   UpdateGatewayRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayRuleRequest,
   output: UpdateGatewayRuleResponse,
@@ -17799,7 +17798,7 @@ export const updateGatewayTarget: API.OperationMethod<
   UpdateGatewayTargetRequest,
   UpdateGatewayTargetResponse,
   UpdateGatewayTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayTargetRequest,
   output: UpdateGatewayTargetResponse,
@@ -17832,7 +17831,7 @@ export const updateHarness: API.OperationMethod<
   UpdateHarnessRequest,
   UpdateHarnessResponse,
   UpdateHarnessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHarnessRequest,
   output: UpdateHarnessResponse,
@@ -17865,7 +17864,7 @@ export const updateHarnessEndpoint: API.OperationMethod<
   UpdateHarnessEndpointRequest,
   UpdateHarnessEndpointResponse,
   UpdateHarnessEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHarnessEndpointRequest,
   output: UpdateHarnessEndpointResponse,
@@ -17899,7 +17898,7 @@ export const updateMemory: API.OperationMethod<
   UpdateMemoryInput,
   UpdateMemoryOutput,
   UpdateMemoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMemoryInput,
   output: UpdateMemoryOutput,
@@ -17936,7 +17935,7 @@ export const updateOauth2CredentialProvider: API.OperationMethod<
   UpdateOauth2CredentialProviderRequest,
   UpdateOauth2CredentialProviderResponse,
   UpdateOauth2CredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOauth2CredentialProviderRequest,
   output: UpdateOauth2CredentialProviderResponse,
@@ -17973,7 +17972,7 @@ export const updateOnlineEvaluationConfig: API.OperationMethod<
   UpdateOnlineEvaluationConfigRequest,
   UpdateOnlineEvaluationConfigResponse,
   UpdateOnlineEvaluationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOnlineEvaluationConfigRequest,
   output: UpdateOnlineEvaluationConfigResponse,
@@ -18007,7 +18006,7 @@ export const updatePaymentConnector: API.OperationMethod<
   UpdatePaymentConnectorRequest,
   UpdatePaymentConnectorResponse,
   UpdatePaymentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePaymentConnectorRequest,
   output: UpdatePaymentConnectorResponse,
@@ -18044,7 +18043,7 @@ export const updatePaymentCredentialProvider: API.OperationMethod<
   UpdatePaymentCredentialProviderRequest,
   UpdatePaymentCredentialProviderResponse,
   UpdatePaymentCredentialProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePaymentCredentialProviderRequest,
   output: UpdatePaymentCredentialProviderResponse,
@@ -18081,7 +18080,7 @@ export const updatePaymentManager: API.OperationMethod<
   UpdatePaymentManagerRequest,
   UpdatePaymentManagerResponse,
   UpdatePaymentManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePaymentManagerRequest,
   output: UpdatePaymentManagerResponse,
@@ -18114,7 +18113,7 @@ export const updatePolicy: API.OperationMethod<
   UpdatePolicyRequest,
   UpdatePolicyResponse,
   UpdatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyRequest,
   output: UpdatePolicyResponse,
@@ -18146,7 +18145,7 @@ export const updatePolicyEngine: API.OperationMethod<
   UpdatePolicyEngineRequest,
   UpdatePolicyEngineResponse,
   UpdatePolicyEngineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyEngineRequest,
   output: UpdatePolicyEngineResponse,
@@ -18179,7 +18178,7 @@ export const updateRegistry: API.OperationMethod<
   UpdateRegistryRequest,
   UpdateRegistryResponse,
   UpdateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegistryRequest,
   output: UpdateRegistryResponse,
@@ -18212,7 +18211,7 @@ export const updateRegistryRecord: API.OperationMethod<
   UpdateRegistryRecordRequest,
   UpdateRegistryRecordResponse,
   UpdateRegistryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegistryRecordRequest,
   output: UpdateRegistryRecordResponse,
@@ -18244,7 +18243,7 @@ export const updateRegistryRecordStatus: API.OperationMethod<
   UpdateRegistryRecordStatusRequest,
   UpdateRegistryRecordStatusResponse,
   UpdateRegistryRecordStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegistryRecordStatusRequest,
   output: UpdateRegistryRecordStatusResponse,
@@ -18276,7 +18275,7 @@ export const updateWorkloadIdentity: API.OperationMethod<
   UpdateWorkloadIdentityRequest,
   UpdateWorkloadIdentityResponse,
   UpdateWorkloadIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkloadIdentityRequest,
   output: UpdateWorkloadIdentityResponse,

--- a/packages/aws/src/services/bedrock-agentcore.ts
+++ b/packages/aws/src/services/bedrock-agentcore.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock AgentCore",
@@ -7274,7 +7273,7 @@ export const batchCreateMemoryRecords: API.OperationMethod<
   BatchCreateMemoryRecordsInput,
   BatchCreateMemoryRecordsOutput,
   BatchCreateMemoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateMemoryRecordsInput,
   output: BatchCreateMemoryRecordsOutput,
@@ -7306,7 +7305,7 @@ export const batchDeleteMemoryRecords: API.OperationMethod<
   BatchDeleteMemoryRecordsInput,
   BatchDeleteMemoryRecordsOutput,
   BatchDeleteMemoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteMemoryRecordsInput,
   output: BatchDeleteMemoryRecordsOutput,
@@ -7338,7 +7337,7 @@ export const batchUpdateMemoryRecords: API.OperationMethod<
   BatchUpdateMemoryRecordsInput,
   BatchUpdateMemoryRecordsOutput,
   BatchUpdateMemoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateMemoryRecordsInput,
   output: BatchUpdateMemoryRecordsOutput,
@@ -7370,7 +7369,7 @@ export const completeResourceTokenAuth: API.OperationMethod<
   CompleteResourceTokenAuthRequest,
   CompleteResourceTokenAuthResponse,
   CompleteResourceTokenAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteResourceTokenAuthRequest,
   output: CompleteResourceTokenAuthResponse,
@@ -7403,7 +7402,7 @@ export const createABTest: API.OperationMethod<
   CreateABTestRequest,
   CreateABTestResponse,
   CreateABTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateABTestRequest,
   output: CreateABTestResponse,
@@ -7442,7 +7441,7 @@ export const createEvent: API.OperationMethod<
   CreateEventInput,
   CreateEventOutput,
   CreateEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventInput,
   output: CreateEventOutput,
@@ -7476,7 +7475,7 @@ export const createPaymentInstrument: API.OperationMethod<
   CreatePaymentInstrumentRequest,
   CreatePaymentInstrumentResponse,
   CreatePaymentInstrumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePaymentInstrumentRequest,
   output: CreatePaymentInstrumentResponse,
@@ -7508,7 +7507,7 @@ export const createPaymentSession: API.OperationMethod<
   CreatePaymentSessionRequest,
   CreatePaymentSessionResponse,
   CreatePaymentSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePaymentSessionRequest,
   output: CreatePaymentSessionResponse,
@@ -7541,7 +7540,7 @@ export const deleteABTest: API.OperationMethod<
   DeleteABTestRequest,
   DeleteABTestResponse,
   DeleteABTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteABTestRequest,
   output: DeleteABTestResponse,
@@ -7575,7 +7574,7 @@ export const deleteBatchEvaluation: API.OperationMethod<
   DeleteBatchEvaluationRequest,
   DeleteBatchEvaluationResponse,
   DeleteBatchEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBatchEvaluationRequest,
   output: DeleteBatchEvaluationResponse,
@@ -7611,7 +7610,7 @@ export const deleteEvent: API.OperationMethod<
   DeleteEventInput,
   DeleteEventOutput,
   DeleteEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventInput,
   output: DeleteEventOutput,
@@ -7647,7 +7646,7 @@ export const deleteMemoryRecord: API.OperationMethod<
   DeleteMemoryRecordInput,
   DeleteMemoryRecordOutput,
   DeleteMemoryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMemoryRecordInput,
   output: DeleteMemoryRecordOutput,
@@ -7679,7 +7678,7 @@ export const deletePaymentInstrument: API.OperationMethod<
   DeletePaymentInstrumentRequest,
   DeletePaymentInstrumentResponse,
   DeletePaymentInstrumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePaymentInstrumentRequest,
   output: DeletePaymentInstrumentResponse,
@@ -7709,7 +7708,7 @@ export const deletePaymentSession: API.OperationMethod<
   DeletePaymentSessionRequest,
   DeletePaymentSessionResponse,
   DeletePaymentSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePaymentSessionRequest,
   output: DeletePaymentSessionResponse,
@@ -7740,7 +7739,7 @@ export const deleteRecommendation: API.OperationMethod<
   DeleteRecommendationRequest,
   DeleteRecommendationResponse,
   DeleteRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommendationRequest,
   output: DeleteRecommendationResponse,
@@ -7775,7 +7774,7 @@ export const evaluate: API.OperationMethod<
   EvaluateRequest,
   EvaluateResponse,
   EvaluateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluateRequest,
   output: EvaluateResponse,
@@ -7810,7 +7809,7 @@ export const getABTest: API.OperationMethod<
   GetABTestRequest,
   GetABTestResponse,
   GetABTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetABTestRequest,
   output: GetABTestResponse,
@@ -7844,7 +7843,7 @@ export const getAgentCard: API.OperationMethod<
   GetAgentCardRequest,
   GetAgentCardResponse,
   GetAgentCardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentCardRequest,
   output: GetAgentCardResponse,
@@ -7878,7 +7877,7 @@ export const getBatchEvaluation: API.OperationMethod<
   GetBatchEvaluationRequest,
   GetBatchEvaluationResponse,
   GetBatchEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBatchEvaluationRequest,
   output: GetBatchEvaluationResponse,
@@ -7919,7 +7918,7 @@ export const getBrowserSession: API.OperationMethod<
   GetBrowserSessionRequest,
   GetBrowserSessionResponse,
   GetBrowserSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBrowserSessionRequest,
   output: GetBrowserSessionResponse,
@@ -7959,7 +7958,7 @@ export const getCodeInterpreterSession: API.OperationMethod<
   GetCodeInterpreterSessionRequest,
   GetCodeInterpreterSessionResponse,
   GetCodeInterpreterSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeInterpreterSessionRequest,
   output: GetCodeInterpreterSessionResponse,
@@ -7993,7 +7992,7 @@ export const getEvent: API.OperationMethod<
   GetEventInput,
   GetEventOutput,
   GetEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventInput,
   output: GetEventOutput,
@@ -8029,7 +8028,7 @@ export const getMemoryRecord: API.OperationMethod<
   GetMemoryRecordInput,
   GetMemoryRecordOutput,
   GetMemoryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemoryRecordInput,
   output: GetMemoryRecordOutput,
@@ -8061,7 +8060,7 @@ export const getPaymentInstrument: API.OperationMethod<
   GetPaymentInstrumentRequest,
   GetPaymentInstrumentResponse,
   GetPaymentInstrumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentInstrumentRequest,
   output: GetPaymentInstrumentResponse,
@@ -8091,7 +8090,7 @@ export const getPaymentInstrumentBalance: API.OperationMethod<
   GetPaymentInstrumentBalanceRequest,
   GetPaymentInstrumentBalanceResponse,
   GetPaymentInstrumentBalanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentInstrumentBalanceRequest,
   output: GetPaymentInstrumentBalanceResponse,
@@ -8121,7 +8120,7 @@ export const getPaymentSession: API.OperationMethod<
   GetPaymentSessionRequest,
   GetPaymentSessionResponse,
   GetPaymentSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPaymentSessionRequest,
   output: GetPaymentSessionResponse,
@@ -8151,7 +8150,7 @@ export const getRecommendation: API.OperationMethod<
   GetRecommendationRequest,
   GetRecommendationResponse,
   GetRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationRequest,
   output: GetRecommendationResponse,
@@ -8182,7 +8181,7 @@ export const getResourceApiKey: API.OperationMethod<
   GetResourceApiKeyRequest,
   GetResourceApiKeyResponse,
   GetResourceApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceApiKeyRequest,
   output: GetResourceApiKeyResponse,
@@ -8214,7 +8213,7 @@ export const getResourceOauth2Token: API.OperationMethod<
   GetResourceOauth2TokenRequest,
   GetResourceOauth2TokenResponse,
   GetResourceOauth2TokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceOauth2TokenRequest,
   output: GetResourceOauth2TokenResponse,
@@ -8246,7 +8245,7 @@ export const getResourcePaymentToken: API.OperationMethod<
   GetResourcePaymentTokenRequest,
   GetResourcePaymentTokenResponse,
   GetResourcePaymentTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePaymentTokenRequest,
   output: GetResourcePaymentTokenResponse,
@@ -8278,7 +8277,7 @@ export const getWorkloadAccessToken: API.OperationMethod<
   GetWorkloadAccessTokenRequest,
   GetWorkloadAccessTokenResponse,
   GetWorkloadAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadAccessTokenRequest,
   output: GetWorkloadAccessTokenResponse,
@@ -8310,7 +8309,7 @@ export const getWorkloadAccessTokenForJWT: API.OperationMethod<
   GetWorkloadAccessTokenForJWTRequest,
   GetWorkloadAccessTokenForJWTResponse,
   GetWorkloadAccessTokenForJWTError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadAccessTokenForJWTRequest,
   output: GetWorkloadAccessTokenForJWTResponse,
@@ -8342,7 +8341,7 @@ export const getWorkloadAccessTokenForUserId: API.OperationMethod<
   GetWorkloadAccessTokenForUserIdRequest,
   GetWorkloadAccessTokenForUserIdResponse,
   GetWorkloadAccessTokenForUserIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadAccessTokenForUserIdRequest,
   output: GetWorkloadAccessTokenForUserIdResponse,
@@ -8386,7 +8385,7 @@ export const invokeAgentRuntime: API.OperationMethod<
   InvokeAgentRuntimeRequest,
   InvokeAgentRuntimeResponse,
   InvokeAgentRuntimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeAgentRuntimeRequest,
   output: InvokeAgentRuntimeResponse,
@@ -8426,7 +8425,7 @@ export const invokeAgentRuntimeCommand: API.OperationMethod<
   InvokeAgentRuntimeCommandRequest,
   InvokeAgentRuntimeCommandResponse,
   InvokeAgentRuntimeCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeAgentRuntimeCommandRequest,
   output: InvokeAgentRuntimeCommandResponse,
@@ -8470,7 +8469,7 @@ export const invokeBrowser: API.OperationMethod<
   InvokeBrowserRequest,
   InvokeBrowserResponse,
   InvokeBrowserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeBrowserRequest,
   output: InvokeBrowserResponse,
@@ -8513,7 +8512,7 @@ export const invokeCodeInterpreter: API.OperationMethod<
   InvokeCodeInterpreterRequest,
   InvokeCodeInterpreterResponse,
   InvokeCodeInterpreterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeCodeInterpreterRequest,
   output: InvokeCodeInterpreterResponse,
@@ -8547,7 +8546,7 @@ export const invokeHarness: API.OperationMethod<
   InvokeHarnessRequest,
   InvokeHarnessResponse,
   InvokeHarnessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeHarnessRequest,
   output: InvokeHarnessResponse,
@@ -8579,7 +8578,7 @@ export const listABTests: API.PaginatedOperationMethod<
   ListABTestsRequest,
   ListABTestsResponse,
   ListABTestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ABTestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListABTestsRequest,
@@ -8620,7 +8619,7 @@ export const listActors: API.PaginatedOperationMethod<
   ListActorsInput,
   ListActorsOutput,
   ListActorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActorsInput,
@@ -8659,7 +8658,7 @@ export const listBatchEvaluations: API.PaginatedOperationMethod<
   ListBatchEvaluationsRequest,
   ListBatchEvaluationsResponse,
   ListBatchEvaluationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchEvaluationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchEvaluationsRequest,
@@ -8706,7 +8705,7 @@ export const listBrowserSessions: API.OperationMethod<
   ListBrowserSessionsRequest,
   ListBrowserSessionsResponse,
   ListBrowserSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBrowserSessionsRequest,
   output: ListBrowserSessionsResponse,
@@ -8746,7 +8745,7 @@ export const listCodeInterpreterSessions: API.OperationMethod<
   ListCodeInterpreterSessionsRequest,
   ListCodeInterpreterSessionsResponse,
   ListCodeInterpreterSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCodeInterpreterSessionsRequest,
   output: ListCodeInterpreterSessionsResponse,
@@ -8780,7 +8779,7 @@ export const listEvents: API.PaginatedOperationMethod<
   ListEventsInput,
   ListEventsOutput,
   ListEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventsInput,
@@ -8822,7 +8821,7 @@ export const listMemoryExtractionJobs: API.PaginatedOperationMethod<
   ListMemoryExtractionJobsInput,
   ListMemoryExtractionJobsOutput,
   ListMemoryExtractionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExtractionJobMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMemoryExtractionJobsInput,
@@ -8864,7 +8863,7 @@ export const listMemoryRecords: API.PaginatedOperationMethod<
   ListMemoryRecordsInput,
   ListMemoryRecordsOutput,
   ListMemoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemoryRecordSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMemoryRecordsInput,
@@ -8902,7 +8901,7 @@ export const listPaymentInstruments: API.PaginatedOperationMethod<
   ListPaymentInstrumentsRequest,
   ListPaymentInstrumentsResponse,
   ListPaymentInstrumentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentInstrumentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPaymentInstrumentsRequest,
@@ -8937,7 +8936,7 @@ export const listPaymentSessions: API.PaginatedOperationMethod<
   ListPaymentSessionsRequest,
   ListPaymentSessionsResponse,
   ListPaymentSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentSessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPaymentSessionsRequest,
@@ -8972,7 +8971,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -9014,7 +9013,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsInput,
   ListSessionsOutput,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsInput,
@@ -9054,7 +9053,7 @@ export const processPayment: API.OperationMethod<
   ProcessPaymentRequest,
   ProcessPaymentResponse,
   ProcessPaymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProcessPaymentRequest,
   output: ProcessPaymentResponse,
@@ -9089,7 +9088,7 @@ export const retrieveMemoryRecords: API.PaginatedOperationMethod<
   RetrieveMemoryRecordsInput,
   RetrieveMemoryRecordsOutput,
   RetrieveMemoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemoryRecordSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: RetrieveMemoryRecordsInput,
@@ -9139,7 +9138,7 @@ export const saveBrowserSessionProfile: API.OperationMethod<
   SaveBrowserSessionProfileRequest,
   SaveBrowserSessionProfileResponse,
   SaveBrowserSessionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SaveBrowserSessionProfileRequest,
   output: SaveBrowserSessionProfileResponse,
@@ -9171,7 +9170,7 @@ export const searchRegistryRecords: API.OperationMethod<
   SearchRegistryRecordsRequest,
   SearchRegistryRecordsResponse,
   SearchRegistryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchRegistryRecordsRequest,
   output: SearchRegistryRecordsResponse,
@@ -9204,7 +9203,7 @@ export const startBatchEvaluation: API.OperationMethod<
   StartBatchEvaluationRequest,
   StartBatchEvaluationResponse,
   StartBatchEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBatchEvaluationRequest,
   output: StartBatchEvaluationResponse,
@@ -9252,7 +9251,7 @@ export const startBrowserSession: API.OperationMethod<
   StartBrowserSessionRequest,
   StartBrowserSessionResponse,
   StartBrowserSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBrowserSessionRequest,
   output: StartBrowserSessionResponse,
@@ -9296,7 +9295,7 @@ export const startCodeInterpreterSession: API.OperationMethod<
   StartCodeInterpreterSessionRequest,
   StartCodeInterpreterSessionResponse,
   StartCodeInterpreterSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCodeInterpreterSessionRequest,
   output: StartCodeInterpreterSessionResponse,
@@ -9331,7 +9330,7 @@ export const startMemoryExtractionJob: API.OperationMethod<
   StartMemoryExtractionJobInput,
   StartMemoryExtractionJobOutput,
   StartMemoryExtractionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMemoryExtractionJobInput,
   output: StartMemoryExtractionJobOutput,
@@ -9363,7 +9362,7 @@ export const startRecommendation: API.OperationMethod<
   StartRecommendationRequest,
   StartRecommendationResponse,
   StartRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecommendationRequest,
   output: StartRecommendationResponse,
@@ -9396,7 +9395,7 @@ export const stopBatchEvaluation: API.OperationMethod<
   StopBatchEvaluationRequest,
   StopBatchEvaluationResponse,
   StopBatchEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBatchEvaluationRequest,
   output: StopBatchEvaluationResponse,
@@ -9438,7 +9437,7 @@ export const stopBrowserSession: API.OperationMethod<
   StopBrowserSessionRequest,
   StopBrowserSessionResponse,
   StopBrowserSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBrowserSessionRequest,
   output: StopBrowserSessionResponse,
@@ -9480,7 +9479,7 @@ export const stopCodeInterpreterSession: API.OperationMethod<
   StopCodeInterpreterSessionRequest,
   StopCodeInterpreterSessionResponse,
   StopCodeInterpreterSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCodeInterpreterSessionRequest,
   output: StopCodeInterpreterSessionResponse,
@@ -9517,7 +9516,7 @@ export const stopRuntimeSession: API.OperationMethod<
   StopRuntimeSessionRequest,
   StopRuntimeSessionResponse,
   StopRuntimeSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRuntimeSessionRequest,
   output: StopRuntimeSessionResponse,
@@ -9555,7 +9554,7 @@ export const updateABTest: API.OperationMethod<
   UpdateABTestRequest,
   UpdateABTestResponse,
   UpdateABTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateABTestRequest,
   output: UpdateABTestResponse,
@@ -9590,7 +9589,7 @@ export const updateBrowserStream: API.OperationMethod<
   UpdateBrowserStreamRequest,
   UpdateBrowserStreamResponse,
   UpdateBrowserStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrowserStreamRequest,
   output: UpdateBrowserStreamResponse,

--- a/packages/aws/src/services/bedrock-data-automation-runtime.ts
+++ b/packages/aws/src/services/bedrock-data-automation-runtime.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock Data Automation Runtime",
   serviceShapeName: "AmazonBedrockKeystoneRuntimeService",
@@ -482,7 +481,7 @@ export const getDataAutomationStatus: API.OperationMethod<
   GetDataAutomationStatusRequest,
   GetDataAutomationStatusResponse,
   GetDataAutomationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAutomationStatusRequest,
   output: GetDataAutomationStatusResponse,
@@ -512,7 +511,7 @@ export const invokeDataAutomation: API.OperationMethod<
   InvokeDataAutomationRequest,
   InvokeDataAutomationResponse,
   InvokeDataAutomationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeDataAutomationRequest,
   output: InvokeDataAutomationResponse,
@@ -542,7 +541,7 @@ export const invokeDataAutomationAsync: API.OperationMethod<
   InvokeDataAutomationAsyncRequest,
   InvokeDataAutomationAsyncResponse,
   InvokeDataAutomationAsyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeDataAutomationAsyncRequest,
   output: InvokeDataAutomationAsyncResponse,
@@ -572,7 +571,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -603,7 +602,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -634,7 +633,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/bedrock-data-automation.ts
+++ b/packages/aws/src/services/bedrock-data-automation.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock Data Automation",
@@ -2347,7 +2346,7 @@ export const copyBlueprintStage: API.OperationMethod<
   CopyBlueprintStageRequest,
   CopyBlueprintStageResponse,
   CopyBlueprintStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyBlueprintStageRequest,
   output: CopyBlueprintStageResponse,
@@ -2378,7 +2377,7 @@ export const createBlueprint: API.OperationMethod<
   CreateBlueprintRequest,
   CreateBlueprintResponse,
   CreateBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBlueprintRequest,
   output: CreateBlueprintResponse,
@@ -2410,7 +2409,7 @@ export const createBlueprintVersion: API.OperationMethod<
   CreateBlueprintVersionRequest,
   CreateBlueprintVersionResponse,
   CreateBlueprintVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBlueprintVersionRequest,
   output: CreateBlueprintVersionResponse,
@@ -2442,7 +2441,7 @@ export const createDataAutomationLibrary: API.OperationMethod<
   CreateDataAutomationLibraryRequest,
   CreateDataAutomationLibraryResponse,
   CreateDataAutomationLibraryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataAutomationLibraryRequest,
   output: CreateDataAutomationLibraryResponse,
@@ -2474,7 +2473,7 @@ export const createDataAutomationProject: API.OperationMethod<
   CreateDataAutomationProjectRequest,
   CreateDataAutomationProjectResponse,
   CreateDataAutomationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataAutomationProjectRequest,
   output: CreateDataAutomationProjectResponse,
@@ -2505,7 +2504,7 @@ export const deleteBlueprint: API.OperationMethod<
   DeleteBlueprintRequest,
   DeleteBlueprintResponse,
   DeleteBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBlueprintRequest,
   output: DeleteBlueprintResponse,
@@ -2536,7 +2535,7 @@ export const deleteDataAutomationLibrary: API.OperationMethod<
   DeleteDataAutomationLibraryRequest,
   DeleteDataAutomationLibraryResponse,
   DeleteDataAutomationLibraryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataAutomationLibraryRequest,
   output: DeleteDataAutomationLibraryResponse,
@@ -2567,7 +2566,7 @@ export const deleteDataAutomationProject: API.OperationMethod<
   DeleteDataAutomationProjectRequest,
   DeleteDataAutomationProjectResponse,
   DeleteDataAutomationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataAutomationProjectRequest,
   output: DeleteDataAutomationProjectResponse,
@@ -2597,7 +2596,7 @@ export const getBlueprint: API.OperationMethod<
   GetBlueprintRequest,
   GetBlueprintResponse,
   GetBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlueprintRequest,
   output: GetBlueprintResponse,
@@ -2627,7 +2626,7 @@ export const getBlueprintOptimizationStatus: API.OperationMethod<
   GetBlueprintOptimizationStatusRequest,
   GetBlueprintOptimizationStatusResponse,
   GetBlueprintOptimizationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlueprintOptimizationStatusRequest,
   output: GetBlueprintOptimizationStatusResponse,
@@ -2657,7 +2656,7 @@ export const getDataAutomationLibrary: API.OperationMethod<
   GetDataAutomationLibraryRequest,
   GetDataAutomationLibraryResponse,
   GetDataAutomationLibraryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAutomationLibraryRequest,
   output: GetDataAutomationLibraryResponse,
@@ -2687,7 +2686,7 @@ export const getDataAutomationLibraryEntity: API.OperationMethod<
   GetDataAutomationLibraryEntityRequest,
   GetDataAutomationLibraryEntityResponse,
   GetDataAutomationLibraryEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAutomationLibraryEntityRequest,
   output: GetDataAutomationLibraryEntityResponse,
@@ -2717,7 +2716,7 @@ export const getDataAutomationLibraryIngestionJob: API.OperationMethod<
   GetDataAutomationLibraryIngestionJobRequest,
   GetDataAutomationLibraryIngestionJobResponse,
   GetDataAutomationLibraryIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAutomationLibraryIngestionJobRequest,
   output: GetDataAutomationLibraryIngestionJobResponse,
@@ -2747,7 +2746,7 @@ export const getDataAutomationProject: API.OperationMethod<
   GetDataAutomationProjectRequest,
   GetDataAutomationProjectResponse,
   GetDataAutomationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAutomationProjectRequest,
   output: GetDataAutomationProjectResponse,
@@ -2778,7 +2777,7 @@ export const invokeBlueprintOptimizationAsync: API.OperationMethod<
   InvokeBlueprintOptimizationAsyncRequest,
   InvokeBlueprintOptimizationAsyncResponse,
   InvokeBlueprintOptimizationAsyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeBlueprintOptimizationAsyncRequest,
   output: InvokeBlueprintOptimizationAsyncResponse,
@@ -2811,7 +2810,7 @@ export const invokeDataAutomationLibraryIngestionJob: API.OperationMethod<
   InvokeDataAutomationLibraryIngestionJobRequest,
   InvokeDataAutomationLibraryIngestionJobResponse,
   InvokeDataAutomationLibraryIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeDataAutomationLibraryIngestionJobRequest,
   output: InvokeDataAutomationLibraryIngestionJobResponse,
@@ -2843,7 +2842,7 @@ export const listBlueprints: API.PaginatedOperationMethod<
   ListBlueprintsRequest,
   ListBlueprintsResponse,
   ListBlueprintsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BlueprintSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBlueprintsRequest,
@@ -2879,7 +2878,7 @@ export const listDataAutomationLibraries: API.PaginatedOperationMethod<
   ListDataAutomationLibrariesRequest,
   ListDataAutomationLibrariesResponse,
   ListDataAutomationLibrariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataAutomationLibrarySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataAutomationLibrariesRequest,
@@ -2915,7 +2914,7 @@ export const listDataAutomationLibraryEntities: API.PaginatedOperationMethod<
   ListDataAutomationLibraryEntitiesRequest,
   ListDataAutomationLibraryEntitiesResponse,
   ListDataAutomationLibraryEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataAutomationLibraryEntitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataAutomationLibraryEntitiesRequest,
@@ -2952,7 +2951,7 @@ export const listDataAutomationLibraryIngestionJobs: API.PaginatedOperationMetho
   ListDataAutomationLibraryIngestionJobsRequest,
   ListDataAutomationLibraryIngestionJobsResponse,
   ListDataAutomationLibraryIngestionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataAutomationLibraryIngestionJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataAutomationLibraryIngestionJobsRequest,
@@ -2989,7 +2988,7 @@ export const listDataAutomationProjects: API.PaginatedOperationMethod<
   ListDataAutomationProjectsRequest,
   ListDataAutomationProjectsResponse,
   ListDataAutomationProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataAutomationProjectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataAutomationProjectsRequest,
@@ -3026,7 +3025,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3057,7 +3056,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3088,7 +3087,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3119,7 +3118,7 @@ export const updateBlueprint: API.OperationMethod<
   UpdateBlueprintRequest,
   UpdateBlueprintResponse,
   UpdateBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBlueprintRequest,
   output: UpdateBlueprintResponse,
@@ -3151,7 +3150,7 @@ export const updateDataAutomationLibrary: API.OperationMethod<
   UpdateDataAutomationLibraryRequest,
   UpdateDataAutomationLibraryResponse,
   UpdateDataAutomationLibraryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataAutomationLibraryRequest,
   output: UpdateDataAutomationLibraryResponse,
@@ -3184,7 +3183,7 @@ export const updateDataAutomationProject: API.OperationMethod<
   UpdateDataAutomationProjectRequest,
   UpdateDataAutomationProjectResponse,
   UpdateDataAutomationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataAutomationProjectRequest,
   output: UpdateDataAutomationProjectResponse,

--- a/packages/aws/src/services/bedrock-runtime.ts
+++ b/packages/aws/src/services/bedrock-runtime.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock Runtime",
@@ -3680,7 +3679,7 @@ export const applyGuardrail: API.OperationMethod<
   ApplyGuardrailRequest,
   ApplyGuardrailResponse,
   ApplyGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyGuardrailRequest,
   output: ApplyGuardrailResponse,
@@ -3732,7 +3731,7 @@ export const converse: API.OperationMethod<
   ConverseRequest,
   ConverseResponse,
   ConverseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConverseRequest,
   output: ConverseResponse,
@@ -3790,7 +3789,7 @@ export const converseStream: API.OperationMethod<
   ConverseStreamRequest,
   ConverseStreamResponse,
   ConverseStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConverseStreamRequest,
   output: ConverseStreamResponse,
@@ -3843,7 +3842,7 @@ export const countTokens: API.OperationMethod<
   CountTokensRequest,
   CountTokensResponse,
   CountTokensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CountTokensRequest,
   output: CountTokensResponse,
@@ -3873,7 +3872,7 @@ export const getAsyncInvoke: API.OperationMethod<
   GetAsyncInvokeRequest,
   GetAsyncInvokeResponse,
   GetAsyncInvokeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAsyncInvokeRequest,
   output: GetAsyncInvokeResponse,
@@ -3902,7 +3901,7 @@ export const invokeGuardrailChecks: API.OperationMethod<
   InvokeGuardrailChecksRequest,
   InvokeGuardrailChecksResponse,
   InvokeGuardrailChecksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeGuardrailChecksRequest,
   output: InvokeGuardrailChecksResponse,
@@ -3945,7 +3944,7 @@ export const invokeModel: API.OperationMethod<
   InvokeModelRequest,
   InvokeModelResponse,
   InvokeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeModelRequest,
   output: InvokeModelResponse,
@@ -3988,7 +3987,7 @@ export const invokeModelWithBidirectionalStream: API.OperationMethod<
   InvokeModelWithBidirectionalStreamRequest,
   InvokeModelWithBidirectionalStreamResponse,
   InvokeModelWithBidirectionalStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeModelWithBidirectionalStreamRequest,
   output: InvokeModelWithBidirectionalStreamResponse,
@@ -4042,7 +4041,7 @@ export const invokeModelWithResponseStream: API.OperationMethod<
   InvokeModelWithResponseStreamRequest,
   InvokeModelWithResponseStreamResponse,
   InvokeModelWithResponseStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeModelWithResponseStreamRequest,
   output: InvokeModelWithResponseStreamResponse,
@@ -4077,7 +4076,7 @@ export const listAsyncInvokes: API.PaginatedOperationMethod<
   ListAsyncInvokesRequest,
   ListAsyncInvokesResponse,
   ListAsyncInvokesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AsyncInvokeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAsyncInvokesRequest,
@@ -4120,7 +4119,7 @@ export const startAsyncInvoke: API.OperationMethod<
   StartAsyncInvokeRequest,
   StartAsyncInvokeResponse,
   StartAsyncInvokeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAsyncInvokeRequest,
   output: StartAsyncInvokeResponse,

--- a/packages/aws/src/services/bedrock.ts
+++ b/packages/aws/src/services/bedrock.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Bedrock",
@@ -9748,7 +9747,7 @@ export const batchDeleteAdvancedPromptOptimizationJob: API.OperationMethod<
   BatchDeleteAdvancedPromptOptimizationJobRequest,
   BatchDeleteAdvancedPromptOptimizationJobResponse,
   BatchDeleteAdvancedPromptOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteAdvancedPromptOptimizationJobRequest,
   output: BatchDeleteAdvancedPromptOptimizationJobResponse,
@@ -9778,7 +9777,7 @@ export const batchDeleteEvaluationJob: API.OperationMethod<
   BatchDeleteEvaluationJobRequest,
   BatchDeleteEvaluationJobResponse,
   BatchDeleteEvaluationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteEvaluationJobRequest,
   output: BatchDeleteEvaluationJobResponse,
@@ -9809,7 +9808,7 @@ export const cancelAutomatedReasoningPolicyBuildWorkflow: API.OperationMethod<
   CancelAutomatedReasoningPolicyBuildWorkflowRequest,
   CancelAutomatedReasoningPolicyBuildWorkflowResponse,
   CancelAutomatedReasoningPolicyBuildWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAutomatedReasoningPolicyBuildWorkflowRequest,
   output: CancelAutomatedReasoningPolicyBuildWorkflowResponse,
@@ -9842,7 +9841,7 @@ export const createAdvancedPromptOptimizationJob: API.OperationMethod<
   CreateAdvancedPromptOptimizationJobRequest,
   CreateAdvancedPromptOptimizationJobResponse,
   CreateAdvancedPromptOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAdvancedPromptOptimizationJobRequest,
   output: CreateAdvancedPromptOptimizationJobResponse,
@@ -9880,7 +9879,7 @@ export const createAutomatedReasoningPolicy: API.OperationMethod<
   CreateAutomatedReasoningPolicyRequest,
   CreateAutomatedReasoningPolicyResponse,
   CreateAutomatedReasoningPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomatedReasoningPolicyRequest,
   output: CreateAutomatedReasoningPolicyResponse,
@@ -9915,7 +9914,7 @@ export const createAutomatedReasoningPolicyTestCase: API.OperationMethod<
   CreateAutomatedReasoningPolicyTestCaseRequest,
   CreateAutomatedReasoningPolicyTestCaseResponse,
   CreateAutomatedReasoningPolicyTestCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomatedReasoningPolicyTestCaseRequest,
   output: CreateAutomatedReasoningPolicyTestCaseResponse,
@@ -9950,7 +9949,7 @@ export const createAutomatedReasoningPolicyVersion: API.OperationMethod<
   CreateAutomatedReasoningPolicyVersionRequest,
   CreateAutomatedReasoningPolicyVersionResponse,
   CreateAutomatedReasoningPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomatedReasoningPolicyVersionRequest,
   output: CreateAutomatedReasoningPolicyVersionResponse,
@@ -10010,7 +10009,7 @@ export const createCustomModel: API.OperationMethod<
   CreateCustomModelRequest,
   CreateCustomModelResponse,
   CreateCustomModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomModelRequest,
   output: CreateCustomModelResponse,
@@ -10055,7 +10054,7 @@ export const createCustomModelDeployment: API.OperationMethod<
   CreateCustomModelDeploymentRequest,
   CreateCustomModelDeploymentResponse,
   CreateCustomModelDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomModelDeploymentRequest,
   output: CreateCustomModelDeploymentResponse,
@@ -10089,7 +10088,7 @@ export const createEvaluationJob: API.OperationMethod<
   CreateEvaluationJobRequest,
   CreateEvaluationJobResponse,
   CreateEvaluationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEvaluationJobRequest,
   output: CreateEvaluationJobResponse,
@@ -10122,7 +10121,7 @@ export const createFoundationModelAgreement: API.OperationMethod<
   CreateFoundationModelAgreementRequest,
   CreateFoundationModelAgreementResponse,
   CreateFoundationModelAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFoundationModelAgreementRequest,
   output: CreateFoundationModelAgreementResponse,
@@ -10170,7 +10169,7 @@ export const createGuardrail: API.OperationMethod<
   CreateGuardrailRequest,
   CreateGuardrailResponse,
   CreateGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGuardrailRequest,
   output: CreateGuardrailResponse,
@@ -10205,7 +10204,7 @@ export const createGuardrailVersion: API.OperationMethod<
   CreateGuardrailVersionRequest,
   CreateGuardrailVersionResponse,
   CreateGuardrailVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGuardrailVersionRequest,
   output: CreateGuardrailVersionResponse,
@@ -10240,7 +10239,7 @@ export const createInferenceProfile: API.OperationMethod<
   CreateInferenceProfileRequest,
   CreateInferenceProfileResponse,
   CreateInferenceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInferenceProfileRequest,
   output: CreateInferenceProfileResponse,
@@ -10275,7 +10274,7 @@ export const createMarketplaceModelEndpoint: API.OperationMethod<
   CreateMarketplaceModelEndpointRequest,
   CreateMarketplaceModelEndpointResponse,
   CreateMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMarketplaceModelEndpointRequest,
   output: CreateMarketplaceModelEndpointResponse,
@@ -10306,7 +10305,7 @@ export const createModelCopyJob: API.OperationMethod<
   CreateModelCopyJobRequest,
   CreateModelCopyJobResponse,
   CreateModelCopyJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelCopyJobRequest,
   output: CreateModelCopyJobResponse,
@@ -10346,7 +10345,7 @@ export const createModelCustomizationJob: API.OperationMethod<
   CreateModelCustomizationJobRequest,
   CreateModelCustomizationJobResponse,
   CreateModelCustomizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelCustomizationJobRequest,
   output: CreateModelCustomizationJobResponse,
@@ -10382,7 +10381,7 @@ export const createModelImportJob: API.OperationMethod<
   CreateModelImportJobRequest,
   CreateModelImportJobResponse,
   CreateModelImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelImportJobRequest,
   output: CreateModelImportJobResponse,
@@ -10419,7 +10418,7 @@ export const createModelInvocationJob: API.OperationMethod<
   CreateModelInvocationJobRequest,
   CreateModelInvocationJobResponse,
   CreateModelInvocationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelInvocationJobRequest,
   output: CreateModelInvocationJobResponse,
@@ -10454,7 +10453,7 @@ export const createPromptRouter: API.OperationMethod<
   CreatePromptRouterRequest,
   CreatePromptRouterResponse,
   CreatePromptRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePromptRouterRequest,
   output: CreatePromptRouterResponse,
@@ -10489,7 +10488,7 @@ export const createProvisionedModelThroughput: API.OperationMethod<
   CreateProvisionedModelThroughputRequest,
   CreateProvisionedModelThroughputResponse,
   CreateProvisionedModelThroughputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisionedModelThroughputRequest,
   output: CreateProvisionedModelThroughputResponse,
@@ -10523,7 +10522,7 @@ export const deleteAutomatedReasoningPolicy: API.OperationMethod<
   DeleteAutomatedReasoningPolicyRequest,
   DeleteAutomatedReasoningPolicyResponse,
   DeleteAutomatedReasoningPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomatedReasoningPolicyRequest,
   output: DeleteAutomatedReasoningPolicyResponse,
@@ -10557,7 +10556,7 @@ export const deleteAutomatedReasoningPolicyBuildWorkflow: API.OperationMethod<
   DeleteAutomatedReasoningPolicyBuildWorkflowRequest,
   DeleteAutomatedReasoningPolicyBuildWorkflowResponse,
   DeleteAutomatedReasoningPolicyBuildWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomatedReasoningPolicyBuildWorkflowRequest,
   output: DeleteAutomatedReasoningPolicyBuildWorkflowResponse,
@@ -10591,7 +10590,7 @@ export const deleteAutomatedReasoningPolicyTestCase: API.OperationMethod<
   DeleteAutomatedReasoningPolicyTestCaseRequest,
   DeleteAutomatedReasoningPolicyTestCaseResponse,
   DeleteAutomatedReasoningPolicyTestCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomatedReasoningPolicyTestCaseRequest,
   output: DeleteAutomatedReasoningPolicyTestCaseResponse,
@@ -10624,7 +10623,7 @@ export const deleteCustomModel: API.OperationMethod<
   DeleteCustomModelRequest,
   DeleteCustomModelResponse,
   DeleteCustomModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomModelRequest,
   output: DeleteCustomModelResponse,
@@ -10664,7 +10663,7 @@ export const deleteCustomModelDeployment: API.OperationMethod<
   DeleteCustomModelDeploymentRequest,
   DeleteCustomModelDeploymentResponse,
   DeleteCustomModelDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomModelDeploymentRequest,
   output: DeleteCustomModelDeploymentResponse,
@@ -10695,7 +10694,7 @@ export const deleteEnforcedGuardrailConfiguration: API.OperationMethod<
   DeleteEnforcedGuardrailConfigurationRequest,
   DeleteEnforcedGuardrailConfigurationResponse,
   DeleteEnforcedGuardrailConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnforcedGuardrailConfigurationRequest,
   output: DeleteEnforcedGuardrailConfigurationResponse,
@@ -10726,7 +10725,7 @@ export const deleteFoundationModelAgreement: API.OperationMethod<
   DeleteFoundationModelAgreementRequest,
   DeleteFoundationModelAgreementResponse,
   DeleteFoundationModelAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFoundationModelAgreementRequest,
   output: DeleteFoundationModelAgreementResponse,
@@ -10763,7 +10762,7 @@ export const deleteGuardrail: API.OperationMethod<
   DeleteGuardrailRequest,
   DeleteGuardrailResponse,
   DeleteGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGuardrailRequest,
   output: DeleteGuardrailResponse,
@@ -10796,7 +10795,7 @@ export const deleteImportedModel: API.OperationMethod<
   DeleteImportedModelRequest,
   DeleteImportedModelResponse,
   DeleteImportedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImportedModelRequest,
   output: DeleteImportedModelResponse,
@@ -10828,7 +10827,7 @@ export const deleteInferenceProfile: API.OperationMethod<
   DeleteInferenceProfileRequest,
   DeleteInferenceProfileResponse,
   DeleteInferenceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInferenceProfileRequest,
   output: DeleteInferenceProfileResponse,
@@ -10859,7 +10858,7 @@ export const deleteMarketplaceModelEndpoint: API.OperationMethod<
   DeleteMarketplaceModelEndpointRequest,
   DeleteMarketplaceModelEndpointResponse,
   DeleteMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMarketplaceModelEndpointRequest,
   output: DeleteMarketplaceModelEndpointResponse,
@@ -10887,7 +10886,7 @@ export const deleteModelInvocationLoggingConfiguration: API.OperationMethod<
   DeleteModelInvocationLoggingConfigurationRequest,
   DeleteModelInvocationLoggingConfigurationResponse,
   DeleteModelInvocationLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelInvocationLoggingConfigurationRequest,
   output: DeleteModelInvocationLoggingConfigurationResponse,
@@ -10911,7 +10910,7 @@ export const deletePromptRouter: API.OperationMethod<
   DeletePromptRouterRequest,
   DeletePromptRouterResponse,
   DeletePromptRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePromptRouterRequest,
   output: DeletePromptRouterResponse,
@@ -10942,7 +10941,7 @@ export const deleteProvisionedModelThroughput: API.OperationMethod<
   DeleteProvisionedModelThroughputRequest,
   DeleteProvisionedModelThroughputResponse,
   DeleteProvisionedModelThroughputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisionedModelThroughputRequest,
   output: DeleteProvisionedModelThroughputResponse,
@@ -10973,7 +10972,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -11004,7 +11003,7 @@ export const deregisterMarketplaceModelEndpoint: API.OperationMethod<
   DeregisterMarketplaceModelEndpointRequest,
   DeregisterMarketplaceModelEndpointResponse,
   DeregisterMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterMarketplaceModelEndpointRequest,
   output: DeregisterMarketplaceModelEndpointResponse,
@@ -11035,7 +11034,7 @@ export const exportAutomatedReasoningPolicyVersion: API.OperationMethod<
   ExportAutomatedReasoningPolicyVersionRequest,
   ExportAutomatedReasoningPolicyVersionResponse,
   ExportAutomatedReasoningPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportAutomatedReasoningPolicyVersionRequest,
   output: ExportAutomatedReasoningPolicyVersionResponse,
@@ -11064,7 +11063,7 @@ export const getAccountDataRetention: API.OperationMethod<
   GetAccountDataRetentionRequest,
   GetAccountDataRetentionResponse,
   GetAccountDataRetentionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountDataRetentionRequest,
   output: GetAccountDataRetentionResponse,
@@ -11093,7 +11092,7 @@ export const getAdvancedPromptOptimizationJob: API.OperationMethod<
   GetAdvancedPromptOptimizationJobRequest,
   GetAdvancedPromptOptimizationJobResponse,
   GetAdvancedPromptOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdvancedPromptOptimizationJobRequest,
   output: GetAdvancedPromptOptimizationJobResponse,
@@ -11123,7 +11122,7 @@ export const getAutomatedReasoningPolicy: API.OperationMethod<
   GetAutomatedReasoningPolicyRequest,
   GetAutomatedReasoningPolicyResponse,
   GetAutomatedReasoningPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyRequest,
   output: GetAutomatedReasoningPolicyResponse,
@@ -11153,7 +11152,7 @@ export const getAutomatedReasoningPolicyAnnotations: API.OperationMethod<
   GetAutomatedReasoningPolicyAnnotationsRequest,
   GetAutomatedReasoningPolicyAnnotationsResponse,
   GetAutomatedReasoningPolicyAnnotationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyAnnotationsRequest,
   output: GetAutomatedReasoningPolicyAnnotationsResponse,
@@ -11183,7 +11182,7 @@ export const getAutomatedReasoningPolicyBuildWorkflow: API.OperationMethod<
   GetAutomatedReasoningPolicyBuildWorkflowRequest,
   GetAutomatedReasoningPolicyBuildWorkflowResponse,
   GetAutomatedReasoningPolicyBuildWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyBuildWorkflowRequest,
   output: GetAutomatedReasoningPolicyBuildWorkflowResponse,
@@ -11213,7 +11212,7 @@ export const getAutomatedReasoningPolicyBuildWorkflowResultAssets: API.Operation
   GetAutomatedReasoningPolicyBuildWorkflowResultAssetsRequest,
   GetAutomatedReasoningPolicyBuildWorkflowResultAssetsResponse,
   GetAutomatedReasoningPolicyBuildWorkflowResultAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyBuildWorkflowResultAssetsRequest,
   output: GetAutomatedReasoningPolicyBuildWorkflowResultAssetsResponse,
@@ -11243,7 +11242,7 @@ export const getAutomatedReasoningPolicyNextScenario: API.OperationMethod<
   GetAutomatedReasoningPolicyNextScenarioRequest,
   GetAutomatedReasoningPolicyNextScenarioResponse,
   GetAutomatedReasoningPolicyNextScenarioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyNextScenarioRequest,
   output: GetAutomatedReasoningPolicyNextScenarioResponse,
@@ -11273,7 +11272,7 @@ export const getAutomatedReasoningPolicyTestCase: API.OperationMethod<
   GetAutomatedReasoningPolicyTestCaseRequest,
   GetAutomatedReasoningPolicyTestCaseResponse,
   GetAutomatedReasoningPolicyTestCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyTestCaseRequest,
   output: GetAutomatedReasoningPolicyTestCaseResponse,
@@ -11303,7 +11302,7 @@ export const getAutomatedReasoningPolicyTestResult: API.OperationMethod<
   GetAutomatedReasoningPolicyTestResultRequest,
   GetAutomatedReasoningPolicyTestResultResponse,
   GetAutomatedReasoningPolicyTestResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedReasoningPolicyTestResultRequest,
   output: GetAutomatedReasoningPolicyTestResultResponse,
@@ -11333,7 +11332,7 @@ export const getCustomModel: API.OperationMethod<
   GetCustomModelRequest,
   GetCustomModelResponse,
   GetCustomModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomModelRequest,
   output: GetCustomModelResponse,
@@ -11371,7 +11370,7 @@ export const getCustomModelDeployment: API.OperationMethod<
   GetCustomModelDeploymentRequest,
   GetCustomModelDeploymentResponse,
   GetCustomModelDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomModelDeploymentRequest,
   output: GetCustomModelDeploymentResponse,
@@ -11401,7 +11400,7 @@ export const getEvaluationJob: API.OperationMethod<
   GetEvaluationJobRequest,
   GetEvaluationJobResponse,
   GetEvaluationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvaluationJobRequest,
   output: GetEvaluationJobResponse,
@@ -11431,7 +11430,7 @@ export const getFoundationModel: API.OperationMethod<
   GetFoundationModelRequest,
   GetFoundationModelResponse,
   GetFoundationModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFoundationModelRequest,
   output: GetFoundationModelResponse,
@@ -11461,7 +11460,7 @@ export const getFoundationModelAvailability: API.OperationMethod<
   GetFoundationModelAvailabilityRequest,
   GetFoundationModelAvailabilityResponse,
   GetFoundationModelAvailabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFoundationModelAvailabilityRequest,
   output: GetFoundationModelAvailabilityResponse,
@@ -11491,7 +11490,7 @@ export const getGuardrail: API.OperationMethod<
   GetGuardrailRequest,
   GetGuardrailResponse,
   GetGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGuardrailRequest,
   output: GetGuardrailResponse,
@@ -11521,7 +11520,7 @@ export const getImportedModel: API.OperationMethod<
   GetImportedModelRequest,
   GetImportedModelResponse,
   GetImportedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportedModelRequest,
   output: GetImportedModelResponse,
@@ -11551,7 +11550,7 @@ export const getInferenceProfile: API.OperationMethod<
   GetInferenceProfileRequest,
   GetInferenceProfileResponse,
   GetInferenceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInferenceProfileRequest,
   output: GetInferenceProfileResponse,
@@ -11581,7 +11580,7 @@ export const getMarketplaceModelEndpoint: API.OperationMethod<
   GetMarketplaceModelEndpointRequest,
   GetMarketplaceModelEndpointResponse,
   GetMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMarketplaceModelEndpointRequest,
   output: GetMarketplaceModelEndpointResponse,
@@ -11611,7 +11610,7 @@ export const getModelCopyJob: API.OperationMethod<
   GetModelCopyJobRequest,
   GetModelCopyJobResponse,
   GetModelCopyJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelCopyJobRequest,
   output: GetModelCopyJobResponse,
@@ -11641,7 +11640,7 @@ export const getModelCustomizationJob: API.OperationMethod<
   GetModelCustomizationJobRequest,
   GetModelCustomizationJobResponse,
   GetModelCustomizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelCustomizationJobRequest,
   output: GetModelCustomizationJobResponse,
@@ -11671,7 +11670,7 @@ export const getModelImportJob: API.OperationMethod<
   GetModelImportJobRequest,
   GetModelImportJobResponse,
   GetModelImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelImportJobRequest,
   output: GetModelImportJobResponse,
@@ -11701,7 +11700,7 @@ export const getModelInvocationJob: API.OperationMethod<
   GetModelInvocationJobRequest,
   GetModelInvocationJobResponse,
   GetModelInvocationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelInvocationJobRequest,
   output: GetModelInvocationJobResponse,
@@ -11729,7 +11728,7 @@ export const getModelInvocationLoggingConfiguration: API.OperationMethod<
   GetModelInvocationLoggingConfigurationRequest,
   GetModelInvocationLoggingConfigurationResponse,
   GetModelInvocationLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelInvocationLoggingConfigurationRequest,
   output: GetModelInvocationLoggingConfigurationResponse,
@@ -11753,7 +11752,7 @@ export const getPromptRouter: API.OperationMethod<
   GetPromptRouterRequest,
   GetPromptRouterResponse,
   GetPromptRouterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPromptRouterRequest,
   output: GetPromptRouterResponse,
@@ -11783,7 +11782,7 @@ export const getProvisionedModelThroughput: API.OperationMethod<
   GetProvisionedModelThroughputRequest,
   GetProvisionedModelThroughputResponse,
   GetProvisionedModelThroughputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProvisionedModelThroughputRequest,
   output: GetProvisionedModelThroughputResponse,
@@ -11813,7 +11812,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -11842,7 +11841,7 @@ export const getUseCaseForModelAccess: API.OperationMethod<
   GetUseCaseForModelAccessRequest,
   GetUseCaseForModelAccessResponse,
   GetUseCaseForModelAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUseCaseForModelAccessRequest,
   output: GetUseCaseForModelAccessResponse,
@@ -11870,7 +11869,7 @@ export const listAdvancedPromptOptimizationJobs: API.PaginatedOperationMethod<
   ListAdvancedPromptOptimizationJobsRequest,
   ListAdvancedPromptOptimizationJobsResponse,
   ListAdvancedPromptOptimizationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdvancedPromptOptimizationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdvancedPromptOptimizationJobsRequest,
@@ -11906,7 +11905,7 @@ export const listAutomatedReasoningPolicies: API.PaginatedOperationMethod<
   ListAutomatedReasoningPoliciesRequest,
   ListAutomatedReasoningPoliciesResponse,
   ListAutomatedReasoningPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomatedReasoningPolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomatedReasoningPoliciesRequest,
@@ -11943,7 +11942,7 @@ export const listAutomatedReasoningPolicyBuildWorkflows: API.PaginatedOperationM
   ListAutomatedReasoningPolicyBuildWorkflowsRequest,
   ListAutomatedReasoningPolicyBuildWorkflowsResponse,
   ListAutomatedReasoningPolicyBuildWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomatedReasoningPolicyBuildWorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomatedReasoningPolicyBuildWorkflowsRequest,
@@ -11980,7 +11979,7 @@ export const listAutomatedReasoningPolicyTestCases: API.PaginatedOperationMethod
   ListAutomatedReasoningPolicyTestCasesRequest,
   ListAutomatedReasoningPolicyTestCasesResponse,
   ListAutomatedReasoningPolicyTestCasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomatedReasoningPolicyTestCase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomatedReasoningPolicyTestCasesRequest,
@@ -12018,7 +12017,7 @@ export const listAutomatedReasoningPolicyTestResults: API.PaginatedOperationMeth
   ListAutomatedReasoningPolicyTestResultsRequest,
   ListAutomatedReasoningPolicyTestResultsResponse,
   ListAutomatedReasoningPolicyTestResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomatedReasoningPolicyTestResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomatedReasoningPolicyTestResultsRequest,
@@ -12065,7 +12064,7 @@ export const listCustomModelDeployments: API.PaginatedOperationMethod<
   ListCustomModelDeploymentsRequest,
   ListCustomModelDeploymentsResponse,
   ListCustomModelDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomModelDeploymentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomModelDeploymentsRequest,
@@ -12102,7 +12101,7 @@ export const listCustomModels: API.PaginatedOperationMethod<
   ListCustomModelsRequest,
   ListCustomModelsResponse,
   ListCustomModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomModelsRequest,
@@ -12138,7 +12137,7 @@ export const listEnforcedGuardrailsConfiguration: API.PaginatedOperationMethod<
   ListEnforcedGuardrailsConfigurationRequest,
   ListEnforcedGuardrailsConfigurationResponse,
   ListEnforcedGuardrailsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountEnforcedGuardrailOutputConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnforcedGuardrailsConfigurationRequest,
@@ -12173,7 +12172,7 @@ export const listEvaluationJobs: API.PaginatedOperationMethod<
   ListEvaluationJobsRequest,
   ListEvaluationJobsResponse,
   ListEvaluationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEvaluationJobsRequest,
@@ -12209,7 +12208,7 @@ export const listFoundationModelAgreementOffers: API.OperationMethod<
   ListFoundationModelAgreementOffersRequest,
   ListFoundationModelAgreementOffersResponse,
   ListFoundationModelAgreementOffersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFoundationModelAgreementOffersRequest,
   output: ListFoundationModelAgreementOffersResponse,
@@ -12238,7 +12237,7 @@ export const listFoundationModels: API.OperationMethod<
   ListFoundationModelsRequest,
   ListFoundationModelsResponse,
   ListFoundationModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFoundationModelsRequest,
   output: ListFoundationModelsResponse,
@@ -12269,7 +12268,7 @@ export const listGuardrails: API.PaginatedOperationMethod<
   ListGuardrailsRequest,
   ListGuardrailsResponse,
   ListGuardrailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GuardrailSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGuardrailsRequest,
@@ -12305,7 +12304,7 @@ export const listImportedModels: API.PaginatedOperationMethod<
   ListImportedModelsRequest,
   ListImportedModelsResponse,
   ListImportedModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportedModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportedModelsRequest,
@@ -12340,7 +12339,7 @@ export const listInferenceProfiles: API.PaginatedOperationMethod<
   ListInferenceProfilesRequest,
   ListInferenceProfilesResponse,
   ListInferenceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InferenceProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceProfilesRequest,
@@ -12376,7 +12375,7 @@ export const listMarketplaceModelEndpoints: API.PaginatedOperationMethod<
   ListMarketplaceModelEndpointsRequest,
   ListMarketplaceModelEndpointsResponse,
   ListMarketplaceModelEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MarketplaceModelEndpointSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMarketplaceModelEndpointsRequest,
@@ -12413,7 +12412,7 @@ export const listModelCopyJobs: API.PaginatedOperationMethod<
   ListModelCopyJobsRequest,
   ListModelCopyJobsResponse,
   ListModelCopyJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelCopyJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelCopyJobsRequest,
@@ -12451,7 +12450,7 @@ export const listModelCustomizationJobs: API.PaginatedOperationMethod<
   ListModelCustomizationJobsRequest,
   ListModelCustomizationJobsResponse,
   ListModelCustomizationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelCustomizationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelCustomizationJobsRequest,
@@ -12486,7 +12485,7 @@ export const listModelImportJobs: API.PaginatedOperationMethod<
   ListModelImportJobsRequest,
   ListModelImportJobsResponse,
   ListModelImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelImportJobsRequest,
@@ -12521,7 +12520,7 @@ export const listModelInvocationJobs: API.PaginatedOperationMethod<
   ListModelInvocationJobsRequest,
   ListModelInvocationJobsResponse,
   ListModelInvocationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelInvocationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelInvocationJobsRequest,
@@ -12556,7 +12555,7 @@ export const listPromptRouters: API.PaginatedOperationMethod<
   ListPromptRoutersRequest,
   ListPromptRoutersResponse,
   ListPromptRoutersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PromptRouterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPromptRoutersRequest,
@@ -12591,7 +12590,7 @@ export const listProvisionedModelThroughputs: API.PaginatedOperationMethod<
   ListProvisionedModelThroughputsRequest,
   ListProvisionedModelThroughputsResponse,
   ListProvisionedModelThroughputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisionedModelThroughputsRequest,
@@ -12629,7 +12628,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -12658,7 +12657,7 @@ export const putAccountDataRetention: API.OperationMethod<
   PutAccountDataRetentionRequest,
   PutAccountDataRetentionResponse,
   PutAccountDataRetentionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountDataRetentionRequest,
   output: PutAccountDataRetentionResponse,
@@ -12688,7 +12687,7 @@ export const putEnforcedGuardrailConfiguration: API.OperationMethod<
   PutEnforcedGuardrailConfigurationRequest,
   PutEnforcedGuardrailConfigurationResponse,
   PutEnforcedGuardrailConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEnforcedGuardrailConfigurationRequest,
   output: PutEnforcedGuardrailConfigurationResponse,
@@ -12718,7 +12717,7 @@ export const putModelInvocationLoggingConfiguration: API.OperationMethod<
   PutModelInvocationLoggingConfigurationRequest,
   PutModelInvocationLoggingConfigurationResponse,
   PutModelInvocationLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutModelInvocationLoggingConfigurationRequest,
   output: PutModelInvocationLoggingConfigurationResponse,
@@ -12747,7 +12746,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -12776,7 +12775,7 @@ export const putUseCaseForModelAccess: API.OperationMethod<
   PutUseCaseForModelAccessRequest,
   PutUseCaseForModelAccessResponse,
   PutUseCaseForModelAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutUseCaseForModelAccessRequest,
   output: PutUseCaseForModelAccessResponse,
@@ -12806,7 +12805,7 @@ export const registerMarketplaceModelEndpoint: API.OperationMethod<
   RegisterMarketplaceModelEndpointRequest,
   RegisterMarketplaceModelEndpointResponse,
   RegisterMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterMarketplaceModelEndpointRequest,
   output: RegisterMarketplaceModelEndpointResponse,
@@ -12840,7 +12839,7 @@ export const startAutomatedReasoningPolicyBuildWorkflow: API.OperationMethod<
   StartAutomatedReasoningPolicyBuildWorkflowRequest,
   StartAutomatedReasoningPolicyBuildWorkflowResponse,
   StartAutomatedReasoningPolicyBuildWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutomatedReasoningPolicyBuildWorkflowRequest,
   output: StartAutomatedReasoningPolicyBuildWorkflowResponse,
@@ -12874,7 +12873,7 @@ export const startAutomatedReasoningPolicyTestWorkflow: API.OperationMethod<
   StartAutomatedReasoningPolicyTestWorkflowRequest,
   StartAutomatedReasoningPolicyTestWorkflowResponse,
   StartAutomatedReasoningPolicyTestWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutomatedReasoningPolicyTestWorkflowRequest,
   output: StartAutomatedReasoningPolicyTestWorkflowResponse,
@@ -12906,7 +12905,7 @@ export const stopAdvancedPromptOptimizationJob: API.OperationMethod<
   StopAdvancedPromptOptimizationJobRequest,
   StopAdvancedPromptOptimizationJobResponse,
   StopAdvancedPromptOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAdvancedPromptOptimizationJobRequest,
   output: StopAdvancedPromptOptimizationJobResponse,
@@ -12938,7 +12937,7 @@ export const stopEvaluationJob: API.OperationMethod<
   StopEvaluationJobRequest,
   StopEvaluationJobResponse,
   StopEvaluationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEvaluationJobRequest,
   output: StopEvaluationJobResponse,
@@ -12970,7 +12969,7 @@ export const stopModelCustomizationJob: API.OperationMethod<
   StopModelCustomizationJobRequest,
   StopModelCustomizationJobResponse,
   StopModelCustomizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopModelCustomizationJobRequest,
   output: StopModelCustomizationJobResponse,
@@ -13002,7 +13001,7 @@ export const stopModelInvocationJob: API.OperationMethod<
   StopModelInvocationJobRequest,
   StopModelInvocationJobResponse,
   StopModelInvocationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopModelInvocationJobRequest,
   output: StopModelInvocationJobResponse,
@@ -13034,7 +13033,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -13065,7 +13064,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -13097,7 +13096,7 @@ export const updateAutomatedReasoningPolicy: API.OperationMethod<
   UpdateAutomatedReasoningPolicyRequest,
   UpdateAutomatedReasoningPolicyResponse,
   UpdateAutomatedReasoningPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomatedReasoningPolicyRequest,
   output: UpdateAutomatedReasoningPolicyResponse,
@@ -13130,7 +13129,7 @@ export const updateAutomatedReasoningPolicyAnnotations: API.OperationMethod<
   UpdateAutomatedReasoningPolicyAnnotationsRequest,
   UpdateAutomatedReasoningPolicyAnnotationsResponse,
   UpdateAutomatedReasoningPolicyAnnotationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomatedReasoningPolicyAnnotationsRequest,
   output: UpdateAutomatedReasoningPolicyAnnotationsResponse,
@@ -13163,7 +13162,7 @@ export const updateAutomatedReasoningPolicyTestCase: API.OperationMethod<
   UpdateAutomatedReasoningPolicyTestCaseRequest,
   UpdateAutomatedReasoningPolicyTestCaseResponse,
   UpdateAutomatedReasoningPolicyTestCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomatedReasoningPolicyTestCaseRequest,
   output: UpdateAutomatedReasoningPolicyTestCaseResponse,
@@ -13195,7 +13194,7 @@ export const updateCustomModelDeployment: API.OperationMethod<
   UpdateCustomModelDeploymentRequest,
   UpdateCustomModelDeploymentResponse,
   UpdateCustomModelDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomModelDeploymentRequest,
   output: UpdateCustomModelDeploymentResponse,
@@ -13247,7 +13246,7 @@ export const updateGuardrail: API.OperationMethod<
   UpdateGuardrailRequest,
   UpdateGuardrailResponse,
   UpdateGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGuardrailRequest,
   output: UpdateGuardrailResponse,
@@ -13281,7 +13280,7 @@ export const updateMarketplaceModelEndpoint: API.OperationMethod<
   UpdateMarketplaceModelEndpointRequest,
   UpdateMarketplaceModelEndpointResponse,
   UpdateMarketplaceModelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMarketplaceModelEndpointRequest,
   output: UpdateMarketplaceModelEndpointResponse,
@@ -13313,7 +13312,7 @@ export const updateProvisionedModelThroughput: API.OperationMethod<
   UpdateProvisionedModelThroughputRequest,
   UpdateProvisionedModelThroughputResponse,
   UpdateProvisionedModelThroughputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProvisionedModelThroughputRequest,
   output: UpdateProvisionedModelThroughputResponse,

--- a/packages/aws/src/services/billing.ts
+++ b/packages/aws/src/services/billing.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Billing",
@@ -759,7 +758,7 @@ export const associateSourceViews: API.OperationMethod<
   AssociateSourceViewsRequest,
   AssociateSourceViewsResponse,
   AssociateSourceViewsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceViewsRequest,
   output: AssociateSourceViewsResponse,
@@ -795,7 +794,7 @@ export const createBillingView: API.OperationMethod<
   CreateBillingViewRequest,
   CreateBillingViewResponse,
   CreateBillingViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillingViewRequest,
   output: CreateBillingViewResponse,
@@ -828,7 +827,7 @@ export const deleteBillingView: API.OperationMethod<
   DeleteBillingViewRequest,
   DeleteBillingViewResponse,
   DeleteBillingViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBillingViewRequest,
   output: DeleteBillingViewResponse,
@@ -860,7 +859,7 @@ export const disassociateSourceViews: API.OperationMethod<
   DisassociateSourceViewsRequest,
   DisassociateSourceViewsResponse,
   DisassociateSourceViewsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSourceViewsRequest,
   output: DisassociateSourceViewsResponse,
@@ -892,7 +891,7 @@ export const getBillingView: API.OperationMethod<
   GetBillingViewRequest,
   GetBillingViewResponse,
   GetBillingViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBillingViewRequest,
   output: GetBillingViewResponse,
@@ -922,7 +921,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -953,7 +952,7 @@ export const listBillingViews: API.PaginatedOperationMethod<
   ListBillingViewsRequest,
   ListBillingViewsResponse,
   ListBillingViewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingViewListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillingViewsRequest,
@@ -989,7 +988,7 @@ export const listSourceViewsForBillingView: API.PaginatedOperationMethod<
   ListSourceViewsForBillingViewRequest,
   ListSourceViewsForBillingViewResponse,
   ListSourceViewsForBillingViewError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingViewArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceViewsForBillingViewRequest,
@@ -1026,7 +1025,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1056,7 +1055,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1086,7 +1085,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1119,7 +1118,7 @@ export const updateBillingView: API.OperationMethod<
   UpdateBillingViewRequest,
   UpdateBillingViewResponse,
   UpdateBillingViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBillingViewRequest,
   output: UpdateBillingViewResponse,

--- a/packages/aws/src/services/billingconductor.ts
+++ b/packages/aws/src/services/billingconductor.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "billingconductor",
@@ -2351,7 +2350,7 @@ export const associateAccounts: API.OperationMethod<
   AssociateAccountsInput,
   AssociateAccountsOutput,
   AssociateAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAccountsInput,
   output: AssociateAccountsOutput,
@@ -2385,7 +2384,7 @@ export const associatePricingRules: API.OperationMethod<
   AssociatePricingRulesInput,
   AssociatePricingRulesOutput,
   AssociatePricingRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePricingRulesInput,
   output: AssociatePricingRulesOutput,
@@ -2419,7 +2418,7 @@ export const batchAssociateResourcesToCustomLineItem: API.OperationMethod<
   BatchAssociateResourcesToCustomLineItemInput,
   BatchAssociateResourcesToCustomLineItemOutput,
   BatchAssociateResourcesToCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateResourcesToCustomLineItemInput,
   output: BatchAssociateResourcesToCustomLineItemOutput,
@@ -2452,7 +2451,7 @@ export const batchDisassociateResourcesFromCustomLineItem: API.OperationMethod<
   BatchDisassociateResourcesFromCustomLineItemInput,
   BatchDisassociateResourcesFromCustomLineItemOutput,
   BatchDisassociateResourcesFromCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateResourcesFromCustomLineItemInput,
   output: BatchDisassociateResourcesFromCustomLineItemOutput,
@@ -2484,7 +2483,7 @@ export const createBillingGroup: API.OperationMethod<
   CreateBillingGroupInput,
   CreateBillingGroupOutput,
   CreateBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillingGroupInput,
   output: CreateBillingGroupOutput,
@@ -2516,7 +2515,7 @@ export const createCustomLineItem: API.OperationMethod<
   CreateCustomLineItemInput,
   CreateCustomLineItemOutput,
   CreateCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomLineItemInput,
   output: CreateCustomLineItemOutput,
@@ -2549,7 +2548,7 @@ export const createPricingPlan: API.OperationMethod<
   CreatePricingPlanInput,
   CreatePricingPlanOutput,
   CreatePricingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePricingPlanInput,
   output: CreatePricingPlanOutput,
@@ -2582,7 +2581,7 @@ export const createPricingRule: API.OperationMethod<
   CreatePricingRuleInput,
   CreatePricingRuleOutput,
   CreatePricingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePricingRuleInput,
   output: CreatePricingRuleOutput,
@@ -2612,7 +2611,7 @@ export const deleteBillingGroup: API.OperationMethod<
   DeleteBillingGroupInput,
   DeleteBillingGroupOutput,
   DeleteBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBillingGroupInput,
   output: DeleteBillingGroupOutput,
@@ -2641,7 +2640,7 @@ export const deleteCustomLineItem: API.OperationMethod<
   DeleteCustomLineItemInput,
   DeleteCustomLineItemOutput,
   DeleteCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomLineItemInput,
   output: DeleteCustomLineItemOutput,
@@ -2671,7 +2670,7 @@ export const deletePricingPlan: API.OperationMethod<
   DeletePricingPlanInput,
   DeletePricingPlanOutput,
   DeletePricingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePricingPlanInput,
   output: DeletePricingPlanOutput,
@@ -2701,7 +2700,7 @@ export const deletePricingRule: API.OperationMethod<
   DeletePricingRuleInput,
   DeletePricingRuleOutput,
   DeletePricingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePricingRuleInput,
   output: DeletePricingRuleOutput,
@@ -2732,7 +2731,7 @@ export const disassociateAccounts: API.OperationMethod<
   DisassociateAccountsInput,
   DisassociateAccountsOutput,
   DisassociateAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAccountsInput,
   output: DisassociateAccountsOutput,
@@ -2764,7 +2763,7 @@ export const disassociatePricingRules: API.OperationMethod<
   DisassociatePricingRulesInput,
   DisassociatePricingRulesOutput,
   DisassociatePricingRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePricingRulesInput,
   output: DisassociatePricingRulesOutput,
@@ -2795,7 +2794,7 @@ export const getBillingGroupCostReport: API.PaginatedOperationMethod<
   GetBillingGroupCostReportInput,
   GetBillingGroupCostReportOutput,
   GetBillingGroupCostReportError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingGroupCostReportResultElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBillingGroupCostReportInput,
@@ -2832,7 +2831,7 @@ export const listAccountAssociations: API.PaginatedOperationMethod<
   ListAccountAssociationsInput,
   ListAccountAssociationsOutput,
   ListAccountAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssociationsListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssociationsInput,
@@ -2868,7 +2867,7 @@ export const listBillingGroupCostReports: API.PaginatedOperationMethod<
   ListBillingGroupCostReportsInput,
   ListBillingGroupCostReportsOutput,
   ListBillingGroupCostReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingGroupCostReportElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillingGroupCostReportsInput,
@@ -2905,7 +2904,7 @@ export const listBillingGroups: API.PaginatedOperationMethod<
   ListBillingGroupsInput,
   ListBillingGroupsOutput,
   ListBillingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingGroupListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillingGroupsInput,
@@ -2942,7 +2941,7 @@ export const listCustomLineItems: API.PaginatedOperationMethod<
   ListCustomLineItemsInput,
   ListCustomLineItemsOutput,
   ListCustomLineItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomLineItemListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomLineItemsInput,
@@ -2978,7 +2977,7 @@ export const listCustomLineItemVersions: API.PaginatedOperationMethod<
   ListCustomLineItemVersionsInput,
   ListCustomLineItemVersionsOutput,
   ListCustomLineItemVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomLineItemVersionListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomLineItemVersionsInput,
@@ -3013,7 +3012,7 @@ export const listPricingPlans: API.PaginatedOperationMethod<
   ListPricingPlansInput,
   ListPricingPlansOutput,
   ListPricingPlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PricingPlanListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPricingPlansInput,
@@ -3049,7 +3048,7 @@ export const listPricingPlansAssociatedWithPricingRule: API.PaginatedOperationMe
   ListPricingPlansAssociatedWithPricingRuleInput,
   ListPricingPlansAssociatedWithPricingRuleOutput,
   ListPricingPlansAssociatedWithPricingRuleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PricingPlanArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPricingPlansAssociatedWithPricingRuleInput,
@@ -3085,7 +3084,7 @@ export const listPricingRules: API.PaginatedOperationMethod<
   ListPricingRulesInput,
   ListPricingRulesOutput,
   ListPricingRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PricingRuleListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPricingRulesInput,
@@ -3121,7 +3120,7 @@ export const listPricingRulesAssociatedToPricingPlan: API.PaginatedOperationMeth
   ListPricingRulesAssociatedToPricingPlanInput,
   ListPricingRulesAssociatedToPricingPlanOutput,
   ListPricingRulesAssociatedToPricingPlanError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PricingRuleArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPricingRulesAssociatedToPricingPlanInput,
@@ -3158,7 +3157,7 @@ export const listResourcesAssociatedToCustomLineItem: API.PaginatedOperationMeth
   ListResourcesAssociatedToCustomLineItemInput,
   ListResourcesAssociatedToCustomLineItemOutput,
   ListResourcesAssociatedToCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListResourcesAssociatedToCustomLineItemResponseElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesAssociatedToCustomLineItemInput,
@@ -3195,7 +3194,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3225,7 +3224,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3255,7 +3254,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3286,7 +3285,7 @@ export const updateBillingGroup: API.OperationMethod<
   UpdateBillingGroupInput,
   UpdateBillingGroupOutput,
   UpdateBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBillingGroupInput,
   output: UpdateBillingGroupOutput,
@@ -3318,7 +3317,7 @@ export const updateCustomLineItem: API.OperationMethod<
   UpdateCustomLineItemInput,
   UpdateCustomLineItemOutput,
   UpdateCustomLineItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomLineItemInput,
   output: UpdateCustomLineItemOutput,
@@ -3350,7 +3349,7 @@ export const updatePricingPlan: API.OperationMethod<
   UpdatePricingPlanInput,
   UpdatePricingPlanOutput,
   UpdatePricingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePricingPlanInput,
   output: UpdatePricingPlanOutput,
@@ -3382,7 +3381,7 @@ export const updatePricingRule: API.OperationMethod<
   UpdatePricingRuleInput,
   UpdatePricingRuleOutput,
   UpdatePricingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePricingRuleInput,
   output: UpdatePricingRuleOutput,

--- a/packages/aws/src/services/braket.ts
+++ b/packages/aws/src/services/braket.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "Braket", serviceShapeName: "Braket" });
 const auth = T.AwsAuthSigv4({ name: "braket" });
 const ver = T.ServiceVersion("2019-09-01");
@@ -1228,7 +1227,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -1260,7 +1259,7 @@ export const cancelQuantumTask: API.OperationMethod<
   CancelQuantumTaskRequest,
   CancelQuantumTaskResponse,
   CancelQuantumTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelQuantumTaskRequest,
   output: CancelQuantumTaskResponse,
@@ -1294,7 +1293,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -1329,7 +1328,7 @@ export const createQuantumTask: API.OperationMethod<
   CreateQuantumTaskRequest,
   CreateQuantumTaskResponse,
   CreateQuantumTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuantumTaskRequest,
   output: CreateQuantumTaskResponse,
@@ -1361,7 +1360,7 @@ export const createSpendingLimit: API.OperationMethod<
   CreateSpendingLimitRequest,
   CreateSpendingLimitResponse,
   CreateSpendingLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSpendingLimitRequest,
   output: CreateSpendingLimitResponse,
@@ -1391,7 +1390,7 @@ export const deleteSpendingLimit: API.OperationMethod<
   DeleteSpendingLimitRequest,
   DeleteSpendingLimitResponse,
   DeleteSpendingLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpendingLimitRequest,
   output: DeleteSpendingLimitResponse,
@@ -1423,7 +1422,7 @@ export const getDevice: API.OperationMethod<
   GetDeviceRequest,
   GetDeviceResponse,
   GetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceRequest,
   output: GetDeviceResponse,
@@ -1453,7 +1452,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -1483,7 +1482,7 @@ export const getQuantumTask: API.OperationMethod<
   GetQuantumTaskRequest,
   GetQuantumTaskResponse,
   GetQuantumTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuantumTaskRequest,
   output: GetQuantumTaskResponse,
@@ -1511,7 +1510,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1538,7 +1537,7 @@ export const searchDevices: API.PaginatedOperationMethod<
   SearchDevicesRequest,
   SearchDevicesResponse,
   SearchDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDevicesRequest,
@@ -1573,7 +1572,7 @@ export const searchJobs: API.PaginatedOperationMethod<
   SearchJobsRequest,
   SearchJobsResponse,
   SearchJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchJobsRequest,
@@ -1608,7 +1607,7 @@ export const searchQuantumTasks: API.PaginatedOperationMethod<
   SearchQuantumTasksRequest,
   SearchQuantumTasksResponse,
   SearchQuantumTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuantumTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchQuantumTasksRequest,
@@ -1643,7 +1642,7 @@ export const searchSpendingLimits: API.PaginatedOperationMethod<
   SearchSpendingLimitsRequest,
   SearchSpendingLimitsResponse,
   SearchSpendingLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpendingLimitSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSpendingLimitsRequest,
@@ -1677,7 +1676,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1703,7 +1702,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1731,7 +1730,7 @@ export const updateSpendingLimit: API.OperationMethod<
   UpdateSpendingLimitRequest,
   UpdateSpendingLimitResponse,
   UpdateSpendingLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpendingLimitRequest,
   output: UpdateSpendingLimitResponse,

--- a/packages/aws/src/services/budgets.ts
+++ b/packages/aws/src/services/budgets.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Budgets",
@@ -1628,7 +1627,7 @@ export const createBudget: API.OperationMethod<
   CreateBudgetRequest,
   CreateBudgetResponse,
   CreateBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBudgetRequest,
   output: CreateBudgetResponse,
@@ -1665,7 +1664,7 @@ export const createBudgetAction: API.OperationMethod<
   CreateBudgetActionRequest,
   CreateBudgetActionResponse,
   CreateBudgetActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBudgetActionRequest,
   output: CreateBudgetActionResponse,
@@ -1700,7 +1699,7 @@ export const createNotification: API.OperationMethod<
   CreateNotificationRequest,
   CreateNotificationResponse,
   CreateNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationRequest,
   output: CreateNotificationResponse,
@@ -1734,7 +1733,7 @@ export const createSubscriber: API.OperationMethod<
   CreateSubscriberRequest,
   CreateSubscriberResponse,
   CreateSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriberRequest,
   output: CreateSubscriberResponse,
@@ -1768,7 +1767,7 @@ export const deleteBudget: API.OperationMethod<
   DeleteBudgetRequest,
   DeleteBudgetResponse,
   DeleteBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBudgetRequest,
   output: DeleteBudgetResponse,
@@ -1799,7 +1798,7 @@ export const deleteBudgetAction: API.OperationMethod<
   DeleteBudgetActionRequest,
   DeleteBudgetActionResponse,
   DeleteBudgetActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBudgetActionRequest,
   output: DeleteBudgetActionResponse,
@@ -1832,7 +1831,7 @@ export const deleteNotification: API.OperationMethod<
   DeleteNotificationRequest,
   DeleteNotificationResponse,
   DeleteNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationRequest,
   output: DeleteNotificationResponse,
@@ -1864,7 +1863,7 @@ export const deleteSubscriber: API.OperationMethod<
   DeleteSubscriberRequest,
   DeleteSubscriberResponse,
   DeleteSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriberRequest,
   output: DeleteSubscriberResponse,
@@ -1897,7 +1896,7 @@ export const describeBudget: API.OperationMethod<
   DescribeBudgetRequest,
   DescribeBudgetResponse,
   DescribeBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBudgetRequest,
   output: DescribeBudgetResponse,
@@ -1927,7 +1926,7 @@ export const describeBudgetAction: API.OperationMethod<
   DescribeBudgetActionRequest,
   DescribeBudgetActionResponse,
   DescribeBudgetActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBudgetActionRequest,
   output: DescribeBudgetActionResponse,
@@ -1958,7 +1957,7 @@ export const describeBudgetActionHistories: API.PaginatedOperationMethod<
   DescribeBudgetActionHistoriesRequest,
   DescribeBudgetActionHistoriesResponse,
   DescribeBudgetActionHistoriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionHistory
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetActionHistoriesRequest,
@@ -1996,7 +1995,7 @@ export const describeBudgetActionsForAccount: API.PaginatedOperationMethod<
   DescribeBudgetActionsForAccountRequest,
   DescribeBudgetActionsForAccountResponse,
   DescribeBudgetActionsForAccountError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Action
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetActionsForAccountRequest,
@@ -2034,7 +2033,7 @@ export const describeBudgetActionsForBudget: API.PaginatedOperationMethod<
   DescribeBudgetActionsForBudgetRequest,
   DescribeBudgetActionsForBudgetResponse,
   DescribeBudgetActionsForBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Action
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetActionsForBudgetRequest,
@@ -2074,7 +2073,7 @@ export const describeBudgetNotificationsForAccount: API.PaginatedOperationMethod
   DescribeBudgetNotificationsForAccountRequest,
   DescribeBudgetNotificationsForAccountResponse,
   DescribeBudgetNotificationsForAccountError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BudgetNotificationsForAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetNotificationsForAccountRequest,
@@ -2116,7 +2115,7 @@ export const describeBudgetPerformanceHistory: API.PaginatedOperationMethod<
   DescribeBudgetPerformanceHistoryRequest,
   DescribeBudgetPerformanceHistoryResponse,
   DescribeBudgetPerformanceHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetPerformanceHistoryRequest,
@@ -2160,7 +2159,7 @@ export const describeBudgets: API.PaginatedOperationMethod<
   DescribeBudgetsRequest,
   DescribeBudgetsResponse,
   DescribeBudgetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Budget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBudgetsRequest,
@@ -2201,7 +2200,7 @@ export const describeNotificationsForBudget: API.PaginatedOperationMethod<
   DescribeNotificationsForBudgetRequest,
   DescribeNotificationsForBudgetResponse,
   DescribeNotificationsForBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Notification
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNotificationsForBudgetRequest,
@@ -2242,7 +2241,7 @@ export const describeSubscribersForNotification: API.PaginatedOperationMethod<
   DescribeSubscribersForNotificationRequest,
   DescribeSubscribersForNotificationResponse,
   DescribeSubscribersForNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscriber
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSubscribersForNotificationRequest,
@@ -2282,7 +2281,7 @@ export const executeBudgetAction: API.OperationMethod<
   ExecuteBudgetActionRequest,
   ExecuteBudgetActionResponse,
   ExecuteBudgetActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteBudgetActionRequest,
   output: ExecuteBudgetActionResponse,
@@ -2313,7 +2312,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2344,7 +2343,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2375,7 +2374,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2419,7 +2418,7 @@ export const updateBudget: API.OperationMethod<
   UpdateBudgetRequest,
   UpdateBudgetResponse,
   UpdateBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBudgetRequest,
   output: UpdateBudgetResponse,
@@ -2452,7 +2451,7 @@ export const updateBudgetAction: API.OperationMethod<
   UpdateBudgetActionRequest,
   UpdateBudgetActionResponse,
   UpdateBudgetActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBudgetActionRequest,
   output: UpdateBudgetActionResponse,
@@ -2484,7 +2483,7 @@ export const updateNotification: API.OperationMethod<
   UpdateNotificationRequest,
   UpdateNotificationResponse,
   UpdateNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationRequest,
   output: UpdateNotificationResponse,
@@ -2516,7 +2515,7 @@ export const updateSubscriber: API.OperationMethod<
   UpdateSubscriberRequest,
   UpdateSubscriberResponse,
   UpdateSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriberRequest,
   output: UpdateSubscriberResponse,

--- a/packages/aws/src/services/chatbot.ts
+++ b/packages/aws/src/services/chatbot.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://wheatley.amazonaws.com/orchestration/2017-10-11/",
@@ -1793,7 +1792,7 @@ export const associateToConfiguration: API.OperationMethod<
   AssociateToConfigurationRequest,
   AssociateToConfigurationResult,
   AssociateToConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateToConfigurationRequest,
   output: AssociateToConfigurationResult,
@@ -1822,7 +1821,7 @@ export const createChimeWebhookConfiguration: API.OperationMethod<
   CreateChimeWebhookConfigurationRequest,
   CreateChimeWebhookConfigurationResult,
   CreateChimeWebhookConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChimeWebhookConfigurationRequest,
   output: CreateChimeWebhookConfigurationResult,
@@ -1852,7 +1851,7 @@ export const createCustomAction: API.OperationMethod<
   CreateCustomActionRequest,
   CreateCustomActionResult,
   CreateCustomActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomActionRequest,
   output: CreateCustomActionResult,
@@ -1883,7 +1882,7 @@ export const createMicrosoftTeamsChannelConfiguration: API.OperationMethod<
   CreateTeamsChannelConfigurationRequest,
   CreateTeamsChannelConfigurationResult,
   CreateMicrosoftTeamsChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTeamsChannelConfigurationRequest,
   output: CreateTeamsChannelConfigurationResult,
@@ -1915,7 +1914,7 @@ export const createSlackChannelConfiguration: API.OperationMethod<
   CreateSlackChannelConfigurationRequest,
   CreateSlackChannelConfigurationResult,
   CreateSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSlackChannelConfigurationRequest,
   output: CreateSlackChannelConfigurationResult,
@@ -1945,7 +1944,7 @@ export const deleteChimeWebhookConfiguration: API.OperationMethod<
   DeleteChimeWebhookConfigurationRequest,
   DeleteChimeWebhookConfigurationResult,
   DeleteChimeWebhookConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChimeWebhookConfigurationRequest,
   output: DeleteChimeWebhookConfigurationResult,
@@ -1973,7 +1972,7 @@ export const deleteCustomAction: API.OperationMethod<
   DeleteCustomActionRequest,
   DeleteCustomActionResult,
   DeleteCustomActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomActionRequest,
   output: DeleteCustomActionResult,
@@ -2001,7 +2000,7 @@ export const deleteMicrosoftTeamsChannelConfiguration: API.OperationMethod<
   DeleteTeamsChannelConfigurationRequest,
   DeleteTeamsChannelConfigurationResult,
   DeleteMicrosoftTeamsChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTeamsChannelConfigurationRequest,
   output: DeleteTeamsChannelConfigurationResult,
@@ -2028,7 +2027,7 @@ export const deleteMicrosoftTeamsConfiguredTeam: API.OperationMethod<
   DeleteTeamsConfiguredTeamRequest,
   DeleteTeamsConfiguredTeamResult,
   DeleteMicrosoftTeamsConfiguredTeamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTeamsConfiguredTeamRequest,
   output: DeleteTeamsConfiguredTeamResult,
@@ -2054,7 +2053,7 @@ export const deleteMicrosoftTeamsUserIdentity: API.OperationMethod<
   DeleteMicrosoftTeamsUserIdentityRequest,
   DeleteMicrosoftTeamsUserIdentityResult,
   DeleteMicrosoftTeamsUserIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMicrosoftTeamsUserIdentityRequest,
   output: DeleteMicrosoftTeamsUserIdentityResult,
@@ -2081,7 +2080,7 @@ export const deleteSlackChannelConfiguration: API.OperationMethod<
   DeleteSlackChannelConfigurationRequest,
   DeleteSlackChannelConfigurationResult,
   DeleteSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlackChannelConfigurationRequest,
   output: DeleteSlackChannelConfigurationResult,
@@ -2108,7 +2107,7 @@ export const deleteSlackUserIdentity: API.OperationMethod<
   DeleteSlackUserIdentityRequest,
   DeleteSlackUserIdentityResult,
   DeleteSlackUserIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlackUserIdentityRequest,
   output: DeleteSlackUserIdentityResult,
@@ -2133,7 +2132,7 @@ export const deleteSlackWorkspaceAuthorization: API.OperationMethod<
   DeleteSlackWorkspaceAuthorizationRequest,
   DeleteSlackWorkspaceAuthorizationResult,
   DeleteSlackWorkspaceAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlackWorkspaceAuthorizationRequest,
   output: DeleteSlackWorkspaceAuthorizationResult,
@@ -2155,7 +2154,7 @@ export const describeChimeWebhookConfigurations: API.PaginatedOperationMethod<
   DescribeChimeWebhookConfigurationsRequest,
   DescribeChimeWebhookConfigurationsResult,
   DescribeChimeWebhookConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChimeWebhookConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeChimeWebhookConfigurationsRequest,
@@ -2188,7 +2187,7 @@ export const describeSlackChannelConfigurations: API.PaginatedOperationMethod<
   DescribeSlackChannelConfigurationsRequest,
   DescribeSlackChannelConfigurationsResult,
   DescribeSlackChannelConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SlackChannelConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSlackChannelConfigurationsRequest,
@@ -2221,7 +2220,7 @@ export const describeSlackUserIdentities: API.PaginatedOperationMethod<
   DescribeSlackUserIdentitiesRequest,
   DescribeSlackUserIdentitiesResult,
   DescribeSlackUserIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SlackUserIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSlackUserIdentitiesRequest,
@@ -2254,7 +2253,7 @@ export const describeSlackWorkspaces: API.PaginatedOperationMethod<
   DescribeSlackWorkspacesRequest,
   DescribeSlackWorkspacesResult,
   DescribeSlackWorkspacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SlackWorkspace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSlackWorkspacesRequest,
@@ -2288,7 +2287,7 @@ export const disassociateFromConfiguration: API.OperationMethod<
   DisassociateFromConfigurationRequest,
   DisassociateFromConfigurationResult,
   DisassociateFromConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromConfigurationRequest,
   output: DisassociateFromConfigurationResult,
@@ -2314,7 +2313,7 @@ export const getAccountPreferences: API.OperationMethod<
   GetAccountPreferencesRequest,
   GetAccountPreferencesResult,
   GetAccountPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountPreferencesRequest,
   output: GetAccountPreferencesResult,
@@ -2337,7 +2336,7 @@ export const getCustomAction: API.OperationMethod<
   GetCustomActionRequest,
   GetCustomActionResult,
   GetCustomActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomActionRequest,
   output: GetCustomActionResult,
@@ -2365,7 +2364,7 @@ export const getMicrosoftTeamsChannelConfiguration: API.OperationMethod<
   GetTeamsChannelConfigurationRequest,
   GetTeamsChannelConfigurationResult,
   GetMicrosoftTeamsChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTeamsChannelConfigurationRequest,
   output: GetTeamsChannelConfigurationResult,
@@ -2388,7 +2387,7 @@ export const listAssociations: API.PaginatedOperationMethod<
   ListAssociationsRequest,
   ListAssociationsResult,
   ListAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociationListing
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociationsRequest,
@@ -2417,7 +2416,7 @@ export const listCustomActions: API.PaginatedOperationMethod<
   ListCustomActionsRequest,
   ListCustomActionsResult,
   ListCustomActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomActionArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomActionsRequest,
@@ -2450,7 +2449,7 @@ export const listMicrosoftTeamsChannelConfigurations: API.PaginatedOperationMeth
   ListTeamsChannelConfigurationsRequest,
   ListTeamsChannelConfigurationsResult,
   ListMicrosoftTeamsChannelConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TeamsChannelConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTeamsChannelConfigurationsRequest,
@@ -2483,7 +2482,7 @@ export const listMicrosoftTeamsConfiguredTeams: API.PaginatedOperationMethod<
   ListMicrosoftTeamsConfiguredTeamsRequest,
   ListMicrosoftTeamsConfiguredTeamsResult,
   ListMicrosoftTeamsConfiguredTeamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredTeam
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrosoftTeamsConfiguredTeamsRequest,
@@ -2516,7 +2515,7 @@ export const listMicrosoftTeamsUserIdentities: API.PaginatedOperationMethod<
   ListMicrosoftTeamsUserIdentitiesRequest,
   ListMicrosoftTeamsUserIdentitiesResult,
   ListMicrosoftTeamsUserIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TeamsUserIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrosoftTeamsUserIdentitiesRequest,
@@ -2549,7 +2548,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2576,7 +2575,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2603,7 +2602,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2629,7 +2628,7 @@ export const updateAccountPreferences: API.OperationMethod<
   UpdateAccountPreferencesRequest,
   UpdateAccountPreferencesResult,
   UpdateAccountPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountPreferencesRequest,
   output: UpdateAccountPreferencesResult,
@@ -2656,7 +2655,7 @@ export const updateChimeWebhookConfiguration: API.OperationMethod<
   UpdateChimeWebhookConfigurationRequest,
   UpdateChimeWebhookConfigurationResult,
   UpdateChimeWebhookConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChimeWebhookConfigurationRequest,
   output: UpdateChimeWebhookConfigurationResult,
@@ -2684,7 +2683,7 @@ export const updateCustomAction: API.OperationMethod<
   UpdateCustomActionRequest,
   UpdateCustomActionResult,
   UpdateCustomActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomActionRequest,
   output: UpdateCustomActionResult,
@@ -2712,7 +2711,7 @@ export const updateMicrosoftTeamsChannelConfiguration: API.OperationMethod<
   UpdateTeamsChannelConfigurationRequest,
   UpdateTeamsChannelConfigurationResult,
   UpdateMicrosoftTeamsChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTeamsChannelConfigurationRequest,
   output: UpdateTeamsChannelConfigurationResult,
@@ -2740,7 +2739,7 @@ export const updateSlackChannelConfiguration: API.OperationMethod<
   UpdateSlackChannelConfigurationRequest,
   UpdateSlackChannelConfigurationResult,
   UpdateSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSlackChannelConfigurationRequest,
   output: UpdateSlackChannelConfigurationResult,

--- a/packages/aws/src/services/chime-sdk-identity.ts
+++ b/packages/aws/src/services/chime-sdk-identity.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime SDK Identity",
@@ -1579,7 +1578,7 @@ export const createAppInstance: API.OperationMethod<
   CreateAppInstanceRequest,
   CreateAppInstanceResponse,
   CreateAppInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppInstanceRequest,
   output: CreateAppInstanceResponse,
@@ -1625,7 +1624,7 @@ export const createAppInstanceAdmin: API.OperationMethod<
   CreateAppInstanceAdminRequest,
   CreateAppInstanceAdminResponse,
   CreateAppInstanceAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppInstanceAdminRequest,
   output: CreateAppInstanceAdminResponse,
@@ -1662,7 +1661,7 @@ export const createAppInstanceBot: API.OperationMethod<
   CreateAppInstanceBotRequest,
   CreateAppInstanceBotResponse,
   CreateAppInstanceBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppInstanceBotRequest,
   output: CreateAppInstanceBotResponse,
@@ -1699,7 +1698,7 @@ export const createAppInstanceUser: API.OperationMethod<
   CreateAppInstanceUserRequest,
   CreateAppInstanceUserResponse,
   CreateAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppInstanceUserRequest,
   output: CreateAppInstanceUserResponse,
@@ -1734,7 +1733,7 @@ export const deleteAppInstance: API.OperationMethod<
   DeleteAppInstanceRequest,
   DeleteAppInstanceResponse,
   DeleteAppInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInstanceRequest,
   output: DeleteAppInstanceResponse,
@@ -1771,7 +1770,7 @@ export const deleteAppInstanceAdmin: API.OperationMethod<
   DeleteAppInstanceAdminRequest,
   DeleteAppInstanceAdminResponse,
   DeleteAppInstanceAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInstanceAdminRequest,
   output: DeleteAppInstanceAdminResponse,
@@ -1807,7 +1806,7 @@ export const deleteAppInstanceBot: API.OperationMethod<
   DeleteAppInstanceBotRequest,
   DeleteAppInstanceBotResponse,
   DeleteAppInstanceBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInstanceBotRequest,
   output: DeleteAppInstanceBotResponse,
@@ -1843,7 +1842,7 @@ export const deleteAppInstanceUser: API.OperationMethod<
   DeleteAppInstanceUserRequest,
   DeleteAppInstanceUserResponse,
   DeleteAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInstanceUserRequest,
   output: DeleteAppInstanceUserResponse,
@@ -1877,7 +1876,7 @@ export const deregisterAppInstanceUserEndpoint: API.OperationMethod<
   DeregisterAppInstanceUserEndpointRequest,
   DeregisterAppInstanceUserEndpointResponse,
   DeregisterAppInstanceUserEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterAppInstanceUserEndpointRequest,
   output: DeregisterAppInstanceUserEndpointResponse,
@@ -1909,7 +1908,7 @@ export const describeAppInstance: API.OperationMethod<
   DescribeAppInstanceRequest,
   DescribeAppInstanceResponse,
   DescribeAppInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInstanceRequest,
   output: DescribeAppInstanceResponse,
@@ -1941,7 +1940,7 @@ export const describeAppInstanceAdmin: API.OperationMethod<
   DescribeAppInstanceAdminRequest,
   DescribeAppInstanceAdminResponse,
   DescribeAppInstanceAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInstanceAdminRequest,
   output: DescribeAppInstanceAdminResponse,
@@ -1974,7 +1973,7 @@ export const describeAppInstanceBot: API.OperationMethod<
   DescribeAppInstanceBotRequest,
   DescribeAppInstanceBotResponse,
   DescribeAppInstanceBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInstanceBotRequest,
   output: DescribeAppInstanceBotResponse,
@@ -2007,7 +2006,7 @@ export const describeAppInstanceUser: API.OperationMethod<
   DescribeAppInstanceUserRequest,
   DescribeAppInstanceUserResponse,
   DescribeAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInstanceUserRequest,
   output: DescribeAppInstanceUserResponse,
@@ -2039,7 +2038,7 @@ export const describeAppInstanceUserEndpoint: API.OperationMethod<
   DescribeAppInstanceUserEndpointRequest,
   DescribeAppInstanceUserEndpointResponse,
   DescribeAppInstanceUserEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInstanceUserEndpointRequest,
   output: DescribeAppInstanceUserEndpointResponse,
@@ -2071,7 +2070,7 @@ export const getAppInstanceRetentionSettings: API.OperationMethod<
   GetAppInstanceRetentionSettingsRequest,
   GetAppInstanceRetentionSettingsResponse,
   GetAppInstanceRetentionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppInstanceRetentionSettingsRequest,
   output: GetAppInstanceRetentionSettingsResponse,
@@ -2104,7 +2103,7 @@ export const listAppInstanceAdmins: API.PaginatedOperationMethod<
   ListAppInstanceAdminsRequest,
   ListAppInstanceAdminsResponse,
   ListAppInstanceAdminsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInstanceAdminsRequest,
@@ -2144,7 +2143,7 @@ export const listAppInstanceBots: API.PaginatedOperationMethod<
   ListAppInstanceBotsRequest,
   ListAppInstanceBotsResponse,
   ListAppInstanceBotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInstanceBotsRequest,
@@ -2184,7 +2183,7 @@ export const listAppInstances: API.PaginatedOperationMethod<
   ListAppInstancesRequest,
   ListAppInstancesResponse,
   ListAppInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInstancesRequest,
@@ -2222,7 +2221,7 @@ export const listAppInstanceUserEndpoints: API.PaginatedOperationMethod<
   ListAppInstanceUserEndpointsRequest,
   ListAppInstanceUserEndpointsResponse,
   ListAppInstanceUserEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInstanceUserEndpointsRequest,
@@ -2261,7 +2260,7 @@ export const listAppInstanceUsers: API.PaginatedOperationMethod<
   ListAppInstanceUsersRequest,
   ListAppInstanceUsersResponse,
   ListAppInstanceUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInstanceUsersRequest,
@@ -2299,7 +2298,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2332,7 +2331,7 @@ export const putAppInstanceRetentionSettings: API.OperationMethod<
   PutAppInstanceRetentionSettingsRequest,
   PutAppInstanceRetentionSettingsResponse,
   PutAppInstanceRetentionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAppInstanceRetentionSettingsRequest,
   output: PutAppInstanceRetentionSettingsResponse,
@@ -2371,7 +2370,7 @@ export const putAppInstanceUserExpirationSettings: API.OperationMethod<
   PutAppInstanceUserExpirationSettingsRequest,
   PutAppInstanceUserExpirationSettingsResponse,
   PutAppInstanceUserExpirationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAppInstanceUserExpirationSettingsRequest,
   output: PutAppInstanceUserExpirationSettingsResponse,
@@ -2406,7 +2405,7 @@ export const registerAppInstanceUserEndpoint: API.OperationMethod<
   RegisterAppInstanceUserEndpointRequest,
   RegisterAppInstanceUserEndpointResponse,
   RegisterAppInstanceUserEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAppInstanceUserEndpointRequest,
   output: RegisterAppInstanceUserEndpointResponse,
@@ -2441,7 +2440,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2474,7 +2473,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2507,7 +2506,7 @@ export const updateAppInstance: API.OperationMethod<
   UpdateAppInstanceRequest,
   UpdateAppInstanceResponse,
   UpdateAppInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppInstanceRequest,
   output: UpdateAppInstanceResponse,
@@ -2542,7 +2541,7 @@ export const updateAppInstanceBot: API.OperationMethod<
   UpdateAppInstanceBotRequest,
   UpdateAppInstanceBotResponse,
   UpdateAppInstanceBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppInstanceBotRequest,
   output: UpdateAppInstanceBotResponse,
@@ -2579,7 +2578,7 @@ export const updateAppInstanceUser: API.OperationMethod<
   UpdateAppInstanceUserRequest,
   UpdateAppInstanceUserResponse,
   UpdateAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppInstanceUserRequest,
   output: UpdateAppInstanceUserResponse,
@@ -2614,7 +2613,7 @@ export const updateAppInstanceUserEndpoint: API.OperationMethod<
   UpdateAppInstanceUserEndpointRequest,
   UpdateAppInstanceUserEndpointResponse,
   UpdateAppInstanceUserEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppInstanceUserEndpointRequest,
   output: UpdateAppInstanceUserEndpointResponse,

--- a/packages/aws/src/services/chime-sdk-media-pipelines.ts
+++ b/packages/aws/src/services/chime-sdk-media-pipelines.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime SDK Media Pipelines",
@@ -2770,7 +2769,7 @@ export const createMediaCapturePipeline: API.OperationMethod<
   CreateMediaCapturePipelineRequest,
   CreateMediaCapturePipelineResponse,
   CreateMediaCapturePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaCapturePipelineRequest,
   output: CreateMediaCapturePipelineResponse,
@@ -2804,7 +2803,7 @@ export const createMediaConcatenationPipeline: API.OperationMethod<
   CreateMediaConcatenationPipelineRequest,
   CreateMediaConcatenationPipelineResponse,
   CreateMediaConcatenationPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaConcatenationPipelineRequest,
   output: CreateMediaConcatenationPipelineResponse,
@@ -2839,7 +2838,7 @@ export const createMediaInsightsPipeline: API.OperationMethod<
   CreateMediaInsightsPipelineRequest,
   CreateMediaInsightsPipelineResponse,
   CreateMediaInsightsPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaInsightsPipelineRequest,
   output: CreateMediaInsightsPipelineResponse,
@@ -2876,7 +2875,7 @@ export const createMediaInsightsPipelineConfiguration: API.OperationMethod<
   CreateMediaInsightsPipelineConfigurationRequest,
   CreateMediaInsightsPipelineConfigurationResponse,
   CreateMediaInsightsPipelineConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaInsightsPipelineConfigurationRequest,
   output: CreateMediaInsightsPipelineConfigurationResponse,
@@ -2911,7 +2910,7 @@ export const createMediaLiveConnectorPipeline: API.OperationMethod<
   CreateMediaLiveConnectorPipelineRequest,
   CreateMediaLiveConnectorPipelineResponse,
   CreateMediaLiveConnectorPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaLiveConnectorPipelineRequest,
   output: CreateMediaLiveConnectorPipelineResponse,
@@ -2962,7 +2961,7 @@ export const createMediaPipelineKinesisVideoStreamPool: API.OperationMethod<
   CreateMediaPipelineKinesisVideoStreamPoolRequest,
   CreateMediaPipelineKinesisVideoStreamPoolResponse,
   CreateMediaPipelineKinesisVideoStreamPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaPipelineKinesisVideoStreamPoolRequest,
   output: CreateMediaPipelineKinesisVideoStreamPoolResponse,
@@ -2998,7 +2997,7 @@ export const createMediaStreamPipeline: API.OperationMethod<
   CreateMediaStreamPipelineRequest,
   CreateMediaStreamPipelineResponse,
   CreateMediaStreamPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMediaStreamPipelineRequest,
   output: CreateMediaStreamPipelineResponse,
@@ -3033,7 +3032,7 @@ export const deleteMediaCapturePipeline: API.OperationMethod<
   DeleteMediaCapturePipelineRequest,
   DeleteMediaCapturePipelineResponse,
   DeleteMediaCapturePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMediaCapturePipelineRequest,
   output: DeleteMediaCapturePipelineResponse,
@@ -3068,7 +3067,7 @@ export const deleteMediaInsightsPipelineConfiguration: API.OperationMethod<
   DeleteMediaInsightsPipelineConfigurationRequest,
   DeleteMediaInsightsPipelineConfigurationResponse,
   DeleteMediaInsightsPipelineConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMediaInsightsPipelineConfigurationRequest,
   output: DeleteMediaInsightsPipelineConfigurationResponse,
@@ -3104,7 +3103,7 @@ export const deleteMediaPipeline: API.OperationMethod<
   DeleteMediaPipelineRequest,
   DeleteMediaPipelineResponse,
   DeleteMediaPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMediaPipelineRequest,
   output: DeleteMediaPipelineResponse,
@@ -3140,7 +3139,7 @@ export const deleteMediaPipelineKinesisVideoStreamPool: API.OperationMethod<
   DeleteMediaPipelineKinesisVideoStreamPoolRequest,
   DeleteMediaPipelineKinesisVideoStreamPoolResponse,
   DeleteMediaPipelineKinesisVideoStreamPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMediaPipelineKinesisVideoStreamPoolRequest,
   output: DeleteMediaPipelineKinesisVideoStreamPoolResponse,
@@ -3175,7 +3174,7 @@ export const getMediaCapturePipeline: API.OperationMethod<
   GetMediaCapturePipelineRequest,
   GetMediaCapturePipelineResponse,
   GetMediaCapturePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaCapturePipelineRequest,
   output: GetMediaCapturePipelineResponse,
@@ -3209,7 +3208,7 @@ export const getMediaInsightsPipelineConfiguration: API.OperationMethod<
   GetMediaInsightsPipelineConfigurationRequest,
   GetMediaInsightsPipelineConfigurationResponse,
   GetMediaInsightsPipelineConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaInsightsPipelineConfigurationRequest,
   output: GetMediaInsightsPipelineConfigurationResponse,
@@ -3243,7 +3242,7 @@ export const getMediaPipeline: API.OperationMethod<
   GetMediaPipelineRequest,
   GetMediaPipelineResponse,
   GetMediaPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaPipelineRequest,
   output: GetMediaPipelineResponse,
@@ -3277,7 +3276,7 @@ export const getMediaPipelineKinesisVideoStreamPool: API.OperationMethod<
   GetMediaPipelineKinesisVideoStreamPoolRequest,
   GetMediaPipelineKinesisVideoStreamPoolResponse,
   GetMediaPipelineKinesisVideoStreamPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaPipelineKinesisVideoStreamPoolRequest,
   output: GetMediaPipelineKinesisVideoStreamPoolResponse,
@@ -3311,7 +3310,7 @@ export const getSpeakerSearchTask: API.OperationMethod<
   GetSpeakerSearchTaskRequest,
   GetSpeakerSearchTaskResponse,
   GetSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpeakerSearchTaskRequest,
   output: GetSpeakerSearchTaskResponse,
@@ -3345,7 +3344,7 @@ export const getVoiceToneAnalysisTask: API.OperationMethod<
   GetVoiceToneAnalysisTaskRequest,
   GetVoiceToneAnalysisTaskResponse,
   GetVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceToneAnalysisTaskRequest,
   output: GetVoiceToneAnalysisTaskResponse,
@@ -3379,7 +3378,7 @@ export const listMediaCapturePipelines: API.PaginatedOperationMethod<
   ListMediaCapturePipelinesRequest,
   ListMediaCapturePipelinesResponse,
   ListMediaCapturePipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMediaCapturePipelinesRequest,
@@ -3419,7 +3418,7 @@ export const listMediaInsightsPipelineConfigurations: API.PaginatedOperationMeth
   ListMediaInsightsPipelineConfigurationsRequest,
   ListMediaInsightsPipelineConfigurationsResponse,
   ListMediaInsightsPipelineConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMediaInsightsPipelineConfigurationsRequest,
@@ -3459,7 +3458,7 @@ export const listMediaPipelineKinesisVideoStreamPools: API.PaginatedOperationMet
   ListMediaPipelineKinesisVideoStreamPoolsRequest,
   ListMediaPipelineKinesisVideoStreamPoolsResponse,
   ListMediaPipelineKinesisVideoStreamPoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMediaPipelineKinesisVideoStreamPoolsRequest,
@@ -3499,7 +3498,7 @@ export const listMediaPipelines: API.PaginatedOperationMethod<
   ListMediaPipelinesRequest,
   ListMediaPipelinesResponse,
   ListMediaPipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMediaPipelinesRequest,
@@ -3539,7 +3538,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3577,7 +3576,7 @@ export const startSpeakerSearchTask: API.OperationMethod<
   StartSpeakerSearchTaskRequest,
   StartSpeakerSearchTaskResponse,
   StartSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSpeakerSearchTaskRequest,
   output: StartSpeakerSearchTaskResponse,
@@ -3618,7 +3617,7 @@ export const startVoiceToneAnalysisTask: API.OperationMethod<
   StartVoiceToneAnalysisTaskRequest,
   StartVoiceToneAnalysisTaskResponse,
   StartVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVoiceToneAnalysisTaskRequest,
   output: StartVoiceToneAnalysisTaskResponse,
@@ -3654,7 +3653,7 @@ export const stopSpeakerSearchTask: API.OperationMethod<
   StopSpeakerSearchTaskRequest,
   StopSpeakerSearchTaskResponse,
   StopSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSpeakerSearchTaskRequest,
   output: StopSpeakerSearchTaskResponse,
@@ -3690,7 +3689,7 @@ export const stopVoiceToneAnalysisTask: API.OperationMethod<
   StopVoiceToneAnalysisTaskRequest,
   StopVoiceToneAnalysisTaskResponse,
   StopVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopVoiceToneAnalysisTaskRequest,
   output: StopVoiceToneAnalysisTaskResponse,
@@ -3725,7 +3724,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3759,7 +3758,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3794,7 +3793,7 @@ export const updateMediaInsightsPipelineConfiguration: API.OperationMethod<
   UpdateMediaInsightsPipelineConfigurationRequest,
   UpdateMediaInsightsPipelineConfigurationResponse,
   UpdateMediaInsightsPipelineConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMediaInsightsPipelineConfigurationRequest,
   output: UpdateMediaInsightsPipelineConfigurationResponse,
@@ -3830,7 +3829,7 @@ export const updateMediaInsightsPipelineStatus: API.OperationMethod<
   UpdateMediaInsightsPipelineStatusRequest,
   UpdateMediaInsightsPipelineStatusResponse,
   UpdateMediaInsightsPipelineStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMediaInsightsPipelineStatusRequest,
   output: UpdateMediaInsightsPipelineStatusResponse,
@@ -3866,7 +3865,7 @@ export const updateMediaPipelineKinesisVideoStreamPool: API.OperationMethod<
   UpdateMediaPipelineKinesisVideoStreamPoolRequest,
   UpdateMediaPipelineKinesisVideoStreamPoolResponse,
   UpdateMediaPipelineKinesisVideoStreamPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMediaPipelineKinesisVideoStreamPoolRequest,
   output: UpdateMediaPipelineKinesisVideoStreamPoolResponse,

--- a/packages/aws/src/services/chime-sdk-meetings.ts
+++ b/packages/aws/src/services/chime-sdk-meetings.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime SDK Meetings",
@@ -1133,7 +1132,7 @@ export const batchCreateAttendee: API.OperationMethod<
   BatchCreateAttendeeRequest,
   BatchCreateAttendeeResponse,
   BatchCreateAttendeeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateAttendeeRequest,
   output: BatchCreateAttendeeResponse,
@@ -1199,7 +1198,7 @@ export const batchUpdateAttendeeCapabilitiesExcept: API.OperationMethod<
   BatchUpdateAttendeeCapabilitiesExceptRequest,
   BatchUpdateAttendeeCapabilitiesExceptResponse,
   BatchUpdateAttendeeCapabilitiesExceptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateAttendeeCapabilitiesExceptRequest,
   output: BatchUpdateAttendeeCapabilitiesExceptResponse,
@@ -1239,7 +1238,7 @@ export const createAttendee: API.OperationMethod<
   CreateAttendeeRequest,
   CreateAttendeeResponse,
   CreateAttendeeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAttendeeRequest,
   output: CreateAttendeeResponse,
@@ -1289,7 +1288,7 @@ export const createMeeting: API.OperationMethod<
   CreateMeetingRequest,
   CreateMeetingResponse,
   CreateMeetingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMeetingRequest,
   output: CreateMeetingResponse,
@@ -1338,7 +1337,7 @@ export const createMeetingWithAttendees: API.OperationMethod<
   CreateMeetingWithAttendeesRequest,
   CreateMeetingWithAttendeesResponse,
   CreateMeetingWithAttendeesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMeetingWithAttendeesRequest,
   output: CreateMeetingWithAttendeesResponse,
@@ -1376,7 +1375,7 @@ export const deleteAttendee: API.OperationMethod<
   DeleteAttendeeRequest,
   DeleteAttendeeResponse,
   DeleteAttendeeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttendeeRequest,
   output: DeleteAttendeeResponse,
@@ -1413,7 +1412,7 @@ export const deleteMeeting: API.OperationMethod<
   DeleteMeetingRequest,
   DeleteMeetingResponse,
   DeleteMeetingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMeetingRequest,
   output: DeleteMeetingResponse,
@@ -1449,7 +1448,7 @@ export const getAttendee: API.OperationMethod<
   GetAttendeeRequest,
   GetAttendeeResponse,
   GetAttendeeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAttendeeRequest,
   output: GetAttendeeResponse,
@@ -1485,7 +1484,7 @@ export const getMeeting: API.OperationMethod<
   GetMeetingRequest,
   GetMeetingResponse,
   GetMeetingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMeetingRequest,
   output: GetMeetingResponse,
@@ -1521,7 +1520,7 @@ export const listAttendees: API.PaginatedOperationMethod<
   ListAttendeesRequest,
   ListAttendeesResponse,
   ListAttendeesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttendeesRequest,
@@ -1562,7 +1561,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1613,7 +1612,7 @@ export const startMeetingTranscription: API.OperationMethod<
   StartMeetingTranscriptionRequest,
   StartMeetingTranscriptionResponse,
   StartMeetingTranscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMeetingTranscriptionRequest,
   output: StartMeetingTranscriptionResponse,
@@ -1659,7 +1658,7 @@ export const stopMeetingTranscription: API.OperationMethod<
   StopMeetingTranscriptionRequest,
   StopMeetingTranscriptionResponse,
   StopMeetingTranscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMeetingTranscriptionRequest,
   output: StopMeetingTranscriptionResponse,
@@ -1696,7 +1695,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1748,7 +1747,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1813,7 +1812,7 @@ export const updateAttendeeCapabilities: API.OperationMethod<
   UpdateAttendeeCapabilitiesRequest,
   UpdateAttendeeCapabilitiesResponse,
   UpdateAttendeeCapabilitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAttendeeCapabilitiesRequest,
   output: UpdateAttendeeCapabilitiesResponse,

--- a/packages/aws/src/services/chime-sdk-messaging.ts
+++ b/packages/aws/src/services/chime-sdk-messaging.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime SDK Messaging",
@@ -2780,7 +2779,7 @@ export const associateChannelFlow: API.OperationMethod<
   AssociateChannelFlowRequest,
   AssociateChannelFlowResponse,
   AssociateChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateChannelFlowRequest,
   output: AssociateChannelFlowResponse,
@@ -2816,7 +2815,7 @@ export const batchCreateChannelMembership: API.OperationMethod<
   BatchCreateChannelMembershipRequest,
   BatchCreateChannelMembershipResponse,
   BatchCreateChannelMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateChannelMembershipRequest,
   output: BatchCreateChannelMembershipResponse,
@@ -2859,7 +2858,7 @@ export const channelFlowCallback: API.OperationMethod<
   ChannelFlowCallbackRequest,
   ChannelFlowCallbackResponse,
   ChannelFlowCallbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChannelFlowCallbackRequest,
   output: ChannelFlowCallbackResponse,
@@ -2901,7 +2900,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -2947,7 +2946,7 @@ export const createChannelBan: API.OperationMethod<
   CreateChannelBanRequest,
   CreateChannelBanResponse,
   CreateChannelBanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelBanRequest,
   output: CreateChannelBanResponse,
@@ -2997,7 +2996,7 @@ export const createChannelFlow: API.OperationMethod<
   CreateChannelFlowRequest,
   CreateChannelFlowResponse,
   CreateChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelFlowRequest,
   output: CreateChannelFlowResponse,
@@ -3056,7 +3055,7 @@ export const createChannelMembership: API.OperationMethod<
   CreateChannelMembershipRequest,
   CreateChannelMembershipResponse,
   CreateChannelMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelMembershipRequest,
   output: CreateChannelMembershipResponse,
@@ -3107,7 +3106,7 @@ export const createChannelModerator: API.OperationMethod<
   CreateChannelModeratorRequest,
   CreateChannelModeratorResponse,
   CreateChannelModeratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelModeratorRequest,
   output: CreateChannelModeratorResponse,
@@ -3147,7 +3146,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -3184,7 +3183,7 @@ export const deleteChannelBan: API.OperationMethod<
   DeleteChannelBanRequest,
   DeleteChannelBanResponse,
   DeleteChannelBanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelBanRequest,
   output: DeleteChannelBanResponse,
@@ -3220,7 +3219,7 @@ export const deleteChannelFlow: API.OperationMethod<
   DeleteChannelFlowRequest,
   DeleteChannelFlowResponse,
   DeleteChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelFlowRequest,
   output: DeleteChannelFlowResponse,
@@ -3258,7 +3257,7 @@ export const deleteChannelMembership: API.OperationMethod<
   DeleteChannelMembershipRequest,
   DeleteChannelMembershipResponse,
   DeleteChannelMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelMembershipRequest,
   output: DeleteChannelMembershipResponse,
@@ -3297,7 +3296,7 @@ export const deleteChannelMessage: API.OperationMethod<
   DeleteChannelMessageRequest,
   DeleteChannelMessageResponse,
   DeleteChannelMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelMessageRequest,
   output: DeleteChannelMessageResponse,
@@ -3333,7 +3332,7 @@ export const deleteChannelModerator: API.OperationMethod<
   DeleteChannelModeratorRequest,
   DeleteChannelModeratorResponse,
   DeleteChannelModeratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelModeratorRequest,
   output: DeleteChannelModeratorResponse,
@@ -3366,7 +3365,7 @@ export const deleteMessagingStreamingConfigurations: API.OperationMethod<
   DeleteMessagingStreamingConfigurationsRequest,
   DeleteMessagingStreamingConfigurationsResponse,
   DeleteMessagingStreamingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessagingStreamingConfigurationsRequest,
   output: DeleteMessagingStreamingConfigurationsResponse,
@@ -3403,7 +3402,7 @@ export const describeChannel: API.OperationMethod<
   DescribeChannelRequest,
   DescribeChannelResponse,
   DescribeChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelRequest,
   output: DescribeChannelResponse,
@@ -3440,7 +3439,7 @@ export const describeChannelBan: API.OperationMethod<
   DescribeChannelBanRequest,
   DescribeChannelBanResponse,
   DescribeChannelBanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelBanRequest,
   output: DescribeChannelBanResponse,
@@ -3473,7 +3472,7 @@ export const describeChannelFlow: API.OperationMethod<
   DescribeChannelFlowRequest,
   DescribeChannelFlowResponse,
   DescribeChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelFlowRequest,
   output: DescribeChannelFlowResponse,
@@ -3510,7 +3509,7 @@ export const describeChannelMembership: API.OperationMethod<
   DescribeChannelMembershipRequest,
   DescribeChannelMembershipResponse,
   DescribeChannelMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelMembershipRequest,
   output: DescribeChannelMembershipResponse,
@@ -3548,7 +3547,7 @@ export const describeChannelMembershipForAppInstanceUser: API.OperationMethod<
   DescribeChannelMembershipForAppInstanceUserRequest,
   DescribeChannelMembershipForAppInstanceUserResponse,
   DescribeChannelMembershipForAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelMembershipForAppInstanceUserRequest,
   output: DescribeChannelMembershipForAppInstanceUserResponse,
@@ -3585,7 +3584,7 @@ export const describeChannelModeratedByAppInstanceUser: API.OperationMethod<
   DescribeChannelModeratedByAppInstanceUserRequest,
   DescribeChannelModeratedByAppInstanceUserResponse,
   DescribeChannelModeratedByAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelModeratedByAppInstanceUserRequest,
   output: DescribeChannelModeratedByAppInstanceUserResponse,
@@ -3622,7 +3621,7 @@ export const describeChannelModerator: API.OperationMethod<
   DescribeChannelModeratorRequest,
   DescribeChannelModeratorResponse,
   DescribeChannelModeratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelModeratorRequest,
   output: DescribeChannelModeratorResponse,
@@ -3664,7 +3663,7 @@ export const disassociateChannelFlow: API.OperationMethod<
   DisassociateChannelFlowRequest,
   DisassociateChannelFlowResponse,
   DisassociateChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateChannelFlowRequest,
   output: DisassociateChannelFlowResponse,
@@ -3706,7 +3705,7 @@ export const getChannelMembershipPreferences: API.OperationMethod<
   GetChannelMembershipPreferencesRequest,
   GetChannelMembershipPreferencesResponse,
   GetChannelMembershipPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelMembershipPreferencesRequest,
   output: GetChannelMembershipPreferencesResponse,
@@ -3743,7 +3742,7 @@ export const getChannelMessage: API.OperationMethod<
   GetChannelMessageRequest,
   GetChannelMessageResponse,
   GetChannelMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelMessageRequest,
   output: GetChannelMessageResponse,
@@ -3803,7 +3802,7 @@ export const getChannelMessageStatus: API.OperationMethod<
   GetChannelMessageStatusRequest,
   GetChannelMessageStatusResponse,
   GetChannelMessageStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelMessageStatusRequest,
   output: GetChannelMessageStatusResponse,
@@ -3834,7 +3833,7 @@ export const getMessagingSessionEndpoint: API.OperationMethod<
   GetMessagingSessionEndpointRequest,
   GetMessagingSessionEndpointResponse,
   GetMessagingSessionEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMessagingSessionEndpointRequest,
   output: GetMessagingSessionEndpointResponse,
@@ -3867,7 +3866,7 @@ export const getMessagingStreamingConfigurations: API.OperationMethod<
   GetMessagingStreamingConfigurationsRequest,
   GetMessagingStreamingConfigurationsResponse,
   GetMessagingStreamingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMessagingStreamingConfigurationsRequest,
   output: GetMessagingStreamingConfigurationsResponse,
@@ -3904,7 +3903,7 @@ export const listChannelBans: API.PaginatedOperationMethod<
   ListChannelBansRequest,
   ListChannelBansResponse,
   ListChannelBansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelBansRequest,
@@ -3942,7 +3941,7 @@ export const listChannelFlows: API.PaginatedOperationMethod<
   ListChannelFlowsRequest,
   ListChannelFlowsResponse,
   ListChannelFlowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelFlowsRequest,
@@ -3987,7 +3986,7 @@ export const listChannelMemberships: API.PaginatedOperationMethod<
   ListChannelMembershipsRequest,
   ListChannelMembershipsResponse,
   ListChannelMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelMembershipsRequest,
@@ -4030,7 +4029,7 @@ export const listChannelMembershipsForAppInstanceUser: API.PaginatedOperationMet
   ListChannelMembershipsForAppInstanceUserRequest,
   ListChannelMembershipsForAppInstanceUserResponse,
   ListChannelMembershipsForAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelMembershipsForAppInstanceUserRequest,
@@ -4078,7 +4077,7 @@ export const listChannelMessages: API.PaginatedOperationMethod<
   ListChannelMessagesRequest,
   ListChannelMessagesResponse,
   ListChannelMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelMessagesRequest,
@@ -4120,7 +4119,7 @@ export const listChannelModerators: API.PaginatedOperationMethod<
   ListChannelModeratorsRequest,
   ListChannelModeratorsResponse,
   ListChannelModeratorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelModeratorsRequest,
@@ -4171,7 +4170,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -4209,7 +4208,7 @@ export const listChannelsAssociatedWithChannelFlow: API.PaginatedOperationMethod
   ListChannelsAssociatedWithChannelFlowRequest,
   ListChannelsAssociatedWithChannelFlowResponse,
   ListChannelsAssociatedWithChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsAssociatedWithChannelFlowRequest,
@@ -4251,7 +4250,7 @@ export const listChannelsModeratedByAppInstanceUser: API.PaginatedOperationMetho
   ListChannelsModeratedByAppInstanceUserRequest,
   ListChannelsModeratedByAppInstanceUserResponse,
   ListChannelsModeratedByAppInstanceUserError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsModeratedByAppInstanceUserRequest,
@@ -4289,7 +4288,7 @@ export const listSubChannels: API.PaginatedOperationMethod<
   ListSubChannelsRequest,
   ListSubChannelsResponse,
   ListSubChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubChannelsRequest,
@@ -4327,7 +4326,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4370,7 +4369,7 @@ export const putChannelExpirationSettings: API.OperationMethod<
   PutChannelExpirationSettingsRequest,
   PutChannelExpirationSettingsResponse,
   PutChannelExpirationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutChannelExpirationSettingsRequest,
   output: PutChannelExpirationSettingsResponse,
@@ -4412,7 +4411,7 @@ export const putChannelMembershipPreferences: API.OperationMethod<
   PutChannelMembershipPreferencesRequest,
   PutChannelMembershipPreferencesResponse,
   PutChannelMembershipPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutChannelMembershipPreferencesRequest,
   output: PutChannelMembershipPreferencesResponse,
@@ -4448,7 +4447,7 @@ export const putMessagingStreamingConfigurations: API.OperationMethod<
   PutMessagingStreamingConfigurationsRequest,
   PutMessagingStreamingConfigurationsResponse,
   PutMessagingStreamingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMessagingStreamingConfigurationsRequest,
   output: PutMessagingStreamingConfigurationsResponse,
@@ -4488,7 +4487,7 @@ export const redactChannelMessage: API.OperationMethod<
   RedactChannelMessageRequest,
   RedactChannelMessageResponse,
   RedactChannelMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RedactChannelMessageRequest,
   output: RedactChannelMessageResponse,
@@ -4529,7 +4528,7 @@ export const searchChannels: API.PaginatedOperationMethod<
   SearchChannelsRequest,
   SearchChannelsResponse,
   SearchChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchChannelsRequest,
@@ -4577,7 +4576,7 @@ export const sendChannelMessage: API.OperationMethod<
   SendChannelMessageRequest,
   SendChannelMessageResponse,
   SendChannelMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendChannelMessageRequest,
   output: SendChannelMessageResponse,
@@ -4611,7 +4610,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4644,7 +4643,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4683,7 +4682,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -4717,7 +4716,7 @@ export const updateChannelFlow: API.OperationMethod<
   UpdateChannelFlowRequest,
   UpdateChannelFlowResponse,
   UpdateChannelFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelFlowRequest,
   output: UpdateChannelFlowResponse,
@@ -4755,7 +4754,7 @@ export const updateChannelMessage: API.OperationMethod<
   UpdateChannelMessageRequest,
   UpdateChannelMessageResponse,
   UpdateChannelMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelMessageRequest,
   output: UpdateChannelMessageResponse,
@@ -4793,7 +4792,7 @@ export const updateChannelReadMarker: API.OperationMethod<
   UpdateChannelReadMarkerRequest,
   UpdateChannelReadMarkerResponse,
   UpdateChannelReadMarkerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelReadMarkerRequest,
   output: UpdateChannelReadMarkerResponse,

--- a/packages/aws/src/services/chime-sdk-voice.ts
+++ b/packages/aws/src/services/chime-sdk-voice.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime SDK Voice",
@@ -4464,7 +4463,7 @@ export const associatePhoneNumbersWithVoiceConnector: API.OperationMethod<
   AssociatePhoneNumbersWithVoiceConnectorRequest,
   AssociatePhoneNumbersWithVoiceConnectorResponse,
   AssociatePhoneNumbersWithVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePhoneNumbersWithVoiceConnectorRequest,
   output: AssociatePhoneNumbersWithVoiceConnectorResponse,
@@ -4500,7 +4499,7 @@ export const associatePhoneNumbersWithVoiceConnectorGroup: API.OperationMethod<
   AssociatePhoneNumbersWithVoiceConnectorGroupRequest,
   AssociatePhoneNumbersWithVoiceConnectorGroupResponse,
   AssociatePhoneNumbersWithVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePhoneNumbersWithVoiceConnectorGroupRequest,
   output: AssociatePhoneNumbersWithVoiceConnectorGroupResponse,
@@ -4539,7 +4538,7 @@ export const batchDeletePhoneNumber: API.OperationMethod<
   BatchDeletePhoneNumberRequest,
   BatchDeletePhoneNumberResponse,
   BatchDeletePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeletePhoneNumberRequest,
   output: BatchDeletePhoneNumberResponse,
@@ -4576,7 +4575,7 @@ export const batchUpdatePhoneNumber: API.OperationMethod<
   BatchUpdatePhoneNumberRequest,
   BatchUpdatePhoneNumberResponse,
   BatchUpdatePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdatePhoneNumberRequest,
   output: BatchUpdatePhoneNumberResponse,
@@ -4611,7 +4610,7 @@ export const createPhoneNumberOrder: API.OperationMethod<
   CreatePhoneNumberOrderRequest,
   CreatePhoneNumberOrderResponse,
   CreatePhoneNumberOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePhoneNumberOrderRequest,
   output: CreatePhoneNumberOrderResponse,
@@ -4647,7 +4646,7 @@ export const createProxySession: API.OperationMethod<
   CreateProxySessionRequest,
   CreateProxySessionResponse,
   CreateProxySessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProxySessionRequest,
   output: CreateProxySessionResponse,
@@ -4684,7 +4683,7 @@ export const createSipMediaApplication: API.OperationMethod<
   CreateSipMediaApplicationRequest,
   CreateSipMediaApplicationResponse,
   CreateSipMediaApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSipMediaApplicationRequest,
   output: CreateSipMediaApplicationResponse,
@@ -4723,7 +4722,7 @@ export const createSipMediaApplicationCall: API.OperationMethod<
   CreateSipMediaApplicationCallRequest,
   CreateSipMediaApplicationCallResponse,
   CreateSipMediaApplicationCallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSipMediaApplicationCallRequest,
   output: CreateSipMediaApplicationCallResponse,
@@ -4761,7 +4760,7 @@ export const createSipRule: API.OperationMethod<
   CreateSipRuleRequest,
   CreateSipRuleResponse,
   CreateSipRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSipRuleRequest,
   output: CreateSipRuleResponse,
@@ -4801,7 +4800,7 @@ export const createVoiceConnector: API.OperationMethod<
   CreateVoiceConnectorRequest,
   CreateVoiceConnectorResponse,
   CreateVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVoiceConnectorRequest,
   output: CreateVoiceConnectorResponse,
@@ -4843,7 +4842,7 @@ export const createVoiceConnectorGroup: API.OperationMethod<
   CreateVoiceConnectorGroupRequest,
   CreateVoiceConnectorGroupResponse,
   CreateVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVoiceConnectorGroupRequest,
   output: CreateVoiceConnectorGroupResponse,
@@ -4888,7 +4887,7 @@ export const createVoiceProfile: API.OperationMethod<
   CreateVoiceProfileRequest,
   CreateVoiceProfileResponse,
   CreateVoiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVoiceProfileRequest,
   output: CreateVoiceProfileResponse,
@@ -4934,7 +4933,7 @@ export const createVoiceProfileDomain: API.OperationMethod<
   CreateVoiceProfileDomainRequest,
   CreateVoiceProfileDomainResponse,
   CreateVoiceProfileDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVoiceProfileDomainRequest,
   output: CreateVoiceProfileDomainResponse,
@@ -4977,7 +4976,7 @@ export const deletePhoneNumber: API.OperationMethod<
   DeletePhoneNumberRequest,
   DeletePhoneNumberResponse,
   DeletePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePhoneNumberRequest,
   output: DeletePhoneNumberResponse,
@@ -5012,7 +5011,7 @@ export const deleteProxySession: API.OperationMethod<
   DeleteProxySessionRequest,
   DeleteProxySessionResponse,
   DeleteProxySessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProxySessionRequest,
   output: DeleteProxySessionResponse,
@@ -5047,7 +5046,7 @@ export const deleteSipMediaApplication: API.OperationMethod<
   DeleteSipMediaApplicationRequest,
   DeleteSipMediaApplicationResponse,
   DeleteSipMediaApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSipMediaApplicationRequest,
   output: DeleteSipMediaApplicationResponse,
@@ -5083,7 +5082,7 @@ export const deleteSipRule: API.OperationMethod<
   DeleteSipRuleRequest,
   DeleteSipRuleResponse,
   DeleteSipRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSipRuleRequest,
   output: DeleteSipRuleResponse,
@@ -5121,7 +5120,7 @@ export const deleteVoiceConnector: API.OperationMethod<
   DeleteVoiceConnectorRequest,
   DeleteVoiceConnectorResponse,
   DeleteVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorRequest,
   output: DeleteVoiceConnectorResponse,
@@ -5157,7 +5156,7 @@ export const deleteVoiceConnectorEmergencyCallingConfiguration: API.OperationMet
   DeleteVoiceConnectorEmergencyCallingConfigurationRequest,
   DeleteVoiceConnectorEmergencyCallingConfigurationResponse,
   DeleteVoiceConnectorEmergencyCallingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorEmergencyCallingConfigurationRequest,
   output: DeleteVoiceConnectorEmergencyCallingConfigurationResponse,
@@ -5191,7 +5190,7 @@ export const deleteVoiceConnectorExternalSystemsConfiguration: API.OperationMeth
   DeleteVoiceConnectorExternalSystemsConfigurationRequest,
   DeleteVoiceConnectorExternalSystemsConfigurationResponse,
   DeleteVoiceConnectorExternalSystemsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorExternalSystemsConfigurationRequest,
   output: DeleteVoiceConnectorExternalSystemsConfigurationResponse,
@@ -5228,7 +5227,7 @@ export const deleteVoiceConnectorGroup: API.OperationMethod<
   DeleteVoiceConnectorGroupRequest,
   DeleteVoiceConnectorGroupResponse,
   DeleteVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorGroupRequest,
   output: DeleteVoiceConnectorGroupResponse,
@@ -5266,7 +5265,7 @@ export const deleteVoiceConnectorOrigination: API.OperationMethod<
   DeleteVoiceConnectorOriginationRequest,
   DeleteVoiceConnectorOriginationResponse,
   DeleteVoiceConnectorOriginationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorOriginationRequest,
   output: DeleteVoiceConnectorOriginationResponse,
@@ -5300,7 +5299,7 @@ export const deleteVoiceConnectorProxy: API.OperationMethod<
   DeleteVoiceConnectorProxyRequest,
   DeleteVoiceConnectorProxyResponse,
   DeleteVoiceConnectorProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorProxyRequest,
   output: DeleteVoiceConnectorProxyResponse,
@@ -5334,7 +5333,7 @@ export const deleteVoiceConnectorStreamingConfiguration: API.OperationMethod<
   DeleteVoiceConnectorStreamingConfigurationRequest,
   DeleteVoiceConnectorStreamingConfigurationResponse,
   DeleteVoiceConnectorStreamingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorStreamingConfigurationRequest,
   output: DeleteVoiceConnectorStreamingConfigurationResponse,
@@ -5371,7 +5370,7 @@ export const deleteVoiceConnectorTermination: API.OperationMethod<
   DeleteVoiceConnectorTerminationRequest,
   DeleteVoiceConnectorTerminationResponse,
   DeleteVoiceConnectorTerminationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorTerminationRequest,
   output: DeleteVoiceConnectorTerminationResponse,
@@ -5406,7 +5405,7 @@ export const deleteVoiceConnectorTerminationCredentials: API.OperationMethod<
   DeleteVoiceConnectorTerminationCredentialsRequest,
   DeleteVoiceConnectorTerminationCredentialsResponse,
   DeleteVoiceConnectorTerminationCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceConnectorTerminationCredentialsRequest,
   output: DeleteVoiceConnectorTerminationCredentialsResponse,
@@ -5442,7 +5441,7 @@ export const deleteVoiceProfile: API.OperationMethod<
   DeleteVoiceProfileRequest,
   DeleteVoiceProfileResponse,
   DeleteVoiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceProfileRequest,
   output: DeleteVoiceProfileResponse,
@@ -5480,7 +5479,7 @@ export const deleteVoiceProfileDomain: API.OperationMethod<
   DeleteVoiceProfileDomainRequest,
   DeleteVoiceProfileDomainResponse,
   DeleteVoiceProfileDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceProfileDomainRequest,
   output: DeleteVoiceProfileDomainResponse,
@@ -5517,7 +5516,7 @@ export const disassociatePhoneNumbersFromVoiceConnector: API.OperationMethod<
   DisassociatePhoneNumbersFromVoiceConnectorRequest,
   DisassociatePhoneNumbersFromVoiceConnectorResponse,
   DisassociatePhoneNumbersFromVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePhoneNumbersFromVoiceConnectorRequest,
   output: DisassociatePhoneNumbersFromVoiceConnectorResponse,
@@ -5552,7 +5551,7 @@ export const disassociatePhoneNumbersFromVoiceConnectorGroup: API.OperationMetho
   DisassociatePhoneNumbersFromVoiceConnectorGroupRequest,
   DisassociatePhoneNumbersFromVoiceConnectorGroupResponse,
   DisassociatePhoneNumbersFromVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePhoneNumbersFromVoiceConnectorGroupRequest,
   output: DisassociatePhoneNumbersFromVoiceConnectorGroupResponse,
@@ -5585,7 +5584,7 @@ export const getGlobalSettings: API.OperationMethod<
   GetGlobalSettingsRequest,
   GetGlobalSettingsResponse,
   GetGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlobalSettingsRequest,
   output: GetGlobalSettingsResponse,
@@ -5619,7 +5618,7 @@ export const getPhoneNumber: API.OperationMethod<
   GetPhoneNumberRequest,
   GetPhoneNumberResponse,
   GetPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberRequest,
   output: GetPhoneNumberResponse,
@@ -5655,7 +5654,7 @@ export const getPhoneNumberOrder: API.OperationMethod<
   GetPhoneNumberOrderRequest,
   GetPhoneNumberOrderResponse,
   GetPhoneNumberOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberOrderRequest,
   output: GetPhoneNumberOrderResponse,
@@ -5689,7 +5688,7 @@ export const getPhoneNumberSettings: API.OperationMethod<
   GetPhoneNumberSettingsRequest,
   GetPhoneNumberSettingsResponse,
   GetPhoneNumberSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberSettingsRequest,
   output: GetPhoneNumberSettingsResponse,
@@ -5722,7 +5721,7 @@ export const getProxySession: API.OperationMethod<
   GetProxySessionRequest,
   GetProxySessionResponse,
   GetProxySessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProxySessionRequest,
   output: GetProxySessionResponse,
@@ -5757,7 +5756,7 @@ export const getSipMediaApplication: API.OperationMethod<
   GetSipMediaApplicationRequest,
   GetSipMediaApplicationResponse,
   GetSipMediaApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSipMediaApplicationRequest,
   output: GetSipMediaApplicationResponse,
@@ -5794,7 +5793,7 @@ export const getSipMediaApplicationAlexaSkillConfiguration: API.OperationMethod<
   GetSipMediaApplicationAlexaSkillConfigurationRequest,
   GetSipMediaApplicationAlexaSkillConfigurationResponse,
   GetSipMediaApplicationAlexaSkillConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSipMediaApplicationAlexaSkillConfigurationRequest,
   output: GetSipMediaApplicationAlexaSkillConfigurationResponse,
@@ -5828,7 +5827,7 @@ export const getSipMediaApplicationLoggingConfiguration: API.OperationMethod<
   GetSipMediaApplicationLoggingConfigurationRequest,
   GetSipMediaApplicationLoggingConfigurationResponse,
   GetSipMediaApplicationLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSipMediaApplicationLoggingConfigurationRequest,
   output: GetSipMediaApplicationLoggingConfigurationResponse,
@@ -5863,7 +5862,7 @@ export const getSipRule: API.OperationMethod<
   GetSipRuleRequest,
   GetSipRuleResponse,
   GetSipRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSipRuleRequest,
   output: GetSipRuleResponse,
@@ -5899,7 +5898,7 @@ export const getSpeakerSearchTask: API.OperationMethod<
   GetSpeakerSearchTaskRequest,
   GetSpeakerSearchTaskResponse,
   GetSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpeakerSearchTaskRequest,
   output: GetSpeakerSearchTaskResponse,
@@ -5936,7 +5935,7 @@ export const getVoiceConnector: API.OperationMethod<
   GetVoiceConnectorRequest,
   GetVoiceConnectorResponse,
   GetVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorRequest,
   output: GetVoiceConnectorResponse,
@@ -5970,7 +5969,7 @@ export const getVoiceConnectorEmergencyCallingConfiguration: API.OperationMethod
   GetVoiceConnectorEmergencyCallingConfigurationRequest,
   GetVoiceConnectorEmergencyCallingConfigurationResponse,
   GetVoiceConnectorEmergencyCallingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorEmergencyCallingConfigurationRequest,
   output: GetVoiceConnectorEmergencyCallingConfigurationResponse,
@@ -6005,7 +6004,7 @@ export const getVoiceConnectorExternalSystemsConfiguration: API.OperationMethod<
   GetVoiceConnectorExternalSystemsConfigurationRequest,
   GetVoiceConnectorExternalSystemsConfigurationResponse,
   GetVoiceConnectorExternalSystemsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorExternalSystemsConfigurationRequest,
   output: GetVoiceConnectorExternalSystemsConfigurationResponse,
@@ -6040,7 +6039,7 @@ export const getVoiceConnectorGroup: API.OperationMethod<
   GetVoiceConnectorGroupRequest,
   GetVoiceConnectorGroupResponse,
   GetVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorGroupRequest,
   output: GetVoiceConnectorGroupResponse,
@@ -6075,7 +6074,7 @@ export const getVoiceConnectorLoggingConfiguration: API.OperationMethod<
   GetVoiceConnectorLoggingConfigurationRequest,
   GetVoiceConnectorLoggingConfigurationResponse,
   GetVoiceConnectorLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorLoggingConfigurationRequest,
   output: GetVoiceConnectorLoggingConfigurationResponse,
@@ -6109,7 +6108,7 @@ export const getVoiceConnectorOrigination: API.OperationMethod<
   GetVoiceConnectorOriginationRequest,
   GetVoiceConnectorOriginationResponse,
   GetVoiceConnectorOriginationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorOriginationRequest,
   output: GetVoiceConnectorOriginationResponse,
@@ -6144,7 +6143,7 @@ export const getVoiceConnectorProxy: API.OperationMethod<
   GetVoiceConnectorProxyRequest,
   GetVoiceConnectorProxyResponse,
   GetVoiceConnectorProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorProxyRequest,
   output: GetVoiceConnectorProxyResponse,
@@ -6180,7 +6179,7 @@ export const getVoiceConnectorStreamingConfiguration: API.OperationMethod<
   GetVoiceConnectorStreamingConfigurationRequest,
   GetVoiceConnectorStreamingConfigurationResponse,
   GetVoiceConnectorStreamingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorStreamingConfigurationRequest,
   output: GetVoiceConnectorStreamingConfigurationResponse,
@@ -6214,7 +6213,7 @@ export const getVoiceConnectorTermination: API.OperationMethod<
   GetVoiceConnectorTerminationRequest,
   GetVoiceConnectorTerminationResponse,
   GetVoiceConnectorTerminationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorTerminationRequest,
   output: GetVoiceConnectorTerminationResponse,
@@ -6250,7 +6249,7 @@ export const getVoiceConnectorTerminationHealth: API.OperationMethod<
   GetVoiceConnectorTerminationHealthRequest,
   GetVoiceConnectorTerminationHealthResponse,
   GetVoiceConnectorTerminationHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceConnectorTerminationHealthRequest,
   output: GetVoiceConnectorTerminationHealthResponse,
@@ -6285,7 +6284,7 @@ export const getVoiceProfile: API.OperationMethod<
   GetVoiceProfileRequest,
   GetVoiceProfileResponse,
   GetVoiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceProfileRequest,
   output: GetVoiceProfileResponse,
@@ -6321,7 +6320,7 @@ export const getVoiceProfileDomain: API.OperationMethod<
   GetVoiceProfileDomainRequest,
   GetVoiceProfileDomainResponse,
   GetVoiceProfileDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceProfileDomainRequest,
   output: GetVoiceProfileDomainResponse,
@@ -6358,7 +6357,7 @@ export const getVoiceToneAnalysisTask: API.OperationMethod<
   GetVoiceToneAnalysisTaskRequest,
   GetVoiceToneAnalysisTaskResponse,
   GetVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceToneAnalysisTaskRequest,
   output: GetVoiceToneAnalysisTaskResponse,
@@ -6393,7 +6392,7 @@ export const listAvailableVoiceConnectorRegions: API.OperationMethod<
   ListAvailableVoiceConnectorRegionsRequest,
   ListAvailableVoiceConnectorRegionsResponse,
   ListAvailableVoiceConnectorRegionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableVoiceConnectorRegionsRequest,
   output: ListAvailableVoiceConnectorRegionsResponse,
@@ -6425,7 +6424,7 @@ export const listPhoneNumberOrders: API.PaginatedOperationMethod<
   ListPhoneNumberOrdersRequest,
   ListPhoneNumberOrdersResponse,
   ListPhoneNumberOrdersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumberOrdersRequest,
@@ -6466,7 +6465,7 @@ export const listPhoneNumbers: API.PaginatedOperationMethod<
   ListPhoneNumbersRequest,
   ListPhoneNumbersResponse,
   ListPhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumbersRequest,
@@ -6506,7 +6505,7 @@ export const listProxySessions: API.PaginatedOperationMethod<
   ListProxySessionsRequest,
   ListProxySessionsResponse,
   ListProxySessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProxySessionsRequest,
@@ -6545,7 +6544,7 @@ export const listSipMediaApplications: API.PaginatedOperationMethod<
   ListSipMediaApplicationsRequest,
   ListSipMediaApplicationsResponse,
   ListSipMediaApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SipMediaApplication
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSipMediaApplicationsRequest,
@@ -6584,7 +6583,7 @@ export const listSipRules: API.PaginatedOperationMethod<
   ListSipRulesRequest,
   ListSipRulesResponse,
   ListSipRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SipRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSipRulesRequest,
@@ -6624,7 +6623,7 @@ export const listSupportedPhoneNumberCountries: API.OperationMethod<
   ListSupportedPhoneNumberCountriesRequest,
   ListSupportedPhoneNumberCountriesResponse,
   ListSupportedPhoneNumberCountriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSupportedPhoneNumberCountriesRequest,
   output: ListSupportedPhoneNumberCountriesResponse,
@@ -6657,7 +6656,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6690,7 +6689,7 @@ export const listVoiceConnectorGroups: API.PaginatedOperationMethod<
   ListVoiceConnectorGroupsRequest,
   ListVoiceConnectorGroupsResponse,
   ListVoiceConnectorGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVoiceConnectorGroupsRequest,
@@ -6729,7 +6728,7 @@ export const listVoiceConnectors: API.PaginatedOperationMethod<
   ListVoiceConnectorsRequest,
   ListVoiceConnectorsResponse,
   ListVoiceConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVoiceConnectorsRequest,
@@ -6768,7 +6767,7 @@ export const listVoiceConnectorTerminationCredentials: API.OperationMethod<
   ListVoiceConnectorTerminationCredentialsRequest,
   ListVoiceConnectorTerminationCredentialsResponse,
   ListVoiceConnectorTerminationCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVoiceConnectorTerminationCredentialsRequest,
   output: ListVoiceConnectorTerminationCredentialsResponse,
@@ -6802,7 +6801,7 @@ export const listVoiceProfileDomains: API.PaginatedOperationMethod<
   ListVoiceProfileDomainsRequest,
   ListVoiceProfileDomainsResponse,
   ListVoiceProfileDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVoiceProfileDomainsRequest,
@@ -6842,7 +6841,7 @@ export const listVoiceProfiles: API.PaginatedOperationMethod<
   ListVoiceProfilesRequest,
   ListVoiceProfilesResponse,
   ListVoiceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVoiceProfilesRequest,
@@ -6885,7 +6884,7 @@ export const putSipMediaApplicationAlexaSkillConfiguration: API.OperationMethod<
   PutSipMediaApplicationAlexaSkillConfigurationRequest,
   PutSipMediaApplicationAlexaSkillConfigurationResponse,
   PutSipMediaApplicationAlexaSkillConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSipMediaApplicationAlexaSkillConfigurationRequest,
   output: PutSipMediaApplicationAlexaSkillConfigurationResponse,
@@ -6919,7 +6918,7 @@ export const putSipMediaApplicationLoggingConfiguration: API.OperationMethod<
   PutSipMediaApplicationLoggingConfigurationRequest,
   PutSipMediaApplicationLoggingConfigurationResponse,
   PutSipMediaApplicationLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSipMediaApplicationLoggingConfigurationRequest,
   output: PutSipMediaApplicationLoggingConfigurationResponse,
@@ -6953,7 +6952,7 @@ export const putVoiceConnectorEmergencyCallingConfiguration: API.OperationMethod
   PutVoiceConnectorEmergencyCallingConfigurationRequest,
   PutVoiceConnectorEmergencyCallingConfigurationResponse,
   PutVoiceConnectorEmergencyCallingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorEmergencyCallingConfigurationRequest,
   output: PutVoiceConnectorEmergencyCallingConfigurationResponse,
@@ -6988,7 +6987,7 @@ export const putVoiceConnectorExternalSystemsConfiguration: API.OperationMethod<
   PutVoiceConnectorExternalSystemsConfigurationRequest,
   PutVoiceConnectorExternalSystemsConfigurationResponse,
   PutVoiceConnectorExternalSystemsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorExternalSystemsConfigurationRequest,
   output: PutVoiceConnectorExternalSystemsConfigurationResponse,
@@ -7023,7 +7022,7 @@ export const putVoiceConnectorLoggingConfiguration: API.OperationMethod<
   PutVoiceConnectorLoggingConfigurationRequest,
   PutVoiceConnectorLoggingConfigurationResponse,
   PutVoiceConnectorLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorLoggingConfigurationRequest,
   output: PutVoiceConnectorLoggingConfigurationResponse,
@@ -7057,7 +7056,7 @@ export const putVoiceConnectorOrigination: API.OperationMethod<
   PutVoiceConnectorOriginationRequest,
   PutVoiceConnectorOriginationResponse,
   PutVoiceConnectorOriginationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorOriginationRequest,
   output: PutVoiceConnectorOriginationResponse,
@@ -7092,7 +7091,7 @@ export const putVoiceConnectorProxy: API.OperationMethod<
   PutVoiceConnectorProxyRequest,
   PutVoiceConnectorProxyResponse,
   PutVoiceConnectorProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorProxyRequest,
   output: PutVoiceConnectorProxyResponse,
@@ -7127,7 +7126,7 @@ export const putVoiceConnectorStreamingConfiguration: API.OperationMethod<
   PutVoiceConnectorStreamingConfigurationRequest,
   PutVoiceConnectorStreamingConfigurationResponse,
   PutVoiceConnectorStreamingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorStreamingConfigurationRequest,
   output: PutVoiceConnectorStreamingConfigurationResponse,
@@ -7162,7 +7161,7 @@ export const putVoiceConnectorTermination: API.OperationMethod<
   PutVoiceConnectorTerminationRequest,
   PutVoiceConnectorTerminationResponse,
   PutVoiceConnectorTerminationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorTerminationRequest,
   output: PutVoiceConnectorTerminationResponse,
@@ -7197,7 +7196,7 @@ export const putVoiceConnectorTerminationCredentials: API.OperationMethod<
   PutVoiceConnectorTerminationCredentialsRequest,
   PutVoiceConnectorTerminationCredentialsResponse,
   PutVoiceConnectorTerminationCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVoiceConnectorTerminationCredentialsRequest,
   output: PutVoiceConnectorTerminationCredentialsResponse,
@@ -7232,7 +7231,7 @@ export const restorePhoneNumber: API.OperationMethod<
   RestorePhoneNumberRequest,
   RestorePhoneNumberResponse,
   RestorePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestorePhoneNumberRequest,
   output: RestorePhoneNumberResponse,
@@ -7267,7 +7266,7 @@ export const searchAvailablePhoneNumbers: API.PaginatedOperationMethod<
   SearchAvailablePhoneNumbersRequest,
   SearchAvailablePhoneNumbersResponse,
   SearchAvailablePhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAvailablePhoneNumbersRequest,
@@ -7315,7 +7314,7 @@ export const startSpeakerSearchTask: API.OperationMethod<
   StartSpeakerSearchTaskRequest,
   StartSpeakerSearchTaskResponse,
   StartSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSpeakerSearchTaskRequest,
   output: StartSpeakerSearchTaskResponse,
@@ -7364,7 +7363,7 @@ export const startVoiceToneAnalysisTask: API.OperationMethod<
   StartVoiceToneAnalysisTaskRequest,
   StartVoiceToneAnalysisTaskResponse,
   StartVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVoiceToneAnalysisTaskRequest,
   output: StartVoiceToneAnalysisTaskResponse,
@@ -7406,7 +7405,7 @@ export const stopSpeakerSearchTask: API.OperationMethod<
   StopSpeakerSearchTaskRequest,
   StopSpeakerSearchTaskResponse,
   StopSpeakerSearchTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSpeakerSearchTaskRequest,
   output: StopSpeakerSearchTaskResponse,
@@ -7446,7 +7445,7 @@ export const stopVoiceToneAnalysisTask: API.OperationMethod<
   StopVoiceToneAnalysisTaskRequest,
   StopVoiceToneAnalysisTaskResponse,
   StopVoiceToneAnalysisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopVoiceToneAnalysisTaskRequest,
   output: StopVoiceToneAnalysisTaskResponse,
@@ -7483,7 +7482,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7516,7 +7515,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7548,7 +7547,7 @@ export const updateGlobalSettings: API.OperationMethod<
   UpdateGlobalSettingsRequest,
   UpdateGlobalSettingsResponse,
   UpdateGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalSettingsRequest,
   output: UpdateGlobalSettingsResponse,
@@ -7591,7 +7590,7 @@ export const updatePhoneNumber: API.OperationMethod<
   UpdatePhoneNumberRequest,
   UpdatePhoneNumberResponse,
   UpdatePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberRequest,
   output: UpdatePhoneNumberResponse,
@@ -7628,7 +7627,7 @@ export const updatePhoneNumberSettings: API.OperationMethod<
   UpdatePhoneNumberSettingsRequest,
   UpdatePhoneNumberSettingsResponse,
   UpdatePhoneNumberSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberSettingsRequest,
   output: UpdatePhoneNumberSettingsResponse,
@@ -7661,7 +7660,7 @@ export const updateProxySession: API.OperationMethod<
   UpdateProxySessionRequest,
   UpdateProxySessionResponse,
   UpdateProxySessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxySessionRequest,
   output: UpdateProxySessionResponse,
@@ -7696,7 +7695,7 @@ export const updateSipMediaApplication: API.OperationMethod<
   UpdateSipMediaApplicationRequest,
   UpdateSipMediaApplicationResponse,
   UpdateSipMediaApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSipMediaApplicationRequest,
   output: UpdateSipMediaApplicationResponse,
@@ -7734,7 +7733,7 @@ export const updateSipMediaApplicationCall: API.OperationMethod<
   UpdateSipMediaApplicationCallRequest,
   UpdateSipMediaApplicationCallResponse,
   UpdateSipMediaApplicationCallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSipMediaApplicationCallRequest,
   output: UpdateSipMediaApplicationCallResponse,
@@ -7771,7 +7770,7 @@ export const updateSipRule: API.OperationMethod<
   UpdateSipRuleRequest,
   UpdateSipRuleResponse,
   UpdateSipRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSipRuleRequest,
   output: UpdateSipRuleResponse,
@@ -7807,7 +7806,7 @@ export const updateVoiceConnector: API.OperationMethod<
   UpdateVoiceConnectorRequest,
   UpdateVoiceConnectorResponse,
   UpdateVoiceConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceConnectorRequest,
   output: UpdateVoiceConnectorResponse,
@@ -7842,7 +7841,7 @@ export const updateVoiceConnectorGroup: API.OperationMethod<
   UpdateVoiceConnectorGroupRequest,
   UpdateVoiceConnectorGroupResponse,
   UpdateVoiceConnectorGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceConnectorGroupRequest,
   output: UpdateVoiceConnectorGroupResponse,
@@ -7889,7 +7888,7 @@ export const updateVoiceProfile: API.OperationMethod<
   UpdateVoiceProfileRequest,
   UpdateVoiceProfileResponse,
   UpdateVoiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceProfileRequest,
   output: UpdateVoiceProfileResponse,
@@ -7927,7 +7926,7 @@ export const updateVoiceProfileDomain: API.OperationMethod<
   UpdateVoiceProfileDomainRequest,
   UpdateVoiceProfileDomainResponse,
   UpdateVoiceProfileDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceProfileDomainRequest,
   output: UpdateVoiceProfileDomainResponse,
@@ -7966,7 +7965,7 @@ export const validateE911Address: API.OperationMethod<
   ValidateE911AddressRequest,
   ValidateE911AddressResponse,
   ValidateE911AddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateE911AddressRequest,
   output: ValidateE911AddressResponse,

--- a/packages/aws/src/services/chime.ts
+++ b/packages/aws/src/services/chime.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Chime",
@@ -2824,7 +2823,7 @@ export const associatePhoneNumberWithUser: API.OperationMethod<
   AssociatePhoneNumberWithUserRequest,
   AssociatePhoneNumberWithUserResponse,
   AssociatePhoneNumberWithUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePhoneNumberWithUserRequest,
   output: AssociatePhoneNumberWithUserResponse,
@@ -2859,7 +2858,7 @@ export const associateSigninDelegateGroupsWithAccount: API.OperationMethod<
   AssociateSigninDelegateGroupsWithAccountRequest,
   AssociateSigninDelegateGroupsWithAccountResponse,
   AssociateSigninDelegateGroupsWithAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSigninDelegateGroupsWithAccountRequest,
   output: AssociateSigninDelegateGroupsWithAccountResponse,
@@ -2894,7 +2893,7 @@ export const batchCreateRoomMembership: API.OperationMethod<
   BatchCreateRoomMembershipRequest,
   BatchCreateRoomMembershipResponse,
   BatchCreateRoomMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateRoomMembershipRequest,
   output: BatchCreateRoomMembershipResponse,
@@ -2932,7 +2931,7 @@ export const batchDeletePhoneNumber: API.OperationMethod<
   BatchDeletePhoneNumberRequest,
   BatchDeletePhoneNumberResponse,
   BatchDeletePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeletePhoneNumberRequest,
   output: BatchDeletePhoneNumberResponse,
@@ -2980,7 +2979,7 @@ export const batchSuspendUser: API.OperationMethod<
   BatchSuspendUserRequest,
   BatchSuspendUserResponse,
   BatchSuspendUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchSuspendUserRequest,
   output: BatchSuspendUserResponse,
@@ -3023,7 +3022,7 @@ export const batchUnsuspendUser: API.OperationMethod<
   BatchUnsuspendUserRequest,
   BatchUnsuspendUserResponse,
   BatchUnsuspendUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUnsuspendUserRequest,
   output: BatchUnsuspendUserResponse,
@@ -3061,7 +3060,7 @@ export const batchUpdatePhoneNumber: API.OperationMethod<
   BatchUpdatePhoneNumberRequest,
   BatchUpdatePhoneNumberResponse,
   BatchUpdatePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdatePhoneNumberRequest,
   output: BatchUpdatePhoneNumberResponse,
@@ -3095,7 +3094,7 @@ export const batchUpdateUser: API.OperationMethod<
   BatchUpdateUserRequest,
   BatchUpdateUserResponse,
   BatchUpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateUserRequest,
   output: BatchUpdateUserResponse,
@@ -3132,7 +3131,7 @@ export const createAccount: API.OperationMethod<
   CreateAccountRequest,
   CreateAccountResponse,
   CreateAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountRequest,
   output: CreateAccountResponse,
@@ -3167,7 +3166,7 @@ export const createBot: API.OperationMethod<
   CreateBotRequest,
   CreateBotResponse,
   CreateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotRequest,
   output: CreateBotResponse,
@@ -3209,7 +3208,7 @@ export const createMeetingDialOut: API.OperationMethod<
   CreateMeetingDialOutRequest,
   CreateMeetingDialOutResponse,
   CreateMeetingDialOutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMeetingDialOutRequest,
   output: CreateMeetingDialOutResponse,
@@ -3246,7 +3245,7 @@ export const createPhoneNumberOrder: API.OperationMethod<
   CreatePhoneNumberOrderRequest,
   CreatePhoneNumberOrderResponse,
   CreatePhoneNumberOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePhoneNumberOrderRequest,
   output: CreatePhoneNumberOrderResponse,
@@ -3282,7 +3281,7 @@ export const createRoom: API.OperationMethod<
   CreateRoomRequest,
   CreateRoomResponse,
   CreateRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoomRequest,
   output: CreateRoomResponse,
@@ -3319,7 +3318,7 @@ export const createRoomMembership: API.OperationMethod<
   CreateRoomMembershipRequest,
   CreateRoomMembershipResponse,
   CreateRoomMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoomMembershipRequest,
   output: CreateRoomMembershipResponse,
@@ -3356,7 +3355,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -3405,7 +3404,7 @@ export const deleteAccount: API.OperationMethod<
   DeleteAccountRequest,
   DeleteAccountResponse,
   DeleteAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountRequest,
   output: DeleteAccountResponse,
@@ -3439,7 +3438,7 @@ export const deleteEventsConfiguration: API.OperationMethod<
   DeleteEventsConfigurationRequest,
   DeleteEventsConfigurationResponse,
   DeleteEventsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventsConfigurationRequest,
   output: DeleteEventsConfigurationResponse,
@@ -3478,7 +3477,7 @@ export const deletePhoneNumber: API.OperationMethod<
   DeletePhoneNumberRequest,
   DeletePhoneNumberResponse,
   DeletePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePhoneNumberRequest,
   output: DeletePhoneNumberResponse,
@@ -3512,7 +3511,7 @@ export const deleteRoom: API.OperationMethod<
   DeleteRoomRequest,
   DeleteRoomResponse,
   DeleteRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoomRequest,
   output: DeleteRoomResponse,
@@ -3546,7 +3545,7 @@ export const deleteRoomMembership: API.OperationMethod<
   DeleteRoomMembershipRequest,
   DeleteRoomMembershipResponse,
   DeleteRoomMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoomMembershipRequest,
   output: DeleteRoomMembershipResponse,
@@ -3580,7 +3579,7 @@ export const disassociatePhoneNumberFromUser: API.OperationMethod<
   DisassociatePhoneNumberFromUserRequest,
   DisassociatePhoneNumberFromUserResponse,
   DisassociatePhoneNumberFromUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePhoneNumberFromUserRequest,
   output: DisassociatePhoneNumberFromUserResponse,
@@ -3614,7 +3613,7 @@ export const disassociateSigninDelegateGroupsFromAccount: API.OperationMethod<
   DisassociateSigninDelegateGroupsFromAccountRequest,
   DisassociateSigninDelegateGroupsFromAccountResponse,
   DisassociateSigninDelegateGroupsFromAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSigninDelegateGroupsFromAccountRequest,
   output: DisassociateSigninDelegateGroupsFromAccountResponse,
@@ -3649,7 +3648,7 @@ export const getAccount: API.OperationMethod<
   GetAccountRequest,
   GetAccountResponse,
   GetAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountRequest,
   output: GetAccountResponse,
@@ -3685,7 +3684,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsResponse,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsResponse,
@@ -3719,7 +3718,7 @@ export const getBot: API.OperationMethod<
   GetBotRequest,
   GetBotResponse,
   GetBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotRequest,
   output: GetBotResponse,
@@ -3753,7 +3752,7 @@ export const getEventsConfiguration: API.OperationMethod<
   GetEventsConfigurationRequest,
   GetEventsConfigurationResponse,
   GetEventsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventsConfigurationRequest,
   output: GetEventsConfigurationResponse,
@@ -3787,7 +3786,7 @@ export const getGlobalSettings: API.OperationMethod<
   GetGlobalSettingsRequest,
   GetGlobalSettingsResponse,
   GetGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlobalSettingsRequest,
   output: GetGlobalSettingsResponse,
@@ -3820,7 +3819,7 @@ export const getPhoneNumber: API.OperationMethod<
   GetPhoneNumberRequest,
   GetPhoneNumberResponse,
   GetPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberRequest,
   output: GetPhoneNumberResponse,
@@ -3855,7 +3854,7 @@ export const getPhoneNumberOrder: API.OperationMethod<
   GetPhoneNumberOrderRequest,
   GetPhoneNumberOrderResponse,
   GetPhoneNumberOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberOrderRequest,
   output: GetPhoneNumberOrderResponse,
@@ -3888,7 +3887,7 @@ export const getPhoneNumberSettings: API.OperationMethod<
   GetPhoneNumberSettingsRequest,
   GetPhoneNumberSettingsResponse,
   GetPhoneNumberSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPhoneNumberSettingsRequest,
   output: GetPhoneNumberSettingsResponse,
@@ -3922,7 +3921,7 @@ export const getRetentionSettings: API.OperationMethod<
   GetRetentionSettingsRequest,
   GetRetentionSettingsResponse,
   GetRetentionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRetentionSettingsRequest,
   output: GetRetentionSettingsResponse,
@@ -3956,7 +3955,7 @@ export const getRoom: API.OperationMethod<
   GetRoomRequest,
   GetRoomResponse,
   GetRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoomRequest,
   output: GetRoomResponse,
@@ -3993,7 +3992,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -4027,7 +4026,7 @@ export const getUserSettings: API.OperationMethod<
   GetUserSettingsRequest,
   GetUserSettingsResponse,
   GetUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserSettingsRequest,
   output: GetUserSettingsResponse,
@@ -4063,7 +4062,7 @@ export const inviteUsers: API.OperationMethod<
   InviteUsersRequest,
   InviteUsersResponse,
   InviteUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InviteUsersRequest,
   output: InviteUsersResponse,
@@ -4099,7 +4098,7 @@ export const listAccounts: API.PaginatedOperationMethod<
   ListAccountsRequest,
   ListAccountsResponse,
   ListAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsRequest,
@@ -4139,7 +4138,7 @@ export const listBots: API.PaginatedOperationMethod<
   ListBotsRequest,
   ListBotsResponse,
   ListBotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotsRequest,
@@ -4178,7 +4177,7 @@ export const listPhoneNumberOrders: API.PaginatedOperationMethod<
   ListPhoneNumberOrdersRequest,
   ListPhoneNumberOrdersResponse,
   ListPhoneNumberOrdersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumberOrdersRequest,
@@ -4217,7 +4216,7 @@ export const listPhoneNumbers: API.PaginatedOperationMethod<
   ListPhoneNumbersRequest,
   ListPhoneNumbersResponse,
   ListPhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumbersRequest,
@@ -4258,7 +4257,7 @@ export const listRoomMemberships: API.PaginatedOperationMethod<
   ListRoomMembershipsRequest,
   ListRoomMembershipsResponse,
   ListRoomMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoomMembershipsRequest,
@@ -4298,7 +4297,7 @@ export const listRooms: API.PaginatedOperationMethod<
   ListRoomsRequest,
   ListRoomsResponse,
   ListRoomsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoomsRequest,
@@ -4338,7 +4337,7 @@ export const listSupportedPhoneNumberCountries: API.OperationMethod<
   ListSupportedPhoneNumberCountriesRequest,
   ListSupportedPhoneNumberCountriesResponse,
   ListSupportedPhoneNumberCountriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSupportedPhoneNumberCountriesRequest,
   output: ListSupportedPhoneNumberCountriesResponse,
@@ -4373,7 +4372,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -4413,7 +4412,7 @@ export const logoutUser: API.OperationMethod<
   LogoutUserRequest,
   LogoutUserResponse,
   LogoutUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LogoutUserRequest,
   output: LogoutUserResponse,
@@ -4449,7 +4448,7 @@ export const putEventsConfiguration: API.OperationMethod<
   PutEventsConfigurationRequest,
   PutEventsConfigurationResponse,
   PutEventsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventsConfigurationRequest,
   output: PutEventsConfigurationResponse,
@@ -4494,7 +4493,7 @@ export const putRetentionSettings: API.OperationMethod<
   PutRetentionSettingsRequest,
   PutRetentionSettingsResponse,
   PutRetentionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRetentionSettingsRequest,
   output: PutRetentionSettingsResponse,
@@ -4529,7 +4528,7 @@ export const redactConversationMessage: API.OperationMethod<
   RedactConversationMessageRequest,
   RedactConversationMessageResponse,
   RedactConversationMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RedactConversationMessageRequest,
   output: RedactConversationMessageResponse,
@@ -4563,7 +4562,7 @@ export const redactRoomMessage: API.OperationMethod<
   RedactRoomMessageRequest,
   RedactRoomMessageResponse,
   RedactRoomMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RedactRoomMessageRequest,
   output: RedactRoomMessageResponse,
@@ -4597,7 +4596,7 @@ export const regenerateSecurityToken: API.OperationMethod<
   RegenerateSecurityTokenRequest,
   RegenerateSecurityTokenResponse,
   RegenerateSecurityTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegenerateSecurityTokenRequest,
   output: RegenerateSecurityTokenResponse,
@@ -4632,7 +4631,7 @@ export const resetPersonalPIN: API.OperationMethod<
   ResetPersonalPINRequest,
   ResetPersonalPINResponse,
   ResetPersonalPINError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetPersonalPINRequest,
   output: ResetPersonalPINResponse,
@@ -4668,7 +4667,7 @@ export const restorePhoneNumber: API.OperationMethod<
   RestorePhoneNumberRequest,
   RestorePhoneNumberResponse,
   RestorePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestorePhoneNumberRequest,
   output: RestorePhoneNumberResponse,
@@ -4707,7 +4706,7 @@ export const searchAvailablePhoneNumbers: API.PaginatedOperationMethod<
   SearchAvailablePhoneNumbersRequest,
   SearchAvailablePhoneNumbersResponse,
   SearchAvailablePhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAvailablePhoneNumbersRequest,
@@ -4747,7 +4746,7 @@ export const updateAccount: API.OperationMethod<
   UpdateAccountRequest,
   UpdateAccountResponse,
   UpdateAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountRequest,
   output: UpdateAccountResponse,
@@ -4786,7 +4785,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsRequest,
   UpdateAccountSettingsResponse,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsRequest,
   output: UpdateAccountSettingsResponse,
@@ -4821,7 +4820,7 @@ export const updateBot: API.OperationMethod<
   UpdateBotRequest,
   UpdateBotResponse,
   UpdateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotRequest,
   output: UpdateBotResponse,
@@ -4854,7 +4853,7 @@ export const updateGlobalSettings: API.OperationMethod<
   UpdateGlobalSettingsRequest,
   UpdateGlobalSettingsResponse,
   UpdateGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalSettingsRequest,
   output: UpdateGlobalSettingsResponse,
@@ -4892,7 +4891,7 @@ export const updatePhoneNumber: API.OperationMethod<
   UpdatePhoneNumberRequest,
   UpdatePhoneNumberResponse,
   UpdatePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberRequest,
   output: UpdatePhoneNumberResponse,
@@ -4928,7 +4927,7 @@ export const updatePhoneNumberSettings: API.OperationMethod<
   UpdatePhoneNumberSettingsRequest,
   UpdatePhoneNumberSettingsResponse,
   UpdatePhoneNumberSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberSettingsRequest,
   output: UpdatePhoneNumberSettingsResponse,
@@ -4961,7 +4960,7 @@ export const updateRoom: API.OperationMethod<
   UpdateRoomRequest,
   UpdateRoomResponse,
   UpdateRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoomRequest,
   output: UpdateRoomResponse,
@@ -4998,7 +4997,7 @@ export const updateRoomMembership: API.OperationMethod<
   UpdateRoomMembershipRequest,
   UpdateRoomMembershipResponse,
   UpdateRoomMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoomMembershipRequest,
   output: UpdateRoomMembershipResponse,
@@ -5032,7 +5031,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,
@@ -5066,7 +5065,7 @@ export const updateUserSettings: API.OperationMethod<
   UpdateUserSettingsRequest,
   UpdateUserSettingsResponse,
   UpdateUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserSettingsRequest,
   output: UpdateUserSettingsResponse,

--- a/packages/aws/src/services/cleanrooms.ts
+++ b/packages/aws/src/services/cleanrooms.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CleanRooms",
@@ -7068,7 +7067,7 @@ export const batchGetCollaborationAnalysisTemplate: API.OperationMethod<
   BatchGetCollaborationAnalysisTemplateInput,
   BatchGetCollaborationAnalysisTemplateOutput,
   BatchGetCollaborationAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCollaborationAnalysisTemplateInput,
   output: BatchGetCollaborationAnalysisTemplateOutput,
@@ -7098,7 +7097,7 @@ export const batchGetSchema: API.OperationMethod<
   BatchGetSchemaInput,
   BatchGetSchemaOutput,
   BatchGetSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSchemaInput,
   output: BatchGetSchemaOutput,
@@ -7128,7 +7127,7 @@ export const batchGetSchemaAnalysisRule: API.OperationMethod<
   BatchGetSchemaAnalysisRuleInput,
   BatchGetSchemaAnalysisRuleOutput,
   BatchGetSchemaAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSchemaAnalysisRuleInput,
   output: BatchGetSchemaAnalysisRuleOutput,
@@ -7160,7 +7159,7 @@ export const createAnalysisTemplate: API.OperationMethod<
   CreateAnalysisTemplateInput,
   CreateAnalysisTemplateOutput,
   CreateAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnalysisTemplateInput,
   output: CreateAnalysisTemplateOutput,
@@ -7192,7 +7191,7 @@ export const createCollaboration: API.OperationMethod<
   CreateCollaborationInput,
   CreateCollaborationOutput,
   CreateCollaborationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCollaborationInput,
   output: CreateCollaborationOutput,
@@ -7224,7 +7223,7 @@ export const createCollaborationChangeRequest: API.OperationMethod<
   CreateCollaborationChangeRequestInput,
   CreateCollaborationChangeRequestOutput,
   CreateCollaborationChangeRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCollaborationChangeRequestInput,
   output: CreateCollaborationChangeRequestOutput,
@@ -7258,7 +7257,7 @@ export const createConfiguredAudienceModelAssociation: API.OperationMethod<
   CreateConfiguredAudienceModelAssociationInput,
   CreateConfiguredAudienceModelAssociationOutput,
   CreateConfiguredAudienceModelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredAudienceModelAssociationInput,
   output: CreateConfiguredAudienceModelAssociationOutput,
@@ -7292,7 +7291,7 @@ export const createConfiguredTable: API.OperationMethod<
   CreateConfiguredTableInput,
   CreateConfiguredTableOutput,
   CreateConfiguredTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredTableInput,
   output: CreateConfiguredTableOutput,
@@ -7326,7 +7325,7 @@ export const createConfiguredTableAnalysisRule: API.OperationMethod<
   CreateConfiguredTableAnalysisRuleInput,
   CreateConfiguredTableAnalysisRuleOutput,
   CreateConfiguredTableAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredTableAnalysisRuleInput,
   output: CreateConfiguredTableAnalysisRuleOutput,
@@ -7360,7 +7359,7 @@ export const createConfiguredTableAssociation: API.OperationMethod<
   CreateConfiguredTableAssociationInput,
   CreateConfiguredTableAssociationOutput,
   CreateConfiguredTableAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredTableAssociationInput,
   output: CreateConfiguredTableAssociationOutput,
@@ -7393,7 +7392,7 @@ export const createConfiguredTableAssociationAnalysisRule: API.OperationMethod<
   CreateConfiguredTableAssociationAnalysisRuleInput,
   CreateConfiguredTableAssociationAnalysisRuleOutput,
   CreateConfiguredTableAssociationAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredTableAssociationAnalysisRuleInput,
   output: CreateConfiguredTableAssociationAnalysisRuleOutput,
@@ -7426,7 +7425,7 @@ export const createIdMappingTable: API.OperationMethod<
   CreateIdMappingTableInput,
   CreateIdMappingTableOutput,
   CreateIdMappingTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdMappingTableInput,
   output: CreateIdMappingTableOutput,
@@ -7460,7 +7459,7 @@ export const createIdNamespaceAssociation: API.OperationMethod<
   CreateIdNamespaceAssociationInput,
   CreateIdNamespaceAssociationOutput,
   CreateIdNamespaceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdNamespaceAssociationInput,
   output: CreateIdNamespaceAssociationOutput,
@@ -7494,7 +7493,7 @@ export const createMembership: API.OperationMethod<
   CreateMembershipInput,
   CreateMembershipOutput,
   CreateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembershipInput,
   output: CreateMembershipOutput,
@@ -7528,7 +7527,7 @@ export const createPrivacyBudgetTemplate: API.OperationMethod<
   CreatePrivacyBudgetTemplateInput,
   CreatePrivacyBudgetTemplateOutput,
   CreatePrivacyBudgetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivacyBudgetTemplateInput,
   output: CreatePrivacyBudgetTemplateOutput,
@@ -7560,7 +7559,7 @@ export const deleteAnalysisTemplate: API.OperationMethod<
   DeleteAnalysisTemplateInput,
   DeleteAnalysisTemplateOutput,
   DeleteAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnalysisTemplateInput,
   output: DeleteAnalysisTemplateOutput,
@@ -7589,7 +7588,7 @@ export const deleteCollaboration: API.OperationMethod<
   DeleteCollaborationInput,
   DeleteCollaborationOutput,
   DeleteCollaborationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCollaborationInput,
   output: DeleteCollaborationOutput,
@@ -7618,7 +7617,7 @@ export const deleteConfiguredAudienceModelAssociation: API.OperationMethod<
   DeleteConfiguredAudienceModelAssociationInput,
   DeleteConfiguredAudienceModelAssociationOutput,
   DeleteConfiguredAudienceModelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredAudienceModelAssociationInput,
   output: DeleteConfiguredAudienceModelAssociationOutput,
@@ -7649,7 +7648,7 @@ export const deleteConfiguredTable: API.OperationMethod<
   DeleteConfiguredTableInput,
   DeleteConfiguredTableOutput,
   DeleteConfiguredTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredTableInput,
   output: DeleteConfiguredTableOutput,
@@ -7681,7 +7680,7 @@ export const deleteConfiguredTableAnalysisRule: API.OperationMethod<
   DeleteConfiguredTableAnalysisRuleInput,
   DeleteConfiguredTableAnalysisRuleOutput,
   DeleteConfiguredTableAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredTableAnalysisRuleInput,
   output: DeleteConfiguredTableAnalysisRuleOutput,
@@ -7713,7 +7712,7 @@ export const deleteConfiguredTableAssociation: API.OperationMethod<
   DeleteConfiguredTableAssociationInput,
   DeleteConfiguredTableAssociationOutput,
   DeleteConfiguredTableAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredTableAssociationInput,
   output: DeleteConfiguredTableAssociationOutput,
@@ -7745,7 +7744,7 @@ export const deleteConfiguredTableAssociationAnalysisRule: API.OperationMethod<
   DeleteConfiguredTableAssociationAnalysisRuleInput,
   DeleteConfiguredTableAssociationAnalysisRuleOutput,
   DeleteConfiguredTableAssociationAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredTableAssociationAnalysisRuleInput,
   output: DeleteConfiguredTableAssociationAnalysisRuleOutput,
@@ -7776,7 +7775,7 @@ export const deleteIdMappingTable: API.OperationMethod<
   DeleteIdMappingTableInput,
   DeleteIdMappingTableOutput,
   DeleteIdMappingTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdMappingTableInput,
   output: DeleteIdMappingTableOutput,
@@ -7806,7 +7805,7 @@ export const deleteIdNamespaceAssociation: API.OperationMethod<
   DeleteIdNamespaceAssociationInput,
   DeleteIdNamespaceAssociationOutput,
   DeleteIdNamespaceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdNamespaceAssociationInput,
   output: DeleteIdNamespaceAssociationOutput,
@@ -7837,7 +7836,7 @@ export const deleteMember: API.OperationMethod<
   DeleteMemberInput,
   DeleteMemberOutput,
   DeleteMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMemberInput,
   output: DeleteMemberOutput,
@@ -7869,7 +7868,7 @@ export const deleteMembership: API.OperationMethod<
   DeleteMembershipInput,
   DeleteMembershipOutput,
   DeleteMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMembershipInput,
   output: DeleteMembershipOutput,
@@ -7900,7 +7899,7 @@ export const deletePrivacyBudgetTemplate: API.OperationMethod<
   DeletePrivacyBudgetTemplateInput,
   DeletePrivacyBudgetTemplateOutput,
   DeletePrivacyBudgetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrivacyBudgetTemplateInput,
   output: DeletePrivacyBudgetTemplateOutput,
@@ -7930,7 +7929,7 @@ export const getAnalysisTemplate: API.OperationMethod<
   GetAnalysisTemplateInput,
   GetAnalysisTemplateOutput,
   GetAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnalysisTemplateInput,
   output: GetAnalysisTemplateOutput,
@@ -7959,7 +7958,7 @@ export const getCollaboration: API.OperationMethod<
   GetCollaborationInput,
   GetCollaborationOutput,
   GetCollaborationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationInput,
   output: GetCollaborationOutput,
@@ -7988,7 +7987,7 @@ export const getCollaborationAnalysisTemplate: API.OperationMethod<
   GetCollaborationAnalysisTemplateInput,
   GetCollaborationAnalysisTemplateOutput,
   GetCollaborationAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationAnalysisTemplateInput,
   output: GetCollaborationAnalysisTemplateOutput,
@@ -8018,7 +8017,7 @@ export const getCollaborationChangeRequest: API.OperationMethod<
   GetCollaborationChangeRequestInput,
   GetCollaborationChangeRequestOutput,
   GetCollaborationChangeRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationChangeRequestInput,
   output: GetCollaborationChangeRequestOutput,
@@ -8048,7 +8047,7 @@ export const getCollaborationConfiguredAudienceModelAssociation: API.OperationMe
   GetCollaborationConfiguredAudienceModelAssociationInput,
   GetCollaborationConfiguredAudienceModelAssociationOutput,
   GetCollaborationConfiguredAudienceModelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationConfiguredAudienceModelAssociationInput,
   output: GetCollaborationConfiguredAudienceModelAssociationOutput,
@@ -8078,7 +8077,7 @@ export const getCollaborationIdNamespaceAssociation: API.OperationMethod<
   GetCollaborationIdNamespaceAssociationInput,
   GetCollaborationIdNamespaceAssociationOutput,
   GetCollaborationIdNamespaceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationIdNamespaceAssociationInput,
   output: GetCollaborationIdNamespaceAssociationOutput,
@@ -8108,7 +8107,7 @@ export const getCollaborationPrivacyBudgetTemplate: API.OperationMethod<
   GetCollaborationPrivacyBudgetTemplateInput,
   GetCollaborationPrivacyBudgetTemplateOutput,
   GetCollaborationPrivacyBudgetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationPrivacyBudgetTemplateInput,
   output: GetCollaborationPrivacyBudgetTemplateOutput,
@@ -8138,7 +8137,7 @@ export const getConfiguredAudienceModelAssociation: API.OperationMethod<
   GetConfiguredAudienceModelAssociationInput,
   GetConfiguredAudienceModelAssociationOutput,
   GetConfiguredAudienceModelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredAudienceModelAssociationInput,
   output: GetConfiguredAudienceModelAssociationOutput,
@@ -8168,7 +8167,7 @@ export const getConfiguredTable: API.OperationMethod<
   GetConfiguredTableInput,
   GetConfiguredTableOutput,
   GetConfiguredTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredTableInput,
   output: GetConfiguredTableOutput,
@@ -8198,7 +8197,7 @@ export const getConfiguredTableAnalysisRule: API.OperationMethod<
   GetConfiguredTableAnalysisRuleInput,
   GetConfiguredTableAnalysisRuleOutput,
   GetConfiguredTableAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredTableAnalysisRuleInput,
   output: GetConfiguredTableAnalysisRuleOutput,
@@ -8228,7 +8227,7 @@ export const getConfiguredTableAssociation: API.OperationMethod<
   GetConfiguredTableAssociationInput,
   GetConfiguredTableAssociationOutput,
   GetConfiguredTableAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredTableAssociationInput,
   output: GetConfiguredTableAssociationOutput,
@@ -8258,7 +8257,7 @@ export const getConfiguredTableAssociationAnalysisRule: API.OperationMethod<
   GetConfiguredTableAssociationAnalysisRuleInput,
   GetConfiguredTableAssociationAnalysisRuleOutput,
   GetConfiguredTableAssociationAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredTableAssociationAnalysisRuleInput,
   output: GetConfiguredTableAssociationAnalysisRuleOutput,
@@ -8288,7 +8287,7 @@ export const getIdMappingTable: API.OperationMethod<
   GetIdMappingTableInput,
   GetIdMappingTableOutput,
   GetIdMappingTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdMappingTableInput,
   output: GetIdMappingTableOutput,
@@ -8318,7 +8317,7 @@ export const getIdNamespaceAssociation: API.OperationMethod<
   GetIdNamespaceAssociationInput,
   GetIdNamespaceAssociationOutput,
   GetIdNamespaceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdNamespaceAssociationInput,
   output: GetIdNamespaceAssociationOutput,
@@ -8348,7 +8347,7 @@ export const getMembership: API.OperationMethod<
   GetMembershipInput,
   GetMembershipOutput,
   GetMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMembershipInput,
   output: GetMembershipOutput,
@@ -8378,7 +8377,7 @@ export const getPrivacyBudgetTemplate: API.OperationMethod<
   GetPrivacyBudgetTemplateInput,
   GetPrivacyBudgetTemplateOutput,
   GetPrivacyBudgetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPrivacyBudgetTemplateInput,
   output: GetPrivacyBudgetTemplateOutput,
@@ -8408,7 +8407,7 @@ export const getProtectedJob: API.OperationMethod<
   GetProtectedJobInput,
   GetProtectedJobOutput,
   GetProtectedJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProtectedJobInput,
   output: GetProtectedJobOutput,
@@ -8438,7 +8437,7 @@ export const getProtectedQuery: API.OperationMethod<
   GetProtectedQueryInput,
   GetProtectedQueryOutput,
   GetProtectedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProtectedQueryInput,
   output: GetProtectedQueryOutput,
@@ -8468,7 +8467,7 @@ export const getSchema: API.OperationMethod<
   GetSchemaInput,
   GetSchemaOutput,
   GetSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaInput,
   output: GetSchemaOutput,
@@ -8498,7 +8497,7 @@ export const getSchemaAnalysisRule: API.OperationMethod<
   GetSchemaAnalysisRuleInput,
   GetSchemaAnalysisRuleOutput,
   GetSchemaAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaAnalysisRuleInput,
   output: GetSchemaAnalysisRuleOutput,
@@ -8528,7 +8527,7 @@ export const listAnalysisTemplates: API.PaginatedOperationMethod<
   ListAnalysisTemplatesInput,
   ListAnalysisTemplatesOutput,
   ListAnalysisTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalysisTemplatesInput,
@@ -8565,7 +8564,7 @@ export const listCollaborationAnalysisTemplates: API.PaginatedOperationMethod<
   ListCollaborationAnalysisTemplatesInput,
   ListCollaborationAnalysisTemplatesOutput,
   ListCollaborationAnalysisTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationAnalysisTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationAnalysisTemplatesInput,
@@ -8602,7 +8601,7 @@ export const listCollaborationChangeRequests: API.PaginatedOperationMethod<
   ListCollaborationChangeRequestsInput,
   ListCollaborationChangeRequestsOutput,
   ListCollaborationChangeRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationChangeRequestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationChangeRequestsInput,
@@ -8639,7 +8638,7 @@ export const listCollaborationConfiguredAudienceModelAssociations: API.Paginated
   ListCollaborationConfiguredAudienceModelAssociationsInput,
   ListCollaborationConfiguredAudienceModelAssociationsOutput,
   ListCollaborationConfiguredAudienceModelAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationConfiguredAudienceModelAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationConfiguredAudienceModelAssociationsInput,
@@ -8676,7 +8675,7 @@ export const listCollaborationIdNamespaceAssociations: API.PaginatedOperationMet
   ListCollaborationIdNamespaceAssociationsInput,
   ListCollaborationIdNamespaceAssociationsOutput,
   ListCollaborationIdNamespaceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationIdNamespaceAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationIdNamespaceAssociationsInput,
@@ -8713,7 +8712,7 @@ export const listCollaborationPrivacyBudgets: API.PaginatedOperationMethod<
   ListCollaborationPrivacyBudgetsInput,
   ListCollaborationPrivacyBudgetsOutput,
   ListCollaborationPrivacyBudgetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationPrivacyBudgetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationPrivacyBudgetsInput,
@@ -8750,7 +8749,7 @@ export const listCollaborationPrivacyBudgetTemplates: API.PaginatedOperationMeth
   ListCollaborationPrivacyBudgetTemplatesInput,
   ListCollaborationPrivacyBudgetTemplatesOutput,
   ListCollaborationPrivacyBudgetTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationPrivacyBudgetTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationPrivacyBudgetTemplatesInput,
@@ -8786,7 +8785,7 @@ export const listCollaborations: API.PaginatedOperationMethod<
   ListCollaborationsInput,
   ListCollaborationsOutput,
   ListCollaborationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationsInput,
@@ -8822,7 +8821,7 @@ export const listConfiguredAudienceModelAssociations: API.PaginatedOperationMeth
   ListConfiguredAudienceModelAssociationsInput,
   ListConfiguredAudienceModelAssociationsOutput,
   ListConfiguredAudienceModelAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredAudienceModelAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredAudienceModelAssociationsInput,
@@ -8859,7 +8858,7 @@ export const listConfiguredTableAssociations: API.PaginatedOperationMethod<
   ListConfiguredTableAssociationsInput,
   ListConfiguredTableAssociationsOutput,
   ListConfiguredTableAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredTableAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredTableAssociationsInput,
@@ -8895,7 +8894,7 @@ export const listConfiguredTables: API.PaginatedOperationMethod<
   ListConfiguredTablesInput,
   ListConfiguredTablesOutput,
   ListConfiguredTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredTableSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredTablesInput,
@@ -8931,7 +8930,7 @@ export const listIdMappingTables: API.PaginatedOperationMethod<
   ListIdMappingTablesInput,
   ListIdMappingTablesOutput,
   ListIdMappingTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdMappingTableSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdMappingTablesInput,
@@ -8968,7 +8967,7 @@ export const listIdNamespaceAssociations: API.PaginatedOperationMethod<
   ListIdNamespaceAssociationsInput,
   ListIdNamespaceAssociationsOutput,
   ListIdNamespaceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdNamespaceAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdNamespaceAssociationsInput,
@@ -9005,7 +9004,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersInput,
   ListMembersOutput,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemberSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersInput,
@@ -9041,7 +9040,7 @@ export const listMemberships: API.PaginatedOperationMethod<
   ListMembershipsInput,
   ListMembershipsOutput,
   ListMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MembershipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembershipsInput,
@@ -9077,7 +9076,7 @@ export const listPrivacyBudgets: API.PaginatedOperationMethod<
   ListPrivacyBudgetsInput,
   ListPrivacyBudgetsOutput,
   ListPrivacyBudgetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrivacyBudgetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrivacyBudgetsInput,
@@ -9114,7 +9113,7 @@ export const listPrivacyBudgetTemplates: API.PaginatedOperationMethod<
   ListPrivacyBudgetTemplatesInput,
   ListPrivacyBudgetTemplatesOutput,
   ListPrivacyBudgetTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrivacyBudgetTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrivacyBudgetTemplatesInput,
@@ -9151,7 +9150,7 @@ export const listProtectedJobs: API.PaginatedOperationMethod<
   ListProtectedJobsInput,
   ListProtectedJobsOutput,
   ListProtectedJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectedJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectedJobsInput,
@@ -9188,7 +9187,7 @@ export const listProtectedQueries: API.PaginatedOperationMethod<
   ListProtectedQueriesInput,
   ListProtectedQueriesOutput,
   ListProtectedQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectedQuerySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectedQueriesInput,
@@ -9225,7 +9224,7 @@ export const listSchemas: API.PaginatedOperationMethod<
   ListSchemasInput,
   ListSchemasOutput,
   ListSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemasInput,
@@ -9259,7 +9258,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -9285,7 +9284,7 @@ export const populateIdMappingTable: API.OperationMethod<
   PopulateIdMappingTableInput,
   PopulateIdMappingTableOutput,
   PopulateIdMappingTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PopulateIdMappingTableInput,
   output: PopulateIdMappingTableOutput,
@@ -9317,7 +9316,7 @@ export const previewPrivacyImpact: API.OperationMethod<
   PreviewPrivacyImpactInput,
   PreviewPrivacyImpactOutput,
   PreviewPrivacyImpactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PreviewPrivacyImpactInput,
   output: PreviewPrivacyImpactOutput,
@@ -9348,7 +9347,7 @@ export const startProtectedJob: API.OperationMethod<
   StartProtectedJobInput,
   StartProtectedJobOutput,
   StartProtectedJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProtectedJobInput,
   output: StartProtectedJobOutput,
@@ -9380,7 +9379,7 @@ export const startProtectedQuery: API.OperationMethod<
   StartProtectedQueryInput,
   StartProtectedQueryOutput,
   StartProtectedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProtectedQueryInput,
   output: StartProtectedQueryOutput,
@@ -9408,7 +9407,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -9429,7 +9428,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -9453,7 +9452,7 @@ export const updateAnalysisTemplate: API.OperationMethod<
   UpdateAnalysisTemplateInput,
   UpdateAnalysisTemplateOutput,
   UpdateAnalysisTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnalysisTemplateInput,
   output: UpdateAnalysisTemplateOutput,
@@ -9482,7 +9481,7 @@ export const updateCollaboration: API.OperationMethod<
   UpdateCollaborationInput,
   UpdateCollaborationOutput,
   UpdateCollaborationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCollaborationInput,
   output: UpdateCollaborationOutput,
@@ -9514,7 +9513,7 @@ export const updateCollaborationChangeRequest: API.OperationMethod<
   UpdateCollaborationChangeRequestInput,
   UpdateCollaborationChangeRequestOutput,
   UpdateCollaborationChangeRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCollaborationChangeRequestInput,
   output: UpdateCollaborationChangeRequestOutput,
@@ -9545,7 +9544,7 @@ export const updateConfiguredAudienceModelAssociation: API.OperationMethod<
   UpdateConfiguredAudienceModelAssociationInput,
   UpdateConfiguredAudienceModelAssociationOutput,
   UpdateConfiguredAudienceModelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredAudienceModelAssociationInput,
   output: UpdateConfiguredAudienceModelAssociationOutput,
@@ -9577,7 +9576,7 @@ export const updateConfiguredTable: API.OperationMethod<
   UpdateConfiguredTableInput,
   UpdateConfiguredTableOutput,
   UpdateConfiguredTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredTableInput,
   output: UpdateConfiguredTableOutput,
@@ -9610,7 +9609,7 @@ export const updateConfiguredTableAnalysisRule: API.OperationMethod<
   UpdateConfiguredTableAnalysisRuleInput,
   UpdateConfiguredTableAnalysisRuleOutput,
   UpdateConfiguredTableAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredTableAnalysisRuleInput,
   output: UpdateConfiguredTableAnalysisRuleOutput,
@@ -9642,7 +9641,7 @@ export const updateConfiguredTableAssociation: API.OperationMethod<
   UpdateConfiguredTableAssociationInput,
   UpdateConfiguredTableAssociationOutput,
   UpdateConfiguredTableAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredTableAssociationInput,
   output: UpdateConfiguredTableAssociationOutput,
@@ -9674,7 +9673,7 @@ export const updateConfiguredTableAssociationAnalysisRule: API.OperationMethod<
   UpdateConfiguredTableAssociationAnalysisRuleInput,
   UpdateConfiguredTableAssociationAnalysisRuleOutput,
   UpdateConfiguredTableAssociationAnalysisRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredTableAssociationAnalysisRuleInput,
   output: UpdateConfiguredTableAssociationAnalysisRuleOutput,
@@ -9705,7 +9704,7 @@ export const updateIdMappingTable: API.OperationMethod<
   UpdateIdMappingTableInput,
   UpdateIdMappingTableOutput,
   UpdateIdMappingTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdMappingTableInput,
   output: UpdateIdMappingTableOutput,
@@ -9735,7 +9734,7 @@ export const updateIdNamespaceAssociation: API.OperationMethod<
   UpdateIdNamespaceAssociationInput,
   UpdateIdNamespaceAssociationOutput,
   UpdateIdNamespaceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdNamespaceAssociationInput,
   output: UpdateIdNamespaceAssociationOutput,
@@ -9766,7 +9765,7 @@ export const updateMembership: API.OperationMethod<
   UpdateMembershipInput,
   UpdateMembershipOutput,
   UpdateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMembershipInput,
   output: UpdateMembershipOutput,
@@ -9798,7 +9797,7 @@ export const updatePrivacyBudgetTemplate: API.OperationMethod<
   UpdatePrivacyBudgetTemplateInput,
   UpdatePrivacyBudgetTemplateOutput,
   UpdatePrivacyBudgetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrivacyBudgetTemplateInput,
   output: UpdatePrivacyBudgetTemplateOutput,
@@ -9830,7 +9829,7 @@ export const updateProtectedJob: API.OperationMethod<
   UpdateProtectedJobInput,
   UpdateProtectedJobOutput,
   UpdateProtectedJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProtectedJobInput,
   output: UpdateProtectedJobOutput,
@@ -9862,7 +9861,7 @@ export const updateProtectedQuery: API.OperationMethod<
   UpdateProtectedQueryInput,
   UpdateProtectedQueryOutput,
   UpdateProtectedQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProtectedQueryInput,
   output: UpdateProtectedQueryOutput,

--- a/packages/aws/src/services/cleanroomsml.ts
+++ b/packages/aws/src/services/cleanroomsml.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CleanRoomsML",
   serviceShapeName: "AWSStarkControlService",
@@ -4392,7 +4391,7 @@ export const cancelTrainedModel: API.OperationMethod<
   CancelTrainedModelRequest,
   CancelTrainedModelResponse,
   CancelTrainedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTrainedModelRequest,
   output: CancelTrainedModelResponse,
@@ -4422,7 +4421,7 @@ export const cancelTrainedModelInferenceJob: API.OperationMethod<
   CancelTrainedModelInferenceJobRequest,
   CancelTrainedModelInferenceJobResponse,
   CancelTrainedModelInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTrainedModelInferenceJobRequest,
   output: CancelTrainedModelInferenceJobResponse,
@@ -4452,7 +4451,7 @@ export const createAudienceModel: API.OperationMethod<
   CreateAudienceModelRequest,
   CreateAudienceModelResponse,
   CreateAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAudienceModelRequest,
   output: CreateAudienceModelResponse,
@@ -4482,7 +4481,7 @@ export const createConfiguredAudienceModel: API.OperationMethod<
   CreateConfiguredAudienceModelRequest,
   CreateConfiguredAudienceModelResponse,
   CreateConfiguredAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredAudienceModelRequest,
   output: CreateConfiguredAudienceModelResponse,
@@ -4511,7 +4510,7 @@ export const createConfiguredModelAlgorithm: API.OperationMethod<
   CreateConfiguredModelAlgorithmRequest,
   CreateConfiguredModelAlgorithmResponse,
   CreateConfiguredModelAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredModelAlgorithmRequest,
   output: CreateConfiguredModelAlgorithmResponse,
@@ -4541,7 +4540,7 @@ export const createConfiguredModelAlgorithmAssociation: API.OperationMethod<
   CreateConfiguredModelAlgorithmAssociationRequest,
   CreateConfiguredModelAlgorithmAssociationResponse,
   CreateConfiguredModelAlgorithmAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfiguredModelAlgorithmAssociationRequest,
   output: CreateConfiguredModelAlgorithmAssociationResponse,
@@ -4573,7 +4572,7 @@ export const createMLInputChannel: API.OperationMethod<
   CreateMLInputChannelRequest,
   CreateMLInputChannelResponse,
   CreateMLInputChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMLInputChannelRequest,
   output: CreateMLInputChannelResponse,
@@ -4606,7 +4605,7 @@ export const createTrainedModel: API.OperationMethod<
   CreateTrainedModelRequest,
   CreateTrainedModelResponse,
   CreateTrainedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrainedModelRequest,
   output: CreateTrainedModelResponse,
@@ -4636,7 +4635,7 @@ export const createTrainingDataset: API.OperationMethod<
   CreateTrainingDatasetRequest,
   CreateTrainingDatasetResponse,
   CreateTrainingDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrainingDatasetRequest,
   output: CreateTrainingDatasetResponse,
@@ -4659,7 +4658,7 @@ export const deleteAudienceGenerationJob: API.OperationMethod<
   DeleteAudienceGenerationJobRequest,
   DeleteAudienceGenerationJobResponse,
   DeleteAudienceGenerationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAudienceGenerationJobRequest,
   output: DeleteAudienceGenerationJobResponse,
@@ -4687,7 +4686,7 @@ export const deleteAudienceModel: API.OperationMethod<
   DeleteAudienceModelRequest,
   DeleteAudienceModelResponse,
   DeleteAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAudienceModelRequest,
   output: DeleteAudienceModelResponse,
@@ -4715,7 +4714,7 @@ export const deleteConfiguredAudienceModel: API.OperationMethod<
   DeleteConfiguredAudienceModelRequest,
   DeleteConfiguredAudienceModelResponse,
   DeleteConfiguredAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredAudienceModelRequest,
   output: DeleteConfiguredAudienceModelResponse,
@@ -4742,7 +4741,7 @@ export const deleteConfiguredAudienceModelPolicy: API.OperationMethod<
   DeleteConfiguredAudienceModelPolicyRequest,
   DeleteConfiguredAudienceModelPolicyResponse,
   DeleteConfiguredAudienceModelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredAudienceModelPolicyRequest,
   output: DeleteConfiguredAudienceModelPolicyResponse,
@@ -4769,7 +4768,7 @@ export const deleteConfiguredModelAlgorithm: API.OperationMethod<
   DeleteConfiguredModelAlgorithmRequest,
   DeleteConfiguredModelAlgorithmResponse,
   DeleteConfiguredModelAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredModelAlgorithmRequest,
   output: DeleteConfiguredModelAlgorithmResponse,
@@ -4798,7 +4797,7 @@ export const deleteConfiguredModelAlgorithmAssociation: API.OperationMethod<
   DeleteConfiguredModelAlgorithmAssociationRequest,
   DeleteConfiguredModelAlgorithmAssociationResponse,
   DeleteConfiguredModelAlgorithmAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfiguredModelAlgorithmAssociationRequest,
   output: DeleteConfiguredModelAlgorithmAssociationResponse,
@@ -4827,7 +4826,7 @@ export const deleteMLConfiguration: API.OperationMethod<
   DeleteMLConfigurationRequest,
   DeleteMLConfigurationResponse,
   DeleteMLConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMLConfigurationRequest,
   output: DeleteMLConfigurationResponse,
@@ -4856,7 +4855,7 @@ export const deleteMLInputChannelData: API.OperationMethod<
   DeleteMLInputChannelDataRequest,
   DeleteMLInputChannelDataResponse,
   DeleteMLInputChannelDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMLInputChannelDataRequest,
   output: DeleteMLInputChannelDataResponse,
@@ -4886,7 +4885,7 @@ export const deleteTrainedModelOutput: API.OperationMethod<
   DeleteTrainedModelOutputRequest,
   DeleteTrainedModelOutputResponse,
   DeleteTrainedModelOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrainedModelOutputRequest,
   output: DeleteTrainedModelOutputResponse,
@@ -4915,7 +4914,7 @@ export const deleteTrainingDataset: API.OperationMethod<
   DeleteTrainingDatasetRequest,
   DeleteTrainingDatasetResponse,
   DeleteTrainingDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrainingDatasetRequest,
   output: DeleteTrainingDatasetResponse,
@@ -4942,7 +4941,7 @@ export const getAudienceGenerationJob: API.OperationMethod<
   GetAudienceGenerationJobRequest,
   GetAudienceGenerationJobResponse,
   GetAudienceGenerationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAudienceGenerationJobRequest,
   output: GetAudienceGenerationJobResponse,
@@ -4968,7 +4967,7 @@ export const getAudienceModel: API.OperationMethod<
   GetAudienceModelRequest,
   GetAudienceModelResponse,
   GetAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAudienceModelRequest,
   output: GetAudienceModelResponse,
@@ -4995,7 +4994,7 @@ export const getCollaborationConfiguredModelAlgorithmAssociation: API.OperationM
   GetCollaborationConfiguredModelAlgorithmAssociationRequest,
   GetCollaborationConfiguredModelAlgorithmAssociationResponse,
   GetCollaborationConfiguredModelAlgorithmAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationConfiguredModelAlgorithmAssociationRequest,
   output: GetCollaborationConfiguredModelAlgorithmAssociationResponse,
@@ -5023,7 +5022,7 @@ export const getCollaborationMLInputChannel: API.OperationMethod<
   GetCollaborationMLInputChannelRequest,
   GetCollaborationMLInputChannelResponse,
   GetCollaborationMLInputChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationMLInputChannelRequest,
   output: GetCollaborationMLInputChannelResponse,
@@ -5051,7 +5050,7 @@ export const getCollaborationTrainedModel: API.OperationMethod<
   GetCollaborationTrainedModelRequest,
   GetCollaborationTrainedModelResponse,
   GetCollaborationTrainedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCollaborationTrainedModelRequest,
   output: GetCollaborationTrainedModelResponse,
@@ -5078,7 +5077,7 @@ export const getConfiguredAudienceModel: API.OperationMethod<
   GetConfiguredAudienceModelRequest,
   GetConfiguredAudienceModelResponse,
   GetConfiguredAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredAudienceModelRequest,
   output: GetConfiguredAudienceModelResponse,
@@ -5104,7 +5103,7 @@ export const getConfiguredAudienceModelPolicy: API.OperationMethod<
   GetConfiguredAudienceModelPolicyRequest,
   GetConfiguredAudienceModelPolicyResponse,
   GetConfiguredAudienceModelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredAudienceModelPolicyRequest,
   output: GetConfiguredAudienceModelPolicyResponse,
@@ -5130,7 +5129,7 @@ export const getConfiguredModelAlgorithm: API.OperationMethod<
   GetConfiguredModelAlgorithmRequest,
   GetConfiguredModelAlgorithmResponse,
   GetConfiguredModelAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredModelAlgorithmRequest,
   output: GetConfiguredModelAlgorithmResponse,
@@ -5157,7 +5156,7 @@ export const getConfiguredModelAlgorithmAssociation: API.OperationMethod<
   GetConfiguredModelAlgorithmAssociationRequest,
   GetConfiguredModelAlgorithmAssociationResponse,
   GetConfiguredModelAlgorithmAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfiguredModelAlgorithmAssociationRequest,
   output: GetConfiguredModelAlgorithmAssociationResponse,
@@ -5185,7 +5184,7 @@ export const getMLConfiguration: API.OperationMethod<
   GetMLConfigurationRequest,
   GetMLConfigurationResponse,
   GetMLConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLConfigurationRequest,
   output: GetMLConfigurationResponse,
@@ -5213,7 +5212,7 @@ export const getMLInputChannel: API.OperationMethod<
   GetMLInputChannelRequest,
   GetMLInputChannelResponse,
   GetMLInputChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLInputChannelRequest,
   output: GetMLInputChannelResponse,
@@ -5241,7 +5240,7 @@ export const getTrainedModel: API.OperationMethod<
   GetTrainedModelRequest,
   GetTrainedModelResponse,
   GetTrainedModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrainedModelRequest,
   output: GetTrainedModelResponse,
@@ -5269,7 +5268,7 @@ export const getTrainedModelInferenceJob: API.OperationMethod<
   GetTrainedModelInferenceJobRequest,
   GetTrainedModelInferenceJobResponse,
   GetTrainedModelInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrainedModelInferenceJobRequest,
   output: GetTrainedModelInferenceJobResponse,
@@ -5296,7 +5295,7 @@ export const getTrainingDataset: API.OperationMethod<
   GetTrainingDatasetRequest,
   GetTrainingDatasetResponse,
   GetTrainingDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrainingDatasetRequest,
   output: GetTrainingDatasetResponse,
@@ -5321,7 +5320,7 @@ export const listAudienceExportJobs: API.PaginatedOperationMethod<
   ListAudienceExportJobsRequest,
   ListAudienceExportJobsResponse,
   ListAudienceExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AudienceExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAudienceExportJobsRequest,
@@ -5349,7 +5348,7 @@ export const listAudienceGenerationJobs: API.PaginatedOperationMethod<
   ListAudienceGenerationJobsRequest,
   ListAudienceGenerationJobsResponse,
   ListAudienceGenerationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AudienceGenerationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAudienceGenerationJobsRequest,
@@ -5377,7 +5376,7 @@ export const listAudienceModels: API.PaginatedOperationMethod<
   ListAudienceModelsRequest,
   ListAudienceModelsResponse,
   ListAudienceModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AudienceModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAudienceModelsRequest,
@@ -5406,7 +5405,7 @@ export const listCollaborationConfiguredModelAlgorithmAssociations: API.Paginate
   ListCollaborationConfiguredModelAlgorithmAssociationsRequest,
   ListCollaborationConfiguredModelAlgorithmAssociationsResponse,
   ListCollaborationConfiguredModelAlgorithmAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationConfiguredModelAlgorithmAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationConfiguredModelAlgorithmAssociationsRequest,
@@ -5435,7 +5434,7 @@ export const listCollaborationMLInputChannels: API.PaginatedOperationMethod<
   ListCollaborationMLInputChannelsRequest,
   ListCollaborationMLInputChannelsResponse,
   ListCollaborationMLInputChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationMLInputChannelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationMLInputChannelsRequest,
@@ -5464,7 +5463,7 @@ export const listCollaborationTrainedModelExportJobs: API.PaginatedOperationMeth
   ListCollaborationTrainedModelExportJobsRequest,
   ListCollaborationTrainedModelExportJobsResponse,
   ListCollaborationTrainedModelExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationTrainedModelExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationTrainedModelExportJobsRequest,
@@ -5493,7 +5492,7 @@ export const listCollaborationTrainedModelInferenceJobs: API.PaginatedOperationM
   ListCollaborationTrainedModelInferenceJobsRequest,
   ListCollaborationTrainedModelInferenceJobsResponse,
   ListCollaborationTrainedModelInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationTrainedModelInferenceJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationTrainedModelInferenceJobsRequest,
@@ -5522,7 +5521,7 @@ export const listCollaborationTrainedModels: API.PaginatedOperationMethod<
   ListCollaborationTrainedModelsRequest,
   ListCollaborationTrainedModelsResponse,
   ListCollaborationTrainedModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollaborationTrainedModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollaborationTrainedModelsRequest,
@@ -5550,7 +5549,7 @@ export const listConfiguredAudienceModels: API.PaginatedOperationMethod<
   ListConfiguredAudienceModelsRequest,
   ListConfiguredAudienceModelsResponse,
   ListConfiguredAudienceModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredAudienceModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredAudienceModelsRequest,
@@ -5579,7 +5578,7 @@ export const listConfiguredModelAlgorithmAssociations: API.PaginatedOperationMet
   ListConfiguredModelAlgorithmAssociationsRequest,
   ListConfiguredModelAlgorithmAssociationsResponse,
   ListConfiguredModelAlgorithmAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredModelAlgorithmAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredModelAlgorithmAssociationsRequest,
@@ -5607,7 +5606,7 @@ export const listConfiguredModelAlgorithms: API.PaginatedOperationMethod<
   ListConfiguredModelAlgorithmsRequest,
   ListConfiguredModelAlgorithmsResponse,
   ListConfiguredModelAlgorithmsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfiguredModelAlgorithmSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfiguredModelAlgorithmsRequest,
@@ -5636,7 +5635,7 @@ export const listMLInputChannels: API.PaginatedOperationMethod<
   ListMLInputChannelsRequest,
   ListMLInputChannelsResponse,
   ListMLInputChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MLInputChannelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMLInputChannelsRequest,
@@ -5665,7 +5664,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5691,7 +5690,7 @@ export const listTrainedModelInferenceJobs: API.PaginatedOperationMethod<
   ListTrainedModelInferenceJobsRequest,
   ListTrainedModelInferenceJobsResponse,
   ListTrainedModelInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainedModelInferenceJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainedModelInferenceJobsRequest,
@@ -5720,7 +5719,7 @@ export const listTrainedModels: API.PaginatedOperationMethod<
   ListTrainedModelsRequest,
   ListTrainedModelsResponse,
   ListTrainedModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainedModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainedModelsRequest,
@@ -5750,7 +5749,7 @@ export const listTrainedModelVersions: API.PaginatedOperationMethod<
   ListTrainedModelVersionsRequest,
   ListTrainedModelVersionsResponse,
   ListTrainedModelVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainedModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainedModelVersionsRequest,
@@ -5783,7 +5782,7 @@ export const listTrainingDatasets: API.PaginatedOperationMethod<
   ListTrainingDatasetsRequest,
   ListTrainingDatasetsResponse,
   ListTrainingDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainingDatasetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainingDatasetsRequest,
@@ -5812,7 +5811,7 @@ export const putConfiguredAudienceModelPolicy: API.OperationMethod<
   PutConfiguredAudienceModelPolicyRequest,
   PutConfiguredAudienceModelPolicyResponse,
   PutConfiguredAudienceModelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfiguredAudienceModelPolicyRequest,
   output: PutConfiguredAudienceModelPolicyResponse,
@@ -5838,7 +5837,7 @@ export const putMLConfiguration: API.OperationMethod<
   PutMLConfigurationRequest,
   PutMLConfigurationResponse,
   PutMLConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMLConfigurationRequest,
   output: PutMLConfigurationResponse,
@@ -5862,7 +5861,7 @@ export const startAudienceExportJob: API.OperationMethod<
   StartAudienceExportJobRequest,
   StartAudienceExportJobResponse,
   StartAudienceExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAudienceExportJobRequest,
   output: StartAudienceExportJobResponse,
@@ -5893,7 +5892,7 @@ export const startAudienceGenerationJob: API.OperationMethod<
   StartAudienceGenerationJobRequest,
   StartAudienceGenerationJobResponse,
   StartAudienceGenerationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAudienceGenerationJobRequest,
   output: StartAudienceGenerationJobResponse,
@@ -5924,7 +5923,7 @@ export const startTrainedModelExportJob: API.OperationMethod<
   StartTrainedModelExportJobRequest,
   StartTrainedModelExportJobResponse,
   StartTrainedModelExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTrainedModelExportJobRequest,
   output: StartTrainedModelExportJobResponse,
@@ -5955,7 +5954,7 @@ export const startTrainedModelInferenceJob: API.OperationMethod<
   StartTrainedModelInferenceJobRequest,
   StartTrainedModelInferenceJobResponse,
   StartTrainedModelInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTrainedModelInferenceJobRequest,
   output: StartTrainedModelInferenceJobResponse,
@@ -5984,7 +5983,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6010,7 +6009,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6037,7 +6036,7 @@ export const updateConfiguredAudienceModel: API.OperationMethod<
   UpdateConfiguredAudienceModelRequest,
   UpdateConfiguredAudienceModelResponse,
   UpdateConfiguredAudienceModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfiguredAudienceModelRequest,
   output: UpdateConfiguredAudienceModelResponse,

--- a/packages/aws/src/services/cloud9.ts
+++ b/packages/aws/src/services/cloud9.ts
@@ -7,7 +7,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Cloud9",
@@ -612,7 +611,7 @@ export const createEnvironmentEC2: API.OperationMethod<
   CreateEnvironmentEC2Request,
   CreateEnvironmentEC2Result,
   CreateEnvironmentEC2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentEC2Request,
   output: CreateEnvironmentEC2Result,
@@ -650,7 +649,7 @@ export const createEnvironmentMembership: API.OperationMethod<
   CreateEnvironmentMembershipRequest,
   CreateEnvironmentMembershipResult,
   CreateEnvironmentMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentMembershipRequest,
   output: CreateEnvironmentMembershipResult,
@@ -689,7 +688,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResult,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResult,
@@ -727,7 +726,7 @@ export const deleteEnvironmentMembership: API.OperationMethod<
   DeleteEnvironmentMembershipRequest,
   DeleteEnvironmentMembershipResult,
   DeleteEnvironmentMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentMembershipRequest,
   output: DeleteEnvironmentMembershipResult,
@@ -765,7 +764,7 @@ export const describeEnvironmentMemberships: API.PaginatedOperationMethod<
   DescribeEnvironmentMembershipsRequest,
   DescribeEnvironmentMembershipsResult,
   DescribeEnvironmentMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEnvironmentMembershipsRequest,
@@ -809,7 +808,7 @@ export const describeEnvironments: API.OperationMethod<
   DescribeEnvironmentsRequest,
   DescribeEnvironmentsResult,
   DescribeEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentsRequest,
   output: DescribeEnvironmentsResult,
@@ -847,7 +846,7 @@ export const describeEnvironmentStatus: API.OperationMethod<
   DescribeEnvironmentStatusRequest,
   DescribeEnvironmentStatusResult,
   DescribeEnvironmentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentStatusRequest,
   output: DescribeEnvironmentStatusResult,
@@ -889,7 +888,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResult,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -929,7 +928,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -963,7 +962,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -995,7 +994,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1030,7 +1029,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentRequest,
   UpdateEnvironmentResult,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentRequest,
   output: UpdateEnvironmentResult,
@@ -1069,7 +1068,7 @@ export const updateEnvironmentMembership: API.OperationMethod<
   UpdateEnvironmentMembershipRequest,
   UpdateEnvironmentMembershipResult,
   UpdateEnvironmentMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentMembershipRequest,
   output: UpdateEnvironmentMembershipResult,

--- a/packages/aws/src/services/cloudcontrol.ts
+++ b/packages/aws/src/services/cloudcontrol.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudControl",
@@ -668,7 +667,7 @@ export const cancelResourceRequest: API.OperationMethod<
   CancelResourceRequestInput,
   CancelResourceRequestOutput,
   CancelResourceRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelResourceRequestInput,
   output: CancelResourceRequestOutput,
@@ -711,7 +710,7 @@ export const createResource: API.OperationMethod<
   CreateResourceInput,
   CreateResourceOutput,
   CreateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceInput,
   output: CreateResourceOutput,
@@ -774,7 +773,7 @@ export const deleteResource: API.OperationMethod<
   DeleteResourceInput,
   DeleteResourceOutput,
   DeleteResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceInput,
   output: DeleteResourceOutput,
@@ -834,7 +833,7 @@ export const getResource: API.OperationMethod<
   GetResourceInput,
   GetResourceOutput,
   GetResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceInput,
   output: GetResourceOutput,
@@ -874,7 +873,7 @@ export const getResourceRequestStatus: API.OperationMethod<
   GetResourceRequestStatusInput,
   GetResourceRequestStatusOutput,
   GetResourceRequestStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceRequestStatusInput,
   output: GetResourceRequestStatusOutput,
@@ -896,7 +895,7 @@ export const listResourceRequests: API.PaginatedOperationMethod<
   ListResourceRequestsInput,
   ListResourceRequestsOutput,
   ListResourceRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProgressEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceRequestsInput,
@@ -942,7 +941,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesInput,
   ListResourcesOutput,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesInput,
@@ -1020,7 +1019,7 @@ export const updateResource: API.OperationMethod<
   UpdateResourceInput,
   UpdateResourceOutput,
   UpdateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceInput,
   output: UpdateResourceOutput,

--- a/packages/aws/src/services/clouddirectory.ts
+++ b/packages/aws/src/services/clouddirectory.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudDirectory",
   serviceShapeName: "AmazonCloudDirectory_20170111",
@@ -4104,7 +4103,7 @@ export const addFacetToObject: API.OperationMethod<
   AddFacetToObjectRequest,
   AddFacetToObjectResponse,
   AddFacetToObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddFacetToObjectRequest,
   output: AddFacetToObjectResponse,
@@ -4143,7 +4142,7 @@ export const applySchema: API.OperationMethod<
   ApplySchemaRequest,
   ApplySchemaResponse,
   ApplySchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplySchemaRequest,
   output: ApplySchemaResponse,
@@ -4188,7 +4187,7 @@ export const attachObject: API.OperationMethod<
   AttachObjectRequest,
   AttachObjectResponse,
   AttachObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachObjectRequest,
   output: AttachObjectResponse,
@@ -4229,7 +4228,7 @@ export const attachPolicy: API.OperationMethod<
   AttachPolicyRequest,
   AttachPolicyResponse,
   AttachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachPolicyRequest,
   output: AttachPolicyResponse,
@@ -4270,7 +4269,7 @@ export const attachToIndex: API.OperationMethod<
   AttachToIndexRequest,
   AttachToIndexResponse,
   AttachToIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachToIndexRequest,
   output: AttachToIndexResponse,
@@ -4312,7 +4311,7 @@ export const attachTypedLink: API.OperationMethod<
   AttachTypedLinkRequest,
   AttachTypedLinkResponse,
   AttachTypedLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachTypedLinkRequest,
   output: AttachTypedLinkResponse,
@@ -4349,7 +4348,7 @@ export const batchRead: API.OperationMethod<
   BatchReadRequest,
   BatchReadResponse,
   BatchReadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchReadRequest,
   output: BatchReadResponse,
@@ -4385,7 +4384,7 @@ export const batchWrite: API.OperationMethod<
   BatchWriteRequest,
   BatchWriteResponse,
   BatchWriteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchWriteRequest,
   output: BatchWriteResponse,
@@ -4425,7 +4424,7 @@ export const createDirectory: API.OperationMethod<
   CreateDirectoryRequest,
   CreateDirectoryResponse,
   CreateDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectoryRequest,
   output: CreateDirectoryResponse,
@@ -4464,7 +4463,7 @@ export const createFacet: API.OperationMethod<
   CreateFacetRequest,
   CreateFacetResponse,
   CreateFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFacetRequest,
   output: CreateFacetResponse,
@@ -4505,7 +4504,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexRequest,
   CreateIndexResponse,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
@@ -4550,7 +4549,7 @@ export const createObject: API.OperationMethod<
   CreateObjectRequest,
   CreateObjectResponse,
   CreateObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateObjectRequest,
   output: CreateObjectResponse,
@@ -4600,7 +4599,7 @@ export const createSchema: API.OperationMethod<
   CreateSchemaRequest,
   CreateSchemaResponse,
   CreateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchemaRequest,
   output: CreateSchemaResponse,
@@ -4637,7 +4636,7 @@ export const createTypedLinkFacet: API.OperationMethod<
   CreateTypedLinkFacetRequest,
   CreateTypedLinkFacetResponse,
   CreateTypedLinkFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTypedLinkFacetRequest,
   output: CreateTypedLinkFacetResponse,
@@ -4678,7 +4677,7 @@ export const deleteDirectory: API.OperationMethod<
   DeleteDirectoryRequest,
   DeleteDirectoryResponse,
   DeleteDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectoryRequest,
   output: DeleteDirectoryResponse,
@@ -4718,7 +4717,7 @@ export const deleteFacet: API.OperationMethod<
   DeleteFacetRequest,
   DeleteFacetResponse,
   DeleteFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFacetRequest,
   output: DeleteFacetResponse,
@@ -4757,7 +4756,7 @@ export const deleteObject: API.OperationMethod<
   DeleteObjectRequest,
   DeleteObjectResponse,
   DeleteObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectRequest,
   output: DeleteObjectResponse,
@@ -4794,7 +4793,7 @@ export const deleteSchema: API.OperationMethod<
   DeleteSchemaRequest,
   DeleteSchemaResponse,
   DeleteSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaRequest,
   output: DeleteSchemaResponse,
@@ -4830,7 +4829,7 @@ export const deleteTypedLinkFacet: API.OperationMethod<
   DeleteTypedLinkFacetRequest,
   DeleteTypedLinkFacetResponse,
   DeleteTypedLinkFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTypedLinkFacetRequest,
   output: DeleteTypedLinkFacetResponse,
@@ -4868,7 +4867,7 @@ export const detachFromIndex: API.OperationMethod<
   DetachFromIndexRequest,
   DetachFromIndexResponse,
   DetachFromIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachFromIndexRequest,
   output: DetachFromIndexResponse,
@@ -4908,7 +4907,7 @@ export const detachObject: API.OperationMethod<
   DetachObjectRequest,
   DetachObjectResponse,
   DetachObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachObjectRequest,
   output: DetachObjectResponse,
@@ -4946,7 +4945,7 @@ export const detachPolicy: API.OperationMethod<
   DetachPolicyRequest,
   DetachPolicyResponse,
   DetachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachPolicyRequest,
   output: DetachPolicyResponse,
@@ -4984,7 +4983,7 @@ export const detachTypedLink: API.OperationMethod<
   DetachTypedLinkRequest,
   DetachTypedLinkResponse,
   DetachTypedLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachTypedLinkRequest,
   output: DetachTypedLinkResponse,
@@ -5022,7 +5021,7 @@ export const disableDirectory: API.OperationMethod<
   DisableDirectoryRequest,
   DisableDirectoryResponse,
   DisableDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDirectoryRequest,
   output: DisableDirectoryResponse,
@@ -5059,7 +5058,7 @@ export const enableDirectory: API.OperationMethod<
   EnableDirectoryRequest,
   EnableDirectoryResponse,
   EnableDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDirectoryRequest,
   output: EnableDirectoryResponse,
@@ -5094,7 +5093,7 @@ export const getAppliedSchemaVersion: API.OperationMethod<
   GetAppliedSchemaVersionRequest,
   GetAppliedSchemaVersionResponse,
   GetAppliedSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppliedSchemaVersionRequest,
   output: GetAppliedSchemaVersionResponse,
@@ -5127,7 +5126,7 @@ export const getDirectory: API.OperationMethod<
   GetDirectoryRequest,
   GetDirectoryResponse,
   GetDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDirectoryRequest,
   output: GetDirectoryResponse,
@@ -5162,7 +5161,7 @@ export const getFacet: API.OperationMethod<
   GetFacetRequest,
   GetFacetResponse,
   GetFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFacetRequest,
   output: GetFacetResponse,
@@ -5199,7 +5198,7 @@ export const getLinkAttributes: API.OperationMethod<
   GetLinkAttributesRequest,
   GetLinkAttributesResponse,
   GetLinkAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkAttributesRequest,
   output: GetLinkAttributesResponse,
@@ -5237,7 +5236,7 @@ export const getObjectAttributes: API.OperationMethod<
   GetObjectAttributesRequest,
   GetObjectAttributesResponse,
   GetObjectAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectAttributesRequest,
   output: GetObjectAttributesResponse,
@@ -5274,7 +5273,7 @@ export const getObjectInformation: API.OperationMethod<
   GetObjectInformationRequest,
   GetObjectInformationResponse,
   GetObjectInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectInformationRequest,
   output: GetObjectInformationResponse,
@@ -5309,7 +5308,7 @@ export const getSchemaAsJson: API.OperationMethod<
   GetSchemaAsJsonRequest,
   GetSchemaAsJsonResponse,
   GetSchemaAsJsonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaAsJsonRequest,
   output: GetSchemaAsJsonResponse,
@@ -5345,7 +5344,7 @@ export const getTypedLinkFacetInformation: API.OperationMethod<
   GetTypedLinkFacetInformationRequest,
   GetTypedLinkFacetInformationResponse,
   GetTypedLinkFacetInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTypedLinkFacetInformationRequest,
   output: GetTypedLinkFacetInformationResponse,
@@ -5382,7 +5381,7 @@ export const listAppliedSchemaArns: API.PaginatedOperationMethod<
   ListAppliedSchemaArnsRequest,
   ListAppliedSchemaArnsResponse,
   ListAppliedSchemaArnsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppliedSchemaArnsRequest,
@@ -5424,7 +5423,7 @@ export const listAttachedIndices: API.PaginatedOperationMethod<
   ListAttachedIndicesRequest,
   ListAttachedIndicesResponse,
   ListAttachedIndicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedIndicesRequest,
@@ -5467,7 +5466,7 @@ export const listDevelopmentSchemaArns: API.PaginatedOperationMethod<
   ListDevelopmentSchemaArnsRequest,
   ListDevelopmentSchemaArnsResponse,
   ListDevelopmentSchemaArnsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevelopmentSchemaArnsRequest,
@@ -5508,7 +5507,7 @@ export const listDirectories: API.PaginatedOperationMethod<
   ListDirectoriesRequest,
   ListDirectoriesResponse,
   ListDirectoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDirectoriesRequest,
@@ -5550,7 +5549,7 @@ export const listFacetAttributes: API.PaginatedOperationMethod<
   ListFacetAttributesRequest,
   ListFacetAttributesResponse,
   ListFacetAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFacetAttributesRequest,
@@ -5593,7 +5592,7 @@ export const listFacetNames: API.PaginatedOperationMethod<
   ListFacetNamesRequest,
   ListFacetNamesResponse,
   ListFacetNamesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFacetNamesRequest,
@@ -5639,7 +5638,7 @@ export const listIncomingTypedLinks: API.OperationMethod<
   ListIncomingTypedLinksRequest,
   ListIncomingTypedLinksResponse,
   ListIncomingTypedLinksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIncomingTypedLinksRequest,
   output: ListIncomingTypedLinksResponse,
@@ -5680,7 +5679,7 @@ export const listIndex: API.PaginatedOperationMethod<
   ListIndexRequest,
   ListIndexResponse,
   ListIndexError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndexRequest,
@@ -5723,7 +5722,7 @@ export const listManagedSchemaArns: API.PaginatedOperationMethod<
   ListManagedSchemaArnsRequest,
   ListManagedSchemaArnsResponse,
   ListManagedSchemaArnsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedSchemaArnsRequest,
@@ -5765,7 +5764,7 @@ export const listObjectAttributes: API.PaginatedOperationMethod<
   ListObjectAttributesRequest,
   ListObjectAttributesResponse,
   ListObjectAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectAttributesRequest,
@@ -5812,7 +5811,7 @@ export const listObjectChildren: API.PaginatedOperationMethod<
   ListObjectChildrenRequest,
   ListObjectChildrenResponse,
   ListObjectChildrenError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectChildrenRequest,
@@ -5865,7 +5864,7 @@ export const listObjectParentPaths: API.PaginatedOperationMethod<
   ListObjectParentPathsRequest,
   ListObjectParentPathsResponse,
   ListObjectParentPathsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectParentPathsRequest,
@@ -5911,7 +5910,7 @@ export const listObjectParents: API.PaginatedOperationMethod<
   ListObjectParentsRequest,
   ListObjectParentsResponse,
   ListObjectParentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectParentsRequest,
@@ -5956,7 +5955,7 @@ export const listObjectPolicies: API.PaginatedOperationMethod<
   ListObjectPoliciesRequest,
   ListObjectPoliciesResponse,
   ListObjectPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectPoliciesRequest,
@@ -6003,7 +6002,7 @@ export const listOutgoingTypedLinks: API.OperationMethod<
   ListOutgoingTypedLinksRequest,
   ListOutgoingTypedLinksResponse,
   ListOutgoingTypedLinksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOutgoingTypedLinksRequest,
   output: ListOutgoingTypedLinksResponse,
@@ -6043,7 +6042,7 @@ export const listPolicyAttachments: API.PaginatedOperationMethod<
   ListPolicyAttachmentsRequest,
   ListPolicyAttachmentsResponse,
   ListPolicyAttachmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyAttachmentsRequest,
@@ -6087,7 +6086,7 @@ export const listPublishedSchemaArns: API.PaginatedOperationMethod<
   ListPublishedSchemaArnsRequest,
   ListPublishedSchemaArnsResponse,
   ListPublishedSchemaArnsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPublishedSchemaArnsRequest,
@@ -6131,7 +6130,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -6174,7 +6173,7 @@ export const listTypedLinkFacetAttributes: API.PaginatedOperationMethod<
   ListTypedLinkFacetAttributesRequest,
   ListTypedLinkFacetAttributesResponse,
   ListTypedLinkFacetAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypedLinkFacetAttributesRequest,
@@ -6218,7 +6217,7 @@ export const listTypedLinkFacetNames: API.PaginatedOperationMethod<
   ListTypedLinkFacetNamesRequest,
   ListTypedLinkFacetNamesResponse,
   ListTypedLinkFacetNamesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypedLinkFacetNamesRequest,
@@ -6266,7 +6265,7 @@ export const lookupPolicy: API.PaginatedOperationMethod<
   LookupPolicyRequest,
   LookupPolicyResponse,
   LookupPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: LookupPolicyRequest,
@@ -6309,7 +6308,7 @@ export const publishSchema: API.OperationMethod<
   PublishSchemaRequest,
   PublishSchemaResponse,
   PublishSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishSchemaRequest,
   output: PublishSchemaResponse,
@@ -6345,7 +6344,7 @@ export const putSchemaFromJson: API.OperationMethod<
   PutSchemaFromJsonRequest,
   PutSchemaFromJsonResponse,
   PutSchemaFromJsonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSchemaFromJsonRequest,
   output: PutSchemaFromJsonResponse,
@@ -6382,7 +6381,7 @@ export const removeFacetFromObject: API.OperationMethod<
   RemoveFacetFromObjectRequest,
   RemoveFacetFromObjectResponse,
   RemoveFacetFromObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFacetFromObjectRequest,
   output: RemoveFacetFromObjectResponse,
@@ -6419,7 +6418,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6455,7 +6454,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6500,7 +6499,7 @@ export const updateFacet: API.OperationMethod<
   UpdateFacetRequest,
   UpdateFacetResponse,
   UpdateFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFacetRequest,
   output: UpdateFacetResponse,
@@ -6540,7 +6539,7 @@ export const updateLinkAttributes: API.OperationMethod<
   UpdateLinkAttributesRequest,
   UpdateLinkAttributesResponse,
   UpdateLinkAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkAttributesRequest,
   output: UpdateLinkAttributesResponse,
@@ -6579,7 +6578,7 @@ export const updateObjectAttributes: API.OperationMethod<
   UpdateObjectAttributesRequest,
   UpdateObjectAttributesResponse,
   UpdateObjectAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateObjectAttributesRequest,
   output: UpdateObjectAttributesResponse,
@@ -6617,7 +6616,7 @@ export const updateSchema: API.OperationMethod<
   UpdateSchemaRequest,
   UpdateSchemaResponse,
   UpdateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSchemaRequest,
   output: UpdateSchemaResponse,
@@ -6655,7 +6654,7 @@ export const updateTypedLinkFacet: API.OperationMethod<
   UpdateTypedLinkFacetRequest,
   UpdateTypedLinkFacetResponse,
   UpdateTypedLinkFacetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTypedLinkFacetRequest,
   output: UpdateTypedLinkFacetResponse,
@@ -6695,7 +6694,7 @@ export const upgradeAppliedSchema: API.OperationMethod<
   UpgradeAppliedSchemaRequest,
   UpgradeAppliedSchemaResponse,
   UpgradeAppliedSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeAppliedSchemaRequest,
   output: UpgradeAppliedSchemaResponse,
@@ -6733,7 +6732,7 @@ export const upgradePublishedSchema: API.OperationMethod<
   UpgradePublishedSchemaRequest,
   UpgradePublishedSchemaResponse,
   UpgradePublishedSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradePublishedSchemaRequest,
   output: UpgradePublishedSchemaResponse,

--- a/packages/aws/src/services/cloudformation.ts
+++ b/packages/aws/src/services/cloudformation.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const ns = T.XmlNamespace(
   "http://cloudformation.amazonaws.com/doc/2010-05-15/",
 );
@@ -6733,7 +6732,7 @@ export const activateOrganizationsAccess: API.OperationMethod<
   ActivateOrganizationsAccessInput,
   ActivateOrganizationsAccessOutput,
   ActivateOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateOrganizationsAccessInput,
   output: ActivateOrganizationsAccessOutput,
@@ -6767,7 +6766,7 @@ export const activateType: API.OperationMethod<
   ActivateTypeInput,
   ActivateTypeOutput,
   ActivateTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateTypeInput,
   output: ActivateTypeOutput,
@@ -6793,7 +6792,7 @@ export const batchDescribeTypeConfigurations: API.OperationMethod<
   BatchDescribeTypeConfigurationsInput,
   BatchDescribeTypeConfigurationsOutput,
   BatchDescribeTypeConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDescribeTypeConfigurationsInput,
   output: BatchDescribeTypeConfigurationsOutput,
@@ -6814,7 +6813,7 @@ export const cancelUpdateStack: API.OperationMethod<
   CancelUpdateStackInput,
   CancelUpdateStackResponse,
   CancelUpdateStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelUpdateStackInput,
   output: CancelUpdateStackResponse,
@@ -6847,7 +6846,7 @@ export const continueUpdateRollback: API.OperationMethod<
   ContinueUpdateRollbackInput,
   ContinueUpdateRollbackOutput,
   ContinueUpdateRollbackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ContinueUpdateRollbackInput,
   output: ContinueUpdateRollbackOutput,
@@ -6890,7 +6889,7 @@ export const createChangeSet: API.OperationMethod<
   CreateChangeSetInput,
   CreateChangeSetOutput,
   CreateChangeSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChangeSetInput,
   output: CreateChangeSetOutput,
@@ -6918,7 +6917,7 @@ export const createGeneratedTemplate: API.OperationMethod<
   CreateGeneratedTemplateInput,
   CreateGeneratedTemplateOutput,
   CreateGeneratedTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGeneratedTemplateInput,
   output: CreateGeneratedTemplateOutput,
@@ -6950,7 +6949,7 @@ export const createStack: API.OperationMethod<
   CreateStackInput,
   CreateStackOutput,
   CreateStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStackInput,
   output: CreateStackOutput,
@@ -6995,7 +6994,7 @@ export const createStackInstances: API.OperationMethod<
   CreateStackInstancesInput,
   CreateStackInstancesOutput,
   CreateStackInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStackInstancesInput,
   output: CreateStackInstancesOutput,
@@ -7021,7 +7020,7 @@ export const createStackRefactor: API.OperationMethod<
   CreateStackRefactorInput,
   CreateStackRefactorOutput,
   CreateStackRefactorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStackRefactorInput,
   output: CreateStackRefactorOutput,
@@ -7043,7 +7042,7 @@ export const createStackSet: API.OperationMethod<
   CreateStackSetInput,
   CreateStackSetOutput,
   CreateStackSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStackSetInput,
   output: CreateStackSetOutput,
@@ -7070,7 +7069,7 @@ export const deactivateOrganizationsAccess: API.OperationMethod<
   DeactivateOrganizationsAccessInput,
   DeactivateOrganizationsAccessOutput,
   DeactivateOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateOrganizationsAccessInput,
   output: DeactivateOrganizationsAccessOutput,
@@ -7102,7 +7101,7 @@ export const deactivateType: API.OperationMethod<
   DeactivateTypeInput,
   DeactivateTypeOutput,
   DeactivateTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateTypeInput,
   output: DeactivateTypeOutput,
@@ -7130,7 +7129,7 @@ export const deleteChangeSet: API.OperationMethod<
   DeleteChangeSetInput,
   DeleteChangeSetOutput,
   DeleteChangeSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChangeSetInput,
   output: DeleteChangeSetOutput,
@@ -7151,7 +7150,7 @@ export const deleteGeneratedTemplate: API.OperationMethod<
   DeleteGeneratedTemplateInput,
   DeleteGeneratedTemplateResponse,
   DeleteGeneratedTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGeneratedTemplateInput,
   output: DeleteGeneratedTemplateResponse,
@@ -7177,7 +7176,7 @@ export const deleteStack: API.OperationMethod<
   DeleteStackInput,
   DeleteStackResponse,
   DeleteStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStackInput,
   output: DeleteStackResponse,
@@ -7213,7 +7212,7 @@ export const deleteStackInstances: API.OperationMethod<
   DeleteStackInstancesInput,
   DeleteStackInstancesOutput,
   DeleteStackInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStackInstancesInput,
   output: DeleteStackInstancesOutput,
@@ -7241,7 +7240,7 @@ export const deleteStackSet: API.OperationMethod<
   DeleteStackSetInput,
   DeleteStackSetOutput,
   DeleteStackSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStackSetInput,
   output: DeleteStackSetOutput,
@@ -7279,7 +7278,7 @@ export const deregisterType: API.OperationMethod<
   DeregisterTypeInput,
   DeregisterTypeOutput,
   DeregisterTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTypeInput,
   output: DeregisterTypeOutput,
@@ -7298,7 +7297,7 @@ export const describeAccountLimits: API.PaginatedOperationMethod<
   DescribeAccountLimitsInput,
   DescribeAccountLimitsOutput,
   DescribeAccountLimitsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountLimit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccountLimitsInput,
@@ -7325,7 +7324,7 @@ export const describeChangeSet: API.PaginatedOperationMethod<
   DescribeChangeSetInput,
   DescribeChangeSetOutput,
   DescribeChangeSetError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Change
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeChangeSetInput,
@@ -7352,7 +7351,7 @@ export const describeChangeSetHooks: API.OperationMethod<
   DescribeChangeSetHooksInput,
   DescribeChangeSetHooksOutput,
   DescribeChangeSetHooksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChangeSetHooksInput,
   output: DescribeChangeSetHooksOutput,
@@ -7393,7 +7392,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsInput,
   DescribeEventsOutput,
   DescribeEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OperationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsInput,
@@ -7422,7 +7421,7 @@ export const describeGeneratedTemplate: API.OperationMethod<
   DescribeGeneratedTemplateInput,
   DescribeGeneratedTemplateOutput,
   DescribeGeneratedTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGeneratedTemplateInput,
   output: DescribeGeneratedTemplateOutput,
@@ -7446,7 +7445,7 @@ export const describeOrganizationsAccess: API.OperationMethod<
   DescribeOrganizationsAccessInput,
   DescribeOrganizationsAccessOutput,
   DescribeOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationsAccessInput,
   output: DescribeOrganizationsAccessOutput,
@@ -7476,7 +7475,7 @@ export const describePublisher: API.OperationMethod<
   DescribePublisherInput,
   DescribePublisherOutput,
   DescribePublisherError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePublisherInput,
   output: DescribePublisherOutput,
@@ -7496,7 +7495,7 @@ export const describeResourceScan: API.OperationMethod<
   DescribeResourceScanInput,
   DescribeResourceScanOutput,
   DescribeResourceScanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceScanInput,
   output: DescribeResourceScanOutput,
@@ -7526,7 +7525,7 @@ export const describeStackDriftDetectionStatus: API.OperationMethod<
   DescribeStackDriftDetectionStatusInput,
   DescribeStackDriftDetectionStatusOutput,
   DescribeStackDriftDetectionStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackDriftDetectionStatusInput,
   output: DescribeStackDriftDetectionStatusOutput,
@@ -7549,7 +7548,7 @@ export const describeStackEvents: API.PaginatedOperationMethod<
   DescribeStackEventsInput,
   DescribeStackEventsOutput,
   DescribeStackEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStackEventsInput,
@@ -7579,7 +7578,7 @@ export const describeStackInstance: API.OperationMethod<
   DescribeStackInstanceInput,
   DescribeStackInstanceOutput,
   DescribeStackInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackInstanceInput,
   output: DescribeStackInstanceOutput,
@@ -7599,7 +7598,7 @@ export const describeStackRefactor: API.OperationMethod<
   DescribeStackRefactorInput,
   DescribeStackRefactorOutput,
   DescribeStackRefactorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackRefactorInput,
   output: DescribeStackRefactorOutput,
@@ -7620,7 +7619,7 @@ export const describeStackResource: API.OperationMethod<
   DescribeStackResourceInput,
   DescribeStackResourceOutput,
   DescribeStackResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackResourceInput,
   output: DescribeStackResourceOutput,
@@ -7650,7 +7649,7 @@ export const describeStackResourceDrifts: API.PaginatedOperationMethod<
   DescribeStackResourceDriftsInput,
   DescribeStackResourceDriftsOutput,
   DescribeStackResourceDriftsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStackResourceDriftsInput,
@@ -7691,7 +7690,7 @@ export const describeStackResources: API.OperationMethod<
   DescribeStackResourcesInput,
   DescribeStackResourcesOutput,
   DescribeStackResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackResourcesInput,
   output: DescribeStackResourcesOutput,
@@ -7714,7 +7713,7 @@ export const describeStacks: API.PaginatedOperationMethod<
   DescribeStacksInput,
   DescribeStacksOutput,
   DescribeStacksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Stack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStacksInput,
@@ -7741,7 +7740,7 @@ export const describeStackSet: API.OperationMethod<
   DescribeStackSetInput,
   DescribeStackSetOutput,
   DescribeStackSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackSetInput,
   output: DescribeStackSetOutput,
@@ -7765,7 +7764,7 @@ export const describeStackSetOperation: API.OperationMethod<
   DescribeStackSetOperationInput,
   DescribeStackSetOperationOutput,
   DescribeStackSetOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStackSetOperationInput,
   output: DescribeStackSetOperationOutput,
@@ -7795,7 +7794,7 @@ export const describeType: API.OperationMethod<
   DescribeTypeInput,
   DescribeTypeOutput,
   DescribeTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTypeInput,
   output: DescribeTypeOutput,
@@ -7821,7 +7820,7 @@ export const describeTypeRegistration: API.OperationMethod<
   DescribeTypeRegistrationInput,
   DescribeTypeRegistrationOutput,
   DescribeTypeRegistrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTypeRegistrationInput,
   output: DescribeTypeRegistrationOutput,
@@ -7863,7 +7862,7 @@ export const detectStackDrift: API.OperationMethod<
   DetectStackDriftInput,
   DetectStackDriftOutput,
   DetectStackDriftError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectStackDriftInput,
   output: DetectStackDriftOutput,
@@ -7895,7 +7894,7 @@ export const detectStackResourceDrift: API.OperationMethod<
   DetectStackResourceDriftInput,
   DetectStackResourceDriftOutput,
   DetectStackResourceDriftError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectStackResourceDriftInput,
   output: DetectStackResourceDriftOutput,
@@ -7946,7 +7945,7 @@ export const detectStackSetDrift: API.OperationMethod<
   DetectStackSetDriftInput,
   DetectStackSetDriftOutput,
   DetectStackSetDriftError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectStackSetDriftInput,
   output: DetectStackSetDriftOutput,
@@ -7970,7 +7969,7 @@ export const estimateTemplateCost: API.OperationMethod<
   EstimateTemplateCostInput,
   EstimateTemplateCostOutput,
   EstimateTemplateCostError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EstimateTemplateCostInput,
   output: EstimateTemplateCostOutput,
@@ -8004,7 +8003,7 @@ export const executeChangeSet: API.OperationMethod<
   ExecuteChangeSetInput,
   ExecuteChangeSetOutput,
   ExecuteChangeSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteChangeSetInput,
   output: ExecuteChangeSetOutput,
@@ -8027,7 +8026,7 @@ export const executeStackRefactor: API.OperationMethod<
   ExecuteStackRefactorInput,
   ExecuteStackRefactorResponse,
   ExecuteStackRefactorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteStackRefactorInput,
   output: ExecuteStackRefactorResponse,
@@ -8050,7 +8049,7 @@ export const getGeneratedTemplate: API.OperationMethod<
   GetGeneratedTemplateInput,
   GetGeneratedTemplateOutput,
   GetGeneratedTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeneratedTemplateInput,
   output: GetGeneratedTemplateOutput,
@@ -8075,7 +8074,7 @@ export const getHookResult: API.OperationMethod<
   GetHookResultInput,
   GetHookResultOutput,
   GetHookResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHookResultInput,
   output: GetHookResultOutput,
@@ -8094,7 +8093,7 @@ export const getStackPolicy: API.OperationMethod<
   GetStackPolicyInput,
   GetStackPolicyOutput,
   GetStackPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStackPolicyInput,
   output: GetStackPolicyOutput,
@@ -8118,7 +8117,7 @@ export const getTemplate: API.OperationMethod<
   GetTemplateInput,
   GetTemplateOutput,
   GetTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateInput,
   output: GetTemplateOutput,
@@ -8145,7 +8144,7 @@ export const getTemplateSummary: API.OperationMethod<
   GetTemplateSummaryInput,
   GetTemplateSummaryOutput,
   GetTemplateSummaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateSummaryInput,
   output: GetTemplateSummaryOutput,
@@ -8174,7 +8173,7 @@ export const importStacksToStackSet: API.OperationMethod<
   ImportStacksToStackSetInput,
   ImportStacksToStackSetOutput,
   ImportStacksToStackSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportStacksToStackSetInput,
   output: ImportStacksToStackSetOutput,
@@ -8202,7 +8201,7 @@ export const listChangeSets: API.PaginatedOperationMethod<
   ListChangeSetsInput,
   ListChangeSetsOutput,
   ListChangeSetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChangeSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChangeSetsInput,
@@ -8231,7 +8230,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsInput,
   ListExportsOutput,
   ListExportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Export
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsInput,
@@ -8255,7 +8254,7 @@ export const listGeneratedTemplates: API.PaginatedOperationMethod<
   ListGeneratedTemplatesInput,
   ListGeneratedTemplatesOutput,
   ListGeneratedTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGeneratedTemplatesInput,
@@ -8293,7 +8292,7 @@ export const listHookResults: API.OperationMethod<
   ListHookResultsInput,
   ListHookResultsOutput,
   ListHookResultsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHookResultsInput,
   output: ListHookResultsOutput,
@@ -8315,7 +8314,7 @@ export const listImports: API.PaginatedOperationMethod<
   ListImportsInput,
   ListImportsOutput,
   ListImportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportsInput,
@@ -8343,7 +8342,7 @@ export const listResourceScanRelatedResources: API.PaginatedOperationMethod<
   ListResourceScanRelatedResourcesInput,
   ListResourceScanRelatedResourcesOutput,
   ListResourceScanRelatedResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScannedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceScanRelatedResourcesInput,
@@ -8374,7 +8373,7 @@ export const listResourceScanResources: API.PaginatedOperationMethod<
   ListResourceScanResourcesInput,
   ListResourceScanResourcesOutput,
   ListResourceScanResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScannedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceScanResourcesInput,
@@ -8400,7 +8399,7 @@ export const listResourceScans: API.PaginatedOperationMethod<
   ListResourceScansInput,
   ListResourceScansOutput,
   ListResourceScansError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceScanSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceScansInput,
@@ -8433,7 +8432,7 @@ export const listStackInstanceResourceDrifts: API.OperationMethod<
   ListStackInstanceResourceDriftsInput,
   ListStackInstanceResourceDriftsOutput,
   ListStackInstanceResourceDriftsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStackInstanceResourceDriftsInput,
   output: ListStackInstanceResourceDriftsOutput,
@@ -8457,7 +8456,7 @@ export const listStackInstances: API.PaginatedOperationMethod<
   ListStackInstancesInput,
   ListStackInstancesOutput,
   ListStackInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackInstancesInput,
@@ -8482,7 +8481,7 @@ export const listStackRefactorActions: API.PaginatedOperationMethod<
   ListStackRefactorActionsInput,
   ListStackRefactorActionsOutput,
   ListStackRefactorActionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackRefactorAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackRefactorActionsInput,
@@ -8507,7 +8506,7 @@ export const listStackRefactors: API.PaginatedOperationMethod<
   ListStackRefactorsInput,
   ListStackRefactorsOutput,
   ListStackRefactorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackRefactorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackRefactorsInput,
@@ -8535,7 +8534,7 @@ export const listStackResources: API.PaginatedOperationMethod<
   ListStackResourcesInput,
   ListStackResourcesOutput,
   ListStackResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackResourcesInput,
@@ -8563,7 +8562,7 @@ export const listStacks: API.PaginatedOperationMethod<
   ListStacksInput,
   ListStacksOutput,
   ListStacksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStacksInput,
@@ -8589,7 +8588,7 @@ export const listStackSetAutoDeploymentTargets: API.OperationMethod<
   ListStackSetAutoDeploymentTargetsInput,
   ListStackSetAutoDeploymentTargetsOutput,
   ListStackSetAutoDeploymentTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStackSetAutoDeploymentTargetsInput,
   output: ListStackSetAutoDeploymentTargetsOutput,
@@ -8613,7 +8612,7 @@ export const listStackSetOperationResults: API.PaginatedOperationMethod<
   ListStackSetOperationResultsInput,
   ListStackSetOperationResultsOutput,
   ListStackSetOperationResultsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackSetOperationResultSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackSetOperationResultsInput,
@@ -8643,7 +8642,7 @@ export const listStackSetOperations: API.PaginatedOperationMethod<
   ListStackSetOperationsInput,
   ListStackSetOperationsOutput,
   ListStackSetOperationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackSetOperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackSetOperationsInput,
@@ -8684,7 +8683,7 @@ export const listStackSets: API.PaginatedOperationMethod<
   ListStackSetsInput,
   ListStackSetsOutput,
   ListStackSetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StackSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStackSetsInput,
@@ -8709,7 +8708,7 @@ export const listTypeRegistrations: API.PaginatedOperationMethod<
   ListTypeRegistrationsInput,
   ListTypeRegistrationsOutput,
   ListTypeRegistrationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypeRegistrationsInput,
@@ -8735,7 +8734,7 @@ export const listTypes: API.PaginatedOperationMethod<
   ListTypesInput,
   ListTypesOutput,
   ListTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TypeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypesInput,
@@ -8760,7 +8759,7 @@ export const listTypeVersions: API.PaginatedOperationMethod<
   ListTypeVersionsInput,
   ListTypeVersionsOutput,
   ListTypeVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypeVersionsInput,
@@ -8794,7 +8793,7 @@ export const publishType: API.OperationMethod<
   PublishTypeInput,
   PublishTypeOutput,
   PublishTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishTypeInput,
   output: PublishTypeOutput,
@@ -8818,7 +8817,7 @@ export const recordHandlerProgress: API.OperationMethod<
   RecordHandlerProgressInput,
   RecordHandlerProgressOutput,
   RecordHandlerProgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecordHandlerProgressInput,
   output: RecordHandlerProgressOutput,
@@ -8845,7 +8844,7 @@ export const registerPublisher: API.OperationMethod<
   RegisterPublisherInput,
   RegisterPublisherOutput,
   RegisterPublisherError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterPublisherInput,
   output: RegisterPublisherOutput,
@@ -8887,7 +8886,7 @@ export const registerType: API.OperationMethod<
   RegisterTypeInput,
   RegisterTypeOutput,
   RegisterTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTypeInput,
   output: RegisterTypeOutput,
@@ -8924,7 +8923,7 @@ export const rollbackStack: API.OperationMethod<
   RollbackStackInput,
   RollbackStackOutput,
   RollbackStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackStackInput,
   output: RollbackStackOutput,
@@ -8942,7 +8941,7 @@ export const setStackPolicy: API.OperationMethod<
   SetStackPolicyInput,
   SetStackPolicyResponse,
   SetStackPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetStackPolicyInput,
   output: SetStackPolicyResponse,
@@ -8979,7 +8978,7 @@ export const setTypeConfiguration: API.OperationMethod<
   SetTypeConfigurationInput,
   SetTypeConfigurationOutput,
   SetTypeConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTypeConfigurationInput,
   output: SetTypeConfigurationOutput,
@@ -9001,7 +9000,7 @@ export const setTypeDefaultVersion: API.OperationMethod<
   SetTypeDefaultVersionInput,
   SetTypeDefaultVersionOutput,
   SetTypeDefaultVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTypeDefaultVersionInput,
   output: SetTypeDefaultVersionOutput,
@@ -9024,7 +9023,7 @@ export const signalResource: API.OperationMethod<
   SignalResourceInput,
   SignalResourceResponse,
   SignalResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignalResourceInput,
   output: SignalResourceResponse,
@@ -9046,7 +9045,7 @@ export const startResourceScan: API.OperationMethod<
   StartResourceScanInput,
   StartResourceScanOutput,
   StartResourceScanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceScanInput,
   output: StartResourceScanOutput,
@@ -9070,7 +9069,7 @@ export const stopStackSetOperation: API.OperationMethod<
   StopStackSetOperationInput,
   StopStackSetOperationOutput,
   StopStackSetOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopStackSetOperationInput,
   output: StopStackSetOperationOutput,
@@ -9120,7 +9119,7 @@ export const testType: API.OperationMethod<
   TestTypeInput,
   TestTypeOutput,
   TestTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestTypeInput,
   output: TestTypeOutput,
@@ -9145,7 +9144,7 @@ export const updateGeneratedTemplate: API.OperationMethod<
   UpdateGeneratedTemplateInput,
   UpdateGeneratedTemplateOutput,
   UpdateGeneratedTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGeneratedTemplateInput,
   output: UpdateGeneratedTemplateOutput,
@@ -9179,7 +9178,7 @@ export const updateStack: API.OperationMethod<
   UpdateStackInput,
   UpdateStackOutput,
   UpdateStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStackInput,
   output: UpdateStackOutput,
@@ -9236,7 +9235,7 @@ export const updateStackInstances: API.OperationMethod<
   UpdateStackInstancesInput,
   UpdateStackInstancesOutput,
   UpdateStackInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStackInstancesInput,
   output: UpdateStackInstancesOutput,
@@ -9286,7 +9285,7 @@ export const updateStackSet: API.OperationMethod<
   UpdateStackSetInput,
   UpdateStackSetOutput,
   UpdateStackSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStackSetInput,
   output: UpdateStackSetOutput,
@@ -9318,7 +9317,7 @@ export const updateTerminationProtection: API.OperationMethod<
   UpdateTerminationProtectionInput,
   UpdateTerminationProtectionOutput,
   UpdateTerminationProtectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTerminationProtectionInput,
   output: UpdateTerminationProtectionOutput,
@@ -9338,7 +9337,7 @@ export const validateTemplate: API.OperationMethod<
   ValidateTemplateInput,
   ValidateTemplateOutput,
   ValidateTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateTemplateInput,
   output: ValidateTemplateOutput,

--- a/packages/aws/src/services/cloudfront-keyvaluestore.ts
+++ b/packages/aws/src/services/cloudfront-keyvaluestore.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudFront KeyValueStore",
@@ -457,7 +456,7 @@ export const deleteKey: API.OperationMethod<
   DeleteKeyRequest,
   DeleteKeyResponse,
   DeleteKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyRequest,
   output: DeleteKeyResponse,
@@ -487,7 +486,7 @@ export const describeKeyValueStore: API.OperationMethod<
   DescribeKeyValueStoreRequest,
   DescribeKeyValueStoreResponse,
   DescribeKeyValueStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyValueStoreRequest,
   output: DescribeKeyValueStoreResponse,
@@ -515,7 +514,7 @@ export const getKey: API.OperationMethod<
   GetKeyRequest,
   GetKeyResponse,
   GetKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyRequest,
   output: GetKeyResponse,
@@ -544,7 +543,7 @@ export const listKeys: API.PaginatedOperationMethod<
   ListKeysRequest,
   ListKeysResponse,
   ListKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListKeysResponseListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeysRequest,
@@ -582,7 +581,7 @@ export const putKey: API.OperationMethod<
   PutKeyRequest,
   PutKeyResponse,
   PutKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutKeyRequest,
   output: PutKeyResponse,
@@ -614,7 +613,7 @@ export const updateKeys: API.OperationMethod<
   UpdateKeysRequest,
   UpdateKeysResponse,
   UpdateKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeysRequest,
   output: UpdateKeysResponse,

--- a/packages/aws/src/services/cloudfront.ts
+++ b/packages/aws/src/services/cloudfront.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://cloudfront.amazonaws.com/doc/2020-05-31/");
 const svc = T.AwsApiService({
@@ -10878,7 +10877,7 @@ export const associateAlias: API.OperationMethod<
   AssociateAliasRequest,
   AssociateAliasResponse,
   AssociateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAliasRequest,
   output: AssociateAliasResponse,
@@ -10909,7 +10908,7 @@ export const associateDistributionTenantWebACL: API.OperationMethod<
   AssociateDistributionTenantWebACLRequest,
   AssociateDistributionTenantWebACLResult,
   AssociateDistributionTenantWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDistributionTenantWebACLRequest,
   output: AssociateDistributionTenantWebACLResult,
@@ -10941,7 +10940,7 @@ export const associateDistributionWebACL: API.OperationMethod<
   AssociateDistributionWebACLRequest,
   AssociateDistributionWebACLResult,
   AssociateDistributionWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDistributionWebACLRequest,
   output: AssociateDistributionWebACLResult,
@@ -11041,7 +11040,7 @@ export const copyDistribution: API.OperationMethod<
   CopyDistributionRequest,
   CopyDistributionResult,
   CopyDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDistributionRequest,
   output: CopyDistributionResult,
@@ -11131,7 +11130,7 @@ export const createAnycastIpList: API.OperationMethod<
   CreateAnycastIpListRequest,
   CreateAnycastIpListResult,
   CreateAnycastIpListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnycastIpListRequest,
   output: CreateAnycastIpListResult,
@@ -11177,7 +11176,7 @@ export const createCachePolicy: API.OperationMethod<
   CreateCachePolicyRequest,
   CreateCachePolicyResult,
   CreateCachePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCachePolicyRequest,
   output: CreateCachePolicyResult,
@@ -11210,7 +11209,7 @@ export const createCloudFrontOriginAccessIdentity: API.OperationMethod<
   CreateCloudFrontOriginAccessIdentityRequest,
   CreateCloudFrontOriginAccessIdentityResult,
   CreateCloudFrontOriginAccessIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudFrontOriginAccessIdentityRequest,
   output: CreateCloudFrontOriginAccessIdentityResult,
@@ -11242,7 +11241,7 @@ export const createConnectionFunction: API.OperationMethod<
   CreateConnectionFunctionRequest,
   CreateConnectionFunctionResult,
   CreateConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionFunctionRequest,
   output: CreateConnectionFunctionResult,
@@ -11275,7 +11274,7 @@ export const createConnectionGroup: API.OperationMethod<
   CreateConnectionGroupRequest,
   CreateConnectionGroupResult,
   CreateConnectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionGroupRequest,
   output: CreateConnectionGroupResult,
@@ -11311,7 +11310,7 @@ export const createContinuousDeploymentPolicy: API.OperationMethod<
   CreateContinuousDeploymentPolicyRequest,
   CreateContinuousDeploymentPolicyResult,
   CreateContinuousDeploymentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContinuousDeploymentPolicyRequest,
   output: CreateContinuousDeploymentPolicyResult,
@@ -11404,7 +11403,7 @@ export const createDistribution: API.OperationMethod<
   CreateDistributionRequest,
   CreateDistributionResult,
   CreateDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDistributionRequest,
   output: CreateDistributionResult,
@@ -11499,7 +11498,7 @@ export const createDistributionTenant: API.OperationMethod<
   CreateDistributionTenantRequest,
   CreateDistributionTenantResult,
   CreateDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDistributionTenantRequest,
   output: CreateDistributionTenantResult,
@@ -11598,7 +11597,7 @@ export const createDistributionWithTags: API.OperationMethod<
   CreateDistributionWithTagsRequest,
   CreateDistributionWithTagsResult,
   CreateDistributionWithTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDistributionWithTagsRequest,
   output: CreateDistributionWithTagsResult,
@@ -11693,7 +11692,7 @@ export const createFieldLevelEncryptionConfig: API.OperationMethod<
   CreateFieldLevelEncryptionConfigRequest,
   CreateFieldLevelEncryptionConfigResult,
   CreateFieldLevelEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFieldLevelEncryptionConfigRequest,
   output: CreateFieldLevelEncryptionConfigResult,
@@ -11729,7 +11728,7 @@ export const createFieldLevelEncryptionProfile: API.OperationMethod<
   CreateFieldLevelEncryptionProfileRequest,
   CreateFieldLevelEncryptionProfileResult,
   CreateFieldLevelEncryptionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFieldLevelEncryptionProfileRequest,
   output: CreateFieldLevelEncryptionProfileResult,
@@ -11768,7 +11767,7 @@ export const createFunction: API.OperationMethod<
   CreateFunctionRequest,
   CreateFunctionResult,
   CreateFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionRequest,
   output: CreateFunctionResult,
@@ -11800,7 +11799,7 @@ export const createInvalidation: API.OperationMethod<
   CreateInvalidationRequest,
   CreateInvalidationResult,
   CreateInvalidationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvalidationRequest,
   output: CreateInvalidationResult,
@@ -11834,7 +11833,7 @@ export const createInvalidationForDistributionTenant: API.OperationMethod<
   CreateInvalidationForDistributionTenantRequest,
   CreateInvalidationForDistributionTenantResult,
   CreateInvalidationForDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvalidationForDistributionTenantRequest,
   output: CreateInvalidationForDistributionTenantResult,
@@ -11867,7 +11866,7 @@ export const createKeyGroup: API.OperationMethod<
   CreateKeyGroupRequest,
   CreateKeyGroupResult,
   CreateKeyGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyGroupRequest,
   output: CreateKeyGroupResult,
@@ -11897,7 +11896,7 @@ export const createKeyValueStore: API.OperationMethod<
   CreateKeyValueStoreRequest,
   CreateKeyValueStoreResult,
   CreateKeyValueStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyValueStoreRequest,
   output: CreateKeyValueStoreResult,
@@ -11929,7 +11928,7 @@ export const createMonitoringSubscription: API.OperationMethod<
   CreateMonitoringSubscriptionRequest,
   CreateMonitoringSubscriptionResult,
   CreateMonitoringSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitoringSubscriptionRequest,
   output: CreateMonitoringSubscriptionResult,
@@ -11960,7 +11959,7 @@ export const createOriginAccessControl: API.OperationMethod<
   CreateOriginAccessControlRequest,
   CreateOriginAccessControlResult,
   CreateOriginAccessControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOriginAccessControlRequest,
   output: CreateOriginAccessControlResult,
@@ -12003,7 +12002,7 @@ export const createOriginRequestPolicy: API.OperationMethod<
   CreateOriginRequestPolicyRequest,
   CreateOriginRequestPolicyResult,
   CreateOriginRequestPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOriginRequestPolicyRequest,
   output: CreateOriginRequestPolicyResult,
@@ -12034,7 +12033,7 @@ export const createPublicKey: API.OperationMethod<
   CreatePublicKeyRequest,
   CreatePublicKeyResult,
   CreatePublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePublicKeyRequest,
   output: CreatePublicKeyResult,
@@ -12061,7 +12060,7 @@ export const createRealtimeLogConfig: API.OperationMethod<
   CreateRealtimeLogConfigRequest,
   CreateRealtimeLogConfigResult,
   CreateRealtimeLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRealtimeLogConfigRequest,
   output: CreateRealtimeLogConfigResult,
@@ -12099,7 +12098,7 @@ export const createResponseHeadersPolicy: API.OperationMethod<
   CreateResponseHeadersPolicyRequest,
   CreateResponseHeadersPolicyResult,
   CreateResponseHeadersPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResponseHeadersPolicyRequest,
   output: CreateResponseHeadersPolicyResult,
@@ -12140,7 +12139,7 @@ export const createStreamingDistribution: API.OperationMethod<
   CreateStreamingDistributionRequest,
   CreateStreamingDistributionResult,
   CreateStreamingDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamingDistributionRequest,
   output: CreateStreamingDistributionResult,
@@ -12187,7 +12186,7 @@ export const createStreamingDistributionWithTags: API.OperationMethod<
   CreateStreamingDistributionWithTagsRequest,
   CreateStreamingDistributionWithTagsResult,
   CreateStreamingDistributionWithTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamingDistributionWithTagsRequest,
   output: CreateStreamingDistributionWithTagsResult,
@@ -12227,7 +12226,7 @@ export const createTrustStore: API.OperationMethod<
   CreateTrustStoreRequest,
   CreateTrustStoreResult,
   CreateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustStoreRequest,
   output: CreateTrustStoreResult,
@@ -12260,7 +12259,7 @@ export const createVpcOrigin: API.OperationMethod<
   CreateVpcOriginRequest,
   CreateVpcOriginResult,
   CreateVpcOriginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcOriginRequest,
   output: CreateVpcOriginResult,
@@ -12295,7 +12294,7 @@ export const deleteAnycastIpList: API.OperationMethod<
   DeleteAnycastIpListRequest,
   DeleteAnycastIpListResponse,
   DeleteAnycastIpListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnycastIpListRequest,
   output: DeleteAnycastIpListResponse,
@@ -12333,7 +12332,7 @@ export const deleteCachePolicy: API.OperationMethod<
   DeleteCachePolicyRequest,
   DeleteCachePolicyResponse,
   DeleteCachePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCachePolicyRequest,
   output: DeleteCachePolicyResponse,
@@ -12364,7 +12363,7 @@ export const deleteCloudFrontOriginAccessIdentity: API.OperationMethod<
   DeleteCloudFrontOriginAccessIdentityRequest,
   DeleteCloudFrontOriginAccessIdentityResponse,
   DeleteCloudFrontOriginAccessIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudFrontOriginAccessIdentityRequest,
   output: DeleteCloudFrontOriginAccessIdentityResponse,
@@ -12396,7 +12395,7 @@ export const deleteConnectionFunction: API.OperationMethod<
   DeleteConnectionFunctionRequest,
   DeleteConnectionFunctionResponse,
   DeleteConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionFunctionRequest,
   output: DeleteConnectionFunctionResponse,
@@ -12429,7 +12428,7 @@ export const deleteConnectionGroup: API.OperationMethod<
   DeleteConnectionGroupRequest,
   DeleteConnectionGroupResponse,
   DeleteConnectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionGroupRequest,
   output: DeleteConnectionGroupResponse,
@@ -12463,7 +12462,7 @@ export const deleteContinuousDeploymentPolicy: API.OperationMethod<
   DeleteContinuousDeploymentPolicyRequest,
   DeleteContinuousDeploymentPolicyResponse,
   DeleteContinuousDeploymentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContinuousDeploymentPolicyRequest,
   output: DeleteContinuousDeploymentPolicyResponse,
@@ -12497,7 +12496,7 @@ export const deleteDistribution: API.OperationMethod<
   DeleteDistributionRequest,
   DeleteDistributionResponse,
   DeleteDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDistributionRequest,
   output: DeleteDistributionResponse,
@@ -12530,7 +12529,7 @@ export const deleteDistributionTenant: API.OperationMethod<
   DeleteDistributionTenantRequest,
   DeleteDistributionTenantResponse,
   DeleteDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDistributionTenantRequest,
   output: DeleteDistributionTenantResponse,
@@ -12560,7 +12559,7 @@ export const deleteFieldLevelEncryptionConfig: API.OperationMethod<
   DeleteFieldLevelEncryptionConfigRequest,
   DeleteFieldLevelEncryptionConfigResponse,
   DeleteFieldLevelEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFieldLevelEncryptionConfigRequest,
   output: DeleteFieldLevelEncryptionConfigResponse,
@@ -12590,7 +12589,7 @@ export const deleteFieldLevelEncryptionProfile: API.OperationMethod<
   DeleteFieldLevelEncryptionProfileRequest,
   DeleteFieldLevelEncryptionProfileResponse,
   DeleteFieldLevelEncryptionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFieldLevelEncryptionProfileRequest,
   output: DeleteFieldLevelEncryptionProfileResponse,
@@ -12624,7 +12623,7 @@ export const deleteFunction: API.OperationMethod<
   DeleteFunctionRequest,
   DeleteFunctionResponse,
   DeleteFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionRequest,
   output: DeleteFunctionResponse,
@@ -12657,7 +12656,7 @@ export const deleteKeyGroup: API.OperationMethod<
   DeleteKeyGroupRequest,
   DeleteKeyGroupResponse,
   DeleteKeyGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyGroupRequest,
   output: DeleteKeyGroupResponse,
@@ -12687,7 +12686,7 @@ export const deleteKeyValueStore: API.OperationMethod<
   DeleteKeyValueStoreRequest,
   DeleteKeyValueStoreResponse,
   DeleteKeyValueStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyValueStoreRequest,
   output: DeleteKeyValueStoreResponse,
@@ -12717,7 +12716,7 @@ export const deleteMonitoringSubscription: API.OperationMethod<
   DeleteMonitoringSubscriptionRequest,
   DeleteMonitoringSubscriptionResult,
   DeleteMonitoringSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitoringSubscriptionRequest,
   output: DeleteMonitoringSubscriptionResult,
@@ -12748,7 +12747,7 @@ export const deleteOriginAccessControl: API.OperationMethod<
   DeleteOriginAccessControlRequest,
   DeleteOriginAccessControlResponse,
   DeleteOriginAccessControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOriginAccessControlRequest,
   output: DeleteOriginAccessControlResponse,
@@ -12783,7 +12782,7 @@ export const deleteOriginRequestPolicy: API.OperationMethod<
   DeleteOriginRequestPolicyRequest,
   DeleteOriginRequestPolicyResponse,
   DeleteOriginRequestPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOriginRequestPolicyRequest,
   output: DeleteOriginRequestPolicyResponse,
@@ -12814,7 +12813,7 @@ export const deletePublicKey: API.OperationMethod<
   DeletePublicKeyRequest,
   DeletePublicKeyResponse,
   DeletePublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublicKeyRequest,
   output: DeletePublicKeyResponse,
@@ -12847,7 +12846,7 @@ export const deleteRealtimeLogConfig: API.OperationMethod<
   DeleteRealtimeLogConfigRequest,
   DeleteRealtimeLogConfigResponse,
   DeleteRealtimeLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRealtimeLogConfigRequest,
   output: DeleteRealtimeLogConfigResponse,
@@ -12877,7 +12876,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -12913,7 +12912,7 @@ export const deleteResponseHeadersPolicy: API.OperationMethod<
   DeleteResponseHeadersPolicyRequest,
   DeleteResponseHeadersPolicyResponse,
   DeleteResponseHeadersPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResponseHeadersPolicyRequest,
   output: DeleteResponseHeadersPolicyResponse,
@@ -12964,7 +12963,7 @@ export const deleteStreamingDistribution: API.OperationMethod<
   DeleteStreamingDistributionRequest,
   DeleteStreamingDistributionResponse,
   DeleteStreamingDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamingDistributionRequest,
   output: DeleteStreamingDistributionResponse,
@@ -12995,7 +12994,7 @@ export const deleteTrustStore: API.OperationMethod<
   DeleteTrustStoreRequest,
   DeleteTrustStoreResponse,
   DeleteTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustStoreRequest,
   output: DeleteTrustStoreResponse,
@@ -13029,7 +13028,7 @@ export const deleteVpcOrigin: API.OperationMethod<
   DeleteVpcOriginRequest,
   DeleteVpcOriginResult,
   DeleteVpcOriginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcOriginRequest,
   output: DeleteVpcOriginResult,
@@ -13061,7 +13060,7 @@ export const describeConnectionFunction: API.OperationMethod<
   DescribeConnectionFunctionRequest,
   DescribeConnectionFunctionResult,
   DescribeConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionFunctionRequest,
   output: DescribeConnectionFunctionResult,
@@ -13084,7 +13083,7 @@ export const describeFunction: API.OperationMethod<
   DescribeFunctionRequest,
   DescribeFunctionResult,
   DescribeFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFunctionRequest,
   output: DescribeFunctionResult,
@@ -13107,7 +13106,7 @@ export const describeKeyValueStore: API.OperationMethod<
   DescribeKeyValueStoreRequest,
   DescribeKeyValueStoreResult,
   DescribeKeyValueStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyValueStoreRequest,
   output: DescribeKeyValueStoreResult,
@@ -13131,7 +13130,7 @@ export const disassociateDistributionTenantWebACL: API.OperationMethod<
   DisassociateDistributionTenantWebACLRequest,
   DisassociateDistributionTenantWebACLResult,
   DisassociateDistributionTenantWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDistributionTenantWebACLRequest,
   output: DisassociateDistributionTenantWebACLResult,
@@ -13161,7 +13160,7 @@ export const disassociateDistributionWebACL: API.OperationMethod<
   DisassociateDistributionWebACLRequest,
   DisassociateDistributionWebACLResult,
   DisassociateDistributionWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDistributionWebACLRequest,
   output: DisassociateDistributionWebACLResult,
@@ -13190,7 +13189,7 @@ export const getAnycastIpList: API.OperationMethod<
   GetAnycastIpListRequest,
   GetAnycastIpListResult,
   GetAnycastIpListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnycastIpListRequest,
   output: GetAnycastIpListResult,
@@ -13217,7 +13216,7 @@ export const getCachePolicy: API.OperationMethod<
   GetCachePolicyRequest,
   GetCachePolicyResult,
   GetCachePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCachePolicyRequest,
   output: GetCachePolicyResult,
@@ -13240,7 +13239,7 @@ export const getCachePolicyConfig: API.OperationMethod<
   GetCachePolicyConfigRequest,
   GetCachePolicyConfigResult,
   GetCachePolicyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCachePolicyConfigRequest,
   output: GetCachePolicyConfigResult,
@@ -13261,7 +13260,7 @@ export const getCloudFrontOriginAccessIdentity: API.OperationMethod<
   GetCloudFrontOriginAccessIdentityRequest,
   GetCloudFrontOriginAccessIdentityResult,
   GetCloudFrontOriginAccessIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudFrontOriginAccessIdentityRequest,
   output: GetCloudFrontOriginAccessIdentityResult,
@@ -13282,7 +13281,7 @@ export const getCloudFrontOriginAccessIdentityConfig: API.OperationMethod<
   GetCloudFrontOriginAccessIdentityConfigRequest,
   GetCloudFrontOriginAccessIdentityConfigResult,
   GetCloudFrontOriginAccessIdentityConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudFrontOriginAccessIdentityConfigRequest,
   output: GetCloudFrontOriginAccessIdentityConfigResult,
@@ -13304,7 +13303,7 @@ export const getConnectionFunction: API.OperationMethod<
   GetConnectionFunctionRequest,
   GetConnectionFunctionResult,
   GetConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionFunctionRequest,
   output: GetConnectionFunctionResult,
@@ -13325,7 +13324,7 @@ export const getConnectionGroup: API.OperationMethod<
   GetConnectionGroupRequest,
   GetConnectionGroupResult,
   GetConnectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionGroupRequest,
   output: GetConnectionGroupResult,
@@ -13346,7 +13345,7 @@ export const getConnectionGroupByRoutingEndpoint: API.OperationMethod<
   GetConnectionGroupByRoutingEndpointRequest,
   GetConnectionGroupByRoutingEndpointResult,
   GetConnectionGroupByRoutingEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionGroupByRoutingEndpointRequest,
   output: GetConnectionGroupByRoutingEndpointResult,
@@ -13367,7 +13366,7 @@ export const getContinuousDeploymentPolicy: API.OperationMethod<
   GetContinuousDeploymentPolicyRequest,
   GetContinuousDeploymentPolicyResult,
   GetContinuousDeploymentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContinuousDeploymentPolicyRequest,
   output: GetContinuousDeploymentPolicyResult,
@@ -13388,7 +13387,7 @@ export const getContinuousDeploymentPolicyConfig: API.OperationMethod<
   GetContinuousDeploymentPolicyConfigRequest,
   GetContinuousDeploymentPolicyConfigResult,
   GetContinuousDeploymentPolicyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContinuousDeploymentPolicyConfigRequest,
   output: GetContinuousDeploymentPolicyConfigResult,
@@ -13409,7 +13408,7 @@ export const getDistribution: API.OperationMethod<
   GetDistributionRequest,
   GetDistributionResult,
   GetDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionRequest,
   output: GetDistributionResult,
@@ -13430,7 +13429,7 @@ export const getDistributionConfig: API.OperationMethod<
   GetDistributionConfigRequest,
   GetDistributionConfigResult,
   GetDistributionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionConfigRequest,
   output: GetDistributionConfigResult,
@@ -13451,7 +13450,7 @@ export const getDistributionTenant: API.OperationMethod<
   GetDistributionTenantRequest,
   GetDistributionTenantResult,
   GetDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionTenantRequest,
   output: GetDistributionTenantResult,
@@ -13472,7 +13471,7 @@ export const getDistributionTenantByDomain: API.OperationMethod<
   GetDistributionTenantByDomainRequest,
   GetDistributionTenantByDomainResult,
   GetDistributionTenantByDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionTenantByDomainRequest,
   output: GetDistributionTenantByDomainResult,
@@ -13493,7 +13492,7 @@ export const getFieldLevelEncryption: API.OperationMethod<
   GetFieldLevelEncryptionRequest,
   GetFieldLevelEncryptionResult,
   GetFieldLevelEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFieldLevelEncryptionRequest,
   output: GetFieldLevelEncryptionResult,
@@ -13514,7 +13513,7 @@ export const getFieldLevelEncryptionConfig: API.OperationMethod<
   GetFieldLevelEncryptionConfigRequest,
   GetFieldLevelEncryptionConfigResult,
   GetFieldLevelEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFieldLevelEncryptionConfigRequest,
   output: GetFieldLevelEncryptionConfigResult,
@@ -13535,7 +13534,7 @@ export const getFieldLevelEncryptionProfile: API.OperationMethod<
   GetFieldLevelEncryptionProfileRequest,
   GetFieldLevelEncryptionProfileResult,
   GetFieldLevelEncryptionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFieldLevelEncryptionProfileRequest,
   output: GetFieldLevelEncryptionProfileResult,
@@ -13556,7 +13555,7 @@ export const getFieldLevelEncryptionProfileConfig: API.OperationMethod<
   GetFieldLevelEncryptionProfileConfigRequest,
   GetFieldLevelEncryptionProfileConfigResult,
   GetFieldLevelEncryptionProfileConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFieldLevelEncryptionProfileConfigRequest,
   output: GetFieldLevelEncryptionProfileConfigResult,
@@ -13579,7 +13578,7 @@ export const getFunction: API.OperationMethod<
   GetFunctionRequest,
   GetFunctionResult,
   GetFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionRequest,
   output: GetFunctionResult,
@@ -13601,7 +13600,7 @@ export const getInvalidation: API.OperationMethod<
   GetInvalidationRequest,
   GetInvalidationResult,
   GetInvalidationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvalidationRequest,
   output: GetInvalidationResult,
@@ -13623,7 +13622,7 @@ export const getInvalidationForDistributionTenant: API.OperationMethod<
   GetInvalidationForDistributionTenantRequest,
   GetInvalidationForDistributionTenantResult,
   GetInvalidationForDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvalidationForDistributionTenantRequest,
   output: GetInvalidationForDistributionTenantResult,
@@ -13643,7 +13642,7 @@ export const getKeyGroup: API.OperationMethod<
   GetKeyGroupRequest,
   GetKeyGroupResult,
   GetKeyGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyGroupRequest,
   output: GetKeyGroupResult,
@@ -13663,7 +13662,7 @@ export const getKeyGroupConfig: API.OperationMethod<
   GetKeyGroupConfigRequest,
   GetKeyGroupConfigResult,
   GetKeyGroupConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyGroupConfigRequest,
   output: GetKeyGroupConfigResult,
@@ -13684,7 +13683,7 @@ export const getManagedCertificateDetails: API.OperationMethod<
   GetManagedCertificateDetailsRequest,
   GetManagedCertificateDetailsResult,
   GetManagedCertificateDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedCertificateDetailsRequest,
   output: GetManagedCertificateDetailsResult,
@@ -13707,7 +13706,7 @@ export const getMonitoringSubscription: API.OperationMethod<
   GetMonitoringSubscriptionRequest,
   GetMonitoringSubscriptionResult,
   GetMonitoringSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitoringSubscriptionRequest,
   output: GetMonitoringSubscriptionResult,
@@ -13733,7 +13732,7 @@ export const getOriginAccessControl: API.OperationMethod<
   GetOriginAccessControlRequest,
   GetOriginAccessControlResult,
   GetOriginAccessControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginAccessControlRequest,
   output: GetOriginAccessControlResult,
@@ -13754,7 +13753,7 @@ export const getOriginAccessControlConfig: API.OperationMethod<
   GetOriginAccessControlConfigRequest,
   GetOriginAccessControlConfigResult,
   GetOriginAccessControlConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginAccessControlConfigRequest,
   output: GetOriginAccessControlConfigResult,
@@ -13781,7 +13780,7 @@ export const getOriginRequestPolicy: API.OperationMethod<
   GetOriginRequestPolicyRequest,
   GetOriginRequestPolicyResult,
   GetOriginRequestPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginRequestPolicyRequest,
   output: GetOriginRequestPolicyResult,
@@ -13804,7 +13803,7 @@ export const getOriginRequestPolicyConfig: API.OperationMethod<
   GetOriginRequestPolicyConfigRequest,
   GetOriginRequestPolicyConfigResult,
   GetOriginRequestPolicyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginRequestPolicyConfigRequest,
   output: GetOriginRequestPolicyConfigResult,
@@ -13822,7 +13821,7 @@ export const getPublicKey: API.OperationMethod<
   GetPublicKeyRequest,
   GetPublicKeyResult,
   GetPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicKeyRequest,
   output: GetPublicKeyResult,
@@ -13843,7 +13842,7 @@ export const getPublicKeyConfig: API.OperationMethod<
   GetPublicKeyConfigRequest,
   GetPublicKeyConfigResult,
   GetPublicKeyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicKeyConfigRequest,
   output: GetPublicKeyConfigResult,
@@ -13867,7 +13866,7 @@ export const getRealtimeLogConfig: API.OperationMethod<
   GetRealtimeLogConfigRequest,
   GetRealtimeLogConfigResult,
   GetRealtimeLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRealtimeLogConfigRequest,
   output: GetRealtimeLogConfigResult,
@@ -13890,7 +13889,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResult,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResult,
@@ -13913,7 +13912,7 @@ export const getResponseHeadersPolicy: API.OperationMethod<
   GetResponseHeadersPolicyRequest,
   GetResponseHeadersPolicyResult,
   GetResponseHeadersPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResponseHeadersPolicyRequest,
   output: GetResponseHeadersPolicyResult,
@@ -13936,7 +13935,7 @@ export const getResponseHeadersPolicyConfig: API.OperationMethod<
   GetResponseHeadersPolicyConfigRequest,
   GetResponseHeadersPolicyConfigResult,
   GetResponseHeadersPolicyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResponseHeadersPolicyConfigRequest,
   output: GetResponseHeadersPolicyConfigResult,
@@ -13957,7 +13956,7 @@ export const getStreamingDistribution: API.OperationMethod<
   GetStreamingDistributionRequest,
   GetStreamingDistributionResult,
   GetStreamingDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamingDistributionRequest,
   output: GetStreamingDistributionResult,
@@ -13978,7 +13977,7 @@ export const getStreamingDistributionConfig: API.OperationMethod<
   GetStreamingDistributionConfigRequest,
   GetStreamingDistributionConfigResult,
   GetStreamingDistributionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamingDistributionConfigRequest,
   output: GetStreamingDistributionConfigResult,
@@ -14000,7 +13999,7 @@ export const getTrustStore: API.OperationMethod<
   GetTrustStoreRequest,
   GetTrustStoreResult,
   GetTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustStoreRequest,
   output: GetTrustStoreResult,
@@ -14023,7 +14022,7 @@ export const getVpcOrigin: API.OperationMethod<
   GetVpcOriginRequest,
   GetVpcOriginResult,
   GetVpcOriginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcOriginRequest,
   output: GetVpcOriginResult,
@@ -14046,7 +14045,7 @@ export const listAnycastIpLists: API.OperationMethod<
   ListAnycastIpListsRequest,
   ListAnycastIpListsResult,
   ListAnycastIpListsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAnycastIpListsRequest,
   output: ListAnycastIpListsResult,
@@ -14072,7 +14071,7 @@ export const listCachePolicies: API.OperationMethod<
   ListCachePoliciesRequest,
   ListCachePoliciesResult,
   ListCachePoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCachePoliciesRequest,
   output: ListCachePoliciesResult,
@@ -14092,7 +14091,7 @@ export const listCloudFrontOriginAccessIdentities: API.PaginatedOperationMethod<
   ListCloudFrontOriginAccessIdentitiesRequest,
   ListCloudFrontOriginAccessIdentitiesResult,
   ListCloudFrontOriginAccessIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudFrontOriginAccessIdentitiesRequest,
@@ -14130,7 +14129,7 @@ export const listConflictingAliases: API.OperationMethod<
   ListConflictingAliasesRequest,
   ListConflictingAliasesResult,
   ListConflictingAliasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConflictingAliasesRequest,
   output: ListConflictingAliasesResult,
@@ -14152,7 +14151,7 @@ export const listConnectionFunctions: API.PaginatedOperationMethod<
   ListConnectionFunctionsRequest,
   ListConnectionFunctionsResult,
   ListConnectionFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionFunctionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionFunctionsRequest,
@@ -14181,7 +14180,7 @@ export const listConnectionGroups: API.PaginatedOperationMethod<
   ListConnectionGroupsRequest,
   ListConnectionGroupsResult,
   ListConnectionGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionGroupsRequest,
@@ -14212,7 +14211,7 @@ export const listContinuousDeploymentPolicies: API.OperationMethod<
   ListContinuousDeploymentPoliciesRequest,
   ListContinuousDeploymentPoliciesResult,
   ListContinuousDeploymentPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListContinuousDeploymentPoliciesRequest,
   output: ListContinuousDeploymentPoliciesResult,
@@ -14230,7 +14229,7 @@ export const listDistributions: API.PaginatedOperationMethod<
   ListDistributionsRequest,
   ListDistributionsResult,
   ListDistributionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionsRequest,
@@ -14260,7 +14259,7 @@ export const listDistributionsByAnycastIpListId: API.OperationMethod<
   ListDistributionsByAnycastIpListIdRequest,
   ListDistributionsByAnycastIpListIdResult,
   ListDistributionsByAnycastIpListIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByAnycastIpListIdRequest,
   output: ListDistributionsByAnycastIpListIdResult,
@@ -14284,7 +14283,7 @@ export const listDistributionsByCachePolicyId: API.OperationMethod<
   ListDistributionsByCachePolicyIdRequest,
   ListDistributionsByCachePolicyIdResult,
   ListDistributionsByCachePolicyIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByCachePolicyIdRequest,
   output: ListDistributionsByCachePolicyIdResult,
@@ -14306,7 +14305,7 @@ export const listDistributionsByConnectionFunction: API.PaginatedOperationMethod
   ListDistributionsByConnectionFunctionRequest,
   ListDistributionsByConnectionFunctionResult,
   ListDistributionsByConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionsByConnectionFunctionRequest,
@@ -14334,7 +14333,7 @@ export const listDistributionsByConnectionMode: API.PaginatedOperationMethod<
   ListDistributionsByConnectionModeRequest,
   ListDistributionsByConnectionModeResult,
   ListDistributionsByConnectionModeError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionsByConnectionModeRequest,
@@ -14364,7 +14363,7 @@ export const listDistributionsByKeyGroup: API.OperationMethod<
   ListDistributionsByKeyGroupRequest,
   ListDistributionsByKeyGroupResult,
   ListDistributionsByKeyGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByKeyGroupRequest,
   output: ListDistributionsByKeyGroupResult,
@@ -14388,7 +14387,7 @@ export const listDistributionsByOriginRequestPolicyId: API.OperationMethod<
   ListDistributionsByOriginRequestPolicyIdRequest,
   ListDistributionsByOriginRequestPolicyIdResult,
   ListDistributionsByOriginRequestPolicyIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByOriginRequestPolicyIdRequest,
   output: ListDistributionsByOriginRequestPolicyIdResult,
@@ -14411,7 +14410,7 @@ export const listDistributionsByOwnedResource: API.OperationMethod<
   ListDistributionsByOwnedResourceRequest,
   ListDistributionsByOwnedResourceResult,
   ListDistributionsByOwnedResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByOwnedResourceRequest,
   output: ListDistributionsByOwnedResourceResult,
@@ -14435,7 +14434,7 @@ export const listDistributionsByRealtimeLogConfig: API.OperationMethod<
   ListDistributionsByRealtimeLogConfigRequest,
   ListDistributionsByRealtimeLogConfigResult,
   ListDistributionsByRealtimeLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByRealtimeLogConfigRequest,
   output: ListDistributionsByRealtimeLogConfigResult,
@@ -14459,7 +14458,7 @@ export const listDistributionsByResponseHeadersPolicyId: API.OperationMethod<
   ListDistributionsByResponseHeadersPolicyIdRequest,
   ListDistributionsByResponseHeadersPolicyIdResult,
   ListDistributionsByResponseHeadersPolicyIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByResponseHeadersPolicyIdRequest,
   output: ListDistributionsByResponseHeadersPolicyIdResult,
@@ -14481,7 +14480,7 @@ export const listDistributionsByTrustStore: API.PaginatedOperationMethod<
   ListDistributionsByTrustStoreRequest,
   ListDistributionsByTrustStoreResult,
   ListDistributionsByTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionsByTrustStoreRequest,
@@ -14511,7 +14510,7 @@ export const listDistributionsByVpcOriginId: API.OperationMethod<
   ListDistributionsByVpcOriginIdRequest,
   ListDistributionsByVpcOriginIdResult,
   ListDistributionsByVpcOriginIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByVpcOriginIdRequest,
   output: ListDistributionsByVpcOriginIdResult,
@@ -14532,7 +14531,7 @@ export const listDistributionsByWebACLId: API.OperationMethod<
   ListDistributionsByWebACLIdRequest,
   ListDistributionsByWebACLIdResult,
   ListDistributionsByWebACLIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributionsByWebACLIdRequest,
   output: ListDistributionsByWebACLIdResult,
@@ -14554,7 +14553,7 @@ export const listDistributionTenants: API.PaginatedOperationMethod<
   ListDistributionTenantsRequest,
   ListDistributionTenantsResult,
   ListDistributionTenantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DistributionTenantSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionTenantsRequest,
@@ -14585,7 +14584,7 @@ export const listDistributionTenantsByCustomization: API.PaginatedOperationMetho
   ListDistributionTenantsByCustomizationRequest,
   ListDistributionTenantsByCustomizationResult,
   ListDistributionTenantsByCustomizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DistributionTenantSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionTenantsByCustomizationRequest,
@@ -14630,7 +14629,7 @@ export const listDomainConflicts: API.PaginatedOperationMethod<
   ListDomainConflictsRequest,
   ListDomainConflictsResult,
   ListDomainConflictsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainConflict
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainConflictsRequest,
@@ -14657,7 +14656,7 @@ export const listFieldLevelEncryptionConfigs: API.OperationMethod<
   ListFieldLevelEncryptionConfigsRequest,
   ListFieldLevelEncryptionConfigsResult,
   ListFieldLevelEncryptionConfigsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFieldLevelEncryptionConfigsRequest,
   output: ListFieldLevelEncryptionConfigsResult,
@@ -14677,7 +14676,7 @@ export const listFieldLevelEncryptionProfiles: API.OperationMethod<
   ListFieldLevelEncryptionProfilesRequest,
   ListFieldLevelEncryptionProfilesResult,
   ListFieldLevelEncryptionProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFieldLevelEncryptionProfilesRequest,
   output: ListFieldLevelEncryptionProfilesResult,
@@ -14702,7 +14701,7 @@ export const listFunctions: API.OperationMethod<
   ListFunctionsRequest,
   ListFunctionsResult,
   ListFunctionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFunctionsRequest,
   output: ListFunctionsResult,
@@ -14724,7 +14723,7 @@ export const listInvalidations: API.PaginatedOperationMethod<
   ListInvalidationsRequest,
   ListInvalidationsResult,
   ListInvalidationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvalidationsRequest,
@@ -14753,7 +14752,7 @@ export const listInvalidationsForDistributionTenant: API.PaginatedOperationMetho
   ListInvalidationsForDistributionTenantRequest,
   ListInvalidationsForDistributionTenantResult,
   ListInvalidationsForDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvalidationsForDistributionTenantRequest,
@@ -14780,7 +14779,7 @@ export const listKeyGroups: API.OperationMethod<
   ListKeyGroupsRequest,
   ListKeyGroupsResult,
   ListKeyGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListKeyGroupsRequest,
   output: ListKeyGroupsResult,
@@ -14802,7 +14801,7 @@ export const listKeyValueStores: API.PaginatedOperationMethod<
   ListKeyValueStoresRequest,
   ListKeyValueStoresResult,
   ListKeyValueStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeyValueStoresRequest,
@@ -14831,7 +14830,7 @@ export const listOriginAccessControls: API.PaginatedOperationMethod<
   ListOriginAccessControlsRequest,
   ListOriginAccessControlsResult,
   ListOriginAccessControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOriginAccessControlsRequest,
@@ -14864,7 +14863,7 @@ export const listOriginRequestPolicies: API.OperationMethod<
   ListOriginRequestPoliciesRequest,
   ListOriginRequestPoliciesResult,
   ListOriginRequestPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOriginRequestPoliciesRequest,
   output: ListOriginRequestPoliciesResult,
@@ -14882,7 +14881,7 @@ export const listPublicKeys: API.PaginatedOperationMethod<
   ListPublicKeysRequest,
   ListPublicKeysResult,
   ListPublicKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPublicKeysRequest,
@@ -14913,7 +14912,7 @@ export const listRealtimeLogConfigs: API.OperationMethod<
   ListRealtimeLogConfigsRequest,
   ListRealtimeLogConfigsResult,
   ListRealtimeLogConfigsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRealtimeLogConfigsRequest,
   output: ListRealtimeLogConfigsResult,
@@ -14939,7 +14938,7 @@ export const listResponseHeadersPolicies: API.OperationMethod<
   ListResponseHeadersPoliciesRequest,
   ListResponseHeadersPoliciesResult,
   ListResponseHeadersPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResponseHeadersPoliciesRequest,
   output: ListResponseHeadersPoliciesResult,
@@ -14957,7 +14956,7 @@ export const listStreamingDistributions: API.PaginatedOperationMethod<
   ListStreamingDistributionsRequest,
   ListStreamingDistributionsResult,
   ListStreamingDistributionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamingDistributionsRequest,
@@ -14987,7 +14986,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -15009,7 +15008,7 @@ export const listTrustStores: API.PaginatedOperationMethod<
   ListTrustStoresRequest,
   ListTrustStoresResult,
   ListTrustStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrustStoreSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustStoresRequest,
@@ -15039,7 +15038,7 @@ export const listVpcOrigins: API.OperationMethod<
   ListVpcOriginsRequest,
   ListVpcOriginsResult,
   ListVpcOriginsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcOriginsRequest,
   output: ListVpcOriginsResult,
@@ -15064,7 +15063,7 @@ export const publishConnectionFunction: API.OperationMethod<
   PublishConnectionFunctionRequest,
   PublishConnectionFunctionResult,
   PublishConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishConnectionFunctionRequest,
   output: PublishConnectionFunctionResult,
@@ -15099,7 +15098,7 @@ export const publishFunction: API.OperationMethod<
   PublishFunctionRequest,
   PublishFunctionResult,
   PublishFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishFunctionRequest,
   output: PublishFunctionResult,
@@ -15130,7 +15129,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResult,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResult,
@@ -15160,7 +15159,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -15185,7 +15184,7 @@ export const testConnectionFunction: API.OperationMethod<
   TestConnectionFunctionRequest,
   TestConnectionFunctionResult,
   TestConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestConnectionFunctionRequest,
   output: TestConnectionFunctionResult,
@@ -15220,7 +15219,7 @@ export const testFunction: API.OperationMethod<
   TestFunctionRequest,
   TestFunctionResult,
   TestFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestFunctionRequest,
   output: TestFunctionResult,
@@ -15249,7 +15248,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -15274,7 +15273,7 @@ export const updateAnycastIpList: API.OperationMethod<
   UpdateAnycastIpListRequest,
   UpdateAnycastIpListResult,
   UpdateAnycastIpListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnycastIpListRequest,
   output: UpdateAnycastIpListResult,
@@ -15321,7 +15320,7 @@ export const updateCachePolicy: API.OperationMethod<
   UpdateCachePolicyRequest,
   UpdateCachePolicyResult,
   UpdateCachePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCachePolicyRequest,
   output: UpdateCachePolicyResult,
@@ -15360,7 +15359,7 @@ export const updateCloudFrontOriginAccessIdentity: API.OperationMethod<
   UpdateCloudFrontOriginAccessIdentityRequest,
   UpdateCloudFrontOriginAccessIdentityResult,
   UpdateCloudFrontOriginAccessIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCloudFrontOriginAccessIdentityRequest,
   output: UpdateCloudFrontOriginAccessIdentityResult,
@@ -15395,7 +15394,7 @@ export const updateConnectionFunction: API.OperationMethod<
   UpdateConnectionFunctionRequest,
   UpdateConnectionFunctionResult,
   UpdateConnectionFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionFunctionRequest,
   output: UpdateConnectionFunctionResult,
@@ -15430,7 +15429,7 @@ export const updateConnectionGroup: API.OperationMethod<
   UpdateConnectionGroupRequest,
   UpdateConnectionGroupResult,
   UpdateConnectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionGroupRequest,
   output: UpdateConnectionGroupResult,
@@ -15473,7 +15472,7 @@ export const updateContinuousDeploymentPolicy: API.OperationMethod<
   UpdateContinuousDeploymentPolicyRequest,
   UpdateContinuousDeploymentPolicyResult,
   UpdateContinuousDeploymentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContinuousDeploymentPolicyRequest,
   output: UpdateContinuousDeploymentPolicyResult,
@@ -15581,7 +15580,7 @@ export const updateDistribution: API.OperationMethod<
   UpdateDistributionRequest,
   UpdateDistributionResult,
   UpdateDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionRequest,
   output: UpdateDistributionResult,
@@ -15677,7 +15676,7 @@ export const updateDistributionTenant: API.OperationMethod<
   UpdateDistributionTenantRequest,
   UpdateDistributionTenantResult,
   UpdateDistributionTenantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionTenantRequest,
   output: UpdateDistributionTenantResult,
@@ -15777,7 +15776,7 @@ export const updateDistributionWithStagingConfig: API.OperationMethod<
   UpdateDistributionWithStagingConfigRequest,
   UpdateDistributionWithStagingConfigResult,
   UpdateDistributionWithStagingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionWithStagingConfigRequest,
   output: UpdateDistributionWithStagingConfigResult,
@@ -15872,7 +15871,7 @@ export const updateDomainAssociation: API.OperationMethod<
   UpdateDomainAssociationRequest,
   UpdateDomainAssociationResult,
   UpdateDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainAssociationRequest,
   output: UpdateDomainAssociationResult,
@@ -15909,7 +15908,7 @@ export const updateFieldLevelEncryptionConfig: API.OperationMethod<
   UpdateFieldLevelEncryptionConfigRequest,
   UpdateFieldLevelEncryptionConfigResult,
   UpdateFieldLevelEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFieldLevelEncryptionConfigRequest,
   output: UpdateFieldLevelEncryptionConfigResult,
@@ -15952,7 +15951,7 @@ export const updateFieldLevelEncryptionProfile: API.OperationMethod<
   UpdateFieldLevelEncryptionProfileRequest,
   UpdateFieldLevelEncryptionProfileResult,
   UpdateFieldLevelEncryptionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFieldLevelEncryptionProfileRequest,
   output: UpdateFieldLevelEncryptionProfileResult,
@@ -15994,7 +15993,7 @@ export const updateFunction: API.OperationMethod<
   UpdateFunctionRequest,
   UpdateFunctionResult,
   UpdateFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionRequest,
   output: UpdateFunctionResult,
@@ -16034,7 +16033,7 @@ export const updateKeyGroup: API.OperationMethod<
   UpdateKeyGroupRequest,
   UpdateKeyGroupResult,
   UpdateKeyGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyGroupRequest,
   output: UpdateKeyGroupResult,
@@ -16066,7 +16065,7 @@ export const updateKeyValueStore: API.OperationMethod<
   UpdateKeyValueStoreRequest,
   UpdateKeyValueStoreResult,
   UpdateKeyValueStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyValueStoreRequest,
   output: UpdateKeyValueStoreResult,
@@ -16099,7 +16098,7 @@ export const updateOriginAccessControl: API.OperationMethod<
   UpdateOriginAccessControlRequest,
   UpdateOriginAccessControlResult,
   UpdateOriginAccessControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOriginAccessControlRequest,
   output: UpdateOriginAccessControlResult,
@@ -16145,7 +16144,7 @@ export const updateOriginRequestPolicy: API.OperationMethod<
   UpdateOriginRequestPolicyRequest,
   UpdateOriginRequestPolicyResult,
   UpdateOriginRequestPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOriginRequestPolicyRequest,
   output: UpdateOriginRequestPolicyResult,
@@ -16183,7 +16182,7 @@ export const updatePublicKey: API.OperationMethod<
   UpdatePublicKeyRequest,
   UpdatePublicKeyResult,
   UpdatePublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePublicKeyRequest,
   output: UpdatePublicKeyResult,
@@ -16223,7 +16222,7 @@ export const updateRealtimeLogConfig: API.OperationMethod<
   UpdateRealtimeLogConfigRequest,
   UpdateRealtimeLogConfigResult,
   UpdateRealtimeLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRealtimeLogConfigRequest,
   output: UpdateRealtimeLogConfigResult,
@@ -16261,7 +16260,7 @@ export const updateResponseHeadersPolicy: API.OperationMethod<
   UpdateResponseHeadersPolicyRequest,
   UpdateResponseHeadersPolicyResult,
   UpdateResponseHeadersPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResponseHeadersPolicyRequest,
   output: UpdateResponseHeadersPolicyResult,
@@ -16306,7 +16305,7 @@ export const updateStreamingDistribution: API.OperationMethod<
   UpdateStreamingDistributionRequest,
   UpdateStreamingDistributionResult,
   UpdateStreamingDistributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamingDistributionRequest,
   output: UpdateStreamingDistributionResult,
@@ -16345,7 +16344,7 @@ export const updateTrustStore: API.OperationMethod<
   UpdateTrustStoreRequest,
   UpdateTrustStoreResult,
   UpdateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustStoreRequest,
   output: UpdateTrustStoreResult,
@@ -16381,7 +16380,7 @@ export const updateVpcOrigin: API.OperationMethod<
   UpdateVpcOriginRequest,
   UpdateVpcOriginResult,
   UpdateVpcOriginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcOriginRequest,
   output: UpdateVpcOriginResult,
@@ -16415,7 +16414,7 @@ export const verifyDnsConfiguration: API.OperationMethod<
   VerifyDnsConfigurationRequest,
   VerifyDnsConfigurationResult,
   VerifyDnsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyDnsConfigurationRequest,
   output: VerifyDnsConfigurationResult,

--- a/packages/aws/src/services/cloudhsm-v2.ts
+++ b/packages/aws/src/services/cloudhsm-v2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudHSM V2",
   serviceShapeName: "BaldrApiService",
@@ -805,7 +804,7 @@ export const copyBackupToRegion: API.OperationMethod<
   CopyBackupToRegionRequest,
   CopyBackupToRegionResponse,
   CopyBackupToRegionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyBackupToRegionRequest,
   output: CopyBackupToRegionResponse,
@@ -840,7 +839,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -874,7 +873,7 @@ export const createHsm: API.OperationMethod<
   CreateHsmRequest,
   CreateHsmResponse,
   CreateHsmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHsmRequest,
   output: CreateHsmResponse,
@@ -908,7 +907,7 @@ export const deleteBackup: API.OperationMethod<
   DeleteBackupRequest,
   DeleteBackupResponse,
   DeleteBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupRequest,
   output: DeleteBackupResponse,
@@ -942,7 +941,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -977,7 +976,7 @@ export const deleteHsm: API.OperationMethod<
   DeleteHsmRequest,
   DeleteHsmResponse,
   DeleteHsmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHsmRequest,
   output: DeleteHsmResponse,
@@ -1011,7 +1010,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -1050,7 +1049,7 @@ export const describeBackups: API.PaginatedOperationMethod<
   DescribeBackupsRequest,
   DescribeBackupsResponse,
   DescribeBackupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBackupsRequest,
@@ -1095,7 +1094,7 @@ export const describeClusters: API.PaginatedOperationMethod<
   DescribeClustersRequest,
   DescribeClustersResponse,
   DescribeClustersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClustersRequest,
@@ -1133,7 +1132,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1168,7 +1167,7 @@ export const initializeCluster: API.OperationMethod<
   InitializeClusterRequest,
   InitializeClusterResponse,
   InitializeClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitializeClusterRequest,
   output: InitializeClusterResponse,
@@ -1207,7 +1206,7 @@ export const listTags: API.PaginatedOperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsRequest,
@@ -1246,7 +1245,7 @@ export const modifyBackupAttributes: API.OperationMethod<
   ModifyBackupAttributesRequest,
   ModifyBackupAttributesResponse,
   ModifyBackupAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyBackupAttributesRequest,
   output: ModifyBackupAttributesResponse,
@@ -1278,7 +1277,7 @@ export const modifyCluster: API.OperationMethod<
   ModifyClusterRequest,
   ModifyClusterResponse,
   ModifyClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterRequest,
   output: ModifyClusterResponse,
@@ -1324,7 +1323,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -1358,7 +1357,7 @@ export const restoreBackup: API.OperationMethod<
   RestoreBackupRequest,
   RestoreBackupResponse,
   RestoreBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreBackupRequest,
   output: RestoreBackupResponse,
@@ -1392,7 +1391,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1427,7 +1426,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/cloudhsm.ts
+++ b/packages/aws/src/services/cloudhsm.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudHSM",
   serviceShapeName: "CloudHsmFrontendService",
@@ -715,7 +714,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceRequest,
   AddTagsToResourceResponse,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceRequest,
   output: AddTagsToResourceResponse,
@@ -753,7 +752,7 @@ export const createHapg: API.OperationMethod<
   CreateHapgRequest,
   CreateHapgResponse,
   CreateHapgError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHapgRequest,
   output: CreateHapgResponse,
@@ -799,7 +798,7 @@ export const createHsm: API.OperationMethod<
   CreateHsmRequest,
   CreateHsmResponse,
   CreateHsmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHsmRequest,
   output: CreateHsmResponse,
@@ -836,7 +835,7 @@ export const createLunaClient: API.OperationMethod<
   CreateLunaClientRequest,
   CreateLunaClientResponse,
   CreateLunaClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLunaClientRequest,
   output: CreateLunaClientResponse,
@@ -873,7 +872,7 @@ export const deleteHapg: API.OperationMethod<
   DeleteHapgRequest,
   DeleteHapgResponse,
   DeleteHapgError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHapgRequest,
   output: DeleteHapgResponse,
@@ -911,7 +910,7 @@ export const deleteHsm: API.OperationMethod<
   DeleteHsmRequest,
   DeleteHsmResponse,
   DeleteHsmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHsmRequest,
   output: DeleteHsmResponse,
@@ -948,7 +947,7 @@ export const deleteLunaClient: API.OperationMethod<
   DeleteLunaClientRequest,
   DeleteLunaClientResponse,
   DeleteLunaClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLunaClientRequest,
   output: DeleteLunaClientResponse,
@@ -985,7 +984,7 @@ export const describeHapg: API.OperationMethod<
   DescribeHapgRequest,
   DescribeHapgResponse,
   DescribeHapgError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHapgRequest,
   output: DescribeHapgResponse,
@@ -1023,7 +1022,7 @@ export const describeHsm: API.OperationMethod<
   DescribeHsmRequest,
   DescribeHsmResponse,
   DescribeHsmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHsmRequest,
   output: DescribeHsmResponse,
@@ -1060,7 +1059,7 @@ export const describeLunaClient: API.OperationMethod<
   DescribeLunaClientRequest,
   DescribeLunaClientResponse,
   DescribeLunaClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLunaClientRequest,
   output: DescribeLunaClientResponse,
@@ -1098,7 +1097,7 @@ export const getConfig: API.OperationMethod<
   GetConfigRequest,
   GetConfigResponse,
   GetConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigRequest,
   output: GetConfigResponse,
@@ -1135,7 +1134,7 @@ export const listAvailableZones: API.OperationMethod<
   ListAvailableZonesRequest,
   ListAvailableZonesResponse,
   ListAvailableZonesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableZonesRequest,
   output: ListAvailableZonesResponse,
@@ -1177,7 +1176,7 @@ export const listHapgs: API.OperationMethod<
   ListHapgsRequest,
   ListHapgsResponse,
   ListHapgsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHapgsRequest,
   output: ListHapgsResponse,
@@ -1220,7 +1219,7 @@ export const listHsms: API.OperationMethod<
   ListHsmsRequest,
   ListHsmsResponse,
   ListHsmsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHsmsRequest,
   output: ListHsmsResponse,
@@ -1262,7 +1261,7 @@ export const listLunaClients: API.OperationMethod<
   ListLunaClientsRequest,
   ListLunaClientsResponse,
   ListLunaClientsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLunaClientsRequest,
   output: ListLunaClientsResponse,
@@ -1299,7 +1298,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1336,7 +1335,7 @@ export const modifyHapg: API.OperationMethod<
   ModifyHapgRequest,
   ModifyHapgResponse,
   ModifyHapgError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyHapgRequest,
   output: ModifyHapgResponse,
@@ -1378,7 +1377,7 @@ export const modifyHsm: API.OperationMethod<
   ModifyHsmRequest,
   ModifyHsmResponse,
   ModifyHsmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyHsmRequest,
   output: ModifyHsmResponse,
@@ -1414,7 +1413,7 @@ export const modifyLunaClient: API.OperationMethod<
   ModifyLunaClientRequest,
   ModifyLunaClientResponse,
   ModifyLunaClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLunaClientRequest,
   output: ModifyLunaClientResponse,
@@ -1450,7 +1449,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceRequest,
   RemoveTagsFromResourceResponse,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceRequest,
   output: RemoveTagsFromResourceResponse,

--- a/packages/aws/src/services/cloudsearch-domain.ts
+++ b/packages/aws/src/services/cloudsearch-domain.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://cloudsearch.amazonaws.com/doc/2013-01-01/");
 const svc = T.AwsApiService({
   sdkId: "CloudSearch Domain",
@@ -432,7 +431,7 @@ export const search: API.OperationMethod<
   SearchRequest,
   SearchResponse,
   SearchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchRequest,
   output: SearchResponse,
@@ -454,7 +453,7 @@ export const suggest: API.OperationMethod<
   SuggestRequest,
   SuggestResponse,
   SuggestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SuggestRequest,
   output: SuggestResponse,
@@ -477,7 +476,7 @@ export const uploadDocuments: API.OperationMethod<
   UploadDocumentsRequest,
   UploadDocumentsResponse,
   UploadDocumentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadDocumentsRequest,
   output: UploadDocumentsResponse,

--- a/packages/aws/src/services/cloudsearch.ts
+++ b/packages/aws/src/services/cloudsearch.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://cloudsearch.amazonaws.com/doc/2013-01-01/");
 const svc = T.AwsApiService({
   sdkId: "CloudSearch",
@@ -1513,7 +1512,7 @@ export const buildSuggesters: API.OperationMethod<
   BuildSuggestersRequest,
   BuildSuggestersResponse,
   BuildSuggestersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BuildSuggestersRequest,
   output: BuildSuggestersResponse,
@@ -1543,7 +1542,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -1574,7 +1573,7 @@ export const defineAnalysisScheme: API.OperationMethod<
   DefineAnalysisSchemeRequest,
   DefineAnalysisSchemeResponse,
   DefineAnalysisSchemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DefineAnalysisSchemeRequest,
   output: DefineAnalysisSchemeResponse,
@@ -1606,7 +1605,7 @@ export const defineExpression: API.OperationMethod<
   DefineExpressionRequest,
   DefineExpressionResponse,
   DefineExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DefineExpressionRequest,
   output: DefineExpressionResponse,
@@ -1638,7 +1637,7 @@ export const defineIndexField: API.OperationMethod<
   DefineIndexFieldRequest,
   DefineIndexFieldResponse,
   DefineIndexFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DefineIndexFieldRequest,
   output: DefineIndexFieldResponse,
@@ -1670,7 +1669,7 @@ export const defineSuggester: API.OperationMethod<
   DefineSuggesterRequest,
   DefineSuggesterResponse,
   DefineSuggesterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DefineSuggesterRequest,
   output: DefineSuggesterResponse,
@@ -1701,7 +1700,7 @@ export const deleteAnalysisScheme: API.OperationMethod<
   DeleteAnalysisSchemeRequest,
   DeleteAnalysisSchemeResponse,
   DeleteAnalysisSchemeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnalysisSchemeRequest,
   output: DeleteAnalysisSchemeResponse,
@@ -1729,7 +1728,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -1753,7 +1752,7 @@ export const deleteExpression: API.OperationMethod<
   DeleteExpressionRequest,
   DeleteExpressionResponse,
   DeleteExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExpressionRequest,
   output: DeleteExpressionResponse,
@@ -1783,7 +1782,7 @@ export const deleteIndexField: API.OperationMethod<
   DeleteIndexFieldRequest,
   DeleteIndexFieldResponse,
   DeleteIndexFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexFieldRequest,
   output: DeleteIndexFieldResponse,
@@ -1813,7 +1812,7 @@ export const deleteSuggester: API.OperationMethod<
   DeleteSuggesterRequest,
   DeleteSuggesterResponse,
   DeleteSuggesterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSuggesterRequest,
   output: DeleteSuggesterResponse,
@@ -1841,7 +1840,7 @@ export const describeAnalysisSchemes: API.OperationMethod<
   DescribeAnalysisSchemesRequest,
   DescribeAnalysisSchemesResponse,
   DescribeAnalysisSchemesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnalysisSchemesRequest,
   output: DescribeAnalysisSchemesResponse,
@@ -1866,7 +1865,7 @@ export const describeAvailabilityOptions: API.OperationMethod<
   DescribeAvailabilityOptionsRequest,
   DescribeAvailabilityOptionsResponse,
   DescribeAvailabilityOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAvailabilityOptionsRequest,
   output: DescribeAvailabilityOptionsResponse,
@@ -1897,7 +1896,7 @@ export const describeDomainEndpointOptions: API.OperationMethod<
   DescribeDomainEndpointOptionsRequest,
   DescribeDomainEndpointOptionsResponse,
   DescribeDomainEndpointOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainEndpointOptionsRequest,
   output: DescribeDomainEndpointOptionsResponse,
@@ -1926,7 +1925,7 @@ export const describeDomains: API.OperationMethod<
   DescribeDomainsRequest,
   DescribeDomainsResponse,
   DescribeDomainsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainsRequest,
   output: DescribeDomainsResponse,
@@ -1948,7 +1947,7 @@ export const describeExpressions: API.OperationMethod<
   DescribeExpressionsRequest,
   DescribeExpressionsResponse,
   DescribeExpressionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExpressionsRequest,
   output: DescribeExpressionsResponse,
@@ -1972,7 +1971,7 @@ export const describeIndexFields: API.OperationMethod<
   DescribeIndexFieldsRequest,
   DescribeIndexFieldsResponse,
   DescribeIndexFieldsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIndexFieldsRequest,
   output: DescribeIndexFieldsResponse,
@@ -1994,7 +1993,7 @@ export const describeScalingParameters: API.OperationMethod<
   DescribeScalingParametersRequest,
   DescribeScalingParametersResponse,
   DescribeScalingParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScalingParametersRequest,
   output: DescribeScalingParametersResponse,
@@ -2017,7 +2016,7 @@ export const describeServiceAccessPolicies: API.OperationMethod<
   DescribeServiceAccessPoliciesRequest,
   DescribeServiceAccessPoliciesResponse,
   DescribeServiceAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceAccessPoliciesRequest,
   output: DescribeServiceAccessPoliciesResponse,
@@ -2039,7 +2038,7 @@ export const describeSuggesters: API.OperationMethod<
   DescribeSuggestersRequest,
   DescribeSuggestersResponse,
   DescribeSuggestersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSuggestersRequest,
   output: DescribeSuggestersResponse,
@@ -2062,7 +2061,7 @@ export const indexDocuments: API.OperationMethod<
   IndexDocumentsRequest,
   IndexDocumentsResponse,
   IndexDocumentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IndexDocumentsRequest,
   output: IndexDocumentsResponse,
@@ -2085,7 +2084,7 @@ export const listDomainNames: API.OperationMethod<
   ListDomainNamesRequest,
   ListDomainNamesResponse,
   ListDomainNamesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDomainNamesRequest,
   output: ListDomainNamesResponse,
@@ -2111,7 +2110,7 @@ export const updateAvailabilityOptions: API.OperationMethod<
   UpdateAvailabilityOptionsRequest,
   UpdateAvailabilityOptionsResponse,
   UpdateAvailabilityOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAvailabilityOptionsRequest,
   output: UpdateAvailabilityOptionsResponse,
@@ -2145,7 +2144,7 @@ export const updateDomainEndpointOptions: API.OperationMethod<
   UpdateDomainEndpointOptionsRequest,
   UpdateDomainEndpointOptionsResponse,
   UpdateDomainEndpointOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainEndpointOptionsRequest,
   output: UpdateDomainEndpointOptionsResponse,
@@ -2178,7 +2177,7 @@ export const updateScalingParameters: API.OperationMethod<
   UpdateScalingParametersRequest,
   UpdateScalingParametersResponse,
   UpdateScalingParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScalingParametersRequest,
   output: UpdateScalingParametersResponse,
@@ -2212,7 +2211,7 @@ export const updateServiceAccessPolicies: API.OperationMethod<
   UpdateServiceAccessPoliciesRequest,
   UpdateServiceAccessPoliciesResponse,
   UpdateServiceAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceAccessPoliciesRequest,
   output: UpdateServiceAccessPoliciesResponse,

--- a/packages/aws/src/services/cloudtrail-data.ts
+++ b/packages/aws/src/services/cloudtrail-data.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CloudTrail Data",
   serviceShapeName: "CloudTrailDataService",
@@ -208,7 +207,7 @@ export const putAuditEvents: API.OperationMethod<
   PutAuditEventsRequest,
   PutAuditEventsResponse,
   PutAuditEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAuditEventsRequest,
   output: PutAuditEventsResponse,

--- a/packages/aws/src/services/cloudtrail.ts
+++ b/packages/aws/src/services/cloudtrail.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://cloudtrail.amazonaws.com/doc/2013-11-01/");
 const svc = T.AwsApiService({
   sdkId: "CloudTrail",
@@ -4237,7 +4236,7 @@ export const addTags: API.OperationMethod<
   AddTagsRequest,
   AddTagsResponse,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsRequest,
   output: AddTagsResponse,
@@ -4288,7 +4287,7 @@ export const cancelQuery: API.OperationMethod<
   CancelQueryRequest,
   CancelQueryResponse,
   CancelQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelQueryRequest,
   output: CancelQueryResponse,
@@ -4332,7 +4331,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -4388,7 +4387,7 @@ export const createDashboard: API.OperationMethod<
   CreateDashboardRequest,
   CreateDashboardResponse,
   CreateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDashboardRequest,
   output: CreateDashboardResponse,
@@ -4436,7 +4435,7 @@ export const createEventDataStore: API.OperationMethod<
   CreateEventDataStoreRequest,
   CreateEventDataStoreResponse,
   CreateEventDataStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventDataStoreRequest,
   output: CreateEventDataStoreResponse,
@@ -4509,7 +4508,7 @@ export const createTrail: API.OperationMethod<
   CreateTrailRequest,
   CreateTrailResponse,
   CreateTrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrailRequest,
   output: CreateTrailResponse,
@@ -4566,7 +4565,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -4593,7 +4592,7 @@ export const deleteDashboard: API.OperationMethod<
   DeleteDashboardRequest,
   DeleteDashboardResponse,
   DeleteDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDashboardRequest,
   output: DeleteDashboardResponse,
@@ -4641,7 +4640,7 @@ export const deleteEventDataStore: API.OperationMethod<
   DeleteEventDataStoreRequest,
   DeleteEventDataStoreResponse,
   DeleteEventDataStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventDataStoreRequest,
   output: DeleteEventDataStoreResponse,
@@ -4682,7 +4681,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -4732,7 +4731,7 @@ export const deleteTrail: API.OperationMethod<
   DeleteTrailRequest,
   DeleteTrailResponse,
   DeleteTrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrailRequest,
   output: DeleteTrailResponse,
@@ -4775,7 +4774,7 @@ export const deregisterOrganizationDelegatedAdmin: API.OperationMethod<
   DeregisterOrganizationDelegatedAdminRequest,
   DeregisterOrganizationDelegatedAdminResponse,
   DeregisterOrganizationDelegatedAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterOrganizationDelegatedAdminRequest,
   output: DeregisterOrganizationDelegatedAdminResponse,
@@ -4821,7 +4820,7 @@ export const describeQuery: API.OperationMethod<
   DescribeQueryRequest,
   DescribeQueryResponse,
   DescribeQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQueryRequest,
   output: DescribeQueryResponse,
@@ -4855,7 +4854,7 @@ export const describeTrails: API.OperationMethod<
   DescribeTrailsRequest,
   DescribeTrailsResponse,
   DescribeTrailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrailsRequest,
   output: DescribeTrailsResponse,
@@ -4898,7 +4897,7 @@ export const disableFederation: API.OperationMethod<
   DisableFederationRequest,
   DisableFederationResponse,
   DisableFederationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableFederationRequest,
   output: DisableFederationResponse,
@@ -4958,7 +4957,7 @@ export const enableFederation: API.OperationMethod<
   EnableFederationRequest,
   EnableFederationResponse,
   EnableFederationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableFederationRequest,
   output: EnableFederationResponse,
@@ -5016,7 +5015,7 @@ export const generateQuery: API.OperationMethod<
   GenerateQueryRequest,
   GenerateQueryResponse,
   GenerateQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateQueryRequest,
   output: GenerateQueryResponse,
@@ -5048,7 +5047,7 @@ export const getChannel: API.OperationMethod<
   GetChannelRequest,
   GetChannelResponse,
   GetChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelRequest,
   output: GetChannelResponse,
@@ -5074,7 +5073,7 @@ export const getDashboard: API.OperationMethod<
   GetDashboardRequest,
   GetDashboardResponse,
   GetDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardRequest,
   output: GetDashboardResponse,
@@ -5105,7 +5104,7 @@ export const getEventConfiguration: API.OperationMethod<
   GetEventConfigurationRequest,
   GetEventConfigurationResponse,
   GetEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventConfigurationRequest,
   output: GetEventConfigurationResponse,
@@ -5144,7 +5143,7 @@ export const getEventDataStore: API.OperationMethod<
   GetEventDataStoreRequest,
   GetEventDataStoreResponse,
   GetEventDataStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventDataStoreRequest,
   output: GetEventDataStoreResponse,
@@ -5197,7 +5196,7 @@ export const getEventSelectors: API.OperationMethod<
   GetEventSelectorsRequest,
   GetEventSelectorsResponse,
   GetEventSelectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventSelectorsRequest,
   output: GetEventSelectorsResponse,
@@ -5227,7 +5226,7 @@ export const getImport: API.OperationMethod<
   GetImportRequest,
   GetImportResponse,
   GetImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportRequest,
   output: GetImportResponse,
@@ -5270,7 +5269,7 @@ export const getInsightSelectors: API.OperationMethod<
   GetInsightSelectorsRequest,
   GetInsightSelectorsResponse,
   GetInsightSelectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightSelectorsRequest,
   output: GetInsightSelectorsResponse,
@@ -5312,7 +5311,7 @@ export const getQueryResults: API.PaginatedOperationMethod<
   GetQueryResultsRequest,
   GetQueryResultsResponse,
   GetQueryResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsRequest,
@@ -5351,7 +5350,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -5382,7 +5381,7 @@ export const getTrail: API.OperationMethod<
   GetTrailRequest,
   GetTrailResponse,
   GetTrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrailRequest,
   output: GetTrailResponse,
@@ -5416,7 +5415,7 @@ export const getTrailStatus: API.OperationMethod<
   GetTrailStatusRequest,
   GetTrailStatusResponse,
   GetTrailStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrailStatusRequest,
   output: GetTrailStatusResponse,
@@ -5444,7 +5443,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -5472,7 +5471,7 @@ export const listDashboards: API.OperationMethod<
   ListDashboardsRequest,
   ListDashboardsResponse,
   ListDashboardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDashboardsRequest,
   output: ListDashboardsResponse,
@@ -5497,7 +5496,7 @@ export const listEventDataStores: API.PaginatedOperationMethod<
   ListEventDataStoresRequest,
   ListEventDataStoresResponse,
   ListEventDataStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventDataStoresRequest,
@@ -5532,7 +5531,7 @@ export const listImportFailures: API.PaginatedOperationMethod<
   ListImportFailuresRequest,
   ListImportFailuresResponse,
   ListImportFailuresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportFailureListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportFailuresRequest,
@@ -5569,7 +5568,7 @@ export const listImports: API.PaginatedOperationMethod<
   ListImportsRequest,
   ListImportsResponse,
   ListImportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportsListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportsRequest,
@@ -5619,7 +5618,7 @@ export const listInsightsData: API.PaginatedOperationMethod<
   ListInsightsDataRequest,
   ListInsightsDataResponse,
   ListInsightsDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInsightsDataRequest,
@@ -5672,7 +5671,7 @@ export const listInsightsMetricData: API.PaginatedOperationMethod<
   ListInsightsMetricDataRequest,
   ListInsightsMetricDataResponse,
   ListInsightsMetricDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInsightsMetricDataRequest,
@@ -5713,7 +5712,7 @@ export const listPublicKeys: API.PaginatedOperationMethod<
   ListPublicKeysRequest,
   ListPublicKeysResponse,
   ListPublicKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PublicKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPublicKeysRequest,
@@ -5760,7 +5759,7 @@ export const listQueries: API.PaginatedOperationMethod<
   ListQueriesRequest,
   ListQueriesResponse,
   ListQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueriesRequest,
@@ -5809,7 +5808,7 @@ export const listTags: API.PaginatedOperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceTag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsRequest,
@@ -5849,7 +5848,7 @@ export const listTrails: API.PaginatedOperationMethod<
   ListTrailsRequest,
   ListTrailsResponse,
   ListTrailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrailInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrailsRequest,
@@ -5918,7 +5917,7 @@ export const lookupEvents: API.PaginatedOperationMethod<
   LookupEventsRequest,
   LookupEventsResponse,
   LookupEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: LookupEventsRequest,
@@ -5971,7 +5970,7 @@ export const putEventConfiguration: API.OperationMethod<
   PutEventConfigurationRequest,
   PutEventConfigurationResponse,
   PutEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventConfigurationRequest,
   output: PutEventConfigurationResponse,
@@ -6077,7 +6076,7 @@ export const putEventSelectors: API.OperationMethod<
   PutEventSelectorsRequest,
   PutEventSelectorsResponse,
   PutEventSelectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventSelectorsRequest,
   output: PutEventSelectorsResponse,
@@ -6151,7 +6150,7 @@ export const putInsightSelectors: API.OperationMethod<
   PutInsightSelectorsRequest,
   PutInsightSelectorsResponse,
   PutInsightSelectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInsightSelectorsRequest,
   output: PutInsightSelectorsResponse,
@@ -6196,7 +6195,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -6237,7 +6236,7 @@ export const registerOrganizationDelegatedAdmin: API.OperationMethod<
   RegisterOrganizationDelegatedAdminRequest,
   RegisterOrganizationDelegatedAdminResponse,
   RegisterOrganizationDelegatedAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOrganizationDelegatedAdminRequest,
   output: RegisterOrganizationDelegatedAdminResponse,
@@ -6286,7 +6285,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsRequest,
   RemoveTagsResponse,
   RemoveTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsRequest,
   output: RemoveTagsResponse,
@@ -6337,7 +6336,7 @@ export const restoreEventDataStore: API.OperationMethod<
   RestoreEventDataStoreRequest,
   RestoreEventDataStoreResponse,
   RestoreEventDataStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreEventDataStoreRequest,
   output: RestoreEventDataStoreResponse,
@@ -6374,7 +6373,7 @@ export const searchSampleQueries: API.OperationMethod<
   SearchSampleQueriesRequest,
   SearchSampleQueriesResponse,
   SearchSampleQueriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchSampleQueriesRequest,
   output: SearchSampleQueriesResponse,
@@ -6405,7 +6404,7 @@ export const startDashboardRefresh: API.OperationMethod<
   StartDashboardRefreshRequest,
   StartDashboardRefreshResponse,
   StartDashboardRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDashboardRefreshRequest,
   output: StartDashboardRefreshResponse,
@@ -6442,7 +6441,7 @@ export const startEventDataStoreIngestion: API.OperationMethod<
   StartEventDataStoreIngestionRequest,
   StartEventDataStoreIngestionResponse,
   StartEventDataStoreIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEventDataStoreIngestionRequest,
   output: StartEventDataStoreIngestionResponse,
@@ -6502,7 +6501,7 @@ export const startImport: API.OperationMethod<
   StartImportRequest,
   StartImportResponse,
   StartImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportRequest,
   output: StartImportResponse,
@@ -6548,7 +6547,7 @@ export const startLogging: API.OperationMethod<
   StartLoggingRequest,
   StartLoggingResponse,
   StartLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLoggingRequest,
   output: StartLoggingResponse,
@@ -6599,7 +6598,7 @@ export const startQuery: API.OperationMethod<
   StartQueryRequest,
   StartQueryResponse,
   StartQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryRequest,
   output: StartQueryResponse,
@@ -6645,7 +6644,7 @@ export const stopEventDataStoreIngestion: API.OperationMethod<
   StopEventDataStoreIngestionRequest,
   StopEventDataStoreIngestionResponse,
   StopEventDataStoreIngestionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEventDataStoreIngestionRequest,
   output: StopEventDataStoreIngestionResponse,
@@ -6680,7 +6679,7 @@ export const stopImport: API.OperationMethod<
   StopImportRequest,
   StopImportResponse,
   StopImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopImportRequest,
   output: StopImportResponse,
@@ -6721,7 +6720,7 @@ export const stopLogging: API.OperationMethod<
   StopLoggingRequest,
   StopLoggingResponse,
   StopLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopLoggingRequest,
   output: StopLoggingResponse,
@@ -6762,7 +6761,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -6807,7 +6806,7 @@ export const updateDashboard: API.OperationMethod<
   UpdateDashboardRequest,
   UpdateDashboardResponse,
   UpdateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardRequest,
   output: UpdateDashboardResponse,
@@ -6868,7 +6867,7 @@ export const updateEventDataStore: API.OperationMethod<
   UpdateEventDataStoreRequest,
   UpdateEventDataStoreResponse,
   UpdateEventDataStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventDataStoreRequest,
   output: UpdateEventDataStoreResponse,
@@ -6948,7 +6947,7 @@ export const updateTrail: API.OperationMethod<
   UpdateTrailRequest,
   UpdateTrailResponse,
   UpdateTrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrailRequest,
   output: UpdateTrailResponse,

--- a/packages/aws/src/services/cloudwatch-events.ts
+++ b/packages/aws/src/services/cloudwatch-events.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://events.amazonaws.com/doc/2015-10-07");
 const svc = T.AwsApiService({
@@ -3096,7 +3095,7 @@ export const activateEventSource: API.OperationMethod<
   ActivateEventSourceRequest,
   ActivateEventSourceResponse,
   ActivateEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateEventSourceRequest,
   output: ActivateEventSourceResponse,
@@ -3125,7 +3124,7 @@ export const cancelReplay: API.OperationMethod<
   CancelReplayRequest,
   CancelReplayResponse,
   CancelReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelReplayRequest,
   output: CancelReplayResponse,
@@ -3154,7 +3153,7 @@ export const createApiDestination: API.OperationMethod<
   CreateApiDestinationRequest,
   CreateApiDestinationResponse,
   CreateApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiDestinationRequest,
   output: CreateApiDestinationResponse,
@@ -3188,7 +3187,7 @@ export const createArchive: API.OperationMethod<
   CreateArchiveRequest,
   CreateArchiveResponse,
   CreateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateArchiveRequest,
   output: CreateArchiveResponse,
@@ -3218,7 +3217,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -3250,7 +3249,7 @@ export const createEventBus: API.OperationMethod<
   CreateEventBusRequest,
   CreateEventBusResponse,
   CreateEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventBusRequest,
   output: CreateEventBusResponse,
@@ -3306,7 +3305,7 @@ export const createPartnerEventSource: API.OperationMethod<
   CreatePartnerEventSourceRequest,
   CreatePartnerEventSourceResponse,
   CreatePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerEventSourceRequest,
   output: CreatePartnerEventSourceResponse,
@@ -3342,7 +3341,7 @@ export const deactivateEventSource: API.OperationMethod<
   DeactivateEventSourceRequest,
   DeactivateEventSourceResponse,
   DeactivateEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateEventSourceRequest,
   output: DeactivateEventSourceResponse,
@@ -3371,7 +3370,7 @@ export const deauthorizeConnection: API.OperationMethod<
   DeauthorizeConnectionRequest,
   DeauthorizeConnectionResponse,
   DeauthorizeConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeauthorizeConnectionRequest,
   output: DeauthorizeConnectionResponse,
@@ -3397,7 +3396,7 @@ export const deleteApiDestination: API.OperationMethod<
   DeleteApiDestinationRequest,
   DeleteApiDestinationResponse,
   DeleteApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiDestinationRequest,
   output: DeleteApiDestinationResponse,
@@ -3423,7 +3422,7 @@ export const deleteArchive: API.OperationMethod<
   DeleteArchiveRequest,
   DeleteArchiveResponse,
   DeleteArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArchiveRequest,
   output: DeleteArchiveResponse,
@@ -3449,7 +3448,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -3475,7 +3474,7 @@ export const deleteEventBus: API.OperationMethod<
   DeleteEventBusRequest,
   DeleteEventBusResponse,
   DeleteEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventBusRequest,
   output: DeleteEventBusResponse,
@@ -3501,7 +3500,7 @@ export const deletePartnerEventSource: API.OperationMethod<
   DeletePartnerEventSourceRequest,
   DeletePartnerEventSourceResponse,
   DeletePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartnerEventSourceRequest,
   output: DeletePartnerEventSourceResponse,
@@ -3542,7 +3541,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -3568,7 +3567,7 @@ export const describeApiDestination: API.OperationMethod<
   DescribeApiDestinationRequest,
   DescribeApiDestinationResponse,
   DescribeApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApiDestinationRequest,
   output: DescribeApiDestinationResponse,
@@ -3590,7 +3589,7 @@ export const describeArchive: API.OperationMethod<
   DescribeArchiveRequest,
   DescribeArchiveResponse,
   DescribeArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeArchiveRequest,
   output: DescribeArchiveResponse,
@@ -3615,7 +3614,7 @@ export const describeConnection: API.OperationMethod<
   DescribeConnectionRequest,
   DescribeConnectionResponse,
   DescribeConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionRequest,
   output: DescribeConnectionResponse,
@@ -3644,7 +3643,7 @@ export const describeEventBus: API.OperationMethod<
   DescribeEventBusRequest,
   DescribeEventBusResponse,
   DescribeEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventBusRequest,
   output: DescribeEventBusResponse,
@@ -3667,7 +3666,7 @@ export const describeEventSource: API.OperationMethod<
   DescribeEventSourceRequest,
   DescribeEventSourceResponse,
   DescribeEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventSourceRequest,
   output: DescribeEventSourceResponse,
@@ -3696,7 +3695,7 @@ export const describePartnerEventSource: API.OperationMethod<
   DescribePartnerEventSourceRequest,
   DescribePartnerEventSourceResponse,
   DescribePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePartnerEventSourceRequest,
   output: DescribePartnerEventSourceResponse,
@@ -3729,7 +3728,7 @@ export const describeReplay: API.OperationMethod<
   DescribeReplayRequest,
   DescribeReplayResponse,
   DescribeReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReplayRequest,
   output: DescribeReplayResponse,
@@ -3753,7 +3752,7 @@ export const describeRule: API.OperationMethod<
   DescribeRuleRequest,
   DescribeRuleResponse,
   DescribeRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleRequest,
   output: DescribeRuleResponse,
@@ -3780,7 +3779,7 @@ export const disableRule: API.OperationMethod<
   DisableRuleRequest,
   DisableRuleResponse,
   DisableRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRuleRequest,
   output: DisableRuleResponse,
@@ -3811,7 +3810,7 @@ export const enableRule: API.OperationMethod<
   EnableRuleRequest,
   EnableRuleResponse,
   EnableRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRuleRequest,
   output: EnableRuleResponse,
@@ -3834,7 +3833,7 @@ export const listApiDestinations: API.OperationMethod<
   ListApiDestinationsRequest,
   ListApiDestinationsResponse,
   ListApiDestinationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListApiDestinationsRequest,
   output: ListApiDestinationsResponse,
@@ -3856,7 +3855,7 @@ export const listArchives: API.OperationMethod<
   ListArchivesRequest,
   ListArchivesResponse,
   ListArchivesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListArchivesRequest,
   output: ListArchivesResponse,
@@ -3874,7 +3873,7 @@ export const listConnections: API.OperationMethod<
   ListConnectionsRequest,
   ListConnectionsResponse,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectionsRequest,
   output: ListConnectionsResponse,
@@ -3893,7 +3892,7 @@ export const listEventBuses: API.OperationMethod<
   ListEventBusesRequest,
   ListEventBusesResponse,
   ListEventBusesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEventBusesRequest,
   output: ListEventBusesResponse,
@@ -3915,7 +3914,7 @@ export const listEventSources: API.OperationMethod<
   ListEventSourcesRequest,
   ListEventSourcesResponse,
   ListEventSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEventSourcesRequest,
   output: ListEventSourcesResponse,
@@ -3939,7 +3938,7 @@ export const listPartnerEventSourceAccounts: API.OperationMethod<
   ListPartnerEventSourceAccountsRequest,
   ListPartnerEventSourceAccountsResponse,
   ListPartnerEventSourceAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPartnerEventSourceAccountsRequest,
   output: ListPartnerEventSourceAccountsResponse,
@@ -3965,7 +3964,7 @@ export const listPartnerEventSources: API.OperationMethod<
   ListPartnerEventSourcesRequest,
   ListPartnerEventSourcesResponse,
   ListPartnerEventSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPartnerEventSourcesRequest,
   output: ListPartnerEventSourcesResponse,
@@ -3984,7 +3983,7 @@ export const listReplays: API.OperationMethod<
   ListReplaysRequest,
   ListReplaysResponse,
   ListReplaysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReplaysRequest,
   output: ListReplaysResponse,
@@ -4006,7 +4005,7 @@ export const listRuleNamesByTarget: API.OperationMethod<
   ListRuleNamesByTargetRequest,
   ListRuleNamesByTargetResponse,
   ListRuleNamesByTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleNamesByTargetRequest,
   output: ListRuleNamesByTargetResponse,
@@ -4031,7 +4030,7 @@ export const listRules: API.OperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRulesRequest,
   output: ListRulesResponse,
@@ -4053,7 +4052,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4074,7 +4073,7 @@ export const listTargetsByRule: API.OperationMethod<
   ListTargetsByRuleRequest,
   ListTargetsByRuleResponse,
   ListTargetsByRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTargetsByRuleRequest,
   output: ListTargetsByRuleResponse,
@@ -4092,7 +4091,7 @@ export const putEvents: API.OperationMethod<
   PutEventsRequest,
   PutEventsResponse,
   PutEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventsRequest,
   output: PutEventsResponse,
@@ -4114,7 +4113,7 @@ export const putPartnerEvents: API.OperationMethod<
   PutPartnerEventsRequest,
   PutPartnerEventsResponse,
   PutPartnerEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPartnerEventsRequest,
   output: PutPartnerEventsResponse,
@@ -4158,7 +4157,7 @@ export const putPermission: API.OperationMethod<
   PutPermissionRequest,
   PutPermissionResponse,
   PutPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionRequest,
   output: PutPermissionResponse,
@@ -4238,7 +4237,7 @@ export const putRule: API.OperationMethod<
   PutRuleRequest,
   PutRuleResponse,
   PutRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRuleRequest,
   output: PutRuleResponse,
@@ -4397,7 +4396,7 @@ export const putTargets: API.OperationMethod<
   PutTargetsRequest,
   PutTargetsResponse,
   PutTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTargetsRequest,
   output: PutTargetsResponse,
@@ -4429,7 +4428,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionRequest,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionRequest,
   output: RemovePermissionResponse,
@@ -4465,7 +4464,7 @@ export const removeTargets: API.OperationMethod<
   RemoveTargetsRequest,
   RemoveTargetsResponse,
   RemoveTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTargetsRequest,
   output: RemoveTargetsResponse,
@@ -4502,7 +4501,7 @@ export const startReplay: API.OperationMethod<
   StartReplayRequest,
   StartReplayResponse,
   StartReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplayRequest,
   output: StartReplayResponse,
@@ -4544,7 +4543,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4575,7 +4574,7 @@ export const testEventPattern: API.OperationMethod<
   TestEventPatternRequest,
   TestEventPatternResponse,
   TestEventPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestEventPatternRequest,
   output: TestEventPatternResponse,
@@ -4599,7 +4598,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4627,7 +4626,7 @@ export const updateApiDestination: API.OperationMethod<
   UpdateApiDestinationRequest,
   UpdateApiDestinationResponse,
   UpdateApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiDestinationRequest,
   output: UpdateApiDestinationResponse,
@@ -4656,7 +4655,7 @@ export const updateArchive: API.OperationMethod<
   UpdateArchiveRequest,
   UpdateArchiveResponse,
   UpdateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateArchiveRequest,
   output: UpdateArchiveResponse,
@@ -4685,7 +4684,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   UpdateConnectionResponse,
   UpdateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: UpdateConnectionResponse,

--- a/packages/aws/src/services/cloudwatch-logs.ts
+++ b/packages/aws/src/services/cloudwatch-logs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://monitoring.amazonaws.com/doc/2014-03-28/");
 const svc = T.AwsApiService({
   sdkId: "CloudWatch Logs",
@@ -6655,7 +6654,7 @@ export const associateKmsKey: API.OperationMethod<
   AssociateKmsKeyRequest,
   AssociateKmsKeyResponse,
   AssociateKmsKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateKmsKeyRequest,
   output: AssociateKmsKeyResponse,
@@ -6686,7 +6685,7 @@ export const associateSourceToS3TableIntegration: API.OperationMethod<
   AssociateSourceToS3TableIntegrationRequest,
   AssociateSourceToS3TableIntegrationResponse,
   AssociateSourceToS3TableIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceToS3TableIntegrationRequest,
   output: AssociateSourceToS3TableIntegrationResponse,
@@ -6717,7 +6716,7 @@ export const cancelExportTask: API.OperationMethod<
   CancelExportTaskRequest,
   CancelExportTaskResponse,
   CancelExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelExportTaskRequest,
   output: CancelExportTaskResponse,
@@ -6746,7 +6745,7 @@ export const cancelImportTask: API.OperationMethod<
   CancelImportTaskRequest,
   CancelImportTaskResponse,
   CancelImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelImportTaskRequest,
   output: CancelImportTaskResponse,
@@ -6807,7 +6806,7 @@ export const createDelivery: API.OperationMethod<
   CreateDeliveryRequest,
   CreateDeliveryResponse,
   CreateDeliveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeliveryRequest,
   output: CreateDeliveryResponse,
@@ -6867,7 +6866,7 @@ export const createExportTask: API.OperationMethod<
   CreateExportTaskRequest,
   CreateExportTaskResponse,
   CreateExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportTaskRequest,
   output: CreateExportTaskResponse,
@@ -6934,7 +6933,7 @@ export const createImportTask: API.OperationMethod<
   CreateImportTaskRequest,
   CreateImportTaskResponse,
   CreateImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImportTaskRequest,
   output: CreateImportTaskResponse,
@@ -6993,7 +6992,7 @@ export const createLogAnomalyDetector: API.OperationMethod<
   CreateLogAnomalyDetectorRequest,
   CreateLogAnomalyDetectorResponse,
   CreateLogAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogAnomalyDetectorRequest,
   output: CreateLogAnomalyDetectorResponse,
@@ -7053,7 +7052,7 @@ export const createLogGroup: API.OperationMethod<
   CreateLogGroupRequest,
   CreateLogGroupResponse,
   CreateLogGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogGroupRequest,
   output: CreateLogGroupResponse,
@@ -7096,7 +7095,7 @@ export const createLogStream: API.OperationMethod<
   CreateLogStreamRequest,
   CreateLogStreamResponse,
   CreateLogStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogStreamRequest,
   output: CreateLogStreamResponse,
@@ -7131,7 +7130,7 @@ export const createLookupTable: API.OperationMethod<
   CreateLookupTableRequest,
   CreateLookupTableResponse,
   CreateLookupTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLookupTableRequest,
   output: CreateLookupTableResponse,
@@ -7167,7 +7166,7 @@ export const createScheduledQuery: API.OperationMethod<
   CreateScheduledQueryRequest,
   CreateScheduledQueryResponse,
   CreateScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledQueryRequest,
   output: CreateScheduledQueryResponse,
@@ -7227,7 +7226,7 @@ export const deleteAccountPolicy: API.OperationMethod<
   DeleteAccountPolicyRequest,
   DeleteAccountPolicyResponse,
   DeleteAccountPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountPolicyRequest,
   output: DeleteAccountPolicyResponse,
@@ -7257,7 +7256,7 @@ export const deleteDataProtectionPolicy: API.OperationMethod<
   DeleteDataProtectionPolicyRequest,
   DeleteDataProtectionPolicyResponse,
   DeleteDataProtectionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataProtectionPolicyRequest,
   output: DeleteDataProtectionPolicyResponse,
@@ -7291,7 +7290,7 @@ export const deleteDelivery: API.OperationMethod<
   DeleteDeliveryRequest,
   DeleteDeliveryResponse,
   DeleteDeliveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliveryRequest,
   output: DeleteDeliveryResponse,
@@ -7329,7 +7328,7 @@ export const deleteDeliveryDestination: API.OperationMethod<
   DeleteDeliveryDestinationRequest,
   DeleteDeliveryDestinationResponse,
   DeleteDeliveryDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliveryDestinationRequest,
   output: DeleteDeliveryDestinationResponse,
@@ -7360,7 +7359,7 @@ export const deleteDeliveryDestinationPolicy: API.OperationMethod<
   DeleteDeliveryDestinationPolicyRequest,
   DeleteDeliveryDestinationPolicyResponse,
   DeleteDeliveryDestinationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliveryDestinationPolicyRequest,
   output: DeleteDeliveryDestinationPolicyResponse,
@@ -7396,7 +7395,7 @@ export const deleteDeliverySource: API.OperationMethod<
   DeleteDeliverySourceRequest,
   DeleteDeliverySourceResponse,
   DeleteDeliverySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliverySourceRequest,
   output: DeleteDeliverySourceResponse,
@@ -7428,7 +7427,7 @@ export const deleteDestination: API.OperationMethod<
   DeleteDestinationRequest,
   DeleteDestinationResponse,
   DeleteDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDestinationRequest,
   output: DeleteDestinationResponse,
@@ -7471,7 +7470,7 @@ export const deleteIndexPolicy: API.OperationMethod<
   DeleteIndexPolicyRequest,
   DeleteIndexPolicyResponse,
   DeleteIndexPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexPolicyRequest,
   output: DeleteIndexPolicyResponse,
@@ -7505,7 +7504,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationRequest,
   DeleteIntegrationResponse,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationRequest,
   output: DeleteIntegrationResponse,
@@ -7533,7 +7532,7 @@ export const deleteLogAnomalyDetector: API.OperationMethod<
   DeleteLogAnomalyDetectorRequest,
   DeleteLogAnomalyDetectorResponse,
   DeleteLogAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLogAnomalyDetectorRequest,
   output: DeleteLogAnomalyDetectorResponse,
@@ -7563,7 +7562,7 @@ export const deleteLogGroup: API.OperationMethod<
   DeleteLogGroupRequest,
   DeleteLogGroupResponse,
   DeleteLogGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLogGroupRequest,
   output: DeleteLogGroupResponse,
@@ -7594,7 +7593,7 @@ export const deleteLogStream: API.OperationMethod<
   DeleteLogStreamRequest,
   DeleteLogStreamResponse,
   DeleteLogStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLogStreamRequest,
   output: DeleteLogStreamResponse,
@@ -7626,7 +7625,7 @@ export const deleteLookupTable: API.OperationMethod<
   DeleteLookupTableRequest,
   DeleteLookupTableResponse,
   DeleteLookupTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLookupTableRequest,
   output: DeleteLookupTableResponse,
@@ -7654,7 +7653,7 @@ export const deleteMetricFilter: API.OperationMethod<
   DeleteMetricFilterRequest,
   DeleteMetricFilterResponse,
   DeleteMetricFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMetricFilterRequest,
   output: DeleteMetricFilterResponse,
@@ -7687,7 +7686,7 @@ export const deleteQueryDefinition: API.OperationMethod<
   DeleteQueryDefinitionRequest,
   DeleteQueryDefinitionResponse,
   DeleteQueryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueryDefinitionRequest,
   output: DeleteQueryDefinitionResponse,
@@ -7715,7 +7714,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -7746,7 +7745,7 @@ export const deleteRetentionPolicy: API.OperationMethod<
   DeleteRetentionPolicyRequest,
   DeleteRetentionPolicyResponse,
   DeleteRetentionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRetentionPolicyRequest,
   output: DeleteRetentionPolicyResponse,
@@ -7776,7 +7775,7 @@ export const deleteScheduledQuery: API.OperationMethod<
   DeleteScheduledQueryRequest,
   DeleteScheduledQueryResponse,
   DeleteScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledQueryRequest,
   output: DeleteScheduledQueryResponse,
@@ -7805,7 +7804,7 @@ export const deleteSubscriptionFilter: API.OperationMethod<
   DeleteSubscriptionFilterRequest,
   DeleteSubscriptionFilterResponse,
   DeleteSubscriptionFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionFilterRequest,
   output: DeleteSubscriptionFilterResponse,
@@ -7837,7 +7836,7 @@ export const deleteSyslogConfiguration: API.OperationMethod<
   DeleteSyslogConfigurationRequest,
   DeleteSyslogConfigurationResponse,
   DeleteSyslogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSyslogConfigurationRequest,
   output: DeleteSyslogConfigurationResponse,
@@ -7875,7 +7874,7 @@ export const deleteTransformer: API.OperationMethod<
   DeleteTransformerRequest,
   DeleteTransformerResponse,
   DeleteTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransformerRequest,
   output: DeleteTransformerResponse,
@@ -7921,7 +7920,7 @@ export const describeAccountPolicies: API.OperationMethod<
   DescribeAccountPoliciesRequest,
   DescribeAccountPoliciesResponse,
   DescribeAccountPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountPoliciesRequest,
   output: DescribeAccountPoliciesResponse,
@@ -7951,7 +7950,7 @@ export const describeConfigurationTemplates: API.PaginatedOperationMethod<
   DescribeConfigurationTemplatesRequest,
   DescribeConfigurationTemplatesResponse,
   DescribeConfigurationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigurationTemplatesRequest,
@@ -7998,7 +7997,7 @@ export const describeDeliveries: API.PaginatedOperationMethod<
   DescribeDeliveriesRequest,
   DescribeDeliveriesResponse,
   DescribeDeliveriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Delivery
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDeliveriesRequest,
@@ -8034,7 +8033,7 @@ export const describeDeliveryDestinations: API.PaginatedOperationMethod<
   DescribeDeliveryDestinationsRequest,
   DescribeDeliveryDestinationsResponse,
   DescribeDeliveryDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeliveryDestination
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDeliveryDestinationsRequest,
@@ -8069,7 +8068,7 @@ export const describeDeliverySources: API.PaginatedOperationMethod<
   DescribeDeliverySourcesRequest,
   DescribeDeliverySourcesResponse,
   DescribeDeliverySourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeliverySource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDeliverySourcesRequest,
@@ -8103,7 +8102,7 @@ export const describeDestinations: API.PaginatedOperationMethod<
   DescribeDestinationsRequest,
   DescribeDestinationsResponse,
   DescribeDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Destination
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDestinationsRequest,
@@ -8132,7 +8131,7 @@ export const describeExportTasks: API.OperationMethod<
   DescribeExportTasksRequest,
   DescribeExportTasksResponse,
   DescribeExportTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExportTasksRequest,
   output: DescribeExportTasksResponse,
@@ -8157,7 +8156,7 @@ export const describeFieldIndexes: API.OperationMethod<
   DescribeFieldIndexesRequest,
   DescribeFieldIndexesResponse,
   DescribeFieldIndexesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFieldIndexesRequest,
   output: DescribeFieldIndexesResponse,
@@ -8188,7 +8187,7 @@ export const describeImportTaskBatches: API.OperationMethod<
   DescribeImportTaskBatchesRequest,
   DescribeImportTaskBatchesResponse,
   DescribeImportTaskBatchesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImportTaskBatchesRequest,
   output: DescribeImportTaskBatchesResponse,
@@ -8218,7 +8217,7 @@ export const describeImportTasks: API.OperationMethod<
   DescribeImportTasksRequest,
   DescribeImportTasksResponse,
   DescribeImportTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImportTasksRequest,
   output: DescribeImportTasksResponse,
@@ -8257,7 +8256,7 @@ export const describeIndexPolicies: API.OperationMethod<
   DescribeIndexPoliciesRequest,
   DescribeIndexPoliciesResponse,
   DescribeIndexPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIndexPoliciesRequest,
   output: DescribeIndexPoliciesResponse,
@@ -8300,7 +8299,7 @@ export const describeLogGroups: API.PaginatedOperationMethod<
   DescribeLogGroupsRequest,
   DescribeLogGroupsResponse,
   DescribeLogGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLogGroupsRequest,
@@ -8341,7 +8340,7 @@ export const describeLogStreams: API.PaginatedOperationMethod<
   DescribeLogStreamsRequest,
   DescribeLogStreamsResponse,
   DescribeLogStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogStream
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLogStreamsRequest,
@@ -8376,7 +8375,7 @@ export const describeLookupTables: API.OperationMethod<
   DescribeLookupTablesRequest,
   DescribeLookupTablesResponse,
   DescribeLookupTablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLookupTablesRequest,
   output: DescribeLookupTablesResponse,
@@ -8405,7 +8404,7 @@ export const describeMetricFilters: API.PaginatedOperationMethod<
   DescribeMetricFiltersRequest,
   DescribeMetricFiltersResponse,
   DescribeMetricFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricFilter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetricFiltersRequest,
@@ -8445,7 +8444,7 @@ export const describeQueries: API.OperationMethod<
   DescribeQueriesRequest,
   DescribeQueriesResponse,
   DescribeQueriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQueriesRequest,
   output: DescribeQueriesResponse,
@@ -8475,7 +8474,7 @@ export const describeQueryDefinitions: API.OperationMethod<
   DescribeQueryDefinitionsRequest,
   DescribeQueryDefinitionsResponse,
   DescribeQueryDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQueryDefinitionsRequest,
   output: DescribeQueryDefinitionsResponse,
@@ -8496,7 +8495,7 @@ export const describeResourcePolicies: API.OperationMethod<
   DescribeResourcePoliciesRequest,
   DescribeResourcePoliciesResponse,
   DescribeResourcePoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePoliciesRequest,
   output: DescribeResourcePoliciesResponse,
@@ -8520,7 +8519,7 @@ export const describeSubscriptionFilters: API.PaginatedOperationMethod<
   DescribeSubscriptionFiltersRequest,
   DescribeSubscriptionFiltersResponse,
   DescribeSubscriptionFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionFilter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSubscriptionFiltersRequest,
@@ -8574,7 +8573,7 @@ export const disassociateKmsKey: API.OperationMethod<
   DisassociateKmsKeyRequest,
   DisassociateKmsKeyResponse,
   DisassociateKmsKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateKmsKeyRequest,
   output: DisassociateKmsKeyResponse,
@@ -8604,7 +8603,7 @@ export const disassociateSourceFromS3TableIntegration: API.OperationMethod<
   DisassociateSourceFromS3TableIntegrationRequest,
   DisassociateSourceFromS3TableIntegrationResponse,
   DisassociateSourceFromS3TableIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSourceFromS3TableIntegrationRequest,
   output: DisassociateSourceFromS3TableIntegrationResponse,
@@ -8678,7 +8677,7 @@ export const filterLogEvents: API.PaginatedOperationMethod<
   FilterLogEventsRequest,
   FilterLogEventsResponse,
   FilterLogEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: FilterLogEventsRequest,
@@ -8711,7 +8710,7 @@ export const getDataProtectionPolicy: API.OperationMethod<
   GetDataProtectionPolicyRequest,
   GetDataProtectionPolicyResponse,
   GetDataProtectionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataProtectionPolicyRequest,
   output: GetDataProtectionPolicyResponse,
@@ -8754,7 +8753,7 @@ export const getDelivery: API.OperationMethod<
   GetDeliveryRequest,
   GetDeliveryResponse,
   GetDeliveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliveryRequest,
   output: GetDeliveryResponse,
@@ -8784,7 +8783,7 @@ export const getDeliveryDestination: API.OperationMethod<
   GetDeliveryDestinationRequest,
   GetDeliveryDestinationResponse,
   GetDeliveryDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliveryDestinationRequest,
   output: GetDeliveryDestinationResponse,
@@ -8813,7 +8812,7 @@ export const getDeliveryDestinationPolicy: API.OperationMethod<
   GetDeliveryDestinationPolicyRequest,
   GetDeliveryDestinationPolicyResponse,
   GetDeliveryDestinationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliveryDestinationPolicyRequest,
   output: GetDeliveryDestinationPolicyResponse,
@@ -8841,7 +8840,7 @@ export const getDeliverySource: API.OperationMethod<
   GetDeliverySourceRequest,
   GetDeliverySourceResponse,
   GetDeliverySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliverySourceRequest,
   output: GetDeliverySourceResponse,
@@ -8869,7 +8868,7 @@ export const getIntegration: API.OperationMethod<
   GetIntegrationRequest,
   GetIntegrationResponse,
   GetIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationRequest,
   output: GetIntegrationResponse,
@@ -8896,7 +8895,7 @@ export const getLogAnomalyDetector: API.OperationMethod<
   GetLogAnomalyDetectorRequest,
   GetLogAnomalyDetectorResponse,
   GetLogAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogAnomalyDetectorRequest,
   output: GetLogAnomalyDetectorResponse,
@@ -8955,7 +8954,7 @@ export const getLogEvents: API.PaginatedOperationMethod<
   GetLogEventsRequest,
   GetLogEventsResponse,
   GetLogEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OutputLogEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLogEventsRequest,
@@ -8990,7 +8989,7 @@ export const getLogFields: API.OperationMethod<
   GetLogFieldsRequest,
   GetLogFieldsResponse,
   GetLogFieldsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogFieldsRequest,
   output: GetLogFieldsResponse,
@@ -9039,7 +9038,7 @@ export const getLogGroupFields: API.OperationMethod<
   GetLogGroupFieldsRequest,
   GetLogGroupFieldsResponse,
   GetLogGroupFieldsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogGroupFieldsRequest,
   output: GetLogGroupFieldsResponse,
@@ -9083,7 +9082,7 @@ export const getLogObject: API.OperationMethod<
   GetLogObjectRequest,
   GetLogObjectResponse,
   GetLogObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogObjectRequest,
   output: GetLogObjectResponse,
@@ -9117,7 +9116,7 @@ export const getLogRecord: API.OperationMethod<
   GetLogRecordRequest,
   GetLogRecordResponse,
   GetLogRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogRecordRequest,
   output: GetLogRecordResponse,
@@ -9145,7 +9144,7 @@ export const getLookupTable: API.OperationMethod<
   GetLookupTableRequest,
   GetLookupTableResponse,
   GetLookupTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLookupTableRequest,
   output: GetLookupTableResponse,
@@ -9199,7 +9198,7 @@ export const getQueryResults: API.OperationMethod<
   GetQueryResultsRequest,
   GetQueryResultsResponse,
   GetQueryResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryResultsRequest,
   output: GetQueryResultsResponse,
@@ -9228,7 +9227,7 @@ export const getScheduledQuery: API.OperationMethod<
   GetScheduledQueryRequest,
   GetScheduledQueryResponse,
   GetScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScheduledQueryRequest,
   output: GetScheduledQueryResponse,
@@ -9259,7 +9258,7 @@ export const getScheduledQueryHistory: API.PaginatedOperationMethod<
   GetScheduledQueryHistoryRequest,
   GetScheduledQueryHistoryResponse,
   GetScheduledQueryHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TriggerHistoryRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetScheduledQueryHistoryRequest,
@@ -9298,7 +9297,7 @@ export const getTransformer: API.OperationMethod<
   GetTransformerRequest,
   GetTransformerResponse,
   GetTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransformerRequest,
   output: GetTransformerResponse,
@@ -9336,7 +9335,7 @@ export const listAggregateLogGroupSummaries: API.PaginatedOperationMethod<
   ListAggregateLogGroupSummariesRequest,
   ListAggregateLogGroupSummariesResponse,
   ListAggregateLogGroupSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregateLogGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAggregateLogGroupSummariesRequest,
@@ -9372,7 +9371,7 @@ export const listAnomalies: API.PaginatedOperationMethod<
   ListAnomaliesRequest,
   ListAnomaliesResponse,
   ListAnomaliesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Anomaly
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnomaliesRequest,
@@ -9407,7 +9406,7 @@ export const listIntegrations: API.OperationMethod<
   ListIntegrationsRequest,
   ListIntegrationsResponse,
   ListIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIntegrationsRequest,
   output: ListIntegrationsResponse,
@@ -9430,7 +9429,7 @@ export const listLogAnomalyDetectors: API.PaginatedOperationMethod<
   ListLogAnomalyDetectorsRequest,
   ListLogAnomalyDetectorsResponse,
   ListLogAnomalyDetectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnomalyDetector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogAnomalyDetectorsRequest,
@@ -9474,7 +9473,7 @@ export const listLogGroups: API.OperationMethod<
   ListLogGroupsRequest,
   ListLogGroupsResponse,
   ListLogGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLogGroupsRequest,
   output: ListLogGroupsResponse,
@@ -9503,7 +9502,7 @@ export const listLogGroupsForQuery: API.PaginatedOperationMethod<
   ListLogGroupsForQueryRequest,
   ListLogGroupsForQueryResponse,
   ListLogGroupsForQueryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogGroupIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogGroupsForQueryRequest,
@@ -9539,7 +9538,7 @@ export const listScheduledQueries: API.PaginatedOperationMethod<
   ListScheduledQueriesRequest,
   ListScheduledQueriesResponse,
   ListScheduledQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledQuerySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledQueriesRequest,
@@ -9576,7 +9575,7 @@ export const listSourcesForS3TableIntegration: API.PaginatedOperationMethod<
   ListSourcesForS3TableIntegrationRequest,
   ListSourcesForS3TableIntegrationResponse,
   ListSourcesForS3TableIntegrationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   S3TableIntegrationSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourcesForS3TableIntegrationRequest,
@@ -9615,7 +9614,7 @@ export const listSyslogConfigurations: API.OperationMethod<
   ListSyslogConfigurationsRequest,
   ListSyslogConfigurationsResponse,
   ListSyslogConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSyslogConfigurationsRequest,
   output: ListSyslogConfigurationsResponse,
@@ -9645,7 +9644,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -9673,7 +9672,7 @@ export const listTagsLogGroup: API.OperationMethod<
   ListTagsLogGroupRequest,
   ListTagsLogGroupResponse,
   ListTagsLogGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsLogGroupRequest,
   output: ListTagsLogGroupResponse,
@@ -10047,7 +10046,7 @@ export const putAccountPolicy: API.OperationMethod<
   PutAccountPolicyRequest,
   PutAccountPolicyResponse,
   PutAccountPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountPolicyRequest,
   output: PutAccountPolicyResponse,
@@ -10081,7 +10080,7 @@ export const putBearerTokenAuthentication: API.OperationMethod<
   PutBearerTokenAuthenticationRequest,
   PutBearerTokenAuthenticationResponse,
   PutBearerTokenAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBearerTokenAuthenticationRequest,
   output: PutBearerTokenAuthenticationResponse,
@@ -10135,7 +10134,7 @@ export const putDataProtectionPolicy: API.OperationMethod<
   PutDataProtectionPolicyRequest,
   PutDataProtectionPolicyResponse,
   PutDataProtectionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataProtectionPolicyRequest,
   output: PutDataProtectionPolicyResponse,
@@ -10199,7 +10198,7 @@ export const putDeliveryDestination: API.OperationMethod<
   PutDeliveryDestinationRequest,
   PutDeliveryDestinationResponse,
   PutDeliveryDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliveryDestinationRequest,
   output: PutDeliveryDestinationResponse,
@@ -10252,7 +10251,7 @@ export const putDeliveryDestinationPolicy: API.OperationMethod<
   PutDeliveryDestinationPolicyRequest,
   PutDeliveryDestinationPolicyResponse,
   PutDeliveryDestinationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliveryDestinationPolicyRequest,
   output: PutDeliveryDestinationPolicyResponse,
@@ -10311,7 +10310,7 @@ export const putDeliverySource: API.OperationMethod<
   PutDeliverySourceRequest,
   PutDeliverySourceResponse,
   PutDeliverySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliverySourceRequest,
   output: PutDeliverySourceResponse,
@@ -10353,7 +10352,7 @@ export const putDestination: API.OperationMethod<
   PutDestinationRequest,
   PutDestinationResponse,
   PutDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDestinationRequest,
   output: PutDestinationResponse,
@@ -10382,7 +10381,7 @@ export const putDestinationPolicy: API.OperationMethod<
   PutDestinationPolicyRequest,
   PutDestinationPolicyResponse,
   PutDestinationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDestinationPolicyRequest,
   output: PutDestinationPolicyResponse,
@@ -10470,7 +10469,7 @@ export const putIndexPolicy: API.OperationMethod<
   PutIndexPolicyRequest,
   PutIndexPolicyResponse,
   PutIndexPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIndexPolicyRequest,
   output: PutIndexPolicyResponse,
@@ -10508,7 +10507,7 @@ export const putIntegration: API.OperationMethod<
   PutIntegrationRequest,
   PutIntegrationResponse,
   PutIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIntegrationRequest,
   output: PutIntegrationResponse,
@@ -10578,7 +10577,7 @@ export const putLogEvents: API.OperationMethod<
   PutLogEventsRequest,
   PutLogEventsResponse,
   PutLogEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLogEventsRequest,
   output: PutLogEventsResponse,
@@ -10614,7 +10613,7 @@ export const putLogGroupDeletionProtection: API.OperationMethod<
   PutLogGroupDeletionProtectionRequest,
   PutLogGroupDeletionProtectionResponse,
   PutLogGroupDeletionProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLogGroupDeletionProtectionRequest,
   output: PutLogGroupDeletionProtectionResponse,
@@ -10672,7 +10671,7 @@ export const putMetricFilter: API.OperationMethod<
   PutMetricFilterRequest,
   PutMetricFilterResponse,
   PutMetricFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetricFilterRequest,
   output: PutMetricFilterResponse,
@@ -10714,7 +10713,7 @@ export const putQueryDefinition: API.OperationMethod<
   PutQueryDefinitionRequest,
   PutQueryDefinitionResponse,
   PutQueryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutQueryDefinitionRequest,
   output: PutQueryDefinitionResponse,
@@ -10760,7 +10759,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -10809,7 +10808,7 @@ export const putRetentionPolicy: API.OperationMethod<
   PutRetentionPolicyRequest,
   PutRetentionPolicyResponse,
   PutRetentionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRetentionPolicyRequest,
   output: PutRetentionPolicyResponse,
@@ -10871,7 +10870,7 @@ export const putSubscriptionFilter: API.OperationMethod<
   PutSubscriptionFilterRequest,
   PutSubscriptionFilterResponse,
   PutSubscriptionFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSubscriptionFilterRequest,
   output: PutSubscriptionFilterResponse,
@@ -10905,7 +10904,7 @@ export const putSyslogConfiguration: API.OperationMethod<
   PutSyslogConfigurationRequest,
   PutSyslogConfigurationResponse,
   PutSyslogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSyslogConfigurationRequest,
   output: PutSyslogConfigurationResponse,
@@ -10968,7 +10967,7 @@ export const putTransformer: API.OperationMethod<
   PutTransformerRequest,
   PutTransformerResponse,
   PutTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTransformerRequest,
   output: PutTransformerResponse,
@@ -11041,7 +11040,7 @@ export const startLiveTail: API.OperationMethod<
   StartLiveTailRequest,
   StartLiveTailResponse,
   StartLiveTailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLiveTailRequest,
   output: StartLiveTailResponse,
@@ -11117,7 +11116,7 @@ export const startQuery: API.OperationMethod<
   StartQueryRequest,
   StartQueryResponse,
   StartQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryRequest,
   output: StartQueryResponse,
@@ -11152,7 +11151,7 @@ export const stopQuery: API.OperationMethod<
   StopQueryRequest,
   StopQueryResponse,
   StopQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryRequest,
   output: StopQueryResponse,
@@ -11192,7 +11191,7 @@ export const tagLogGroup: API.OperationMethod<
   TagLogGroupRequest,
   TagLogGroupResponse,
   TagLogGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagLogGroupRequest,
   output: TagLogGroupResponse,
@@ -11231,7 +11230,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -11258,7 +11257,7 @@ export const testMetricFilter: API.OperationMethod<
   TestMetricFilterRequest,
   TestMetricFilterResponse,
   TestMetricFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestMetricFilterRequest,
   output: TestMetricFilterResponse,
@@ -11282,7 +11281,7 @@ export const testTransformer: API.OperationMethod<
   TestTransformerRequest,
   TestTransformerResponse,
   TestTransformerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestTransformerRequest,
   output: TestTransformerResponse,
@@ -11313,7 +11312,7 @@ export const untagLogGroup: API.OperationMethod<
   UntagLogGroupRequest,
   UntagLogGroupResponse,
   UntagLogGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagLogGroupRequest,
   output: UntagLogGroupResponse,
@@ -11335,7 +11334,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -11373,7 +11372,7 @@ export const updateAnomaly: API.OperationMethod<
   UpdateAnomalyRequest,
   UpdateAnomalyResponse,
   UpdateAnomalyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnomalyRequest,
   output: UpdateAnomalyResponse,
@@ -11405,7 +11404,7 @@ export const updateDeliveryConfiguration: API.OperationMethod<
   UpdateDeliveryConfigurationRequest,
   UpdateDeliveryConfigurationResponse,
   UpdateDeliveryConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeliveryConfigurationRequest,
   output: UpdateDeliveryConfigurationResponse,
@@ -11435,7 +11434,7 @@ export const updateLogAnomalyDetector: API.OperationMethod<
   UpdateLogAnomalyDetectorRequest,
   UpdateLogAnomalyDetectorResponse,
   UpdateLogAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLogAnomalyDetectorRequest,
   output: UpdateLogAnomalyDetectorResponse,
@@ -11468,7 +11467,7 @@ export const updateLookupTable: API.OperationMethod<
   UpdateLookupTableRequest,
   UpdateLookupTableResponse,
   UpdateLookupTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLookupTableRequest,
   output: UpdateLookupTableResponse,
@@ -11500,7 +11499,7 @@ export const updateScheduledQuery: API.OperationMethod<
   UpdateScheduledQueryRequest,
   UpdateScheduledQueryResponse,
   UpdateScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledQueryRequest,
   output: UpdateScheduledQueryResponse,

--- a/packages/aws/src/services/cloudwatch.ts
+++ b/packages/aws/src/services/cloudwatch.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://monitoring.amazonaws.com/doc/2010-08-01/");
 const svc = T.AwsApiService({
   sdkId: "CloudWatch",
@@ -3368,7 +3367,7 @@ export const associateDatasetKmsKey: API.OperationMethod<
   AssociateDatasetKmsKeyInput,
   AssociateDatasetKmsKeyOutput,
   AssociateDatasetKmsKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDatasetKmsKeyInput,
   output: AssociateDatasetKmsKeyOutput,
@@ -3404,7 +3403,7 @@ export const deleteAlarmMuteRule: API.OperationMethod<
   DeleteAlarmMuteRuleInput,
   DeleteAlarmMuteRuleResponse,
   DeleteAlarmMuteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlarmMuteRuleInput,
   output: DeleteAlarmMuteRuleResponse,
@@ -3446,7 +3445,7 @@ export const deleteAlarms: API.OperationMethod<
   DeleteAlarmsInput,
   DeleteAlarmsResponse,
   DeleteAlarmsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlarmsInput,
   output: DeleteAlarmsResponse,
@@ -3472,7 +3471,7 @@ export const deleteAnomalyDetector: API.OperationMethod<
   DeleteAnomalyDetectorInput,
   DeleteAnomalyDetectorOutput,
   DeleteAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnomalyDetectorInput,
   output: DeleteAnomalyDetectorOutput,
@@ -3502,7 +3501,7 @@ export const deleteDashboards: API.OperationMethod<
   DeleteDashboardsInput,
   DeleteDashboardsOutput,
   DeleteDashboardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDashboardsInput,
   output: DeleteDashboardsOutput,
@@ -3530,7 +3529,7 @@ export const deleteInsightRules: API.OperationMethod<
   DeleteInsightRulesInput,
   DeleteInsightRulesOutput,
   DeleteInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInsightRulesInput,
   output: DeleteInsightRulesOutput,
@@ -3552,7 +3551,7 @@ export const deleteMetricStream: API.OperationMethod<
   DeleteMetricStreamInput,
   DeleteMetricStreamOutput,
   DeleteMetricStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMetricStreamInput,
   output: DeleteMetricStreamOutput,
@@ -3580,7 +3579,7 @@ export const describeAlarmContributors: API.OperationMethod<
   DescribeAlarmContributorsInput,
   DescribeAlarmContributorsOutput,
   DescribeAlarmContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlarmContributorsInput,
   output: DescribeAlarmContributorsOutput,
@@ -3607,7 +3606,7 @@ export const describeAlarmHistory: API.PaginatedOperationMethod<
   DescribeAlarmHistoryInput,
   DescribeAlarmHistoryOutput,
   DescribeAlarmHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AlarmHistoryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAlarmHistoryInput,
@@ -3638,7 +3637,7 @@ export const describeAlarms: API.PaginatedOperationMethod<
   DescribeAlarmsInput,
   DescribeAlarmsOutput,
   DescribeAlarmsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAlarmsInput,
@@ -3667,7 +3666,7 @@ export const describeAlarmsForMetric: API.OperationMethod<
   DescribeAlarmsForMetricInput,
   DescribeAlarmsForMetricOutput,
   DescribeAlarmsForMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlarmsForMetricInput,
   output: DescribeAlarmsForMetricOutput,
@@ -3695,7 +3694,7 @@ export const describeAnomalyDetectors: API.PaginatedOperationMethod<
   DescribeAnomalyDetectorsInput,
   DescribeAnomalyDetectorsOutput,
   DescribeAnomalyDetectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnomalyDetector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAnomalyDetectorsInput,
@@ -3728,7 +3727,7 @@ export const describeInsightRules: API.PaginatedOperationMethod<
   DescribeInsightRulesInput,
   DescribeInsightRulesOutput,
   DescribeInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInsightRulesInput,
@@ -3753,7 +3752,7 @@ export const disableAlarmActions: API.OperationMethod<
   DisableAlarmActionsInput,
   DisableAlarmActionsResponse,
   DisableAlarmActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAlarmActionsInput,
   output: DisableAlarmActionsResponse,
@@ -3775,7 +3774,7 @@ export const disableInsightRules: API.OperationMethod<
   DisableInsightRulesInput,
   DisableInsightRulesOutput,
   DisableInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableInsightRulesInput,
   output: DisableInsightRulesOutput,
@@ -3823,7 +3822,7 @@ export const disassociateDatasetKmsKey: API.OperationMethod<
   DisassociateDatasetKmsKeyInput,
   DisassociateDatasetKmsKeyOutput,
   DisassociateDatasetKmsKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDatasetKmsKeyInput,
   output: DisassociateDatasetKmsKeyOutput,
@@ -3841,7 +3840,7 @@ export const enableAlarmActions: API.OperationMethod<
   EnableAlarmActionsInput,
   EnableAlarmActionsResponse,
   EnableAlarmActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAlarmActionsInput,
   output: EnableAlarmActionsResponse,
@@ -3864,7 +3863,7 @@ export const enableInsightRules: API.OperationMethod<
   EnableInsightRulesInput,
   EnableInsightRulesOutput,
   EnableInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableInsightRulesInput,
   output: EnableInsightRulesOutput,
@@ -3906,7 +3905,7 @@ export const getAlarmMuteRule: API.OperationMethod<
   GetAlarmMuteRuleInput,
   GetAlarmMuteRuleOutput,
   GetAlarmMuteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAlarmMuteRuleInput,
   output: GetAlarmMuteRuleOutput,
@@ -3932,7 +3931,7 @@ export const getDashboard: API.OperationMethod<
   GetDashboardInput,
   GetDashboardOutput,
   GetDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardInput,
   output: GetDashboardOutput,
@@ -3966,7 +3965,7 @@ export const getDataset: API.OperationMethod<
   GetDatasetInput,
   GetDatasetOutput,
   GetDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatasetInput,
   output: GetDatasetOutput,
@@ -4019,7 +4018,7 @@ export const getInsightRuleReport: API.OperationMethod<
   GetInsightRuleReportInput,
   GetInsightRuleReportOutput,
   GetInsightRuleReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightRuleReportInput,
   output: GetInsightRuleReportOutput,
@@ -4104,7 +4103,7 @@ export const getMetricData: API.PaginatedOperationMethod<
   GetMetricDataInput,
   GetMetricDataOutput,
   GetMetricDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMetricDataInput,
@@ -4187,7 +4186,7 @@ export const getMetricStatistics: API.OperationMethod<
   GetMetricStatisticsInput,
   GetMetricStatisticsOutput,
   GetMetricStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricStatisticsInput,
   output: GetMetricStatisticsOutput,
@@ -4216,7 +4215,7 @@ export const getMetricStream: API.OperationMethod<
   GetMetricStreamInput,
   GetMetricStreamOutput,
   GetMetricStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricStreamInput,
   output: GetMetricStreamOutput,
@@ -4254,7 +4253,7 @@ export const getMetricWidgetImage: API.OperationMethod<
   GetMetricWidgetImageInput,
   GetMetricWidgetImageOutput,
   GetMetricWidgetImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricWidgetImageInput,
   output: GetMetricWidgetImageOutput,
@@ -4274,7 +4273,7 @@ export const getOTelEnrichment: API.OperationMethod<
   GetOTelEnrichmentInput,
   GetOTelEnrichmentOutput,
   GetOTelEnrichmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOTelEnrichmentInput,
   output: GetOTelEnrichmentOutput,
@@ -4307,7 +4306,7 @@ export const listAlarmMuteRules: API.PaginatedOperationMethod<
   ListAlarmMuteRulesInput,
   ListAlarmMuteRulesOutput,
   ListAlarmMuteRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AlarmMuteRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAlarmMuteRulesInput,
@@ -4342,7 +4341,7 @@ export const listDashboards: API.PaginatedOperationMethod<
   ListDashboardsInput,
   ListDashboardsOutput,
   ListDashboardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDashboardsInput,
@@ -4371,7 +4370,7 @@ export const listManagedInsightRules: API.PaginatedOperationMethod<
   ListManagedInsightRulesInput,
   ListManagedInsightRulesOutput,
   ListManagedInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedInsightRulesInput,
@@ -4415,7 +4414,7 @@ export const listMetrics: API.PaginatedOperationMethod<
   ListMetricsInput,
   ListMetricsOutput,
   ListMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricsInput,
@@ -4440,7 +4439,7 @@ export const listMetricStreams: API.PaginatedOperationMethod<
   ListMetricStreamsInput,
   ListMetricStreamsOutput,
   ListMetricStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricStreamsInput,
@@ -4474,7 +4473,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -4528,7 +4527,7 @@ export const putAlarmMuteRule: API.OperationMethod<
   PutAlarmMuteRuleInput,
   PutAlarmMuteRuleResponse,
   PutAlarmMuteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAlarmMuteRuleInput,
   output: PutAlarmMuteRuleResponse,
@@ -4560,7 +4559,7 @@ export const putAnomalyDetector: API.OperationMethod<
   PutAnomalyDetectorInput,
   PutAnomalyDetectorOutput,
   PutAnomalyDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAnomalyDetectorInput,
   output: PutAnomalyDetectorOutput,
@@ -4639,7 +4638,7 @@ export const putCompositeAlarm: API.OperationMethod<
   PutCompositeAlarmInput,
   PutCompositeAlarmResponse,
   PutCompositeAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCompositeAlarmInput,
   output: PutCompositeAlarmResponse,
@@ -4679,7 +4678,7 @@ export const putDashboard: API.OperationMethod<
   PutDashboardInput,
   PutDashboardOutput,
   PutDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDashboardInput,
   output: PutDashboardOutput,
@@ -4707,7 +4706,7 @@ export const putInsightRule: API.OperationMethod<
   PutInsightRuleInput,
   PutInsightRuleOutput,
   PutInsightRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInsightRuleInput,
   output: PutInsightRuleOutput,
@@ -4742,7 +4741,7 @@ export const putLogAlarm: API.OperationMethod<
   PutLogAlarmInput,
   PutLogAlarmResponse,
   PutLogAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLogAlarmInput,
   output: PutLogAlarmResponse,
@@ -4770,7 +4769,7 @@ export const putManagedInsightRules: API.OperationMethod<
   PutManagedInsightRulesInput,
   PutManagedInsightRulesOutput,
   PutManagedInsightRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutManagedInsightRulesInput,
   output: PutManagedInsightRulesOutput,
@@ -4836,7 +4835,7 @@ export const putMetricAlarm: API.OperationMethod<
   PutMetricAlarmInput,
   PutMetricAlarmResponse,
   PutMetricAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetricAlarmInput,
   output: PutMetricAlarmResponse,
@@ -4911,7 +4910,7 @@ export const putMetricData: API.OperationMethod<
   PutMetricDataInput,
   PutMetricDataResponse,
   PutMetricDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetricDataInput,
   output: PutMetricDataResponse,
@@ -4974,7 +4973,7 @@ export const putMetricStream: API.OperationMethod<
   PutMetricStreamInput,
   PutMetricStreamOutput,
   PutMetricStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetricStreamInput,
   output: PutMetricStreamOutput,
@@ -5019,7 +5018,7 @@ export const setAlarmState: API.OperationMethod<
   SetAlarmStateInput,
   SetAlarmStateResponse,
   SetAlarmStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetAlarmStateInput,
   output: SetAlarmStateResponse,
@@ -5041,7 +5040,7 @@ export const startMetricStreams: API.OperationMethod<
   StartMetricStreamsInput,
   StartMetricStreamsOutput,
   StartMetricStreamsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetricStreamsInput,
   output: StartMetricStreamsOutput,
@@ -5070,7 +5069,7 @@ export const startOTelEnrichment: API.OperationMethod<
   StartOTelEnrichmentInput,
   StartOTelEnrichmentOutput,
   StartOTelEnrichmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOTelEnrichmentInput,
   output: StartOTelEnrichmentOutput,
@@ -5092,7 +5091,7 @@ export const stopMetricStreams: API.OperationMethod<
   StopMetricStreamsInput,
   StopMetricStreamsOutput,
   StopMetricStreamsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMetricStreamsInput,
   output: StopMetricStreamsOutput,
@@ -5116,7 +5115,7 @@ export const stopOTelEnrichment: API.OperationMethod<
   StopOTelEnrichmentInput,
   StopOTelEnrichmentOutput,
   StopOTelEnrichmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopOTelEnrichmentInput,
   output: StopOTelEnrichmentOutput,
@@ -5157,7 +5156,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -5188,7 +5187,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,

--- a/packages/aws/src/services/codeartifact.ts
+++ b/packages/aws/src/services/codeartifact.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "codeartifact",
@@ -2734,7 +2733,7 @@ export const associateExternalConnection: API.OperationMethod<
   AssociateExternalConnectionRequest,
   AssociateExternalConnectionResult,
   AssociateExternalConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateExternalConnectionRequest,
   output: AssociateExternalConnectionResult,
@@ -2770,7 +2769,7 @@ export const copyPackageVersions: API.OperationMethod<
   CopyPackageVersionsRequest,
   CopyPackageVersionsResult,
   CopyPackageVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyPackageVersionsRequest,
   output: CopyPackageVersionsResult,
@@ -2811,7 +2810,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResult,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResult,
@@ -2845,7 +2844,7 @@ export const createPackageGroup: API.OperationMethod<
   CreatePackageGroupRequest,
   CreatePackageGroupResult,
   CreatePackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageGroupRequest,
   output: CreatePackageGroupResult,
@@ -2879,7 +2878,7 @@ export const createRepository: API.OperationMethod<
   CreateRepositoryRequest,
   CreateRepositoryResult,
   CreateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryRequest,
   output: CreateRepositoryResult,
@@ -2912,7 +2911,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResult,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResult,
@@ -2943,7 +2942,7 @@ export const deleteDomainPermissionsPolicy: API.OperationMethod<
   DeleteDomainPermissionsPolicyRequest,
   DeleteDomainPermissionsPolicyResult,
   DeleteDomainPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainPermissionsPolicyRequest,
   output: DeleteDomainPermissionsPolicyResult,
@@ -2976,7 +2975,7 @@ export const deletePackage: API.OperationMethod<
   DeletePackageRequest,
   DeletePackageResult,
   DeletePackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageRequest,
   output: DeletePackageResult,
@@ -3013,7 +3012,7 @@ export const deletePackageGroup: API.OperationMethod<
   DeletePackageGroupRequest,
   DeletePackageGroupResult,
   DeletePackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageGroupRequest,
   output: DeletePackageGroupResult,
@@ -3050,7 +3049,7 @@ export const deletePackageVersions: API.OperationMethod<
   DeletePackageVersionsRequest,
   DeletePackageVersionsResult,
   DeletePackageVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageVersionsRequest,
   output: DeletePackageVersionsResult,
@@ -3082,7 +3081,7 @@ export const deleteRepository: API.OperationMethod<
   DeleteRepositoryRequest,
   DeleteRepositoryResult,
   DeleteRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryRequest,
   output: DeleteRepositoryResult,
@@ -3118,7 +3117,7 @@ export const deleteRepositoryPermissionsPolicy: API.OperationMethod<
   DeleteRepositoryPermissionsPolicyRequest,
   DeleteRepositoryPermissionsPolicyResult,
   DeleteRepositoryPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryPermissionsPolicyRequest,
   output: DeleteRepositoryPermissionsPolicyResult,
@@ -3151,7 +3150,7 @@ export const describeDomain: API.OperationMethod<
   DescribeDomainRequest,
   DescribeDomainResult,
   DescribeDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainRequest,
   output: DescribeDomainResult,
@@ -3183,7 +3182,7 @@ export const describePackage: API.OperationMethod<
   DescribePackageRequest,
   DescribePackageResult,
   DescribePackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageRequest,
   output: DescribePackageResult,
@@ -3214,7 +3213,7 @@ export const describePackageGroup: API.OperationMethod<
   DescribePackageGroupRequest,
   DescribePackageGroupResult,
   DescribePackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageGroupRequest,
   output: DescribePackageGroupResult,
@@ -3247,7 +3246,7 @@ export const describePackageVersion: API.OperationMethod<
   DescribePackageVersionRequest,
   DescribePackageVersionResult,
   DescribePackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageVersionRequest,
   output: DescribePackageVersionResult,
@@ -3279,7 +3278,7 @@ export const describeRepository: API.OperationMethod<
   DescribeRepositoryRequest,
   DescribeRepositoryResult,
   DescribeRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRepositoryRequest,
   output: DescribeRepositoryResult,
@@ -3311,7 +3310,7 @@ export const disassociateExternalConnection: API.OperationMethod<
   DisassociateExternalConnectionRequest,
   DisassociateExternalConnectionResult,
   DisassociateExternalConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateExternalConnectionRequest,
   output: DisassociateExternalConnectionResult,
@@ -3351,7 +3350,7 @@ export const disposePackageVersions: API.OperationMethod<
   DisposePackageVersionsRequest,
   DisposePackageVersionsResult,
   DisposePackageVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisposePackageVersionsRequest,
   output: DisposePackageVersionsResult,
@@ -3387,7 +3386,7 @@ export const getAssociatedPackageGroup: API.OperationMethod<
   GetAssociatedPackageGroupRequest,
   GetAssociatedPackageGroupResult,
   GetAssociatedPackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociatedPackageGroupRequest,
   output: GetAssociatedPackageGroupResult,
@@ -3435,7 +3434,7 @@ export const getAuthorizationToken: API.OperationMethod<
   GetAuthorizationTokenRequest,
   GetAuthorizationTokenResult,
   GetAuthorizationTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizationTokenRequest,
   output: GetAuthorizationTokenResult,
@@ -3469,7 +3468,7 @@ export const getDomainPermissionsPolicy: API.OperationMethod<
   GetDomainPermissionsPolicyRequest,
   GetDomainPermissionsPolicyResult,
   GetDomainPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainPermissionsPolicyRequest,
   output: GetDomainPermissionsPolicyResult,
@@ -3502,7 +3501,7 @@ export const getPackageVersionAsset: API.OperationMethod<
   GetPackageVersionAssetRequest,
   GetPackageVersionAssetResult,
   GetPackageVersionAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPackageVersionAssetRequest,
   output: GetPackageVersionAssetResult,
@@ -3535,7 +3534,7 @@ export const getPackageVersionReadme: API.OperationMethod<
   GetPackageVersionReadmeRequest,
   GetPackageVersionReadmeResult,
   GetPackageVersionReadmeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPackageVersionReadmeRequest,
   output: GetPackageVersionReadmeResult,
@@ -3582,7 +3581,7 @@ export const getRepositoryEndpoint: API.OperationMethod<
   GetRepositoryEndpointRequest,
   GetRepositoryEndpointResult,
   GetRepositoryEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryEndpointRequest,
   output: GetRepositoryEndpointResult,
@@ -3612,7 +3611,7 @@ export const getRepositoryPermissionsPolicy: API.OperationMethod<
   GetRepositoryPermissionsPolicyRequest,
   GetRepositoryPermissionsPolicyResult,
   GetRepositoryPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryPermissionsPolicyRequest,
   output: GetRepositoryPermissionsPolicyResult,
@@ -3644,7 +3643,7 @@ export const listAllowedRepositoriesForGroup: API.PaginatedOperationMethod<
   ListAllowedRepositoriesForGroupRequest,
   ListAllowedRepositoriesForGroupResult,
   ListAllowedRepositoriesForGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositoryName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAllowedRepositoriesForGroupRequest,
@@ -3683,7 +3682,7 @@ export const listAssociatedPackages: API.PaginatedOperationMethod<
   ListAssociatedPackagesRequest,
   ListAssociatedPackagesResult,
   ListAssociatedPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedPackage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedPackagesRequest,
@@ -3720,7 +3719,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResult,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -3756,7 +3755,7 @@ export const listPackageGroups: API.PaginatedOperationMethod<
   ListPackageGroupsRequest,
   ListPackageGroupsResult,
   ListPackageGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackageGroupsRequest,
@@ -3795,7 +3794,7 @@ export const listPackages: API.PaginatedOperationMethod<
   ListPackagesRequest,
   ListPackagesResult,
   ListPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagesRequest,
@@ -3834,7 +3833,7 @@ export const listPackageVersionAssets: API.PaginatedOperationMethod<
   ListPackageVersionAssetsRequest,
   ListPackageVersionAssetsResult,
   ListPackageVersionAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackageVersionAssetsRequest,
@@ -3875,7 +3874,7 @@ export const listPackageVersionDependencies: API.OperationMethod<
   ListPackageVersionDependenciesRequest,
   ListPackageVersionDependenciesResult,
   ListPackageVersionDependenciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPackageVersionDependenciesRequest,
   output: ListPackageVersionDependenciesResult,
@@ -3907,7 +3906,7 @@ export const listPackageVersions: API.PaginatedOperationMethod<
   ListPackageVersionsRequest,
   ListPackageVersionsResult,
   ListPackageVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackageVersionsRequest,
@@ -3946,7 +3945,7 @@ export const listRepositories: API.PaginatedOperationMethod<
   ListRepositoriesRequest,
   ListRepositoriesResult,
   ListRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoriesRequest,
@@ -3985,7 +3984,7 @@ export const listRepositoriesInDomain: API.PaginatedOperationMethod<
   ListRepositoriesInDomainRequest,
   ListRepositoriesInDomainResult,
   ListRepositoriesInDomainError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoriesInDomainRequest,
@@ -4026,7 +4025,7 @@ export const listSubPackageGroups: API.PaginatedOperationMethod<
   ListSubPackageGroupsRequest,
   ListSubPackageGroupsResult,
   ListSubPackageGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubPackageGroupsRequest,
@@ -4062,7 +4061,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -4102,7 +4101,7 @@ export const publishPackageVersion: API.OperationMethod<
   PublishPackageVersionRequest,
   PublishPackageVersionResult,
   PublishPackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishPackageVersionRequest,
   output: PublishPackageVersionResult,
@@ -4140,7 +4139,7 @@ export const putDomainPermissionsPolicy: API.OperationMethod<
   PutDomainPermissionsPolicyRequest,
   PutDomainPermissionsPolicyResult,
   PutDomainPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDomainPermissionsPolicyRequest,
   output: PutDomainPermissionsPolicyResult,
@@ -4181,7 +4180,7 @@ export const putPackageOriginConfiguration: API.OperationMethod<
   PutPackageOriginConfigurationRequest,
   PutPackageOriginConfigurationResult,
   PutPackageOriginConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPackageOriginConfigurationRequest,
   output: PutPackageOriginConfigurationResult,
@@ -4217,7 +4216,7 @@ export const putRepositoryPermissionsPolicy: API.OperationMethod<
   PutRepositoryPermissionsPolicyRequest,
   PutRepositoryPermissionsPolicyResult,
   PutRepositoryPermissionsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRepositoryPermissionsPolicyRequest,
   output: PutRepositoryPermissionsPolicyResult,
@@ -4249,7 +4248,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -4278,7 +4277,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -4309,7 +4308,7 @@ export const updatePackageGroup: API.OperationMethod<
   UpdatePackageGroupRequest,
   UpdatePackageGroupResult,
   UpdatePackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageGroupRequest,
   output: UpdatePackageGroupResult,
@@ -4347,7 +4346,7 @@ export const updatePackageGroupOriginConfiguration: API.OperationMethod<
   UpdatePackageGroupOriginConfigurationRequest,
   UpdatePackageGroupOriginConfigurationResult,
   UpdatePackageGroupOriginConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageGroupOriginConfigurationRequest,
   output: UpdatePackageGroupOriginConfigurationResult,
@@ -4382,7 +4381,7 @@ export const updatePackageVersionsStatus: API.OperationMethod<
   UpdatePackageVersionsStatusRequest,
   UpdatePackageVersionsStatusResult,
   UpdatePackageVersionsStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageVersionsStatusRequest,
   output: UpdatePackageVersionsStatusResult,
@@ -4415,7 +4414,7 @@ export const updateRepository: API.OperationMethod<
   UpdateRepositoryRequest,
   UpdateRepositoryResult,
   UpdateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryRequest,
   output: UpdateRepositoryResult,

--- a/packages/aws/src/services/codebuild.ts
+++ b/packages/aws/src/services/codebuild.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeBuild",
@@ -3559,7 +3558,7 @@ export const batchDeleteBuilds: API.OperationMethod<
   BatchDeleteBuildsInput,
   BatchDeleteBuildsOutput,
   BatchDeleteBuildsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteBuildsInput,
   output: BatchDeleteBuildsOutput,
@@ -3577,7 +3576,7 @@ export const batchGetBuildBatches: API.OperationMethod<
   BatchGetBuildBatchesInput,
   BatchGetBuildBatchesOutput,
   BatchGetBuildBatchesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetBuildBatchesInput,
   output: BatchGetBuildBatchesOutput,
@@ -3595,7 +3594,7 @@ export const batchGetBuilds: API.OperationMethod<
   BatchGetBuildsInput,
   BatchGetBuildsOutput,
   BatchGetBuildsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetBuildsInput,
   output: BatchGetBuildsOutput,
@@ -3615,7 +3614,7 @@ export const batchGetCommandExecutions: API.OperationMethod<
   BatchGetCommandExecutionsInput,
   BatchGetCommandExecutionsOutput,
   BatchGetCommandExecutionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCommandExecutionsInput,
   output: BatchGetCommandExecutionsOutput,
@@ -3633,7 +3632,7 @@ export const batchGetFleets: API.OperationMethod<
   BatchGetFleetsInput,
   BatchGetFleetsOutput,
   BatchGetFleetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFleetsInput,
   output: BatchGetFleetsOutput,
@@ -3651,7 +3650,7 @@ export const batchGetProjects: API.OperationMethod<
   BatchGetProjectsInput,
   BatchGetProjectsOutput,
   BatchGetProjectsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetProjectsInput,
   output: BatchGetProjectsOutput,
@@ -3669,7 +3668,7 @@ export const batchGetReportGroups: API.OperationMethod<
   BatchGetReportGroupsInput,
   BatchGetReportGroupsOutput,
   BatchGetReportGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetReportGroupsInput,
   output: BatchGetReportGroupsOutput,
@@ -3687,7 +3686,7 @@ export const batchGetReports: API.OperationMethod<
   BatchGetReportsInput,
   BatchGetReportsOutput,
   BatchGetReportsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetReportsInput,
   output: BatchGetReportsOutput,
@@ -3705,7 +3704,7 @@ export const batchGetSandboxes: API.OperationMethod<
   BatchGetSandboxesInput,
   BatchGetSandboxesOutput,
   BatchGetSandboxesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSandboxesInput,
   output: BatchGetSandboxesOutput,
@@ -3727,7 +3726,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetInput,
   CreateFleetOutput,
   CreateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetInput,
   output: CreateFleetOutput,
@@ -3753,7 +3752,7 @@ export const createProject: API.OperationMethod<
   CreateProjectInput,
   CreateProjectOutput,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectInput,
   output: CreateProjectOutput,
@@ -3779,7 +3778,7 @@ export const createReportGroup: API.OperationMethod<
   CreateReportGroupInput,
   CreateReportGroupOutput,
   CreateReportGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReportGroupInput,
   output: CreateReportGroupOutput,
@@ -3815,7 +3814,7 @@ export const createWebhook: API.OperationMethod<
   CreateWebhookInput,
   CreateWebhookOutput,
   CreateWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebhookInput,
   output: CreateWebhookOutput,
@@ -3838,7 +3837,7 @@ export const deleteBuildBatch: API.OperationMethod<
   DeleteBuildBatchInput,
   DeleteBuildBatchOutput,
   DeleteBuildBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBuildBatchInput,
   output: DeleteBuildBatchOutput,
@@ -3856,7 +3855,7 @@ export const deleteFleet: API.OperationMethod<
   DeleteFleetInput,
   DeleteFleetOutput,
   DeleteFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetInput,
   output: DeleteFleetOutput,
@@ -3874,7 +3873,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectInput,
   DeleteProjectOutput,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectInput,
   output: DeleteProjectOutput,
@@ -3892,7 +3891,7 @@ export const deleteReport: API.OperationMethod<
   DeleteReportInput,
   DeleteReportOutput,
   DeleteReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReportInput,
   output: DeleteReportOutput,
@@ -3910,7 +3909,7 @@ export const deleteReportGroup: API.OperationMethod<
   DeleteReportGroupInput,
   DeleteReportGroupOutput,
   DeleteReportGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReportGroupInput,
   output: DeleteReportGroupOutput,
@@ -3928,7 +3927,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyInput,
   DeleteResourcePolicyOutput,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyInput,
   output: DeleteResourcePolicyOutput,
@@ -3949,7 +3948,7 @@ export const deleteSourceCredentials: API.OperationMethod<
   DeleteSourceCredentialsInput,
   DeleteSourceCredentialsOutput,
   DeleteSourceCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceCredentialsInput,
   output: DeleteSourceCredentialsOutput,
@@ -3973,7 +3972,7 @@ export const deleteWebhook: API.OperationMethod<
   DeleteWebhookInput,
   DeleteWebhookOutput,
   DeleteWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebhookInput,
   output: DeleteWebhookOutput,
@@ -3995,7 +3994,7 @@ export const describeCodeCoverages: API.PaginatedOperationMethod<
   DescribeCodeCoveragesInput,
   DescribeCodeCoveragesOutput,
   DescribeCodeCoveragesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeCoverage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCodeCoveragesInput,
@@ -4023,7 +4022,7 @@ export const describeTestCases: API.PaginatedOperationMethod<
   DescribeTestCasesInput,
   DescribeTestCasesOutput,
   DescribeTestCasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TestCase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTestCasesInput,
@@ -4051,7 +4050,7 @@ export const getReportGroupTrend: API.OperationMethod<
   GetReportGroupTrendInput,
   GetReportGroupTrendOutput,
   GetReportGroupTrendError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReportGroupTrendInput,
   output: GetReportGroupTrendOutput,
@@ -4072,7 +4071,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -4095,7 +4094,7 @@ export const importSourceCredentials: API.OperationMethod<
   ImportSourceCredentialsInput,
   ImportSourceCredentialsOutput,
   ImportSourceCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportSourceCredentialsInput,
   output: ImportSourceCredentialsOutput,
@@ -4120,7 +4119,7 @@ export const invalidateProjectCache: API.OperationMethod<
   InvalidateProjectCacheInput,
   InvalidateProjectCacheOutput,
   InvalidateProjectCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvalidateProjectCacheInput,
   output: InvalidateProjectCacheOutput,
@@ -4138,7 +4137,7 @@ export const listBuildBatches: API.PaginatedOperationMethod<
   ListBuildBatchesInput,
   ListBuildBatchesOutput,
   ListBuildBatchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuildBatchesInput,
@@ -4166,7 +4165,7 @@ export const listBuildBatchesForProject: API.PaginatedOperationMethod<
   ListBuildBatchesForProjectInput,
   ListBuildBatchesForProjectOutput,
   ListBuildBatchesForProjectError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuildBatchesForProjectInput,
@@ -4191,7 +4190,7 @@ export const listBuilds: API.PaginatedOperationMethod<
   ListBuildsInput,
   ListBuildsOutput,
   ListBuildsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuildsInput,
@@ -4219,7 +4218,7 @@ export const listBuildsForProject: API.PaginatedOperationMethod<
   ListBuildsForProjectInput,
   ListBuildsForProjectOutput,
   ListBuildsForProjectError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuildsForProjectInput,
@@ -4246,7 +4245,7 @@ export const listCommandExecutionsForSandbox: API.PaginatedOperationMethod<
   ListCommandExecutionsForSandboxInput,
   ListCommandExecutionsForSandboxOutput,
   ListCommandExecutionsForSandboxError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CommandExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommandExecutionsForSandboxInput,
@@ -4271,7 +4270,7 @@ export const listCuratedEnvironmentImages: API.OperationMethod<
   ListCuratedEnvironmentImagesInput,
   ListCuratedEnvironmentImagesOutput,
   ListCuratedEnvironmentImagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCuratedEnvironmentImagesInput,
   output: ListCuratedEnvironmentImagesOutput,
@@ -4289,7 +4288,7 @@ export const listFleets: API.PaginatedOperationMethod<
   ListFleetsInput,
   ListFleetsOutput,
   ListFleetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetsInput,
@@ -4314,7 +4313,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsInput,
   ListProjectsOutput,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsInput,
@@ -4338,7 +4337,7 @@ export const listReportGroups: API.PaginatedOperationMethod<
   ListReportGroupsInput,
   ListReportGroupsOutput,
   ListReportGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportGroupsInput,
@@ -4363,7 +4362,7 @@ export const listReports: API.PaginatedOperationMethod<
   ListReportsInput,
   ListReportsOutput,
   ListReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportsInput,
@@ -4391,7 +4390,7 @@ export const listReportsForReportGroup: API.PaginatedOperationMethod<
   ListReportsForReportGroupInput,
   ListReportsForReportGroupOutput,
   ListReportsForReportGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportsForReportGroupInput,
@@ -4416,7 +4415,7 @@ export const listSandboxes: API.PaginatedOperationMethod<
   ListSandboxesInput,
   ListSandboxesOutput,
   ListSandboxesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSandboxesInput,
@@ -4444,7 +4443,7 @@ export const listSandboxesForProject: API.PaginatedOperationMethod<
   ListSandboxesForProjectInput,
   ListSandboxesForProjectOutput,
   ListSandboxesForProjectError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSandboxesForProjectInput,
@@ -4469,7 +4468,7 @@ export const listSharedProjects: API.PaginatedOperationMethod<
   ListSharedProjectsInput,
   ListSharedProjectsOutput,
   ListSharedProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSharedProjectsInput,
@@ -4494,7 +4493,7 @@ export const listSharedReportGroups: API.PaginatedOperationMethod<
   ListSharedReportGroupsInput,
   ListSharedReportGroupsOutput,
   ListSharedReportGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSharedReportGroupsInput,
@@ -4519,7 +4518,7 @@ export const listSourceCredentials: API.OperationMethod<
   ListSourceCredentialsInput,
   ListSourceCredentialsOutput,
   ListSourceCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSourceCredentialsInput,
   output: ListSourceCredentialsOutput,
@@ -4541,7 +4540,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyInput,
   PutResourcePolicyOutput,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyInput,
   output: PutResourcePolicyOutput,
@@ -4563,7 +4562,7 @@ export const retryBuild: API.OperationMethod<
   RetryBuildInput,
   RetryBuildOutput,
   RetryBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryBuildInput,
   output: RetryBuildOutput,
@@ -4588,7 +4587,7 @@ export const retryBuildBatch: API.OperationMethod<
   RetryBuildBatchInput,
   RetryBuildBatchOutput,
   RetryBuildBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryBuildBatchInput,
   output: RetryBuildBatchOutput,
@@ -4614,7 +4613,7 @@ export const startBuild: API.OperationMethod<
   StartBuildInput,
   StartBuildOutput,
   StartBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBuildInput,
   output: StartBuildOutput,
@@ -4639,7 +4638,7 @@ export const startBuildBatch: API.OperationMethod<
   StartBuildBatchInput,
   StartBuildBatchOutput,
   StartBuildBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBuildBatchInput,
   output: StartBuildBatchOutput,
@@ -4660,7 +4659,7 @@ export const startCommandExecution: API.OperationMethod<
   StartCommandExecutionInput,
   StartCommandExecutionOutput,
   StartCommandExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCommandExecutionInput,
   output: StartCommandExecutionOutput,
@@ -4682,7 +4681,7 @@ export const startSandbox: API.OperationMethod<
   StartSandboxInput,
   StartSandboxOutput,
   StartSandboxError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSandboxInput,
   output: StartSandboxOutput,
@@ -4707,7 +4706,7 @@ export const startSandboxConnection: API.OperationMethod<
   StartSandboxConnectionInput,
   StartSandboxConnectionOutput,
   StartSandboxConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSandboxConnectionInput,
   output: StartSandboxConnectionOutput,
@@ -4728,7 +4727,7 @@ export const stopBuild: API.OperationMethod<
   StopBuildInput,
   StopBuildOutput,
   StopBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBuildInput,
   output: StopBuildOutput,
@@ -4749,7 +4748,7 @@ export const stopBuildBatch: API.OperationMethod<
   StopBuildBatchInput,
   StopBuildBatchOutput,
   StopBuildBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBuildBatchInput,
   output: StopBuildBatchOutput,
@@ -4770,7 +4769,7 @@ export const stopSandbox: API.OperationMethod<
   StopSandboxInput,
   StopSandboxOutput,
   StopSandboxError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSandboxInput,
   output: StopSandboxOutput,
@@ -4792,7 +4791,7 @@ export const updateFleet: API.OperationMethod<
   UpdateFleetInput,
   UpdateFleetOutput,
   UpdateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetInput,
   output: UpdateFleetOutput,
@@ -4817,7 +4816,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectInput,
   UpdateProjectOutput,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectInput,
   output: UpdateProjectOutput,
@@ -4864,7 +4863,7 @@ export const updateProjectVisibility: API.OperationMethod<
   UpdateProjectVisibilityInput,
   UpdateProjectVisibilityOutput,
   UpdateProjectVisibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectVisibilityInput,
   output: UpdateProjectVisibilityOutput,
@@ -4885,7 +4884,7 @@ export const updateReportGroup: API.OperationMethod<
   UpdateReportGroupInput,
   UpdateReportGroupOutput,
   UpdateReportGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReportGroupInput,
   output: UpdateReportGroupOutput,
@@ -4909,7 +4908,7 @@ export const updateWebhook: API.OperationMethod<
   UpdateWebhookInput,
   UpdateWebhookOutput,
   UpdateWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebhookInput,
   output: UpdateWebhookOutput,

--- a/packages/aws/src/services/codecatalyst.ts
+++ b/packages/aws/src/services/codecatalyst.ts
@@ -7,7 +7,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeCatalyst",
@@ -2120,7 +2119,7 @@ export const createAccessToken: API.OperationMethod<
   CreateAccessTokenRequest,
   CreateAccessTokenResponse,
   CreateAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessTokenRequest,
   output: CreateAccessTokenResponse,
@@ -2142,7 +2141,7 @@ export const createDevEnvironment: API.OperationMethod<
   CreateDevEnvironmentRequest,
   CreateDevEnvironmentResponse,
   CreateDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDevEnvironmentRequest,
   output: CreateDevEnvironmentResponse,
@@ -2160,7 +2159,7 @@ export const createProject: API.OperationMethod<
   CreateProjectRequest,
   CreateProjectResponse,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectRequest,
   output: CreateProjectResponse,
@@ -2179,7 +2178,7 @@ export const createSourceRepository: API.OperationMethod<
   CreateSourceRepositoryRequest,
   CreateSourceRepositoryResponse,
   CreateSourceRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSourceRepositoryRequest,
   output: CreateSourceRepositoryResponse,
@@ -2199,7 +2198,7 @@ export const createSourceRepositoryBranch: API.OperationMethod<
   CreateSourceRepositoryBranchRequest,
   CreateSourceRepositoryBranchResponse,
   CreateSourceRepositoryBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSourceRepositoryBranchRequest,
   output: CreateSourceRepositoryBranchResponse,
@@ -2217,7 +2216,7 @@ export const deleteAccessToken: API.OperationMethod<
   DeleteAccessTokenRequest,
   DeleteAccessTokenResponse,
   DeleteAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessTokenRequest,
   output: DeleteAccessTokenResponse,
@@ -2235,7 +2234,7 @@ export const deleteDevEnvironment: API.OperationMethod<
   DeleteDevEnvironmentRequest,
   DeleteDevEnvironmentResponse,
   DeleteDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDevEnvironmentRequest,
   output: DeleteDevEnvironmentResponse,
@@ -2253,7 +2252,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectRequest,
   DeleteProjectResponse,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectRequest,
   output: DeleteProjectResponse,
@@ -2271,7 +2270,7 @@ export const deleteSourceRepository: API.OperationMethod<
   DeleteSourceRepositoryRequest,
   DeleteSourceRepositoryResponse,
   DeleteSourceRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceRepositoryRequest,
   output: DeleteSourceRepositoryResponse,
@@ -2291,7 +2290,7 @@ export const deleteSpace: API.OperationMethod<
   DeleteSpaceRequest,
   DeleteSpaceResponse,
   DeleteSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpaceRequest,
   output: DeleteSpaceResponse,
@@ -2309,7 +2308,7 @@ export const getDevEnvironment: API.OperationMethod<
   GetDevEnvironmentRequest,
   GetDevEnvironmentResponse,
   GetDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDevEnvironmentRequest,
   output: GetDevEnvironmentResponse,
@@ -2327,7 +2326,7 @@ export const getProject: API.OperationMethod<
   GetProjectRequest,
   GetProjectResponse,
   GetProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProjectRequest,
   output: GetProjectResponse,
@@ -2345,7 +2344,7 @@ export const getSourceRepository: API.OperationMethod<
   GetSourceRepositoryRequest,
   GetSourceRepositoryResponse,
   GetSourceRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSourceRepositoryRequest,
   output: GetSourceRepositoryResponse,
@@ -2364,7 +2363,7 @@ export const getSourceRepositoryCloneUrls: API.OperationMethod<
   GetSourceRepositoryCloneUrlsRequest,
   GetSourceRepositoryCloneUrlsResponse,
   GetSourceRepositoryCloneUrlsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSourceRepositoryCloneUrlsRequest,
   output: GetSourceRepositoryCloneUrlsResponse,
@@ -2382,7 +2381,7 @@ export const getSpace: API.OperationMethod<
   GetSpaceRequest,
   GetSpaceResponse,
   GetSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpaceRequest,
   output: GetSpaceResponse,
@@ -2401,7 +2400,7 @@ export const getSubscription: API.OperationMethod<
   GetSubscriptionRequest,
   GetSubscriptionResponse,
   GetSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionRequest,
   output: GetSubscriptionResponse,
@@ -2419,7 +2418,7 @@ export const getUserDetails: API.OperationMethod<
   GetUserDetailsRequest,
   GetUserDetailsResponse,
   GetUserDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserDetailsRequest,
   output: GetUserDetailsResponse,
@@ -2437,7 +2436,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -2455,7 +2454,7 @@ export const getWorkflowRun: API.OperationMethod<
   GetWorkflowRunRequest,
   GetWorkflowRunResponse,
   GetWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRunRequest,
   output: GetWorkflowRunResponse,
@@ -2473,7 +2472,7 @@ export const listAccessTokens: API.PaginatedOperationMethod<
   ListAccessTokensRequest,
   ListAccessTokensResponse,
   ListAccessTokensError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessTokenSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessTokensRequest,
@@ -2498,7 +2497,7 @@ export const listDevEnvironments: API.PaginatedOperationMethod<
   ListDevEnvironmentsRequest,
   ListDevEnvironmentsResponse,
   ListDevEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DevEnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevEnvironmentsRequest,
@@ -2523,7 +2522,7 @@ export const listDevEnvironmentSessions: API.PaginatedOperationMethod<
   ListDevEnvironmentSessionsRequest,
   ListDevEnvironmentSessionsResponse,
   ListDevEnvironmentSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DevEnvironmentSessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevEnvironmentSessionsRequest,
@@ -2556,7 +2555,7 @@ export const listEventLogs: API.PaginatedOperationMethod<
   ListEventLogsRequest,
   ListEventLogsResponse,
   ListEventLogsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventLogEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventLogsRequest,
@@ -2581,7 +2580,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsRequest,
   ListProjectsResponse,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsRequest,
@@ -2606,7 +2605,7 @@ export const listSourceRepositories: API.PaginatedOperationMethod<
   ListSourceRepositoriesRequest,
   ListSourceRepositoriesResponse,
   ListSourceRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSourceRepositoriesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceRepositoriesRequest,
@@ -2631,7 +2630,7 @@ export const listSourceRepositoryBranches: API.PaginatedOperationMethod<
   ListSourceRepositoryBranchesRequest,
   ListSourceRepositoryBranchesResponse,
   ListSourceRepositoryBranchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSourceRepositoryBranchesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceRepositoryBranchesRequest,
@@ -2656,7 +2655,7 @@ export const listSpaces: API.PaginatedOperationMethod<
   ListSpacesRequest,
   ListSpacesResponse,
   ListSpacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpacesRequest,
@@ -2680,7 +2679,7 @@ export const listWorkflowRuns: API.PaginatedOperationMethod<
   ListWorkflowRunsRequest,
   ListWorkflowRunsResponse,
   ListWorkflowRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowRunsRequest,
@@ -2705,7 +2704,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -2730,7 +2729,7 @@ export const startDevEnvironment: API.OperationMethod<
   StartDevEnvironmentRequest,
   StartDevEnvironmentResponse,
   StartDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDevEnvironmentRequest,
   output: StartDevEnvironmentResponse,
@@ -2748,7 +2747,7 @@ export const startDevEnvironmentSession: API.OperationMethod<
   StartDevEnvironmentSessionRequest,
   StartDevEnvironmentSessionResponse,
   StartDevEnvironmentSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDevEnvironmentSessionRequest,
   output: StartDevEnvironmentSessionResponse,
@@ -2766,7 +2765,7 @@ export const startWorkflowRun: API.OperationMethod<
   StartWorkflowRunRequest,
   StartWorkflowRunResponse,
   StartWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkflowRunRequest,
   output: StartWorkflowRunResponse,
@@ -2784,7 +2783,7 @@ export const stopDevEnvironment: API.OperationMethod<
   StopDevEnvironmentRequest,
   StopDevEnvironmentResponse,
   StopDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDevEnvironmentRequest,
   output: StopDevEnvironmentResponse,
@@ -2802,7 +2801,7 @@ export const stopDevEnvironmentSession: API.OperationMethod<
   StopDevEnvironmentSessionRequest,
   StopDevEnvironmentSessionResponse,
   StopDevEnvironmentSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDevEnvironmentSessionRequest,
   output: StopDevEnvironmentSessionResponse,
@@ -2820,7 +2819,7 @@ export const updateDevEnvironment: API.OperationMethod<
   UpdateDevEnvironmentRequest,
   UpdateDevEnvironmentResponse,
   UpdateDevEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDevEnvironmentRequest,
   output: UpdateDevEnvironmentResponse,
@@ -2838,7 +2837,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectRequest,
   UpdateProjectResponse,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectRequest,
   output: UpdateProjectResponse,
@@ -2856,7 +2855,7 @@ export const updateSpace: API.OperationMethod<
   UpdateSpaceRequest,
   UpdateSpaceResponse,
   UpdateSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpaceRequest,
   output: UpdateSpaceResponse,
@@ -2874,7 +2873,7 @@ export const verifySession: API.OperationMethod<
   VerifySessionRequest,
   VerifySessionResponse,
   VerifySessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifySessionRequest,
   output: VerifySessionResponse,

--- a/packages/aws/src/services/codecommit.ts
+++ b/packages/aws/src/services/codecommit.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://codecommit.amazonaws.com/doc/2015-04-13");
 const svc = T.AwsApiService({
   sdkId: "CodeCommit",
@@ -5025,7 +5024,7 @@ export const associateApprovalRuleTemplateWithRepository: API.OperationMethod<
   AssociateApprovalRuleTemplateWithRepositoryInput,
   AssociateApprovalRuleTemplateWithRepositoryResponse,
   AssociateApprovalRuleTemplateWithRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApprovalRuleTemplateWithRepositoryInput,
   output: AssociateApprovalRuleTemplateWithRepositoryResponse,
@@ -5067,7 +5066,7 @@ export const batchAssociateApprovalRuleTemplateWithRepositories: API.OperationMe
   BatchAssociateApprovalRuleTemplateWithRepositoriesInput,
   BatchAssociateApprovalRuleTemplateWithRepositoriesOutput,
   BatchAssociateApprovalRuleTemplateWithRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateApprovalRuleTemplateWithRepositoriesInput,
   output: BatchAssociateApprovalRuleTemplateWithRepositoriesOutput,
@@ -5118,7 +5117,7 @@ export const batchDescribeMergeConflicts: API.OperationMethod<
   BatchDescribeMergeConflictsInput,
   BatchDescribeMergeConflictsOutput,
   BatchDescribeMergeConflictsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDescribeMergeConflictsInput,
   output: BatchDescribeMergeConflictsOutput,
@@ -5169,7 +5168,7 @@ export const batchDisassociateApprovalRuleTemplateFromRepositories: API.Operatio
   BatchDisassociateApprovalRuleTemplateFromRepositoriesInput,
   BatchDisassociateApprovalRuleTemplateFromRepositoriesOutput,
   BatchDisassociateApprovalRuleTemplateFromRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateApprovalRuleTemplateFromRepositoriesInput,
   output: BatchDisassociateApprovalRuleTemplateFromRepositoriesOutput,
@@ -5209,7 +5208,7 @@ export const batchGetCommits: API.OperationMethod<
   BatchGetCommitsInput,
   BatchGetCommitsOutput,
   BatchGetCommitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCommitsInput,
   output: BatchGetCommitsOutput,
@@ -5253,7 +5252,7 @@ export const batchGetRepositories: API.OperationMethod<
   BatchGetRepositoriesInput,
   BatchGetRepositoriesOutput,
   BatchGetRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRepositoriesInput,
   output: BatchGetRepositoriesOutput,
@@ -5292,7 +5291,7 @@ export const createApprovalRuleTemplate: API.OperationMethod<
   CreateApprovalRuleTemplateInput,
   CreateApprovalRuleTemplateOutput,
   CreateApprovalRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApprovalRuleTemplateInput,
   output: CreateApprovalRuleTemplateOutput,
@@ -5335,7 +5334,7 @@ export const createBranch: API.OperationMethod<
   CreateBranchInput,
   CreateBranchResponse,
   CreateBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBranchInput,
   output: CreateBranchResponse,
@@ -5407,7 +5406,7 @@ export const createCommit: API.OperationMethod<
   CreateCommitInput,
   CreateCommitOutput,
   CreateCommitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCommitInput,
   output: CreateCommitOutput,
@@ -5490,7 +5489,7 @@ export const createPullRequest: API.OperationMethod<
   CreatePullRequestInput,
   CreatePullRequestOutput,
   CreatePullRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePullRequestInput,
   output: CreatePullRequestOutput,
@@ -5550,7 +5549,7 @@ export const createPullRequestApprovalRule: API.OperationMethod<
   CreatePullRequestApprovalRuleInput,
   CreatePullRequestApprovalRuleOutput,
   CreatePullRequestApprovalRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePullRequestApprovalRuleInput,
   output: CreatePullRequestApprovalRuleOutput,
@@ -5602,7 +5601,7 @@ export const createRepository: API.OperationMethod<
   CreateRepositoryInput,
   CreateRepositoryOutput,
   CreateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryInput,
   output: CreateRepositoryOutput,
@@ -5681,7 +5680,7 @@ export const createUnreferencedMergeCommit: API.OperationMethod<
   CreateUnreferencedMergeCommitInput,
   CreateUnreferencedMergeCommitOutput,
   CreateUnreferencedMergeCommitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUnreferencedMergeCommitInput,
   output: CreateUnreferencedMergeCommitOutput,
@@ -5740,7 +5739,7 @@ export const deleteApprovalRuleTemplate: API.OperationMethod<
   DeleteApprovalRuleTemplateInput,
   DeleteApprovalRuleTemplateOutput,
   DeleteApprovalRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApprovalRuleTemplateInput,
   output: DeleteApprovalRuleTemplateOutput,
@@ -5774,7 +5773,7 @@ export const deleteBranch: API.OperationMethod<
   DeleteBranchInput,
   DeleteBranchOutput,
   DeleteBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBranchInput,
   output: DeleteBranchOutput,
@@ -5809,7 +5808,7 @@ export const deleteCommentContent: API.OperationMethod<
   DeleteCommentContentInput,
   DeleteCommentContentOutput,
   DeleteCommentContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCommentContentInput,
   output: DeleteCommentContentOutput,
@@ -5857,7 +5856,7 @@ export const deleteFile: API.OperationMethod<
   DeleteFileInput,
   DeleteFileOutput,
   DeleteFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileInput,
   output: DeleteFileOutput,
@@ -5913,7 +5912,7 @@ export const deletePullRequestApprovalRule: API.OperationMethod<
   DeletePullRequestApprovalRuleInput,
   DeletePullRequestApprovalRuleOutput,
   DeletePullRequestApprovalRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePullRequestApprovalRuleInput,
   output: DeletePullRequestApprovalRuleOutput,
@@ -5956,7 +5955,7 @@ export const deleteRepository: API.OperationMethod<
   DeleteRepositoryInput,
   DeleteRepositoryOutput,
   DeleteRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryInput,
   output: DeleteRepositoryOutput,
@@ -6008,7 +6007,7 @@ export const describeMergeConflicts: API.PaginatedOperationMethod<
   DescribeMergeConflictsInput,
   DescribeMergeConflictsOutput,
   DescribeMergeConflictsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMergeConflictsInput,
@@ -6070,7 +6069,7 @@ export const describePullRequestEvents: API.PaginatedOperationMethod<
   DescribePullRequestEventsInput,
   DescribePullRequestEventsOutput,
   DescribePullRequestEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePullRequestEventsInput,
@@ -6123,7 +6122,7 @@ export const disassociateApprovalRuleTemplateFromRepository: API.OperationMethod
   DisassociateApprovalRuleTemplateFromRepositoryInput,
   DisassociateApprovalRuleTemplateFromRepositoryResponse,
   DisassociateApprovalRuleTemplateFromRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApprovalRuleTemplateFromRepositoryInput,
   output: DisassociateApprovalRuleTemplateFromRepositoryResponse,
@@ -6165,7 +6164,7 @@ export const evaluatePullRequestApprovalRules: API.OperationMethod<
   EvaluatePullRequestApprovalRulesInput,
   EvaluatePullRequestApprovalRulesOutput,
   EvaluatePullRequestApprovalRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluatePullRequestApprovalRulesInput,
   output: EvaluatePullRequestApprovalRulesOutput,
@@ -6199,7 +6198,7 @@ export const getApprovalRuleTemplate: API.OperationMethod<
   GetApprovalRuleTemplateInput,
   GetApprovalRuleTemplateOutput,
   GetApprovalRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApprovalRuleTemplateInput,
   output: GetApprovalRuleTemplateOutput,
@@ -6234,7 +6233,7 @@ export const getBlob: API.OperationMethod<
   GetBlobInput,
   GetBlobOutput,
   GetBlobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlobInput,
   output: GetBlobOutput,
@@ -6277,7 +6276,7 @@ export const getBranch: API.OperationMethod<
   GetBranchInput,
   GetBranchOutput,
   GetBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBranchInput,
   output: GetBranchOutput,
@@ -6320,7 +6319,7 @@ export const getComment: API.OperationMethod<
   GetCommentInput,
   GetCommentOutput,
   GetCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommentInput,
   output: GetCommentOutput,
@@ -6356,7 +6355,7 @@ export const getCommentReactions: API.PaginatedOperationMethod<
   GetCommentReactionsInput,
   GetCommentReactionsOutput,
   GetCommentReactionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCommentReactionsInput,
@@ -6405,7 +6404,7 @@ export const getCommentsForComparedCommit: API.PaginatedOperationMethod<
   GetCommentsForComparedCommitInput,
   GetCommentsForComparedCommitOutput,
   GetCommentsForComparedCommitError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCommentsForComparedCommitInput,
@@ -6464,7 +6463,7 @@ export const getCommentsForPullRequest: API.PaginatedOperationMethod<
   GetCommentsForPullRequestInput,
   GetCommentsForPullRequestOutput,
   GetCommentsForPullRequestError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCommentsForPullRequestInput,
@@ -6518,7 +6517,7 @@ export const getCommit: API.OperationMethod<
   GetCommitInput,
   GetCommitOutput,
   GetCommitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommitInput,
   output: GetCommitOutput,
@@ -6567,7 +6566,7 @@ export const getDifferences: API.PaginatedOperationMethod<
   GetDifferencesInput,
   GetDifferencesOutput,
   GetDifferencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDifferencesInput,
@@ -6623,7 +6622,7 @@ export const getFile: API.OperationMethod<
   GetFileInput,
   GetFileOutput,
   GetFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFileInput,
   output: GetFileOutput,
@@ -6670,7 +6669,7 @@ export const getFolder: API.OperationMethod<
   GetFolderInput,
   GetFolderOutput,
   GetFolderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFolderInput,
   output: GetFolderOutput,
@@ -6716,7 +6715,7 @@ export const getMergeCommit: API.OperationMethod<
   GetMergeCommitInput,
   GetMergeCommitOutput,
   GetMergeCommitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMergeCommitInput,
   output: GetMergeCommitOutput,
@@ -6771,7 +6770,7 @@ export const getMergeConflicts: API.PaginatedOperationMethod<
   GetMergeConflictsInput,
   GetMergeConflictsOutput,
   GetMergeConflictsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMergeConflictsInput,
@@ -6837,7 +6836,7 @@ export const getMergeOptions: API.OperationMethod<
   GetMergeOptionsInput,
   GetMergeOptionsOutput,
   GetMergeOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMergeOptionsInput,
   output: GetMergeOptionsOutput,
@@ -6881,7 +6880,7 @@ export const getPullRequest: API.OperationMethod<
   GetPullRequestInput,
   GetPullRequestOutput,
   GetPullRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPullRequestInput,
   output: GetPullRequestOutput,
@@ -6920,7 +6919,7 @@ export const getPullRequestApprovalStates: API.OperationMethod<
   GetPullRequestApprovalStatesInput,
   GetPullRequestApprovalStatesOutput,
   GetPullRequestApprovalStatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPullRequestApprovalStatesInput,
   output: GetPullRequestApprovalStatesOutput,
@@ -6961,7 +6960,7 @@ export const getPullRequestOverrideState: API.OperationMethod<
   GetPullRequestOverrideStateInput,
   GetPullRequestOverrideStateOutput,
   GetPullRequestOverrideStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPullRequestOverrideStateInput,
   output: GetPullRequestOverrideStateOutput,
@@ -7005,7 +7004,7 @@ export const getRepository: API.OperationMethod<
   GetRepositoryInput,
   GetRepositoryOutput,
   GetRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryInput,
   output: GetRepositoryOutput,
@@ -7041,7 +7040,7 @@ export const getRepositoryTriggers: API.OperationMethod<
   GetRepositoryTriggersInput,
   GetRepositoryTriggersOutput,
   GetRepositoryTriggersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryTriggersInput,
   output: GetRepositoryTriggersOutput,
@@ -7072,7 +7071,7 @@ export const listApprovalRuleTemplates: API.PaginatedOperationMethod<
   ListApprovalRuleTemplatesInput,
   ListApprovalRuleTemplatesOutput,
   ListApprovalRuleTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApprovalRuleTemplatesInput,
@@ -7107,7 +7106,7 @@ export const listAssociatedApprovalRuleTemplatesForRepository: API.PaginatedOper
   ListAssociatedApprovalRuleTemplatesForRepositoryInput,
   ListAssociatedApprovalRuleTemplatesForRepositoryOutput,
   ListAssociatedApprovalRuleTemplatesForRepositoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedApprovalRuleTemplatesForRepositoryInput,
@@ -7152,7 +7151,7 @@ export const listBranches: API.PaginatedOperationMethod<
   ListBranchesInput,
   ListBranchesOutput,
   ListBranchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BranchName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBranchesInput,
@@ -7201,7 +7200,7 @@ export const listFileCommitHistory: API.PaginatedOperationMethod<
   ListFileCommitHistoryRequest,
   ListFileCommitHistoryResponse,
   ListFileCommitHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFileCommitHistoryRequest,
@@ -7255,7 +7254,7 @@ export const listPullRequests: API.PaginatedOperationMethod<
   ListPullRequestsInput,
   ListPullRequestsOutput,
   ListPullRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPullRequestsInput,
@@ -7297,7 +7296,7 @@ export const listRepositories: API.PaginatedOperationMethod<
   ListRepositoriesInput,
   ListRepositoriesOutput,
   ListRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositoryNameIdPair
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoriesInput,
@@ -7336,7 +7335,7 @@ export const listRepositoriesForApprovalRuleTemplate: API.PaginatedOperationMeth
   ListRepositoriesForApprovalRuleTemplateInput,
   ListRepositoriesForApprovalRuleTemplateOutput,
   ListRepositoriesForApprovalRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoriesForApprovalRuleTemplateInput,
@@ -7377,7 +7376,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -7420,7 +7419,7 @@ export const mergeBranchesByFastForward: API.OperationMethod<
   MergeBranchesByFastForwardInput,
   MergeBranchesByFastForwardOutput,
   MergeBranchesByFastForwardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeBranchesByFastForwardInput,
   output: MergeBranchesByFastForwardOutput,
@@ -7498,7 +7497,7 @@ export const mergeBranchesBySquash: API.OperationMethod<
   MergeBranchesBySquashInput,
   MergeBranchesBySquashOutput,
   MergeBranchesBySquashError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeBranchesBySquashInput,
   output: MergeBranchesBySquashOutput,
@@ -7596,7 +7595,7 @@ export const mergeBranchesByThreeWay: API.OperationMethod<
   MergeBranchesByThreeWayInput,
   MergeBranchesByThreeWayOutput,
   MergeBranchesByThreeWayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeBranchesByThreeWayInput,
   output: MergeBranchesByThreeWayOutput,
@@ -7675,7 +7674,7 @@ export const mergePullRequestByFastForward: API.OperationMethod<
   MergePullRequestByFastForwardInput,
   MergePullRequestByFastForwardOutput,
   MergePullRequestByFastForwardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergePullRequestByFastForwardInput,
   output: MergePullRequestByFastForwardOutput,
@@ -7753,7 +7752,7 @@ export const mergePullRequestBySquash: API.OperationMethod<
   MergePullRequestBySquashInput,
   MergePullRequestBySquashOutput,
   MergePullRequestBySquashError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergePullRequestBySquashInput,
   output: MergePullRequestBySquashOutput,
@@ -7850,7 +7849,7 @@ export const mergePullRequestByThreeWay: API.OperationMethod<
   MergePullRequestByThreeWayInput,
   MergePullRequestByThreeWayOutput,
   MergePullRequestByThreeWayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergePullRequestByThreeWayInput,
   output: MergePullRequestByThreeWayOutput,
@@ -7923,7 +7922,7 @@ export const overridePullRequestApprovalRules: API.OperationMethod<
   OverridePullRequestApprovalRulesInput,
   OverridePullRequestApprovalRulesResponse,
   OverridePullRequestApprovalRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OverridePullRequestApprovalRulesInput,
   output: OverridePullRequestApprovalRulesResponse,
@@ -7981,7 +7980,7 @@ export const postCommentForComparedCommit: API.OperationMethod<
   PostCommentForComparedCommitInput,
   PostCommentForComparedCommitOutput,
   PostCommentForComparedCommitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostCommentForComparedCommitInput,
   output: PostCommentForComparedCommitOutput,
@@ -8051,7 +8050,7 @@ export const postCommentForPullRequest: API.OperationMethod<
   PostCommentForPullRequestInput,
   PostCommentForPullRequestOutput,
   PostCommentForPullRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostCommentForPullRequestInput,
   output: PostCommentForPullRequestOutput,
@@ -8106,7 +8105,7 @@ export const postCommentReply: API.OperationMethod<
   PostCommentReplyInput,
   PostCommentReplyOutput,
   PostCommentReplyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostCommentReplyInput,
   output: PostCommentReplyOutput,
@@ -8142,7 +8141,7 @@ export const putCommentReaction: API.OperationMethod<
   PutCommentReactionInput,
   PutCommentReactionResponse,
   PutCommentReactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCommentReactionInput,
   output: PutCommentReactionResponse,
@@ -8199,7 +8198,7 @@ export const putFile: API.OperationMethod<
   PutFileInput,
   PutFileOutput,
   PutFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFileInput,
   output: PutFileOutput,
@@ -8270,7 +8269,7 @@ export const putRepositoryTriggers: API.OperationMethod<
   PutRepositoryTriggersInput,
   PutRepositoryTriggersOutput,
   PutRepositoryTriggersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRepositoryTriggersInput,
   output: PutRepositoryTriggersOutput,
@@ -8322,7 +8321,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -8374,7 +8373,7 @@ export const testRepositoryTriggers: API.OperationMethod<
   TestRepositoryTriggersInput,
   TestRepositoryTriggersOutput,
   TestRepositoryTriggersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestRepositoryTriggersInput,
   output: TestRepositoryTriggersOutput,
@@ -8425,7 +8424,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -8462,7 +8461,7 @@ export const updateApprovalRuleTemplateContent: API.OperationMethod<
   UpdateApprovalRuleTemplateContentInput,
   UpdateApprovalRuleTemplateContentOutput,
   UpdateApprovalRuleTemplateContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApprovalRuleTemplateContentInput,
   output: UpdateApprovalRuleTemplateContentOutput,
@@ -8492,7 +8491,7 @@ export const updateApprovalRuleTemplateDescription: API.OperationMethod<
   UpdateApprovalRuleTemplateDescriptionInput,
   UpdateApprovalRuleTemplateDescriptionOutput,
   UpdateApprovalRuleTemplateDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApprovalRuleTemplateDescriptionInput,
   output: UpdateApprovalRuleTemplateDescriptionOutput,
@@ -8520,7 +8519,7 @@ export const updateApprovalRuleTemplateName: API.OperationMethod<
   UpdateApprovalRuleTemplateNameInput,
   UpdateApprovalRuleTemplateNameOutput,
   UpdateApprovalRuleTemplateNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApprovalRuleTemplateNameInput,
   output: UpdateApprovalRuleTemplateNameOutput,
@@ -8551,7 +8550,7 @@ export const updateComment: API.OperationMethod<
   UpdateCommentInput,
   UpdateCommentOutput,
   UpdateCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCommentInput,
   output: UpdateCommentOutput,
@@ -8591,7 +8590,7 @@ export const updateDefaultBranch: API.OperationMethod<
   UpdateDefaultBranchInput,
   UpdateDefaultBranchResponse,
   UpdateDefaultBranchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDefaultBranchInput,
   output: UpdateDefaultBranchResponse,
@@ -8639,7 +8638,7 @@ export const updatePullRequestApprovalRuleContent: API.OperationMethod<
   UpdatePullRequestApprovalRuleContentInput,
   UpdatePullRequestApprovalRuleContentOutput,
   UpdatePullRequestApprovalRuleContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullRequestApprovalRuleContentInput,
   output: UpdatePullRequestApprovalRuleContentOutput,
@@ -8691,7 +8690,7 @@ export const updatePullRequestApprovalState: API.OperationMethod<
   UpdatePullRequestApprovalStateInput,
   UpdatePullRequestApprovalStateResponse,
   UpdatePullRequestApprovalStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullRequestApprovalStateInput,
   output: UpdatePullRequestApprovalStateResponse,
@@ -8732,7 +8731,7 @@ export const updatePullRequestDescription: API.OperationMethod<
   UpdatePullRequestDescriptionInput,
   UpdatePullRequestDescriptionOutput,
   UpdatePullRequestDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullRequestDescriptionInput,
   output: UpdatePullRequestDescriptionOutput,
@@ -8768,7 +8767,7 @@ export const updatePullRequestStatus: API.OperationMethod<
   UpdatePullRequestStatusInput,
   UpdatePullRequestStatusOutput,
   UpdatePullRequestStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullRequestStatusInput,
   output: UpdatePullRequestStatusOutput,
@@ -8805,7 +8804,7 @@ export const updatePullRequestTitle: API.OperationMethod<
   UpdatePullRequestTitleInput,
   UpdatePullRequestTitleOutput,
   UpdatePullRequestTitleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullRequestTitleInput,
   output: UpdatePullRequestTitleOutput,
@@ -8846,7 +8845,7 @@ export const updateRepositoryDescription: API.OperationMethod<
   UpdateRepositoryDescriptionInput,
   UpdateRepositoryDescriptionResponse,
   UpdateRepositoryDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryDescriptionInput,
   output: UpdateRepositoryDescriptionResponse,
@@ -8886,7 +8885,7 @@ export const updateRepositoryEncryptionKey: API.OperationMethod<
   UpdateRepositoryEncryptionKeyInput,
   UpdateRepositoryEncryptionKeyOutput,
   UpdateRepositoryEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryEncryptionKeyInput,
   output: UpdateRepositoryEncryptionKeyOutput,
@@ -8925,7 +8924,7 @@ export const updateRepositoryName: API.OperationMethod<
   UpdateRepositoryNameInput,
   UpdateRepositoryNameResponse,
   UpdateRepositoryNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryNameInput,
   output: UpdateRepositoryNameResponse,

--- a/packages/aws/src/services/codeconnections.ts
+++ b/packages/aws/src/services/codeconnections.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeConnections",
   serviceShapeName: "CodeConnections_20231201",
@@ -1215,7 +1214,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionInput,
   CreateConnectionOutput,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionInput,
   output: CreateConnectionOutput,
@@ -1243,7 +1242,7 @@ export const createHost: API.OperationMethod<
   CreateHostInput,
   CreateHostOutput,
   CreateHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHostInput,
   output: CreateHostOutput,
@@ -1269,7 +1268,7 @@ export const createRepositoryLink: API.OperationMethod<
   CreateRepositoryLinkInput,
   CreateRepositoryLinkOutput,
   CreateRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryLinkInput,
   output: CreateRepositoryLinkOutput,
@@ -1305,7 +1304,7 @@ export const createSyncConfiguration: API.OperationMethod<
   CreateSyncConfigurationInput,
   CreateSyncConfigurationOutput,
   CreateSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSyncConfigurationInput,
   output: CreateSyncConfigurationOutput,
@@ -1331,7 +1330,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionInput,
   DeleteConnectionOutput,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionInput,
   output: DeleteConnectionOutput,
@@ -1354,7 +1353,7 @@ export const deleteHost: API.OperationMethod<
   DeleteHostInput,
   DeleteHostOutput,
   DeleteHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHostInput,
   output: DeleteHostOutput,
@@ -1381,7 +1380,7 @@ export const deleteRepositoryLink: API.OperationMethod<
   DeleteRepositoryLinkInput,
   DeleteRepositoryLinkOutput,
   DeleteRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryLinkInput,
   output: DeleteRepositoryLinkOutput,
@@ -1415,7 +1414,7 @@ export const deleteSyncConfiguration: API.OperationMethod<
   DeleteSyncConfigurationInput,
   DeleteSyncConfigurationOutput,
   DeleteSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSyncConfigurationInput,
   output: DeleteSyncConfigurationOutput,
@@ -1443,7 +1442,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionInput,
   GetConnectionOutput,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionInput,
   output: GetConnectionOutput,
@@ -1465,7 +1464,7 @@ export const getHost: API.OperationMethod<
   GetHostInput,
   GetHostOutput,
   GetHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostInput,
   output: GetHostOutput,
@@ -1491,7 +1490,7 @@ export const getRepositoryLink: API.OperationMethod<
   GetRepositoryLinkInput,
   GetRepositoryLinkOutput,
   GetRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryLinkInput,
   output: GetRepositoryLinkOutput,
@@ -1523,7 +1522,7 @@ export const getRepositorySyncStatus: API.OperationMethod<
   GetRepositorySyncStatusInput,
   GetRepositorySyncStatusOutput,
   GetRepositorySyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositorySyncStatusInput,
   output: GetRepositorySyncStatusOutput,
@@ -1554,7 +1553,7 @@ export const getResourceSyncStatus: API.OperationMethod<
   GetResourceSyncStatusInput,
   GetResourceSyncStatusOutput,
   GetResourceSyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSyncStatusInput,
   output: GetResourceSyncStatusOutput,
@@ -1584,7 +1583,7 @@ export const getSyncBlockerSummary: API.OperationMethod<
   GetSyncBlockerSummaryInput,
   GetSyncBlockerSummaryOutput,
   GetSyncBlockerSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSyncBlockerSummaryInput,
   output: GetSyncBlockerSummaryOutput,
@@ -1614,7 +1613,7 @@ export const getSyncConfiguration: API.OperationMethod<
   GetSyncConfigurationInput,
   GetSyncConfigurationOutput,
   GetSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSyncConfigurationInput,
   output: GetSyncConfigurationOutput,
@@ -1638,7 +1637,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsInput,
   ListConnectionsOutput,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsInput,
@@ -1662,7 +1661,7 @@ export const listHosts: API.PaginatedOperationMethod<
   ListHostsInput,
   ListHostsOutput,
   ListHostsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHostsInput,
@@ -1693,7 +1692,7 @@ export const listRepositoryLinks: API.PaginatedOperationMethod<
   ListRepositoryLinksInput,
   ListRepositoryLinksOutput,
   ListRepositoryLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoryLinksInput,
@@ -1730,7 +1729,7 @@ export const listRepositorySyncDefinitions: API.OperationMethod<
   ListRepositorySyncDefinitionsInput,
   ListRepositorySyncDefinitionsOutput,
   ListRepositorySyncDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRepositorySyncDefinitionsInput,
   output: ListRepositorySyncDefinitionsOutput,
@@ -1760,7 +1759,7 @@ export const listSyncConfigurations: API.PaginatedOperationMethod<
   ListSyncConfigurationsInput,
   ListSyncConfigurationsOutput,
   ListSyncConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSyncConfigurationsInput,
@@ -1790,7 +1789,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1812,7 +1811,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1830,7 +1829,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1853,7 +1852,7 @@ export const updateHost: API.OperationMethod<
   UpdateHostInput,
   UpdateHostOutput,
   UpdateHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostInput,
   output: UpdateHostOutput,
@@ -1886,7 +1885,7 @@ export const updateRepositoryLink: API.OperationMethod<
   UpdateRepositoryLinkInput,
   UpdateRepositoryLinkOutput,
   UpdateRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryLinkInput,
   output: UpdateRepositoryLinkOutput,
@@ -1920,7 +1919,7 @@ export const updateSyncBlocker: API.OperationMethod<
   UpdateSyncBlockerInput,
   UpdateSyncBlockerOutput,
   UpdateSyncBlockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSyncBlockerInput,
   output: UpdateSyncBlockerOutput,
@@ -1954,7 +1953,7 @@ export const updateSyncConfiguration: API.OperationMethod<
   UpdateSyncConfigurationInput,
   UpdateSyncConfigurationOutput,
   UpdateSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSyncConfigurationInput,
   output: UpdateSyncConfigurationOutput,

--- a/packages/aws/src/services/codedeploy.ts
+++ b/packages/aws/src/services/codedeploy.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://codedeploy.amazonaws.com/doc/2014-10-06/");
 const svc = T.AwsApiService({
   sdkId: "CodeDeploy",
@@ -3388,7 +3387,7 @@ export const addTagsToOnPremisesInstances: API.OperationMethod<
   AddTagsToOnPremisesInstancesInput,
   AddTagsToOnPremisesInstancesResponse,
   AddTagsToOnPremisesInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToOnPremisesInstancesInput,
   output: AddTagsToOnPremisesInstancesResponse,
@@ -3422,7 +3421,7 @@ export const batchGetApplicationRevisions: API.OperationMethod<
   BatchGetApplicationRevisionsInput,
   BatchGetApplicationRevisionsOutput,
   BatchGetApplicationRevisionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetApplicationRevisionsInput,
   output: BatchGetApplicationRevisionsOutput,
@@ -3453,7 +3452,7 @@ export const batchGetApplications: API.OperationMethod<
   BatchGetApplicationsInput,
   BatchGetApplicationsOutput,
   BatchGetApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetApplicationsInput,
   output: BatchGetApplicationsOutput,
@@ -3484,7 +3483,7 @@ export const batchGetDeploymentGroups: API.OperationMethod<
   BatchGetDeploymentGroupsInput,
   BatchGetDeploymentGroupsOutput,
   BatchGetDeploymentGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDeploymentGroupsInput,
   output: BatchGetDeploymentGroupsOutput,
@@ -3524,7 +3523,7 @@ export const batchGetDeploymentInstances: API.OperationMethod<
   BatchGetDeploymentInstancesInput,
   BatchGetDeploymentInstancesOutput,
   BatchGetDeploymentInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDeploymentInstancesInput,
   output: BatchGetDeploymentInstancesOutput,
@@ -3555,7 +3554,7 @@ export const batchGetDeployments: API.OperationMethod<
   BatchGetDeploymentsInput,
   BatchGetDeploymentsOutput,
   BatchGetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDeploymentsInput,
   output: BatchGetDeploymentsOutput,
@@ -3604,7 +3603,7 @@ export const batchGetDeploymentTargets: API.OperationMethod<
   BatchGetDeploymentTargetsInput,
   BatchGetDeploymentTargetsOutput,
   BatchGetDeploymentTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDeploymentTargetsInput,
   output: BatchGetDeploymentTargetsOutput,
@@ -3637,7 +3636,7 @@ export const batchGetOnPremisesInstances: API.OperationMethod<
   BatchGetOnPremisesInstancesInput,
   BatchGetOnPremisesInstancesOutput,
   BatchGetOnPremisesInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetOnPremisesInstancesInput,
   output: BatchGetOnPremisesInstancesOutput,
@@ -3672,7 +3671,7 @@ export const continueDeployment: API.OperationMethod<
   ContinueDeploymentInput,
   ContinueDeploymentResponse,
   ContinueDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ContinueDeploymentInput,
   output: ContinueDeploymentResponse,
@@ -3706,7 +3705,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationInput,
   CreateApplicationOutput,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationInput,
   output: CreateApplicationOutput,
@@ -3758,7 +3757,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentInput,
   CreateDeploymentOutput,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentInput,
   output: CreateDeploymentOutput,
@@ -3812,7 +3811,7 @@ export const createDeploymentConfig: API.OperationMethod<
   CreateDeploymentConfigInput,
   CreateDeploymentConfigOutput,
   CreateDeploymentConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentConfigInput,
   output: CreateDeploymentConfigOutput,
@@ -3873,7 +3872,7 @@ export const createDeploymentGroup: API.OperationMethod<
   CreateDeploymentGroupInput,
   CreateDeploymentGroupOutput,
   CreateDeploymentGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentGroupInput,
   output: CreateDeploymentGroupOutput,
@@ -3929,7 +3928,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationInput,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationInput,
   output: DeleteApplicationResponse,
@@ -3959,7 +3958,7 @@ export const deleteDeploymentConfig: API.OperationMethod<
   DeleteDeploymentConfigInput,
   DeleteDeploymentConfigResponse,
   DeleteDeploymentConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentConfigInput,
   output: DeleteDeploymentConfigResponse,
@@ -3988,7 +3987,7 @@ export const deleteDeploymentGroup: API.OperationMethod<
   DeleteDeploymentGroupInput,
   DeleteDeploymentGroupOutput,
   DeleteDeploymentGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentGroupInput,
   output: DeleteDeploymentGroupOutput,
@@ -4018,7 +4017,7 @@ export const deleteGitHubAccountToken: API.OperationMethod<
   DeleteGitHubAccountTokenInput,
   DeleteGitHubAccountTokenOutput,
   DeleteGitHubAccountTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGitHubAccountTokenInput,
   output: DeleteGitHubAccountTokenOutput,
@@ -4048,7 +4047,7 @@ export const deleteResourcesByExternalId: API.OperationMethod<
   DeleteResourcesByExternalIdInput,
   DeleteResourcesByExternalIdOutput,
   DeleteResourcesByExternalIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcesByExternalIdInput,
   output: DeleteResourcesByExternalIdOutput,
@@ -4069,7 +4068,7 @@ export const deregisterOnPremisesInstance: API.OperationMethod<
   DeregisterOnPremisesInstanceInput,
   DeregisterOnPremisesInstanceResponse,
   DeregisterOnPremisesInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterOnPremisesInstanceInput,
   output: DeregisterOnPremisesInstanceResponse,
@@ -4091,7 +4090,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationInput,
   GetApplicationOutput,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationInput,
   output: GetApplicationOutput,
@@ -4120,7 +4119,7 @@ export const getApplicationRevision: API.OperationMethod<
   GetApplicationRevisionInput,
   GetApplicationRevisionOutput,
   GetApplicationRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRevisionInput,
   output: GetApplicationRevisionOutput,
@@ -4154,7 +4153,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentInput,
   GetDeploymentOutput,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentInput,
   output: GetDeploymentOutput,
@@ -4181,7 +4180,7 @@ export const getDeploymentConfig: API.OperationMethod<
   GetDeploymentConfigInput,
   GetDeploymentConfigOutput,
   GetDeploymentConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentConfigInput,
   output: GetDeploymentConfigOutput,
@@ -4212,7 +4211,7 @@ export const getDeploymentGroup: API.OperationMethod<
   GetDeploymentGroupInput,
   GetDeploymentGroupOutput,
   GetDeploymentGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentGroupInput,
   output: GetDeploymentGroupOutput,
@@ -4246,7 +4245,7 @@ export const getDeploymentInstance: API.OperationMethod<
   GetDeploymentInstanceInput,
   GetDeploymentInstanceOutput,
   GetDeploymentInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentInstanceInput,
   output: GetDeploymentInstanceOutput,
@@ -4281,7 +4280,7 @@ export const getDeploymentTarget: API.OperationMethod<
   GetDeploymentTargetInput,
   GetDeploymentTargetOutput,
   GetDeploymentTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentTargetInput,
   output: GetDeploymentTargetOutput,
@@ -4312,7 +4311,7 @@ export const getOnPremisesInstance: API.OperationMethod<
   GetOnPremisesInstanceInput,
   GetOnPremisesInstanceOutput,
   GetOnPremisesInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOnPremisesInstanceInput,
   output: GetOnPremisesInstanceOutput,
@@ -4345,7 +4344,7 @@ export const listApplicationRevisions: API.PaginatedOperationMethod<
   ListApplicationRevisionsInput,
   ListApplicationRevisionsOutput,
   ListApplicationRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RevisionLocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationRevisionsInput,
@@ -4380,7 +4379,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsInput,
   ListApplicationsOutput,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsInput,
@@ -4406,7 +4405,7 @@ export const listDeploymentConfigs: API.PaginatedOperationMethod<
   ListDeploymentConfigsInput,
   ListDeploymentConfigsOutput,
   ListDeploymentConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentConfigName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentConfigsInput,
@@ -4436,7 +4435,7 @@ export const listDeploymentGroups: API.PaginatedOperationMethod<
   ListDeploymentGroupsInput,
   ListDeploymentGroupsOutput,
   ListDeploymentGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentGroupName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentGroupsInput,
@@ -4481,7 +4480,7 @@ export const listDeploymentInstances: API.PaginatedOperationMethod<
   ListDeploymentInstancesInput,
   ListDeploymentInstancesOutput,
   ListDeploymentInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentInstancesInput,
@@ -4529,7 +4528,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsInput,
   ListDeploymentsOutput,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsInput,
@@ -4575,7 +4574,7 @@ export const listDeploymentTargets: API.OperationMethod<
   ListDeploymentTargetsInput,
   ListDeploymentTargetsOutput,
   ListDeploymentTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeploymentTargetsInput,
   output: ListDeploymentTargetsOutput,
@@ -4607,7 +4606,7 @@ export const listGitHubAccountTokenNames: API.OperationMethod<
   ListGitHubAccountTokenNamesInput,
   ListGitHubAccountTokenNamesOutput,
   ListGitHubAccountTokenNamesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGitHubAccountTokenNamesInput,
   output: ListGitHubAccountTokenNamesOutput,
@@ -4637,7 +4636,7 @@ export const listOnPremisesInstances: API.OperationMethod<
   ListOnPremisesInstancesInput,
   ListOnPremisesInstancesOutput,
   ListOnPremisesInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOnPremisesInstancesInput,
   output: ListOnPremisesInstancesOutput,
@@ -4664,7 +4663,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -4702,7 +4701,7 @@ export const putLifecycleEventHookExecutionStatus: API.OperationMethod<
   PutLifecycleEventHookExecutionStatusInput,
   PutLifecycleEventHookExecutionStatusOutput,
   PutLifecycleEventHookExecutionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLifecycleEventHookExecutionStatusInput,
   output: PutLifecycleEventHookExecutionStatusOutput,
@@ -4735,7 +4734,7 @@ export const registerApplicationRevision: API.OperationMethod<
   RegisterApplicationRevisionInput,
   RegisterApplicationRevisionResponse,
   RegisterApplicationRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterApplicationRevisionInput,
   output: RegisterApplicationRevisionResponse,
@@ -4773,7 +4772,7 @@ export const registerOnPremisesInstance: API.OperationMethod<
   RegisterOnPremisesInstanceInput,
   RegisterOnPremisesInstanceResponse,
   RegisterOnPremisesInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOnPremisesInstanceInput,
   output: RegisterOnPremisesInstanceResponse,
@@ -4810,7 +4809,7 @@ export const removeTagsFromOnPremisesInstances: API.OperationMethod<
   RemoveTagsFromOnPremisesInstancesInput,
   RemoveTagsFromOnPremisesInstancesResponse,
   RemoveTagsFromOnPremisesInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromOnPremisesInstancesInput,
   output: RemoveTagsFromOnPremisesInstancesResponse,
@@ -4844,7 +4843,7 @@ export const skipWaitTimeForInstanceTermination: API.OperationMethod<
   SkipWaitTimeForInstanceTerminationInput,
   SkipWaitTimeForInstanceTerminationResponse,
   SkipWaitTimeForInstanceTerminationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SkipWaitTimeForInstanceTerminationInput,
   output: SkipWaitTimeForInstanceTerminationResponse,
@@ -4876,7 +4875,7 @@ export const stopDeployment: API.OperationMethod<
   StopDeploymentInput,
   StopDeploymentOutput,
   StopDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDeploymentInput,
   output: StopDeploymentOutput,
@@ -4911,7 +4910,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -4949,7 +4948,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -4981,7 +4980,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationInput,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationInput,
   output: UpdateApplicationResponse,
@@ -5036,7 +5035,7 @@ export const updateDeploymentGroup: API.OperationMethod<
   UpdateDeploymentGroupInput,
   UpdateDeploymentGroupOutput,
   UpdateDeploymentGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeploymentGroupInput,
   output: UpdateDeploymentGroupOutput,

--- a/packages/aws/src/services/codeguru-reviewer.ts
+++ b/packages/aws/src/services/codeguru-reviewer.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeGuru Reviewer",
   serviceShapeName: "AWSGuruFrontendService",
@@ -1198,7 +1197,7 @@ export const associateRepository: API.OperationMethod<
   AssociateRepositoryRequest,
   AssociateRepositoryResponse,
   AssociateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateRepositoryRequest,
   output: AssociateRepositoryResponse,
@@ -1232,7 +1231,7 @@ export const createCodeReview: API.OperationMethod<
   CreateCodeReviewRequest,
   CreateCodeReviewResponse,
   CreateCodeReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeReviewRequest,
   output: CreateCodeReviewResponse,
@@ -1263,7 +1262,7 @@ export const describeCodeReview: API.OperationMethod<
   DescribeCodeReviewRequest,
   DescribeCodeReviewResponse,
   DescribeCodeReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCodeReviewRequest,
   output: DescribeCodeReviewResponse,
@@ -1293,7 +1292,7 @@ export const describeRecommendationFeedback: API.OperationMethod<
   DescribeRecommendationFeedbackRequest,
   DescribeRecommendationFeedbackResponse,
   DescribeRecommendationFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecommendationFeedbackRequest,
   output: DescribeRecommendationFeedbackResponse,
@@ -1324,7 +1323,7 @@ export const describeRepositoryAssociation: API.OperationMethod<
   DescribeRepositoryAssociationRequest,
   DescribeRepositoryAssociationResponse,
   DescribeRepositoryAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRepositoryAssociationRequest,
   output: DescribeRepositoryAssociationResponse,
@@ -1355,7 +1354,7 @@ export const disassociateRepository: API.OperationMethod<
   DisassociateRepositoryRequest,
   DisassociateRepositoryResponse,
   DisassociateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRepositoryRequest,
   output: DisassociateRepositoryResponse,
@@ -1385,7 +1384,7 @@ export const listCodeReviews: API.PaginatedOperationMethod<
   ListCodeReviewsRequest,
   ListCodeReviewsResponse,
   ListCodeReviewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeReviewsRequest,
@@ -1421,7 +1420,7 @@ export const listRecommendationFeedback: API.PaginatedOperationMethod<
   ListRecommendationFeedbackRequest,
   ListRecommendationFeedbackResponse,
   ListRecommendationFeedbackError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationFeedbackRequest,
@@ -1457,7 +1456,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -1492,7 +1491,7 @@ export const listRepositoryAssociations: API.PaginatedOperationMethod<
   ListRepositoryAssociationsRequest,
   ListRepositoryAssociationsResponse,
   ListRepositoryAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositoryAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoryAssociationsRequest,
@@ -1521,7 +1520,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1550,7 +1549,7 @@ export const putRecommendationFeedback: API.OperationMethod<
   PutRecommendationFeedbackRequest,
   PutRecommendationFeedbackResponse,
   PutRecommendationFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecommendationFeedbackRequest,
   output: PutRecommendationFeedbackResponse,
@@ -1578,7 +1577,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1604,7 +1603,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/codeguru-security.ts
+++ b/packages/aws/src/services/codeguru-security.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeGuru Security",
@@ -933,7 +932,7 @@ export const batchGetFindings: API.OperationMethod<
   BatchGetFindingsRequest,
   BatchGetFindingsResponse,
   BatchGetFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFindingsRequest,
   output: BatchGetFindingsResponse,
@@ -963,7 +962,7 @@ export const createScan: API.OperationMethod<
   CreateScanRequest,
   CreateScanResponse,
   CreateScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScanRequest,
   output: CreateScanResponse,
@@ -995,7 +994,7 @@ export const createUploadUrl: API.OperationMethod<
   CreateUploadUrlRequest,
   CreateUploadUrlResponse,
   CreateUploadUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUploadUrlRequest,
   output: CreateUploadUrlResponse,
@@ -1023,7 +1022,7 @@ export const getAccountConfiguration: API.OperationMethod<
   GetAccountConfigurationRequest,
   GetAccountConfigurationResponse,
   GetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountConfigurationRequest,
   output: GetAccountConfigurationResponse,
@@ -1053,7 +1052,7 @@ export const getFindings: API.PaginatedOperationMethod<
   GetFindingsRequest,
   GetFindingsResponse,
   GetFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Finding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingsRequest,
@@ -1090,7 +1089,7 @@ export const getMetricsSummary: API.OperationMethod<
   GetMetricsSummaryRequest,
   GetMetricsSummaryResponse,
   GetMetricsSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricsSummaryRequest,
   output: GetMetricsSummaryResponse,
@@ -1119,7 +1118,7 @@ export const getScan: API.OperationMethod<
   GetScanRequest,
   GetScanResponse,
   GetScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScanRequest,
   output: GetScanResponse,
@@ -1148,7 +1147,7 @@ export const listFindingsMetrics: API.PaginatedOperationMethod<
   ListFindingsMetricsRequest,
   ListFindingsMetricsResponse,
   ListFindingsMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountFindingsMetric
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsMetricsRequest,
@@ -1183,7 +1182,7 @@ export const listScans: API.PaginatedOperationMethod<
   ListScansRequest,
   ListScansResponse,
   ListScansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScanSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScansRequest,
@@ -1220,7 +1219,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1252,7 +1251,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1284,7 +1283,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1315,7 +1314,7 @@ export const updateAccountConfiguration: API.OperationMethod<
   UpdateAccountConfigurationRequest,
   UpdateAccountConfigurationResponse,
   UpdateAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountConfigurationRequest,
   output: UpdateAccountConfigurationResponse,

--- a/packages/aws/src/services/codeguruprofiler.ts
+++ b/packages/aws/src/services/codeguruprofiler.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeGuruProfiler",
   serviceShapeName: "CodeGuruProfiler",
@@ -1328,7 +1327,7 @@ export const addNotificationChannels: API.OperationMethod<
   AddNotificationChannelsRequest,
   AddNotificationChannelsResponse,
   AddNotificationChannelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddNotificationChannelsRequest,
   output: AddNotificationChannelsResponse,
@@ -1359,7 +1358,7 @@ export const batchGetFrameMetricData: API.OperationMethod<
   BatchGetFrameMetricDataRequest,
   BatchGetFrameMetricDataResponse,
   BatchGetFrameMetricDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFrameMetricDataRequest,
   output: BatchGetFrameMetricDataResponse,
@@ -1389,7 +1388,7 @@ export const configureAgent: API.OperationMethod<
   ConfigureAgentRequest,
   ConfigureAgentResponse,
   ConfigureAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureAgentRequest,
   output: ConfigureAgentResponse,
@@ -1418,7 +1417,7 @@ export const createProfilingGroup: API.OperationMethod<
   CreateProfilingGroupRequest,
   CreateProfilingGroupResponse,
   CreateProfilingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfilingGroupRequest,
   output: CreateProfilingGroupResponse,
@@ -1448,7 +1447,7 @@ export const deleteProfilingGroup: API.OperationMethod<
   DeleteProfilingGroupRequest,
   DeleteProfilingGroupResponse,
   DeleteProfilingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfilingGroupRequest,
   output: DeleteProfilingGroupResponse,
@@ -1480,7 +1479,7 @@ export const describeProfilingGroup: API.OperationMethod<
   DescribeProfilingGroupRequest,
   DescribeProfilingGroupResponse,
   DescribeProfilingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProfilingGroupRequest,
   output: DescribeProfilingGroupResponse,
@@ -1511,7 +1510,7 @@ export const getFindingsReportAccountSummary: API.PaginatedOperationMethod<
   GetFindingsReportAccountSummaryRequest,
   GetFindingsReportAccountSummaryResponse,
   GetFindingsReportAccountSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingsReportAccountSummaryRequest,
@@ -1540,7 +1539,7 @@ export const getNotificationConfiguration: API.OperationMethod<
   GetNotificationConfigurationRequest,
   GetNotificationConfigurationResponse,
   GetNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationConfigurationRequest,
   output: GetNotificationConfigurationResponse,
@@ -1567,7 +1566,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -1633,7 +1632,7 @@ export const getProfile: API.OperationMethod<
   GetProfileRequest,
   GetProfileResponse,
   GetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileRequest,
   output: GetProfileResponse,
@@ -1670,7 +1669,7 @@ export const getRecommendations: API.OperationMethod<
   GetRecommendationsRequest,
   GetRecommendationsResponse,
   GetRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationsRequest,
   output: GetRecommendationsResponse,
@@ -1698,7 +1697,7 @@ export const listFindingsReports: API.PaginatedOperationMethod<
   ListFindingsReportsRequest,
   ListFindingsReportsResponse,
   ListFindingsReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsReportsRequest,
@@ -1733,7 +1732,7 @@ export const listProfileTimes: API.PaginatedOperationMethod<
   ListProfileTimesRequest,
   ListProfileTimesResponse,
   ListProfileTimesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileTime
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfileTimesRequest,
@@ -1770,7 +1769,7 @@ export const listProfilingGroups: API.PaginatedOperationMethod<
   ListProfilingGroupsRequest,
   ListProfilingGroupsResponse,
   ListProfilingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilingGroupsRequest,
@@ -1798,7 +1797,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1829,7 +1828,7 @@ export const postAgentProfile: API.OperationMethod<
   PostAgentProfileRequest,
   PostAgentProfileResponse,
   PostAgentProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostAgentProfileRequest,
   output: PostAgentProfileResponse,
@@ -1877,7 +1876,7 @@ export const putPermission: API.OperationMethod<
   PutPermissionRequest,
   PutPermissionResponse,
   PutPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionRequest,
   output: PutPermissionResponse,
@@ -1906,7 +1905,7 @@ export const removeNotificationChannel: API.OperationMethod<
   RemoveNotificationChannelRequest,
   RemoveNotificationChannelResponse,
   RemoveNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveNotificationChannelRequest,
   output: RemoveNotificationChannelResponse,
@@ -1943,7 +1942,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionRequest,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionRequest,
   output: RemovePermissionResponse,
@@ -1973,7 +1972,7 @@ export const submitFeedback: API.OperationMethod<
   SubmitFeedbackRequest,
   SubmitFeedbackResponse,
   SubmitFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitFeedbackRequest,
   output: SubmitFeedbackResponse,
@@ -2000,7 +1999,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2026,7 +2025,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2054,7 +2053,7 @@ export const updateProfilingGroup: API.OperationMethod<
   UpdateProfilingGroupRequest,
   UpdateProfilingGroupResponse,
   UpdateProfilingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfilingGroupRequest,
   output: UpdateProfilingGroupResponse,

--- a/packages/aws/src/services/codepipeline.ts
+++ b/packages/aws/src/services/codepipeline.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://codepipeline.amazonaws.com/doc/2015-07-09/");
 const svc = T.AwsApiService({
@@ -3778,7 +3777,7 @@ export const acknowledgeJob: API.OperationMethod<
   AcknowledgeJobInput,
   AcknowledgeJobOutput,
   AcknowledgeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcknowledgeJobInput,
   output: AcknowledgeJobOutput,
@@ -3802,7 +3801,7 @@ export const acknowledgeThirdPartyJob: API.OperationMethod<
   AcknowledgeThirdPartyJobInput,
   AcknowledgeThirdPartyJobOutput,
   AcknowledgeThirdPartyJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcknowledgeThirdPartyJobInput,
   output: AcknowledgeThirdPartyJobOutput,
@@ -3832,7 +3831,7 @@ export const createCustomActionType: API.OperationMethod<
   CreateCustomActionTypeInput,
   CreateCustomActionTypeOutput,
   CreateCustomActionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomActionTypeInput,
   output: CreateCustomActionTypeOutput,
@@ -3872,7 +3871,7 @@ export const createPipeline: API.OperationMethod<
   CreatePipelineInput,
   CreatePipelineOutput,
   CreatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipelineInput,
   output: CreatePipelineOutput,
@@ -3911,7 +3910,7 @@ export const deleteCustomActionType: API.OperationMethod<
   DeleteCustomActionTypeInput,
   DeleteCustomActionTypeResponse,
   DeleteCustomActionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomActionTypeInput,
   output: DeleteCustomActionTypeResponse,
@@ -3932,7 +3931,7 @@ export const deletePipeline: API.OperationMethod<
   DeletePipelineInput,
   DeletePipelineResponse,
   DeletePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipelineInput,
   output: DeletePipelineResponse,
@@ -3956,7 +3955,7 @@ export const deleteWebhook: API.OperationMethod<
   DeleteWebhookInput,
   DeleteWebhookOutput,
   DeleteWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebhookInput,
   output: DeleteWebhookOutput,
@@ -3979,7 +3978,7 @@ export const deregisterWebhookWithThirdParty: API.OperationMethod<
   DeregisterWebhookWithThirdPartyInput,
   DeregisterWebhookWithThirdPartyOutput,
   DeregisterWebhookWithThirdPartyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterWebhookWithThirdPartyInput,
   output: DeregisterWebhookWithThirdPartyOutput,
@@ -4002,7 +4001,7 @@ export const disableStageTransition: API.OperationMethod<
   DisableStageTransitionInput,
   DisableStageTransitionResponse,
   DisableStageTransitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableStageTransitionInput,
   output: DisableStageTransitionResponse,
@@ -4028,7 +4027,7 @@ export const enableStageTransition: API.OperationMethod<
   EnableStageTransitionInput,
   EnableStageTransitionResponse,
   EnableStageTransitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableStageTransitionInput,
   output: EnableStageTransitionResponse,
@@ -4055,7 +4054,7 @@ export const getActionType: API.OperationMethod<
   GetActionTypeInput,
   GetActionTypeOutput,
   GetActionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActionTypeInput,
   output: GetActionTypeOutput,
@@ -4081,7 +4080,7 @@ export const getJobDetails: API.OperationMethod<
   GetJobDetailsInput,
   GetJobDetailsOutput,
   GetJobDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobDetailsInput,
   output: GetJobDetailsOutput,
@@ -4105,7 +4104,7 @@ export const getPipeline: API.OperationMethod<
   GetPipelineInput,
   GetPipelineOutput,
   GetPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineInput,
   output: GetPipelineOutput,
@@ -4133,7 +4132,7 @@ export const getPipelineExecution: API.OperationMethod<
   GetPipelineExecutionInput,
   GetPipelineExecutionOutput,
   GetPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineExecutionInput,
   output: GetPipelineExecutionOutput,
@@ -4163,7 +4162,7 @@ export const getPipelineState: API.OperationMethod<
   GetPipelineStateInput,
   GetPipelineStateOutput,
   GetPipelineStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineStateInput,
   output: GetPipelineStateOutput,
@@ -4192,7 +4191,7 @@ export const getThirdPartyJobDetails: API.OperationMethod<
   GetThirdPartyJobDetailsInput,
   GetThirdPartyJobDetailsOutput,
   GetThirdPartyJobDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThirdPartyJobDetailsInput,
   output: GetThirdPartyJobDetailsOutput,
@@ -4220,7 +4219,7 @@ export const listActionExecutions: API.PaginatedOperationMethod<
   ListActionExecutionsInput,
   ListActionExecutionsOutput,
   ListActionExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionExecutionDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionExecutionsInput,
@@ -4254,7 +4253,7 @@ export const listActionTypes: API.PaginatedOperationMethod<
   ListActionTypesInput,
   ListActionTypesOutput,
   ListActionTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionTypesInput,
@@ -4283,7 +4282,7 @@ export const listDeployActionExecutionTargets: API.PaginatedOperationMethod<
   ListDeployActionExecutionTargetsInput,
   ListDeployActionExecutionTargetsOutput,
   ListDeployActionExecutionTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeployActionExecutionTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeployActionExecutionTargetsInput,
@@ -4321,7 +4320,7 @@ export const listPipelineExecutions: API.PaginatedOperationMethod<
   ListPipelineExecutionsInput,
   ListPipelineExecutionsOutput,
   ListPipelineExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineExecutionsInput,
@@ -4353,7 +4352,7 @@ export const listPipelines: API.PaginatedOperationMethod<
   ListPipelinesInput,
   ListPipelinesOutput,
   ListPipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelinesInput,
@@ -4384,7 +4383,7 @@ export const listRuleExecutions: API.PaginatedOperationMethod<
   ListRuleExecutionsInput,
   ListRuleExecutionsOutput,
   ListRuleExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleExecutionDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRuleExecutionsInput,
@@ -4419,7 +4418,7 @@ export const listRuleTypes: API.OperationMethod<
   ListRuleTypesInput,
   ListRuleTypesOutput,
   ListRuleTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleTypesInput,
   output: ListRuleTypesOutput,
@@ -4443,7 +4442,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -4480,7 +4479,7 @@ export const listWebhooks: API.PaginatedOperationMethod<
   ListWebhooksInput,
   ListWebhooksOutput,
   ListWebhooksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListWebhookItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWebhooksInput,
@@ -4515,7 +4514,7 @@ export const overrideStageCondition: API.OperationMethod<
   OverrideStageConditionInput,
   OverrideStageConditionResponse,
   OverrideStageConditionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OverrideStageConditionInput,
   output: OverrideStageConditionResponse,
@@ -4552,7 +4551,7 @@ export const pollForJobs: API.OperationMethod<
   PollForJobsInput,
   PollForJobsOutput,
   PollForJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PollForJobsInput,
   output: PollForJobsOutput,
@@ -4578,7 +4577,7 @@ export const pollForThirdPartyJobs: API.OperationMethod<
   PollForThirdPartyJobsInput,
   PollForThirdPartyJobsOutput,
   PollForThirdPartyJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PollForThirdPartyJobsInput,
   output: PollForThirdPartyJobsOutput,
@@ -4603,7 +4602,7 @@ export const putActionRevision: API.OperationMethod<
   PutActionRevisionInput,
   PutActionRevisionOutput,
   PutActionRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutActionRevisionInput,
   output: PutActionRevisionOutput,
@@ -4635,7 +4634,7 @@ export const putApprovalResult: API.OperationMethod<
   PutApprovalResultInput,
   PutApprovalResultOutput,
   PutApprovalResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApprovalResultInput,
   output: PutApprovalResultOutput,
@@ -4665,7 +4664,7 @@ export const putJobFailureResult: API.OperationMethod<
   PutJobFailureResultInput,
   PutJobFailureResultResponse,
   PutJobFailureResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutJobFailureResultInput,
   output: PutJobFailureResultResponse,
@@ -4689,7 +4688,7 @@ export const putJobSuccessResult: API.OperationMethod<
   PutJobSuccessResultInput,
   PutJobSuccessResultResponse,
   PutJobSuccessResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutJobSuccessResultInput,
   output: PutJobSuccessResultResponse,
@@ -4718,7 +4717,7 @@ export const putThirdPartyJobFailureResult: API.OperationMethod<
   PutThirdPartyJobFailureResultInput,
   PutThirdPartyJobFailureResultResponse,
   PutThirdPartyJobFailureResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutThirdPartyJobFailureResultInput,
   output: PutThirdPartyJobFailureResultResponse,
@@ -4747,7 +4746,7 @@ export const putThirdPartyJobSuccessResult: API.OperationMethod<
   PutThirdPartyJobSuccessResultInput,
   PutThirdPartyJobSuccessResultResponse,
   PutThirdPartyJobSuccessResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutThirdPartyJobSuccessResultInput,
   output: PutThirdPartyJobSuccessResultResponse,
@@ -4796,7 +4795,7 @@ export const putWebhook: API.OperationMethod<
   PutWebhookInput,
   PutWebhookOutput,
   PutWebhookError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutWebhookInput,
   output: PutWebhookOutput,
@@ -4827,7 +4826,7 @@ export const registerWebhookWithThirdParty: API.OperationMethod<
   RegisterWebhookWithThirdPartyInput,
   RegisterWebhookWithThirdPartyOutput,
   RegisterWebhookWithThirdPartyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterWebhookWithThirdPartyInput,
   output: RegisterWebhookWithThirdPartyOutput,
@@ -4860,7 +4859,7 @@ export const retryStageExecution: API.OperationMethod<
   RetryStageExecutionInput,
   RetryStageExecutionOutput,
   RetryStageExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryStageExecutionInput,
   output: RetryStageExecutionOutput,
@@ -4894,7 +4893,7 @@ export const rollbackStage: API.OperationMethod<
   RollbackStageInput,
   RollbackStageOutput,
   RollbackStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackStageInput,
   output: RollbackStageOutput,
@@ -4926,7 +4925,7 @@ export const startPipelineExecution: API.OperationMethod<
   StartPipelineExecutionInput,
   StartPipelineExecutionOutput,
   StartPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPipelineExecutionInput,
   output: StartPipelineExecutionOutput,
@@ -4960,7 +4959,7 @@ export const stopPipelineExecution: API.OperationMethod<
   StopPipelineExecutionInput,
   StopPipelineExecutionOutput,
   StopPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPipelineExecutionInput,
   output: StopPipelineExecutionOutput,
@@ -4992,7 +4991,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -5023,7 +5022,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -5054,7 +5053,7 @@ export const updateActionType: API.OperationMethod<
   UpdateActionTypeInput,
   UpdateActionTypeResponse,
   UpdateActionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActionTypeInput,
   output: UpdateActionTypeResponse,
@@ -5086,7 +5085,7 @@ export const updatePipeline: API.OperationMethod<
   UpdatePipelineInput,
   UpdatePipelineOutput,
   UpdatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipelineInput,
   output: UpdatePipelineOutput,

--- a/packages/aws/src/services/codestar-connections.ts
+++ b/packages/aws/src/services/codestar-connections.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "CodeStar connections",
   serviceShapeName: "CodeStar_connections_20191201",
@@ -1205,7 +1204,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionInput,
   CreateConnectionOutput,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionInput,
   output: CreateConnectionOutput,
@@ -1233,7 +1232,7 @@ export const createHost: API.OperationMethod<
   CreateHostInput,
   CreateHostOutput,
   CreateHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHostInput,
   output: CreateHostOutput,
@@ -1259,7 +1258,7 @@ export const createRepositoryLink: API.OperationMethod<
   CreateRepositoryLinkInput,
   CreateRepositoryLinkOutput,
   CreateRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryLinkInput,
   output: CreateRepositoryLinkOutput,
@@ -1295,7 +1294,7 @@ export const createSyncConfiguration: API.OperationMethod<
   CreateSyncConfigurationInput,
   CreateSyncConfigurationOutput,
   CreateSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSyncConfigurationInput,
   output: CreateSyncConfigurationOutput,
@@ -1321,7 +1320,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionInput,
   DeleteConnectionOutput,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionInput,
   output: DeleteConnectionOutput,
@@ -1344,7 +1343,7 @@ export const deleteHost: API.OperationMethod<
   DeleteHostInput,
   DeleteHostOutput,
   DeleteHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHostInput,
   output: DeleteHostOutput,
@@ -1371,7 +1370,7 @@ export const deleteRepositoryLink: API.OperationMethod<
   DeleteRepositoryLinkInput,
   DeleteRepositoryLinkOutput,
   DeleteRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryLinkInput,
   output: DeleteRepositoryLinkOutput,
@@ -1405,7 +1404,7 @@ export const deleteSyncConfiguration: API.OperationMethod<
   DeleteSyncConfigurationInput,
   DeleteSyncConfigurationOutput,
   DeleteSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSyncConfigurationInput,
   output: DeleteSyncConfigurationOutput,
@@ -1433,7 +1432,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionInput,
   GetConnectionOutput,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionInput,
   output: GetConnectionOutput,
@@ -1455,7 +1454,7 @@ export const getHost: API.OperationMethod<
   GetHostInput,
   GetHostOutput,
   GetHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostInput,
   output: GetHostOutput,
@@ -1481,7 +1480,7 @@ export const getRepositoryLink: API.OperationMethod<
   GetRepositoryLinkInput,
   GetRepositoryLinkOutput,
   GetRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryLinkInput,
   output: GetRepositoryLinkOutput,
@@ -1513,7 +1512,7 @@ export const getRepositorySyncStatus: API.OperationMethod<
   GetRepositorySyncStatusInput,
   GetRepositorySyncStatusOutput,
   GetRepositorySyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositorySyncStatusInput,
   output: GetRepositorySyncStatusOutput,
@@ -1544,7 +1543,7 @@ export const getResourceSyncStatus: API.OperationMethod<
   GetResourceSyncStatusInput,
   GetResourceSyncStatusOutput,
   GetResourceSyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSyncStatusInput,
   output: GetResourceSyncStatusOutput,
@@ -1574,7 +1573,7 @@ export const getSyncBlockerSummary: API.OperationMethod<
   GetSyncBlockerSummaryInput,
   GetSyncBlockerSummaryOutput,
   GetSyncBlockerSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSyncBlockerSummaryInput,
   output: GetSyncBlockerSummaryOutput,
@@ -1604,7 +1603,7 @@ export const getSyncConfiguration: API.OperationMethod<
   GetSyncConfigurationInput,
   GetSyncConfigurationOutput,
   GetSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSyncConfigurationInput,
   output: GetSyncConfigurationOutput,
@@ -1628,7 +1627,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsInput,
   ListConnectionsOutput,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsInput,
@@ -1652,7 +1651,7 @@ export const listHosts: API.PaginatedOperationMethod<
   ListHostsInput,
   ListHostsOutput,
   ListHostsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHostsInput,
@@ -1683,7 +1682,7 @@ export const listRepositoryLinks: API.PaginatedOperationMethod<
   ListRepositoryLinksInput,
   ListRepositoryLinksOutput,
   ListRepositoryLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoryLinksInput,
@@ -1720,7 +1719,7 @@ export const listRepositorySyncDefinitions: API.OperationMethod<
   ListRepositorySyncDefinitionsInput,
   ListRepositorySyncDefinitionsOutput,
   ListRepositorySyncDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRepositorySyncDefinitionsInput,
   output: ListRepositorySyncDefinitionsOutput,
@@ -1750,7 +1749,7 @@ export const listSyncConfigurations: API.PaginatedOperationMethod<
   ListSyncConfigurationsInput,
   ListSyncConfigurationsOutput,
   ListSyncConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSyncConfigurationsInput,
@@ -1780,7 +1779,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1802,7 +1801,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1820,7 +1819,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1843,7 +1842,7 @@ export const updateHost: API.OperationMethod<
   UpdateHostInput,
   UpdateHostOutput,
   UpdateHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostInput,
   output: UpdateHostOutput,
@@ -1876,7 +1875,7 @@ export const updateRepositoryLink: API.OperationMethod<
   UpdateRepositoryLinkInput,
   UpdateRepositoryLinkOutput,
   UpdateRepositoryLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryLinkInput,
   output: UpdateRepositoryLinkOutput,
@@ -1910,7 +1909,7 @@ export const updateSyncBlocker: API.OperationMethod<
   UpdateSyncBlockerInput,
   UpdateSyncBlockerOutput,
   UpdateSyncBlockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSyncBlockerInput,
   output: UpdateSyncBlockerOutput,
@@ -1944,7 +1943,7 @@ export const updateSyncConfiguration: API.OperationMethod<
   UpdateSyncConfigurationInput,
   UpdateSyncConfigurationOutput,
   UpdateSyncConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSyncConfigurationInput,
   output: UpdateSyncConfigurationOutput,

--- a/packages/aws/src/services/codestar-notifications.ts
+++ b/packages/aws/src/services/codestar-notifications.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "codestar notifications",
@@ -728,7 +727,7 @@ export const createNotificationRule: API.OperationMethod<
   CreateNotificationRuleRequest,
   CreateNotificationRuleResult,
   CreateNotificationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationRuleRequest,
   output: CreateNotificationRuleResult,
@@ -757,7 +756,7 @@ export const deleteNotificationRule: API.OperationMethod<
   DeleteNotificationRuleRequest,
   DeleteNotificationRuleResult,
   DeleteNotificationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationRuleRequest,
   output: DeleteNotificationRuleResult,
@@ -779,7 +778,7 @@ export const deleteTarget: API.OperationMethod<
   DeleteTargetRequest,
   DeleteTargetResult,
   DeleteTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTargetRequest,
   output: DeleteTargetResult,
@@ -800,7 +799,7 @@ export const describeNotificationRule: API.OperationMethod<
   DescribeNotificationRuleRequest,
   DescribeNotificationRuleResult,
   DescribeNotificationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotificationRuleRequest,
   output: DescribeNotificationRuleResult,
@@ -821,7 +820,7 @@ export const listEventTypes: API.PaginatedOperationMethod<
   ListEventTypesRequest,
   ListEventTypesResult,
   ListEventTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventTypeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventTypesRequest,
@@ -849,7 +848,7 @@ export const listNotificationRules: API.PaginatedOperationMethod<
   ListNotificationRulesRequest,
   ListNotificationRulesResult,
   ListNotificationRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationRulesRequest,
@@ -877,7 +876,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -898,7 +897,7 @@ export const listTargets: API.PaginatedOperationMethod<
   ListTargetsRequest,
   ListTargetsResult,
   ListTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetsRequest,
@@ -929,7 +928,7 @@ export const subscribe: API.OperationMethod<
   SubscribeRequest,
   SubscribeResult,
   SubscribeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubscribeRequest,
   output: SubscribeResult,
@@ -956,7 +955,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -981,7 +980,7 @@ export const unsubscribe: API.OperationMethod<
   UnsubscribeRequest,
   UnsubscribeResult,
   UnsubscribeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnsubscribeRequest,
   output: UnsubscribeResult,
@@ -1005,7 +1004,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -1036,7 +1035,7 @@ export const updateNotificationRule: API.OperationMethod<
   UpdateNotificationRuleRequest,
   UpdateNotificationRuleResult,
   UpdateNotificationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationRuleRequest,
   output: UpdateNotificationRuleResult,

--- a/packages/aws/src/services/cognito-identity-provider.ts
+++ b/packages/aws/src/services/cognito-identity-provider.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://cognito-idp.amazonaws.com/doc/2016-04-18/");
 const svc = T.AwsApiService({
@@ -6841,7 +6840,7 @@ export const addCustomAttributes: API.OperationMethod<
   AddCustomAttributesRequest,
   AddCustomAttributesResponse,
   AddCustomAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddCustomAttributesRequest,
   output: AddCustomAttributesResponse,
@@ -6874,7 +6873,7 @@ export const addUserPoolClientSecret: API.OperationMethod<
   AddUserPoolClientSecretRequest,
   AddUserPoolClientSecretResponse,
   AddUserPoolClientSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddUserPoolClientSecretRequest,
   output: AddUserPoolClientSecretResponse,
@@ -6919,7 +6918,7 @@ export const adminAddUserToGroup: API.OperationMethod<
   AdminAddUserToGroupRequest,
   AdminAddUserToGroupResponse,
   AdminAddUserToGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminAddUserToGroupRequest,
   output: AdminAddUserToGroupResponse,
@@ -6976,7 +6975,7 @@ export const adminConfirmSignUp: API.OperationMethod<
   AdminConfirmSignUpRequest,
   AdminConfirmSignUpResponse,
   AdminConfirmSignUpError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminConfirmSignUpRequest,
   output: AdminConfirmSignUpResponse,
@@ -7070,7 +7069,7 @@ export const adminCreateUser: API.OperationMethod<
   AdminCreateUserRequest,
   AdminCreateUserResponse,
   AdminCreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminCreateUserRequest,
   output: AdminCreateUserResponse,
@@ -7124,7 +7123,7 @@ export const adminDeleteUser: API.OperationMethod<
   AdminDeleteUserRequest,
   AdminDeleteUserResponse,
   AdminDeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminDeleteUserRequest,
   output: AdminDeleteUserResponse,
@@ -7170,7 +7169,7 @@ export const adminDeleteUserAttributes: API.OperationMethod<
   AdminDeleteUserAttributesRequest,
   AdminDeleteUserAttributesResponse,
   AdminDeleteUserAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminDeleteUserAttributesRequest,
   output: AdminDeleteUserAttributesResponse,
@@ -7241,7 +7240,7 @@ export const adminDisableProviderForUser: API.OperationMethod<
   AdminDisableProviderForUserRequest,
   AdminDisableProviderForUserResponse,
   AdminDisableProviderForUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminDisableProviderForUserRequest,
   output: AdminDisableProviderForUserResponse,
@@ -7288,7 +7287,7 @@ export const adminDisableUser: API.OperationMethod<
   AdminDisableUserRequest,
   AdminDisableUserResponse,
   AdminDisableUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminDisableUserRequest,
   output: AdminDisableUserResponse,
@@ -7333,7 +7332,7 @@ export const adminEnableUser: API.OperationMethod<
   AdminEnableUserRequest,
   AdminEnableUserResponse,
   AdminEnableUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminEnableUserRequest,
   output: AdminEnableUserResponse,
@@ -7380,7 +7379,7 @@ export const adminForgetDevice: API.OperationMethod<
   AdminForgetDeviceRequest,
   AdminForgetDeviceResponse,
   AdminForgetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminForgetDeviceRequest,
   output: AdminForgetDeviceResponse,
@@ -7426,7 +7425,7 @@ export const adminGetDevice: API.OperationMethod<
   AdminGetDeviceRequest,
   AdminGetDeviceResponse,
   AdminGetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminGetDeviceRequest,
   output: AdminGetDeviceResponse,
@@ -7474,7 +7473,7 @@ export const adminGetUser: API.OperationMethod<
   AdminGetUserRequest,
   AdminGetUserResponse,
   AdminGetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminGetUserRequest,
   output: AdminGetUserResponse,
@@ -7550,7 +7549,7 @@ export const adminInitiateAuth: API.OperationMethod<
   AdminInitiateAuthRequest,
   AdminInitiateAuthResponse,
   AdminInitiateAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminInitiateAuthRequest,
   output: AdminInitiateAuthResponse,
@@ -7621,7 +7620,7 @@ export const adminLinkProviderForUser: API.OperationMethod<
   AdminLinkProviderForUserRequest,
   AdminLinkProviderForUserResponse,
   AdminLinkProviderForUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminLinkProviderForUserRequest,
   output: AdminLinkProviderForUserResponse,
@@ -7670,7 +7669,7 @@ export const adminListDevices: API.OperationMethod<
   AdminListDevicesRequest,
   AdminListDevicesResponse,
   AdminListDevicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminListDevicesRequest,
   output: AdminListDevicesResponse,
@@ -7716,7 +7715,7 @@ export const adminListGroupsForUser: API.PaginatedOperationMethod<
   AdminListGroupsForUserRequest,
   AdminListGroupsForUserResponse,
   AdminListGroupsForUserError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: AdminListGroupsForUserRequest,
@@ -7769,7 +7768,7 @@ export const adminListUserAuthEvents: API.PaginatedOperationMethod<
   AdminListUserAuthEventsRequest,
   AdminListUserAuthEventsResponse,
   AdminListUserAuthEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuthEventType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: AdminListUserAuthEventsRequest,
@@ -7823,7 +7822,7 @@ export const adminRemoveUserFromGroup: API.OperationMethod<
   AdminRemoveUserFromGroupRequest,
   AdminRemoveUserFromGroupResponse,
   AdminRemoveUserFromGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminRemoveUserFromGroupRequest,
   output: AdminRemoveUserFromGroupResponse,
@@ -7899,7 +7898,7 @@ export const adminResetUserPassword: API.OperationMethod<
   AdminResetUserPasswordRequest,
   AdminResetUserPasswordResponse,
   AdminResetUserPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminResetUserPasswordRequest,
   output: AdminResetUserPasswordResponse,
@@ -7990,7 +7989,7 @@ export const adminRespondToAuthChallenge: API.OperationMethod<
   AdminRespondToAuthChallengeRequest,
   AdminRespondToAuthChallengeResponse,
   AdminRespondToAuthChallengeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminRespondToAuthChallengeRequest,
   output: AdminRespondToAuthChallengeResponse,
@@ -8055,7 +8054,7 @@ export const adminSetUserMFAPreference: API.OperationMethod<
   AdminSetUserMFAPreferenceRequest,
   AdminSetUserMFAPreferenceResponse,
   AdminSetUserMFAPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminSetUserMFAPreferenceRequest,
   output: AdminSetUserMFAPreferenceResponse,
@@ -8130,7 +8129,7 @@ export const adminSetUserPassword: API.OperationMethod<
   AdminSetUserPasswordRequest,
   AdminSetUserPasswordResponse,
   AdminSetUserPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminSetUserPasswordRequest,
   output: AdminSetUserPasswordResponse,
@@ -8177,7 +8176,7 @@ export const adminSetUserSettings: API.OperationMethod<
   AdminSetUserSettingsRequest,
   AdminSetUserSettingsResponse,
   AdminSetUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminSetUserSettingsRequest,
   output: AdminSetUserSettingsResponse,
@@ -8231,7 +8230,7 @@ export const adminUpdateAuthEventFeedback: API.OperationMethod<
   AdminUpdateAuthEventFeedbackRequest,
   AdminUpdateAuthEventFeedbackResponse,
   AdminUpdateAuthEventFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminUpdateAuthEventFeedbackRequest,
   output: AdminUpdateAuthEventFeedbackResponse,
@@ -8282,7 +8281,7 @@ export const adminUpdateDeviceStatus: API.OperationMethod<
   AdminUpdateDeviceStatusRequest,
   AdminUpdateDeviceStatusResponse,
   AdminUpdateDeviceStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminUpdateDeviceStatusRequest,
   output: AdminUpdateDeviceStatusResponse,
@@ -8360,7 +8359,7 @@ export const adminUpdateUserAttributes: API.OperationMethod<
   AdminUpdateUserAttributesRequest,
   AdminUpdateUserAttributesResponse,
   AdminUpdateUserAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminUpdateUserAttributesRequest,
   output: AdminUpdateUserAttributesResponse,
@@ -8434,7 +8433,7 @@ export const adminUserGlobalSignOut: API.OperationMethod<
   AdminUserGlobalSignOutRequest,
   AdminUserGlobalSignOutResponse,
   AdminUserGlobalSignOutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdminUserGlobalSignOutRequest,
   output: AdminUserGlobalSignOutResponse,
@@ -8480,7 +8479,7 @@ export const associateSoftwareToken: API.OperationMethod<
   AssociateSoftwareTokenRequest,
   AssociateSoftwareTokenResponse,
   AssociateSoftwareTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSoftwareTokenRequest,
   output: AssociateSoftwareTokenResponse,
@@ -8528,7 +8527,7 @@ export const changePassword: API.OperationMethod<
   ChangePasswordRequest,
   ChangePasswordResponse,
   ChangePasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangePasswordRequest,
   output: ChangePasswordResponse,
@@ -8578,7 +8577,7 @@ export const completeWebAuthnRegistration: API.OperationMethod<
   CompleteWebAuthnRegistrationRequest,
   CompleteWebAuthnRegistrationResponse,
   CompleteWebAuthnRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteWebAuthnRegistrationRequest,
   output: CompleteWebAuthnRegistrationResponse,
@@ -8637,7 +8636,7 @@ export const confirmDevice: API.OperationMethod<
   ConfirmDeviceRequest,
   ConfirmDeviceResponse,
   ConfirmDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmDeviceRequest,
   output: ConfirmDeviceResponse,
@@ -8696,7 +8695,7 @@ export const confirmForgotPassword: API.OperationMethod<
   ConfirmForgotPasswordRequest,
   ConfirmForgotPasswordResponse,
   ConfirmForgotPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmForgotPasswordRequest,
   output: ConfirmForgotPasswordResponse,
@@ -8764,7 +8763,7 @@ export const confirmSignUp: API.OperationMethod<
   ConfirmSignUpRequest,
   ConfirmSignUpResponse,
   ConfirmSignUpError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmSignUpRequest,
   output: ConfirmSignUpResponse,
@@ -8819,7 +8818,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -8866,7 +8865,7 @@ export const createIdentityProvider: API.OperationMethod<
   CreateIdentityProviderRequest,
   CreateIdentityProviderResponse,
   CreateIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentityProviderRequest,
   output: CreateIdentityProviderResponse,
@@ -8927,7 +8926,7 @@ export const createManagedLoginBranding: API.OperationMethod<
   CreateManagedLoginBrandingRequest,
   CreateManagedLoginBrandingResponse,
   CreateManagedLoginBrandingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateManagedLoginBrandingRequest,
   output: CreateManagedLoginBrandingResponse,
@@ -8975,7 +8974,7 @@ export const createResourceServer: API.OperationMethod<
   CreateResourceServerRequest,
   CreateResourceServerResponse,
   CreateResourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceServerRequest,
   output: CreateResourceServerResponse,
@@ -9034,7 +9033,7 @@ export const createTerms: API.OperationMethod<
   CreateTermsRequest,
   CreateTermsResponse,
   CreateTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTermsRequest,
   output: CreateTermsResponse,
@@ -9082,7 +9081,7 @@ export const createUserImportJob: API.OperationMethod<
   CreateUserImportJobRequest,
   CreateUserImportJobResponse,
   CreateUserImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserImportJobRequest,
   output: CreateUserImportJobResponse,
@@ -9151,7 +9150,7 @@ export const createUserPool: API.OperationMethod<
   CreateUserPoolRequest,
   CreateUserPoolResponse,
   CreateUserPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserPoolRequest,
   output: CreateUserPoolResponse,
@@ -9209,7 +9208,7 @@ export const createUserPoolClient: API.OperationMethod<
   CreateUserPoolClientRequest,
   CreateUserPoolClientResponse,
   CreateUserPoolClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserPoolClientRequest,
   output: CreateUserPoolClientResponse,
@@ -9268,7 +9267,7 @@ export const createUserPoolDomain: API.OperationMethod<
   CreateUserPoolDomainRequest,
   CreateUserPoolDomainResponse,
   CreateUserPoolDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserPoolDomainRequest,
   output: CreateUserPoolDomainResponse,
@@ -9317,7 +9316,7 @@ export const createUserPoolReplica: API.OperationMethod<
   CreateUserPoolReplicaRequest,
   CreateUserPoolReplicaResponse,
   CreateUserPoolReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserPoolReplicaRequest,
   output: CreateUserPoolReplicaResponse,
@@ -9366,7 +9365,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -9411,7 +9410,7 @@ export const deleteIdentityProvider: API.OperationMethod<
   DeleteIdentityProviderRequest,
   DeleteIdentityProviderResponse,
   DeleteIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityProviderRequest,
   output: DeleteIdentityProviderResponse,
@@ -9458,7 +9457,7 @@ export const deleteManagedLoginBranding: API.OperationMethod<
   DeleteManagedLoginBrandingRequest,
   DeleteManagedLoginBrandingResponse,
   DeleteManagedLoginBrandingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteManagedLoginBrandingRequest,
   output: DeleteManagedLoginBrandingResponse,
@@ -9505,7 +9504,7 @@ export const deleteResourceServer: API.OperationMethod<
   DeleteResourceServerRequest,
   DeleteResourceServerResponse,
   DeleteResourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceServerRequest,
   output: DeleteResourceServerResponse,
@@ -9548,7 +9547,7 @@ export const deleteTerms: API.OperationMethod<
   DeleteTermsRequest,
   DeleteTermsResponse,
   DeleteTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTermsRequest,
   output: DeleteTermsResponse,
@@ -9593,7 +9592,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -9642,7 +9641,7 @@ export const deleteUserAttributes: API.OperationMethod<
   DeleteUserAttributesRequest,
   DeleteUserAttributesResponse,
   DeleteUserAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserAttributesRequest,
   output: DeleteUserAttributesResponse,
@@ -9689,7 +9688,7 @@ export const deleteUserPool: API.OperationMethod<
   DeleteUserPoolRequest,
   DeleteUserPoolResponse,
   DeleteUserPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPoolRequest,
   output: DeleteUserPoolResponse,
@@ -9724,7 +9723,7 @@ export const deleteUserPoolClient: API.OperationMethod<
   DeleteUserPoolClientRequest,
   DeleteUserPoolClientResponse,
   DeleteUserPoolClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPoolClientRequest,
   output: DeleteUserPoolClientResponse,
@@ -9756,7 +9755,7 @@ export const deleteUserPoolClientSecret: API.OperationMethod<
   DeleteUserPoolClientSecretRequest,
   DeleteUserPoolClientSecretResponse,
   DeleteUserPoolClientSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPoolClientSecretRequest,
   output: DeleteUserPoolClientSecretResponse,
@@ -9789,7 +9788,7 @@ export const deleteUserPoolDomain: API.OperationMethod<
   DeleteUserPoolDomainRequest,
   DeleteUserPoolDomainResponse,
   DeleteUserPoolDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPoolDomainRequest,
   output: DeleteUserPoolDomainResponse,
@@ -9832,7 +9831,7 @@ export const deleteUserPoolReplica: API.OperationMethod<
   DeleteUserPoolReplicaRequest,
   DeleteUserPoolReplicaResponse,
   DeleteUserPoolReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPoolReplicaRequest,
   output: DeleteUserPoolReplicaResponse,
@@ -9875,7 +9874,7 @@ export const deleteWebAuthnCredential: API.OperationMethod<
   DeleteWebAuthnCredentialRequest,
   DeleteWebAuthnCredentialResponse,
   DeleteWebAuthnCredentialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebAuthnCredentialRequest,
   output: DeleteWebAuthnCredentialResponse,
@@ -9910,7 +9909,7 @@ export const describeIdentityProvider: API.OperationMethod<
   DescribeIdentityProviderRequest,
   DescribeIdentityProviderResponse,
   DescribeIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityProviderRequest,
   output: DescribeIdentityProviderResponse,
@@ -9942,7 +9941,7 @@ export const describeManagedLoginBranding: API.OperationMethod<
   DescribeManagedLoginBrandingRequest,
   DescribeManagedLoginBrandingResponse,
   DescribeManagedLoginBrandingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedLoginBrandingRequest,
   output: DescribeManagedLoginBrandingResponse,
@@ -9975,7 +9974,7 @@ export const describeManagedLoginBrandingByClient: API.OperationMethod<
   DescribeManagedLoginBrandingByClientRequest,
   DescribeManagedLoginBrandingByClientResponse,
   DescribeManagedLoginBrandingByClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedLoginBrandingByClientRequest,
   output: DescribeManagedLoginBrandingByClientResponse,
@@ -10007,7 +10006,7 @@ export const describeResourceServer: API.OperationMethod<
   DescribeResourceServerRequest,
   DescribeResourceServerResponse,
   DescribeResourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceServerRequest,
   output: DescribeResourceServerResponse,
@@ -10043,7 +10042,7 @@ export const describeRiskConfiguration: API.OperationMethod<
   DescribeRiskConfigurationRequest,
   DescribeRiskConfigurationResponse,
   DescribeRiskConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRiskConfigurationRequest,
   output: DescribeRiskConfigurationResponse,
@@ -10086,7 +10085,7 @@ export const describeTerms: API.OperationMethod<
   DescribeTermsRequest,
   DescribeTermsResponse,
   DescribeTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTermsRequest,
   output: DescribeTermsResponse,
@@ -10118,7 +10117,7 @@ export const describeUserImportJob: API.OperationMethod<
   DescribeUserImportJobRequest,
   DescribeUserImportJobResponse,
   DescribeUserImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserImportJobRequest,
   output: DescribeUserImportJobResponse,
@@ -10163,7 +10162,7 @@ export const describeUserPool: API.OperationMethod<
   DescribeUserPoolRequest,
   DescribeUserPoolResponse,
   DescribeUserPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserPoolRequest,
   output: DescribeUserPoolResponse,
@@ -10208,7 +10207,7 @@ export const describeUserPoolClient: API.OperationMethod<
   DescribeUserPoolClientRequest,
   DescribeUserPoolClientResponse,
   DescribeUserPoolClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserPoolClientRequest,
   output: DescribeUserPoolClientResponse,
@@ -10250,7 +10249,7 @@ export const describeUserPoolDomain: API.OperationMethod<
   DescribeUserPoolDomainRequest,
   DescribeUserPoolDomainResponse,
   DescribeUserPoolDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserPoolDomainRequest,
   output: DescribeUserPoolDomainResponse,
@@ -10294,7 +10293,7 @@ export const forgetDevice: API.OperationMethod<
   ForgetDeviceRequest,
   ForgetDeviceResponse,
   ForgetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ForgetDeviceRequest,
   output: ForgetDeviceResponse,
@@ -10374,7 +10373,7 @@ export const forgotPassword: API.OperationMethod<
   ForgotPasswordRequest,
   ForgotPasswordResponse,
   ForgotPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ForgotPasswordRequest,
   output: ForgotPasswordResponse,
@@ -10431,7 +10430,7 @@ export const getCSVHeader: API.OperationMethod<
   GetCSVHeaderRequest,
   GetCSVHeaderResponse,
   GetCSVHeaderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCSVHeaderRequest,
   output: GetCSVHeaderResponse,
@@ -10476,7 +10475,7 @@ export const getDevice: API.OperationMethod<
   GetDeviceRequest,
   GetDeviceResponse,
   GetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceRequest,
   output: GetDeviceResponse,
@@ -10526,7 +10525,7 @@ export const getGroup: API.OperationMethod<
   GetGroupRequest,
   GetGroupResponse,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupRequest,
   output: GetGroupResponse,
@@ -10559,7 +10558,7 @@ export const getIdentityProviderByIdentifier: API.OperationMethod<
   GetIdentityProviderByIdentifierRequest,
   GetIdentityProviderByIdentifierResponse,
   GetIdentityProviderByIdentifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityProviderByIdentifierRequest,
   output: GetIdentityProviderByIdentifierResponse,
@@ -10600,7 +10599,7 @@ export const getLogDeliveryConfiguration: API.OperationMethod<
   GetLogDeliveryConfigurationRequest,
   GetLogDeliveryConfigurationResponse,
   GetLogDeliveryConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogDeliveryConfigurationRequest,
   output: GetLogDeliveryConfigurationResponse,
@@ -10646,7 +10645,7 @@ export const getSigningCertificate: API.OperationMethod<
   GetSigningCertificateRequest,
   GetSigningCertificateResponse,
   GetSigningCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSigningCertificateRequest,
   output: GetSigningCertificateResponse,
@@ -10686,7 +10685,7 @@ export const getTokensFromRefreshToken: API.OperationMethod<
   GetTokensFromRefreshTokenRequest,
   GetTokensFromRefreshTokenResponse,
   GetTokensFromRefreshTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTokensFromRefreshTokenRequest,
   output: GetTokensFromRefreshTokenResponse,
@@ -10728,7 +10727,7 @@ export const getUICustomization: API.OperationMethod<
   GetUICustomizationRequest,
   GetUICustomizationResponse,
   GetUICustomizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUICustomizationRequest,
   output: GetUICustomizationResponse,
@@ -10771,7 +10770,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -10844,7 +10843,7 @@ export const getUserAttributeVerificationCode: API.OperationMethod<
   GetUserAttributeVerificationCodeRequest,
   GetUserAttributeVerificationCodeResponse,
   GetUserAttributeVerificationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserAttributeVerificationCodeRequest,
   output: GetUserAttributeVerificationCodeResponse,
@@ -10905,7 +10904,7 @@ export const getUserAuthFactors: API.OperationMethod<
   GetUserAuthFactorsRequest,
   GetUserAuthFactorsResponse,
   GetUserAuthFactorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserAuthFactorsRequest,
   output: GetUserAuthFactorsResponse,
@@ -10962,7 +10961,7 @@ export const getUserPoolMfaConfig: API.OperationMethod<
   GetUserPoolMfaConfigRequest,
   GetUserPoolMfaConfigResponse,
   GetUserPoolMfaConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserPoolMfaConfigRequest,
   output: GetUserPoolMfaConfigResponse,
@@ -11026,7 +11025,7 @@ export const globalSignOut: API.OperationMethod<
   GlobalSignOutRequest,
   GlobalSignOutResponse,
   GlobalSignOutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GlobalSignOutRequest,
   output: GlobalSignOutResponse,
@@ -11099,7 +11098,7 @@ export const initiateAuth: API.OperationMethod<
   InitiateAuthRequest,
   InitiateAuthResponse,
   InitiateAuthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateAuthRequest,
   output: InitiateAuthResponse,
@@ -11156,7 +11155,7 @@ export const listDevices: API.OperationMethod<
   ListDevicesRequest,
   ListDevicesResponse,
   ListDevicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDevicesRequest,
   output: ListDevicesResponse,
@@ -11203,7 +11202,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -11252,7 +11251,7 @@ export const listIdentityProviders: API.PaginatedOperationMethod<
   ListIdentityProvidersRequest,
   ListIdentityProvidersResponse,
   ListIdentityProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProviderDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentityProvidersRequest,
@@ -11301,7 +11300,7 @@ export const listResourceServers: API.PaginatedOperationMethod<
   ListResourceServersRequest,
   ListResourceServersResponse,
   ListResourceServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceServerType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceServersRequest,
@@ -11342,7 +11341,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -11384,7 +11383,7 @@ export const listTerms: API.OperationMethod<
   ListTermsRequest,
   ListTermsResponse,
   ListTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTermsRequest,
   output: ListTermsResponse,
@@ -11428,7 +11427,7 @@ export const listUserImportJobs: API.OperationMethod<
   ListUserImportJobsRequest,
   ListUserImportJobsResponse,
   ListUserImportJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUserImportJobsRequest,
   output: ListUserImportJobsResponse,
@@ -11471,7 +11470,7 @@ export const listUserPoolClients: API.PaginatedOperationMethod<
   ListUserPoolClientsRequest,
   ListUserPoolClientsResponse,
   ListUserPoolClientsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserPoolClientDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserPoolClientsRequest,
@@ -11509,7 +11508,7 @@ export const listUserPoolClientSecrets: API.OperationMethod<
   ListUserPoolClientSecretsRequest,
   ListUserPoolClientSecretsResponse,
   ListUserPoolClientSecretsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUserPoolClientSecretsRequest,
   output: ListUserPoolClientSecretsResponse,
@@ -11552,7 +11551,7 @@ export const listUserPoolReplicas: API.OperationMethod<
   ListUserPoolReplicasRequest,
   ListUserPoolReplicasResponse,
   ListUserPoolReplicasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUserPoolReplicasRequest,
   output: ListUserPoolReplicasResponse,
@@ -11592,7 +11591,7 @@ export const listUserPools: API.PaginatedOperationMethod<
   ListUserPoolsRequest,
   ListUserPoolsResponse,
   ListUserPoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserPoolDescriptionType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserPoolsRequest,
@@ -11644,7 +11643,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -11694,7 +11693,7 @@ export const listUsersInGroup: API.PaginatedOperationMethod<
   ListUsersInGroupRequest,
   ListUsersInGroupResponse,
   ListUsersInGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersInGroupRequest,
@@ -11743,7 +11742,7 @@ export const listWebAuthnCredentials: API.OperationMethod<
   ListWebAuthnCredentialsRequest,
   ListWebAuthnCredentialsResponse,
   ListWebAuthnCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebAuthnCredentialsRequest,
   output: ListWebAuthnCredentialsResponse,
@@ -11813,7 +11812,7 @@ export const resendConfirmationCode: API.OperationMethod<
   ResendConfirmationCodeRequest,
   ResendConfirmationCodeResponse,
   ResendConfirmationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResendConfirmationCodeRequest,
   output: ResendConfirmationCodeResponse,
@@ -11902,7 +11901,7 @@ export const respondToAuthChallenge: API.OperationMethod<
   RespondToAuthChallengeRequest,
   RespondToAuthChallengeResponse,
   RespondToAuthChallengeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RespondToAuthChallengeRequest,
   output: RespondToAuthChallengeResponse,
@@ -11961,7 +11960,7 @@ export const revokeToken: API.OperationMethod<
   RevokeTokenRequest,
   RevokeTokenResponse,
   RevokeTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeTokenRequest,
   output: RevokeTokenResponse,
@@ -11998,7 +11997,7 @@ export const setLogDeliveryConfiguration: API.OperationMethod<
   SetLogDeliveryConfigurationRequest,
   SetLogDeliveryConfigurationResponse,
   SetLogDeliveryConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLogDeliveryConfigurationRequest,
   output: SetLogDeliveryConfigurationResponse,
@@ -12057,7 +12056,7 @@ export const setRiskConfiguration: API.OperationMethod<
   SetRiskConfigurationRequest,
   SetRiskConfigurationResponse,
   SetRiskConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetRiskConfigurationRequest,
   output: SetRiskConfigurationResponse,
@@ -12108,7 +12107,7 @@ export const setUICustomization: API.OperationMethod<
   SetUICustomizationRequest,
   SetUICustomizationResponse,
   SetUICustomizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetUICustomizationRequest,
   output: SetUICustomizationResponse,
@@ -12158,7 +12157,7 @@ export const setUserMFAPreference: API.OperationMethod<
   SetUserMFAPreferenceRequest,
   SetUserMFAPreferenceResponse,
   SetUserMFAPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetUserMFAPreferenceRequest,
   output: SetUserMFAPreferenceResponse,
@@ -12215,7 +12214,7 @@ export const setUserPoolMfaConfig: API.OperationMethod<
   SetUserPoolMfaConfigRequest,
   SetUserPoolMfaConfigResponse,
   SetUserPoolMfaConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetUserPoolMfaConfigRequest,
   output: SetUserPoolMfaConfigResponse,
@@ -12263,7 +12262,7 @@ export const setUserSettings: API.OperationMethod<
   SetUserSettingsRequest,
   SetUserSettingsResponse,
   SetUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetUserSettingsRequest,
   output: SetUserSettingsResponse,
@@ -12338,7 +12337,7 @@ export const signUp: API.OperationMethod<
   SignUpRequest,
   SignUpResponse,
   SignUpError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignUpRequest,
   output: SignUpResponse,
@@ -12384,7 +12383,7 @@ export const startUserImportJob: API.OperationMethod<
   StartUserImportJobRequest,
   StartUserImportJobResponse,
   StartUserImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartUserImportJobRequest,
   output: StartUserImportJobResponse,
@@ -12426,7 +12425,7 @@ export const startWebAuthnRegistration: API.OperationMethod<
   StartWebAuthnRegistrationRequest,
   StartWebAuthnRegistrationResponse,
   StartWebAuthnRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWebAuthnRegistrationRequest,
   output: StartWebAuthnRegistrationResponse,
@@ -12465,7 +12464,7 @@ export const stopUserImportJob: API.OperationMethod<
   StopUserImportJobRequest,
   StopUserImportJobResponse,
   StopUserImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopUserImportJobRequest,
   output: StopUserImportJobResponse,
@@ -12514,7 +12513,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -12546,7 +12545,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -12598,7 +12597,7 @@ export const updateAuthEventFeedback: API.OperationMethod<
   UpdateAuthEventFeedbackRequest,
   UpdateAuthEventFeedbackResponse,
   UpdateAuthEventFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuthEventFeedbackRequest,
   output: UpdateAuthEventFeedbackResponse,
@@ -12649,7 +12648,7 @@ export const updateDeviceStatus: API.OperationMethod<
   UpdateDeviceStatusRequest,
   UpdateDeviceStatusResponse,
   UpdateDeviceStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceStatusRequest,
   output: UpdateDeviceStatusResponse,
@@ -12697,7 +12696,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -12743,7 +12742,7 @@ export const updateIdentityProvider: API.OperationMethod<
   UpdateIdentityProviderRequest,
   UpdateIdentityProviderResponse,
   UpdateIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdentityProviderRequest,
   output: UpdateIdentityProviderResponse,
@@ -12797,7 +12796,7 @@ export const updateManagedLoginBranding: API.OperationMethod<
   UpdateManagedLoginBrandingRequest,
   UpdateManagedLoginBrandingResponse,
   UpdateManagedLoginBrandingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateManagedLoginBrandingRequest,
   output: UpdateManagedLoginBrandingResponse,
@@ -12844,7 +12843,7 @@ export const updateResourceServer: API.OperationMethod<
   UpdateResourceServerRequest,
   UpdateResourceServerResponse,
   UpdateResourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceServerRequest,
   output: UpdateResourceServerResponse,
@@ -12901,7 +12900,7 @@ export const updateTerms: API.OperationMethod<
   UpdateTermsRequest,
   UpdateTermsResponse,
   UpdateTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTermsRequest,
   output: UpdateTermsResponse,
@@ -12977,7 +12976,7 @@ export const updateUserAttributes: API.OperationMethod<
   UpdateUserAttributesRequest,
   UpdateUserAttributesResponse,
   UpdateUserAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserAttributesRequest,
   output: UpdateUserAttributesResponse,
@@ -13067,7 +13066,7 @@ export const updateUserPool: API.OperationMethod<
   UpdateUserPoolRequest,
   UpdateUserPoolResponse,
   UpdateUserPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserPoolRequest,
   output: UpdateUserPoolResponse,
@@ -13130,7 +13129,7 @@ export const updateUserPoolClient: API.OperationMethod<
   UpdateUserPoolClientRequest,
   UpdateUserPoolClientResponse,
   UpdateUserPoolClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserPoolClientRequest,
   output: UpdateUserPoolClientResponse,
@@ -13199,7 +13198,7 @@ export const updateUserPoolDomain: API.OperationMethod<
   UpdateUserPoolDomainRequest,
   UpdateUserPoolDomainResponse,
   UpdateUserPoolDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserPoolDomainRequest,
   output: UpdateUserPoolDomainResponse,
@@ -13245,7 +13244,7 @@ export const updateUserPoolReplica: API.OperationMethod<
   UpdateUserPoolReplicaRequest,
   UpdateUserPoolReplicaResponse,
   UpdateUserPoolReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserPoolReplicaRequest,
   output: UpdateUserPoolReplicaResponse,
@@ -13293,7 +13292,7 @@ export const verifySoftwareToken: API.OperationMethod<
   VerifySoftwareTokenRequest,
   VerifySoftwareTokenResponse,
   VerifySoftwareTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifySoftwareTokenRequest,
   output: VerifySoftwareTokenResponse,
@@ -13354,7 +13353,7 @@ export const verifyUserAttribute: API.OperationMethod<
   VerifyUserAttributeRequest,
   VerifyUserAttributeResponse,
   VerifyUserAttributeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyUserAttributeRequest,
   output: VerifyUserAttributeResponse,

--- a/packages/aws/src/services/cognito-identity.ts
+++ b/packages/aws/src/services/cognito-identity.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://cognito-identity.amazonaws.com/doc/2014-06-30/",
@@ -1139,7 +1138,7 @@ export const createIdentityPool: API.OperationMethod<
   CreateIdentityPoolInput,
   IdentityPool,
   CreateIdentityPoolError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentityPoolInput,
   output: IdentityPool,
@@ -1172,7 +1171,7 @@ export const deleteIdentities: API.OperationMethod<
   DeleteIdentitiesInput,
   DeleteIdentitiesResponse,
   DeleteIdentitiesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentitiesInput,
   output: DeleteIdentitiesResponse,
@@ -1204,7 +1203,7 @@ export const deleteIdentityPool: API.OperationMethod<
   DeleteIdentityPoolInput,
   DeleteIdentityPoolResponse,
   DeleteIdentityPoolError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityPoolInput,
   output: DeleteIdentityPoolResponse,
@@ -1238,7 +1237,7 @@ export const describeIdentity: API.OperationMethod<
   DescribeIdentityInput,
   IdentityDescription,
   DescribeIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityInput,
   output: IdentityDescription,
@@ -1272,7 +1271,7 @@ export const describeIdentityPool: API.OperationMethod<
   DescribeIdentityPoolInput,
   IdentityPool,
   DescribeIdentityPoolError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityPoolInput,
   output: IdentityPool,
@@ -1309,7 +1308,7 @@ export const getCredentialsForIdentity: API.OperationMethod<
   GetCredentialsForIdentityInput,
   GetCredentialsForIdentityResponse,
   GetCredentialsForIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCredentialsForIdentityInput,
   output: GetCredentialsForIdentityResponse,
@@ -1348,7 +1347,7 @@ export const getId: API.OperationMethod<
   GetIdInput,
   GetIdResponse,
   GetIdError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdInput,
   output: GetIdResponse,
@@ -1385,7 +1384,7 @@ export const getIdentityPoolRoles: API.OperationMethod<
   GetIdentityPoolRolesInput,
   GetIdentityPoolRolesResponse,
   GetIdentityPoolRolesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityPoolRolesInput,
   output: GetIdentityPoolRolesResponse,
@@ -1424,7 +1423,7 @@ export const getOpenIdToken: API.OperationMethod<
   GetOpenIdTokenInput,
   GetOpenIdTokenResponse,
   GetOpenIdTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpenIdTokenInput,
   output: GetOpenIdTokenResponse,
@@ -1473,7 +1472,7 @@ export const getOpenIdTokenForDeveloperIdentity: API.OperationMethod<
   GetOpenIdTokenForDeveloperIdentityInput,
   GetOpenIdTokenForDeveloperIdentityResponse,
   GetOpenIdTokenForDeveloperIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpenIdTokenForDeveloperIdentityInput,
   output: GetOpenIdTokenForDeveloperIdentityResponse,
@@ -1506,7 +1505,7 @@ export const getPrincipalTagAttributeMap: API.OperationMethod<
   GetPrincipalTagAttributeMapInput,
   GetPrincipalTagAttributeMapResponse,
   GetPrincipalTagAttributeMapError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPrincipalTagAttributeMapInput,
   output: GetPrincipalTagAttributeMapResponse,
@@ -1539,7 +1538,7 @@ export const listIdentities: API.OperationMethod<
   ListIdentitiesInput,
   ListIdentitiesResponse,
   ListIdentitiesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIdentitiesInput,
   output: ListIdentitiesResponse,
@@ -1572,7 +1571,7 @@ export const listIdentityPools: API.PaginatedOperationMethod<
   ListIdentityPoolsInput,
   ListIdentityPoolsResponse,
   ListIdentityPoolsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   IdentityPoolShortDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentityPoolsInput,
@@ -1614,7 +1613,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceResponse,
@@ -1663,7 +1662,7 @@ export const lookupDeveloperIdentity: API.OperationMethod<
   LookupDeveloperIdentityInput,
   LookupDeveloperIdentityResponse,
   LookupDeveloperIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LookupDeveloperIdentityInput,
   output: LookupDeveloperIdentityResponse,
@@ -1710,7 +1709,7 @@ export const mergeDeveloperIdentities: API.OperationMethod<
   MergeDeveloperIdentitiesInput,
   MergeDeveloperIdentitiesResponse,
   MergeDeveloperIdentitiesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeDeveloperIdentitiesInput,
   output: MergeDeveloperIdentitiesResponse,
@@ -1746,7 +1745,7 @@ export const setIdentityPoolRoles: API.OperationMethod<
   SetIdentityPoolRolesInput,
   SetIdentityPoolRolesResponse,
   SetIdentityPoolRolesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityPoolRolesInput,
   output: SetIdentityPoolRolesResponse,
@@ -1779,7 +1778,7 @@ export const setPrincipalTagAttributeMap: API.OperationMethod<
   SetPrincipalTagAttributeMapInput,
   SetPrincipalTagAttributeMapResponse,
   SetPrincipalTagAttributeMapError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetPrincipalTagAttributeMapInput,
   output: SetPrincipalTagAttributeMapResponse,
@@ -1826,7 +1825,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -1863,7 +1862,7 @@ export const unlinkDeveloperIdentity: API.OperationMethod<
   UnlinkDeveloperIdentityInput,
   UnlinkDeveloperIdentityResponse,
   UnlinkDeveloperIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnlinkDeveloperIdentityInput,
   output: UnlinkDeveloperIdentityResponse,
@@ -1900,7 +1899,7 @@ export const unlinkIdentity: API.OperationMethod<
   UnlinkIdentityInput,
   UnlinkIdentityResponse,
   UnlinkIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnlinkIdentityInput,
   output: UnlinkIdentityResponse,
@@ -1933,7 +1932,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -1971,7 +1970,7 @@ export const updateIdentityPool: API.OperationMethod<
   IdentityPool,
   IdentityPool,
   UpdateIdentityPoolError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IdentityPool,
   output: IdentityPool,

--- a/packages/aws/src/services/cognito-sync.ts
+++ b/packages/aws/src/services/cognito-sync.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://cognito-sync.amazonaws.com/doc/2014-06-30/");
 const svc = T.AwsApiService({
   sdkId: "Cognito Sync",
@@ -1034,7 +1033,7 @@ export const bulkPublish: API.OperationMethod<
   BulkPublishRequest,
   BulkPublishResponse,
   BulkPublishError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BulkPublishRequest,
   output: BulkPublishResponse,
@@ -1071,7 +1070,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -1106,7 +1105,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -1179,7 +1178,7 @@ export const describeIdentityPoolUsage: API.OperationMethod<
   DescribeIdentityPoolUsageRequest,
   DescribeIdentityPoolUsageResponse,
   DescribeIdentityPoolUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityPoolUsageRequest,
   output: DescribeIdentityPoolUsageResponse,
@@ -1254,7 +1253,7 @@ export const describeIdentityUsage: API.OperationMethod<
   DescribeIdentityUsageRequest,
   DescribeIdentityUsageResponse,
   DescribeIdentityUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityUsageRequest,
   output: DescribeIdentityUsageResponse,
@@ -1285,7 +1284,7 @@ export const getBulkPublishDetails: API.OperationMethod<
   GetBulkPublishDetailsRequest,
   GetBulkPublishDetailsResponse,
   GetBulkPublishDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBulkPublishDetailsRequest,
   output: GetBulkPublishDetailsResponse,
@@ -1316,7 +1315,7 @@ export const getCognitoEvents: API.OperationMethod<
   GetCognitoEventsRequest,
   GetCognitoEventsResponse,
   GetCognitoEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCognitoEventsRequest,
   output: GetCognitoEventsResponse,
@@ -1388,7 +1387,7 @@ export const getIdentityPoolConfiguration: API.OperationMethod<
   GetIdentityPoolConfigurationRequest,
   GetIdentityPoolConfigurationResponse,
   GetIdentityPoolConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityPoolConfigurationRequest,
   output: GetIdentityPoolConfigurationResponse,
@@ -1471,7 +1470,7 @@ export const listDatasets: API.OperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDatasetsRequest,
   output: ListDatasetsResponse,
@@ -1553,7 +1552,7 @@ export const listIdentityPoolUsage: API.OperationMethod<
   ListIdentityPoolUsageRequest,
   ListIdentityPoolUsageResponse,
   ListIdentityPoolUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIdentityPoolUsageRequest,
   output: ListIdentityPoolUsageResponse,
@@ -1632,7 +1631,7 @@ export const listRecords: API.OperationMethod<
   ListRecordsRequest,
   ListRecordsResponse,
   ListRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRecordsRequest,
   output: ListRecordsResponse,
@@ -1703,7 +1702,7 @@ export const registerDevice: API.OperationMethod<
   RegisterDeviceRequest,
   RegisterDeviceResponse,
   RegisterDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDeviceRequest,
   output: RegisterDeviceResponse,
@@ -1736,7 +1735,7 @@ export const setCognitoEvents: API.OperationMethod<
   SetCognitoEventsRequest,
   SetCognitoEventsResponse,
   SetCognitoEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetCognitoEventsRequest,
   output: SetCognitoEventsResponse,
@@ -1814,7 +1813,7 @@ export const setIdentityPoolConfiguration: API.OperationMethod<
   SetIdentityPoolConfigurationRequest,
   SetIdentityPoolConfigurationResponse,
   SetIdentityPoolConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityPoolConfigurationRequest,
   output: SetIdentityPoolConfigurationResponse,
@@ -1886,7 +1885,7 @@ export const subscribeToDataset: API.OperationMethod<
   SubscribeToDatasetRequest,
   SubscribeToDatasetResponse,
   SubscribeToDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubscribeToDatasetRequest,
   output: SubscribeToDatasetResponse,
@@ -1959,7 +1958,7 @@ export const unsubscribeFromDataset: API.OperationMethod<
   UnsubscribeFromDatasetRequest,
   UnsubscribeFromDatasetResponse,
   UnsubscribeFromDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnsubscribeFromDatasetRequest,
   output: UnsubscribeFromDatasetResponse,
@@ -2000,7 +1999,7 @@ export const updateRecords: API.OperationMethod<
   UpdateRecordsRequest,
   UpdateRecordsResponse,
   UpdateRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecordsRequest,
   output: UpdateRecordsResponse,

--- a/packages/aws/src/services/comprehend.ts
+++ b/packages/aws/src/services/comprehend.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Comprehend",
@@ -4828,7 +4827,7 @@ export const batchDetectDominantLanguage: API.OperationMethod<
   BatchDetectDominantLanguageRequest,
   BatchDetectDominantLanguageResponse,
   BatchDetectDominantLanguageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectDominantLanguageRequest,
   output: BatchDetectDominantLanguageResponse,
@@ -4859,7 +4858,7 @@ export const batchDetectEntities: API.OperationMethod<
   BatchDetectEntitiesRequest,
   BatchDetectEntitiesResponse,
   BatchDetectEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectEntitiesRequest,
   output: BatchDetectEntitiesResponse,
@@ -4889,7 +4888,7 @@ export const batchDetectKeyPhrases: API.OperationMethod<
   BatchDetectKeyPhrasesRequest,
   BatchDetectKeyPhrasesResponse,
   BatchDetectKeyPhrasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectKeyPhrasesRequest,
   output: BatchDetectKeyPhrasesResponse,
@@ -4921,7 +4920,7 @@ export const batchDetectSentiment: API.OperationMethod<
   BatchDetectSentimentRequest,
   BatchDetectSentimentResponse,
   BatchDetectSentimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectSentimentRequest,
   output: BatchDetectSentimentResponse,
@@ -4953,7 +4952,7 @@ export const batchDetectSyntax: API.OperationMethod<
   BatchDetectSyntaxRequest,
   BatchDetectSyntaxResponse,
   BatchDetectSyntaxError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectSyntaxRequest,
   output: BatchDetectSyntaxResponse,
@@ -4986,7 +4985,7 @@ export const batchDetectTargetedSentiment: API.OperationMethod<
   BatchDetectTargetedSentimentRequest,
   BatchDetectTargetedSentimentResponse,
   BatchDetectTargetedSentimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDetectTargetedSentimentRequest,
   output: BatchDetectTargetedSentimentResponse,
@@ -5036,7 +5035,7 @@ export const classifyDocument: API.OperationMethod<
   ClassifyDocumentRequest,
   ClassifyDocumentResponse,
   ClassifyDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClassifyDocumentRequest,
   output: ClassifyDocumentResponse,
@@ -5067,7 +5066,7 @@ export const containsPiiEntities: API.OperationMethod<
   ContainsPiiEntitiesRequest,
   ContainsPiiEntitiesResponse,
   ContainsPiiEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ContainsPiiEntitiesRequest,
   output: ContainsPiiEntitiesResponse,
@@ -5100,7 +5099,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -5139,7 +5138,7 @@ export const createDocumentClassifier: API.OperationMethod<
   CreateDocumentClassifierRequest,
   CreateDocumentClassifierResponse,
   CreateDocumentClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDocumentClassifierRequest,
   output: CreateDocumentClassifierResponse,
@@ -5177,7 +5176,7 @@ export const createEndpoint: API.OperationMethod<
   CreateEndpointRequest,
   CreateEndpointResponse,
   CreateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointRequest,
   output: CreateEndpointResponse,
@@ -5215,7 +5214,7 @@ export const createEntityRecognizer: API.OperationMethod<
   CreateEntityRecognizerRequest,
   CreateEntityRecognizerResponse,
   CreateEntityRecognizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEntityRecognizerRequest,
   output: CreateEntityRecognizerResponse,
@@ -5267,7 +5266,7 @@ export const createFlywheel: API.OperationMethod<
   CreateFlywheelRequest,
   CreateFlywheelResponse,
   CreateFlywheelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlywheelRequest,
   output: CreateFlywheelResponse,
@@ -5311,7 +5310,7 @@ export const deleteDocumentClassifier: API.OperationMethod<
   DeleteDocumentClassifierRequest,
   DeleteDocumentClassifierResponse,
   DeleteDocumentClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentClassifierRequest,
   output: DeleteDocumentClassifierResponse,
@@ -5344,7 +5343,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointRequest,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointRequest,
   output: DeleteEndpointResponse,
@@ -5383,7 +5382,7 @@ export const deleteEntityRecognizer: API.OperationMethod<
   DeleteEntityRecognizerRequest,
   DeleteEntityRecognizerResponse,
   DeleteEntityRecognizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEntityRecognizerRequest,
   output: DeleteEntityRecognizerResponse,
@@ -5419,7 +5418,7 @@ export const deleteFlywheel: API.OperationMethod<
   DeleteFlywheelRequest,
   DeleteFlywheelResponse,
   DeleteFlywheelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlywheelRequest,
   output: DeleteFlywheelResponse,
@@ -5448,7 +5447,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -5477,7 +5476,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -5506,7 +5505,7 @@ export const describeDocumentClassificationJob: API.OperationMethod<
   DescribeDocumentClassificationJobRequest,
   DescribeDocumentClassificationJobResponse,
   DescribeDocumentClassificationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDocumentClassificationJobRequest,
   output: DescribeDocumentClassificationJobResponse,
@@ -5534,7 +5533,7 @@ export const describeDocumentClassifier: API.OperationMethod<
   DescribeDocumentClassifierRequest,
   DescribeDocumentClassifierResponse,
   DescribeDocumentClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDocumentClassifierRequest,
   output: DescribeDocumentClassifierResponse,
@@ -5563,7 +5562,7 @@ export const describeDominantLanguageDetectionJob: API.OperationMethod<
   DescribeDominantLanguageDetectionJobRequest,
   DescribeDominantLanguageDetectionJobResponse,
   DescribeDominantLanguageDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDominantLanguageDetectionJobRequest,
   output: DescribeDominantLanguageDetectionJobResponse,
@@ -5593,7 +5592,7 @@ export const describeEndpoint: API.OperationMethod<
   DescribeEndpointRequest,
   DescribeEndpointResponse,
   DescribeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointRequest,
   output: DescribeEndpointResponse,
@@ -5622,7 +5621,7 @@ export const describeEntitiesDetectionJob: API.OperationMethod<
   DescribeEntitiesDetectionJobRequest,
   DescribeEntitiesDetectionJobResponse,
   DescribeEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntitiesDetectionJobRequest,
   output: DescribeEntitiesDetectionJobResponse,
@@ -5651,7 +5650,7 @@ export const describeEntityRecognizer: API.OperationMethod<
   DescribeEntityRecognizerRequest,
   DescribeEntityRecognizerResponse,
   DescribeEntityRecognizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntityRecognizerRequest,
   output: DescribeEntityRecognizerResponse,
@@ -5680,7 +5679,7 @@ export const describeEventsDetectionJob: API.OperationMethod<
   DescribeEventsDetectionJobRequest,
   DescribeEventsDetectionJobResponse,
   DescribeEventsDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventsDetectionJobRequest,
   output: DescribeEventsDetectionJobResponse,
@@ -5710,7 +5709,7 @@ export const describeFlywheel: API.OperationMethod<
   DescribeFlywheelRequest,
   DescribeFlywheelResponse,
   DescribeFlywheelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlywheelRequest,
   output: DescribeFlywheelResponse,
@@ -5740,7 +5739,7 @@ export const describeFlywheelIteration: API.OperationMethod<
   DescribeFlywheelIterationRequest,
   DescribeFlywheelIterationResponse,
   DescribeFlywheelIterationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlywheelIterationRequest,
   output: DescribeFlywheelIterationResponse,
@@ -5769,7 +5768,7 @@ export const describeKeyPhrasesDetectionJob: API.OperationMethod<
   DescribeKeyPhrasesDetectionJobRequest,
   DescribeKeyPhrasesDetectionJobResponse,
   DescribeKeyPhrasesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyPhrasesDetectionJobRequest,
   output: DescribeKeyPhrasesDetectionJobResponse,
@@ -5798,7 +5797,7 @@ export const describePiiEntitiesDetectionJob: API.OperationMethod<
   DescribePiiEntitiesDetectionJobRequest,
   DescribePiiEntitiesDetectionJobResponse,
   DescribePiiEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePiiEntitiesDetectionJobRequest,
   output: DescribePiiEntitiesDetectionJobResponse,
@@ -5826,7 +5825,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -5854,7 +5853,7 @@ export const describeSentimentDetectionJob: API.OperationMethod<
   DescribeSentimentDetectionJobRequest,
   DescribeSentimentDetectionJobResponse,
   DescribeSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSentimentDetectionJobRequest,
   output: DescribeSentimentDetectionJobResponse,
@@ -5883,7 +5882,7 @@ export const describeTargetedSentimentDetectionJob: API.OperationMethod<
   DescribeTargetedSentimentDetectionJobRequest,
   DescribeTargetedSentimentDetectionJobResponse,
   DescribeTargetedSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTargetedSentimentDetectionJobRequest,
   output: DescribeTargetedSentimentDetectionJobResponse,
@@ -5912,7 +5911,7 @@ export const describeTopicsDetectionJob: API.OperationMethod<
   DescribeTopicsDetectionJobRequest,
   DescribeTopicsDetectionJobResponse,
   DescribeTopicsDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicsDetectionJobRequest,
   output: DescribeTopicsDetectionJobResponse,
@@ -5940,7 +5939,7 @@ export const detectDominantLanguage: API.OperationMethod<
   DetectDominantLanguageRequest,
   DetectDominantLanguageResponse,
   DetectDominantLanguageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectDominantLanguageRequest,
   output: DetectDominantLanguageResponse,
@@ -5985,7 +5984,7 @@ export const detectEntities: API.OperationMethod<
   DetectEntitiesRequest,
   DetectEntitiesResponse,
   DetectEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectEntitiesRequest,
   output: DetectEntitiesResponse,
@@ -6014,7 +6013,7 @@ export const detectKeyPhrases: API.OperationMethod<
   DetectKeyPhrasesRequest,
   DetectKeyPhrasesResponse,
   DetectKeyPhrasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectKeyPhrasesRequest,
   output: DetectKeyPhrasesResponse,
@@ -6043,7 +6042,7 @@ export const detectPiiEntities: API.OperationMethod<
   DetectPiiEntitiesRequest,
   DetectPiiEntitiesResponse,
   DetectPiiEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectPiiEntitiesRequest,
   output: DetectPiiEntitiesResponse,
@@ -6072,7 +6071,7 @@ export const detectSentiment: API.OperationMethod<
   DetectSentimentRequest,
   DetectSentimentResponse,
   DetectSentimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectSentimentRequest,
   output: DetectSentimentResponse,
@@ -6102,7 +6101,7 @@ export const detectSyntax: API.OperationMethod<
   DetectSyntaxRequest,
   DetectSyntaxResponse,
   DetectSyntaxError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectSyntaxRequest,
   output: DetectSyntaxResponse,
@@ -6132,7 +6131,7 @@ export const detectTargetedSentiment: API.OperationMethod<
   DetectTargetedSentimentRequest,
   DetectTargetedSentimentResponse,
   DetectTargetedSentimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectTargetedSentimentRequest,
   output: DetectTargetedSentimentResponse,
@@ -6162,7 +6161,7 @@ export const detectToxicContent: API.OperationMethod<
   DetectToxicContentRequest,
   DetectToxicContentResponse,
   DetectToxicContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectToxicContentRequest,
   output: DetectToxicContentResponse,
@@ -6202,7 +6201,7 @@ export const importModel: API.OperationMethod<
   ImportModelRequest,
   ImportModelResponse,
   ImportModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportModelRequest,
   output: ImportModelResponse,
@@ -6237,7 +6236,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -6272,7 +6271,7 @@ export const listDocumentClassificationJobs: API.PaginatedOperationMethod<
   ListDocumentClassificationJobsRequest,
   ListDocumentClassificationJobsResponse,
   ListDocumentClassificationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentClassificationJobsRequest,
@@ -6306,7 +6305,7 @@ export const listDocumentClassifiers: API.PaginatedOperationMethod<
   ListDocumentClassifiersRequest,
   ListDocumentClassifiersResponse,
   ListDocumentClassifiersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentClassifiersRequest,
@@ -6339,7 +6338,7 @@ export const listDocumentClassifierSummaries: API.PaginatedOperationMethod<
   ListDocumentClassifierSummariesRequest,
   ListDocumentClassifierSummariesResponse,
   ListDocumentClassifierSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentClassifierSummariesRequest,
@@ -6372,7 +6371,7 @@ export const listDominantLanguageDetectionJobs: API.PaginatedOperationMethod<
   ListDominantLanguageDetectionJobsRequest,
   ListDominantLanguageDetectionJobsResponse,
   ListDominantLanguageDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDominantLanguageDetectionJobsRequest,
@@ -6406,7 +6405,7 @@ export const listEndpoints: API.PaginatedOperationMethod<
   ListEndpointsRequest,
   ListEndpointsResponse,
   ListEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointProperties
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointsRequest,
@@ -6440,7 +6439,7 @@ export const listEntitiesDetectionJobs: API.PaginatedOperationMethod<
   ListEntitiesDetectionJobsRequest,
   ListEntitiesDetectionJobsResponse,
   ListEntitiesDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitiesDetectionJobsRequest,
@@ -6480,7 +6479,7 @@ export const listEntityRecognizers: API.PaginatedOperationMethod<
   ListEntityRecognizersRequest,
   ListEntityRecognizersResponse,
   ListEntityRecognizersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntityRecognizersRequest,
@@ -6513,7 +6512,7 @@ export const listEntityRecognizerSummaries: API.PaginatedOperationMethod<
   ListEntityRecognizerSummariesRequest,
   ListEntityRecognizerSummariesResponse,
   ListEntityRecognizerSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntityRecognizerSummariesRequest,
@@ -6547,7 +6546,7 @@ export const listEventsDetectionJobs: API.PaginatedOperationMethod<
   ListEventsDetectionJobsRequest,
   ListEventsDetectionJobsResponse,
   ListEventsDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventsDetectionJobsRequest,
@@ -6585,7 +6584,7 @@ export const listFlywheelIterationHistory: API.PaginatedOperationMethod<
   ListFlywheelIterationHistoryRequest,
   ListFlywheelIterationHistoryResponse,
   ListFlywheelIterationHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlywheelIterationHistoryRequest,
@@ -6620,7 +6619,7 @@ export const listFlywheels: API.PaginatedOperationMethod<
   ListFlywheelsRequest,
   ListFlywheelsResponse,
   ListFlywheelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlywheelsRequest,
@@ -6654,7 +6653,7 @@ export const listKeyPhrasesDetectionJobs: API.PaginatedOperationMethod<
   ListKeyPhrasesDetectionJobsRequest,
   ListKeyPhrasesDetectionJobsResponse,
   ListKeyPhrasesDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeyPhrasesDetectionJobsRequest,
@@ -6688,7 +6687,7 @@ export const listPiiEntitiesDetectionJobs: API.PaginatedOperationMethod<
   ListPiiEntitiesDetectionJobsRequest,
   ListPiiEntitiesDetectionJobsResponse,
   ListPiiEntitiesDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PiiEntitiesDetectionJobProperties
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPiiEntitiesDetectionJobsRequest,
@@ -6723,7 +6722,7 @@ export const listSentimentDetectionJobs: API.PaginatedOperationMethod<
   ListSentimentDetectionJobsRequest,
   ListSentimentDetectionJobsResponse,
   ListSentimentDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSentimentDetectionJobsRequest,
@@ -6756,7 +6755,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6783,7 +6782,7 @@ export const listTargetedSentimentDetectionJobs: API.PaginatedOperationMethod<
   ListTargetedSentimentDetectionJobsRequest,
   ListTargetedSentimentDetectionJobsResponse,
   ListTargetedSentimentDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetedSentimentDetectionJobsRequest,
@@ -6817,7 +6816,7 @@ export const listTopicsDetectionJobs: API.PaginatedOperationMethod<
   ListTopicsDetectionJobsRequest,
   ListTopicsDetectionJobsResponse,
   ListTopicsDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicsDetectionJobsRequest,
@@ -6852,7 +6851,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -6885,7 +6884,7 @@ export const startDocumentClassificationJob: API.OperationMethod<
   StartDocumentClassificationJobRequest,
   StartDocumentClassificationJobResponse,
   StartDocumentClassificationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDocumentClassificationJobRequest,
   output: StartDocumentClassificationJobResponse,
@@ -6921,7 +6920,7 @@ export const startDominantLanguageDetectionJob: API.OperationMethod<
   StartDominantLanguageDetectionJobRequest,
   StartDominantLanguageDetectionJobResponse,
   StartDominantLanguageDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDominantLanguageDetectionJobRequest,
   output: StartDominantLanguageDetectionJobResponse,
@@ -6960,7 +6959,7 @@ export const startEntitiesDetectionJob: API.OperationMethod<
   StartEntitiesDetectionJobRequest,
   StartEntitiesDetectionJobResponse,
   StartEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEntitiesDetectionJobRequest,
   output: StartEntitiesDetectionJobResponse,
@@ -6995,7 +6994,7 @@ export const startEventsDetectionJob: API.OperationMethod<
   StartEventsDetectionJobRequest,
   StartEventsDetectionJobResponse,
   StartEventsDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEventsDetectionJobRequest,
   output: StartEventsDetectionJobResponse,
@@ -7029,7 +7028,7 @@ export const startFlywheelIteration: API.OperationMethod<
   StartFlywheelIterationRequest,
   StartFlywheelIterationResponse,
   StartFlywheelIterationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlywheelIterationRequest,
   output: StartFlywheelIterationResponse,
@@ -7062,7 +7061,7 @@ export const startKeyPhrasesDetectionJob: API.OperationMethod<
   StartKeyPhrasesDetectionJobRequest,
   StartKeyPhrasesDetectionJobResponse,
   StartKeyPhrasesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartKeyPhrasesDetectionJobRequest,
   output: StartKeyPhrasesDetectionJobResponse,
@@ -7094,7 +7093,7 @@ export const startPiiEntitiesDetectionJob: API.OperationMethod<
   StartPiiEntitiesDetectionJobRequest,
   StartPiiEntitiesDetectionJobResponse,
   StartPiiEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPiiEntitiesDetectionJobRequest,
   output: StartPiiEntitiesDetectionJobResponse,
@@ -7128,7 +7127,7 @@ export const startSentimentDetectionJob: API.OperationMethod<
   StartSentimentDetectionJobRequest,
   StartSentimentDetectionJobResponse,
   StartSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSentimentDetectionJobRequest,
   output: StartSentimentDetectionJobResponse,
@@ -7162,7 +7161,7 @@ export const startTargetedSentimentDetectionJob: API.OperationMethod<
   StartTargetedSentimentDetectionJobRequest,
   StartTargetedSentimentDetectionJobResponse,
   StartTargetedSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTargetedSentimentDetectionJobRequest,
   output: StartTargetedSentimentDetectionJobResponse,
@@ -7195,7 +7194,7 @@ export const startTopicsDetectionJob: API.OperationMethod<
   StartTopicsDetectionJobRequest,
   StartTopicsDetectionJobResponse,
   StartTopicsDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTopicsDetectionJobRequest,
   output: StartTopicsDetectionJobResponse,
@@ -7236,7 +7235,7 @@ export const stopDominantLanguageDetectionJob: API.OperationMethod<
   StopDominantLanguageDetectionJobRequest,
   StopDominantLanguageDetectionJobResponse,
   StopDominantLanguageDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDominantLanguageDetectionJobRequest,
   output: StopDominantLanguageDetectionJobResponse,
@@ -7274,7 +7273,7 @@ export const stopEntitiesDetectionJob: API.OperationMethod<
   StopEntitiesDetectionJobRequest,
   StopEntitiesDetectionJobResponse,
   StopEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEntitiesDetectionJobRequest,
   output: StopEntitiesDetectionJobResponse,
@@ -7301,7 +7300,7 @@ export const stopEventsDetectionJob: API.OperationMethod<
   StopEventsDetectionJobRequest,
   StopEventsDetectionJobResponse,
   StopEventsDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEventsDetectionJobRequest,
   output: StopEventsDetectionJobResponse,
@@ -7340,7 +7339,7 @@ export const stopKeyPhrasesDetectionJob: API.OperationMethod<
   StopKeyPhrasesDetectionJobRequest,
   StopKeyPhrasesDetectionJobResponse,
   StopKeyPhrasesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopKeyPhrasesDetectionJobRequest,
   output: StopKeyPhrasesDetectionJobResponse,
@@ -7366,7 +7365,7 @@ export const stopPiiEntitiesDetectionJob: API.OperationMethod<
   StopPiiEntitiesDetectionJobRequest,
   StopPiiEntitiesDetectionJobResponse,
   StopPiiEntitiesDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPiiEntitiesDetectionJobRequest,
   output: StopPiiEntitiesDetectionJobResponse,
@@ -7404,7 +7403,7 @@ export const stopSentimentDetectionJob: API.OperationMethod<
   StopSentimentDetectionJobRequest,
   StopSentimentDetectionJobResponse,
   StopSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSentimentDetectionJobRequest,
   output: StopSentimentDetectionJobResponse,
@@ -7442,7 +7441,7 @@ export const stopTargetedSentimentDetectionJob: API.OperationMethod<
   StopTargetedSentimentDetectionJobRequest,
   StopTargetedSentimentDetectionJobResponse,
   StopTargetedSentimentDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTargetedSentimentDetectionJobRequest,
   output: StopTargetedSentimentDetectionJobResponse,
@@ -7475,7 +7474,7 @@ export const stopTrainingDocumentClassifier: API.OperationMethod<
   StopTrainingDocumentClassifierRequest,
   StopTrainingDocumentClassifierResponse,
   StopTrainingDocumentClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTrainingDocumentClassifierRequest,
   output: StopTrainingDocumentClassifierResponse,
@@ -7509,7 +7508,7 @@ export const stopTrainingEntityRecognizer: API.OperationMethod<
   StopTrainingEntityRecognizerRequest,
   StopTrainingEntityRecognizerResponse,
   StopTrainingEntityRecognizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTrainingEntityRecognizerRequest,
   output: StopTrainingEntityRecognizerResponse,
@@ -7540,7 +7539,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7570,7 +7569,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7603,7 +7602,7 @@ export const updateEndpoint: API.OperationMethod<
   UpdateEndpointRequest,
   UpdateEndpointResponse,
   UpdateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointRequest,
   output: UpdateEndpointResponse,
@@ -7635,7 +7634,7 @@ export const updateFlywheel: API.OperationMethod<
   UpdateFlywheelRequest,
   UpdateFlywheelResponse,
   UpdateFlywheelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlywheelRequest,
   output: UpdateFlywheelResponse,

--- a/packages/aws/src/services/comprehendmedical.ts
+++ b/packages/aws/src/services/comprehendmedical.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ComprehendMedical",
   serviceShapeName: "ComprehendMedical_20181030",
@@ -1460,7 +1459,7 @@ export const describeEntitiesDetectionV2Job: API.OperationMethod<
   DescribeEntitiesDetectionV2JobRequest,
   DescribeEntitiesDetectionV2JobResponse,
   DescribeEntitiesDetectionV2JobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntitiesDetectionV2JobRequest,
   output: DescribeEntitiesDetectionV2JobResponse,
@@ -1489,7 +1488,7 @@ export const describeICD10CMInferenceJob: API.OperationMethod<
   DescribeICD10CMInferenceJobRequest,
   DescribeICD10CMInferenceJobResponse,
   DescribeICD10CMInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeICD10CMInferenceJobRequest,
   output: DescribeICD10CMInferenceJobResponse,
@@ -1518,7 +1517,7 @@ export const describePHIDetectionJob: API.OperationMethod<
   DescribePHIDetectionJobRequest,
   DescribePHIDetectionJobResponse,
   DescribePHIDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePHIDetectionJobRequest,
   output: DescribePHIDetectionJobResponse,
@@ -1547,7 +1546,7 @@ export const describeRxNormInferenceJob: API.OperationMethod<
   DescribeRxNormInferenceJobRequest,
   DescribeRxNormInferenceJobResponse,
   DescribeRxNormInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRxNormInferenceJobRequest,
   output: DescribeRxNormInferenceJobResponse,
@@ -1575,7 +1574,7 @@ export const describeSNOMEDCTInferenceJob: API.OperationMethod<
   DescribeSNOMEDCTInferenceJobRequest,
   DescribeSNOMEDCTInferenceJobResponse,
   DescribeSNOMEDCTInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSNOMEDCTInferenceJobRequest,
   output: DescribeSNOMEDCTInferenceJobResponse,
@@ -1609,7 +1608,7 @@ export const detectEntities: API.OperationMethod<
   DetectEntitiesRequest,
   DetectEntitiesResponse,
   DetectEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectEntitiesRequest,
   output: DetectEntitiesResponse,
@@ -1652,7 +1651,7 @@ export const detectEntitiesV2: API.OperationMethod<
   DetectEntitiesV2Request,
   DetectEntitiesV2Response,
   DetectEntitiesV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectEntitiesV2Request,
   output: DetectEntitiesV2Response,
@@ -1686,7 +1685,7 @@ export const detectPHI: API.OperationMethod<
   DetectPHIRequest,
   DetectPHIResponse,
   DetectPHIError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectPHIRequest,
   output: DetectPHIResponse,
@@ -1721,7 +1720,7 @@ export const inferICD10CM: API.OperationMethod<
   InferICD10CMRequest,
   InferICD10CMResponse,
   InferICD10CMError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InferICD10CMRequest,
   output: InferICD10CMResponse,
@@ -1755,7 +1754,7 @@ export const inferRxNorm: API.OperationMethod<
   InferRxNormRequest,
   InferRxNormResponse,
   InferRxNormError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InferRxNormRequest,
   output: InferRxNormResponse,
@@ -1787,7 +1786,7 @@ export const inferSNOMEDCT: API.OperationMethod<
   InferSNOMEDCTRequest,
   InferSNOMEDCTResponse,
   InferSNOMEDCTError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InferSNOMEDCTRequest,
   output: InferSNOMEDCTResponse,
@@ -1817,7 +1816,7 @@ export const listEntitiesDetectionV2Jobs: API.OperationMethod<
   ListEntitiesDetectionV2JobsRequest,
   ListEntitiesDetectionV2JobsResponse,
   ListEntitiesDetectionV2JobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEntitiesDetectionV2JobsRequest,
   output: ListEntitiesDetectionV2JobsResponse,
@@ -1845,7 +1844,7 @@ export const listICD10CMInferenceJobs: API.OperationMethod<
   ListICD10CMInferenceJobsRequest,
   ListICD10CMInferenceJobsResponse,
   ListICD10CMInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListICD10CMInferenceJobsRequest,
   output: ListICD10CMInferenceJobsResponse,
@@ -1874,7 +1873,7 @@ export const listPHIDetectionJobs: API.OperationMethod<
   ListPHIDetectionJobsRequest,
   ListPHIDetectionJobsResponse,
   ListPHIDetectionJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPHIDetectionJobsRequest,
   output: ListPHIDetectionJobsResponse,
@@ -1902,7 +1901,7 @@ export const listRxNormInferenceJobs: API.OperationMethod<
   ListRxNormInferenceJobsRequest,
   ListRxNormInferenceJobsResponse,
   ListRxNormInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRxNormInferenceJobsRequest,
   output: ListRxNormInferenceJobsResponse,
@@ -1930,7 +1929,7 @@ export const listSNOMEDCTInferenceJobs: API.OperationMethod<
   ListSNOMEDCTInferenceJobsRequest,
   ListSNOMEDCTInferenceJobsResponse,
   ListSNOMEDCTInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSNOMEDCTInferenceJobsRequest,
   output: ListSNOMEDCTInferenceJobsResponse,
@@ -1959,7 +1958,7 @@ export const startEntitiesDetectionV2Job: API.OperationMethod<
   StartEntitiesDetectionV2JobRequest,
   StartEntitiesDetectionV2JobResponse,
   StartEntitiesDetectionV2JobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEntitiesDetectionV2JobRequest,
   output: StartEntitiesDetectionV2JobResponse,
@@ -1989,7 +1988,7 @@ export const startICD10CMInferenceJob: API.OperationMethod<
   StartICD10CMInferenceJobRequest,
   StartICD10CMInferenceJobResponse,
   StartICD10CMInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartICD10CMInferenceJobRequest,
   output: StartICD10CMInferenceJobResponse,
@@ -2018,7 +2017,7 @@ export const startPHIDetectionJob: API.OperationMethod<
   StartPHIDetectionJobRequest,
   StartPHIDetectionJobResponse,
   StartPHIDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPHIDetectionJobRequest,
   output: StartPHIDetectionJobResponse,
@@ -2048,7 +2047,7 @@ export const startRxNormInferenceJob: API.OperationMethod<
   StartRxNormInferenceJobRequest,
   StartRxNormInferenceJobResponse,
   StartRxNormInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRxNormInferenceJobRequest,
   output: StartRxNormInferenceJobResponse,
@@ -2076,7 +2075,7 @@ export const startSNOMEDCTInferenceJob: API.OperationMethod<
   StartSNOMEDCTInferenceJobRequest,
   StartSNOMEDCTInferenceJobResponse,
   StartSNOMEDCTInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSNOMEDCTInferenceJobRequest,
   output: StartSNOMEDCTInferenceJobResponse,
@@ -2103,7 +2102,7 @@ export const stopEntitiesDetectionV2Job: API.OperationMethod<
   StopEntitiesDetectionV2JobRequest,
   StopEntitiesDetectionV2JobResponse,
   StopEntitiesDetectionV2JobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEntitiesDetectionV2JobRequest,
   output: StopEntitiesDetectionV2JobResponse,
@@ -2129,7 +2128,7 @@ export const stopICD10CMInferenceJob: API.OperationMethod<
   StopICD10CMInferenceJobRequest,
   StopICD10CMInferenceJobResponse,
   StopICD10CMInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopICD10CMInferenceJobRequest,
   output: StopICD10CMInferenceJobResponse,
@@ -2155,7 +2154,7 @@ export const stopPHIDetectionJob: API.OperationMethod<
   StopPHIDetectionJobRequest,
   StopPHIDetectionJobResponse,
   StopPHIDetectionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPHIDetectionJobRequest,
   output: StopPHIDetectionJobResponse,
@@ -2181,7 +2180,7 @@ export const stopRxNormInferenceJob: API.OperationMethod<
   StopRxNormInferenceJobRequest,
   StopRxNormInferenceJobResponse,
   StopRxNormInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRxNormInferenceJobRequest,
   output: StopRxNormInferenceJobResponse,
@@ -2208,7 +2207,7 @@ export const stopSNOMEDCTInferenceJob: API.OperationMethod<
   StopSNOMEDCTInferenceJobRequest,
   StopSNOMEDCTInferenceJobResponse,
   StopSNOMEDCTInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSNOMEDCTInferenceJobRequest,
   output: StopSNOMEDCTInferenceJobResponse,

--- a/packages/aws/src/services/compute-optimizer-automation.ts
+++ b/packages/aws/src/services/compute-optimizer-automation.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Compute Optimizer Automation",
   serviceShapeName: "ComputeOptimizerAutomationService",
@@ -1612,7 +1611,7 @@ export const associateAccounts: API.OperationMethod<
   AssociateAccountsRequest,
   AssociateAccountsResponse,
   AssociateAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAccountsRequest,
   output: AssociateAccountsResponse,
@@ -1653,7 +1652,7 @@ export const createAutomationRule: API.OperationMethod<
   CreateAutomationRuleRequest,
   CreateAutomationRuleResponse,
   CreateAutomationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomationRuleRequest,
   output: CreateAutomationRuleResponse,
@@ -1694,7 +1693,7 @@ export const deleteAutomationRule: API.OperationMethod<
   DeleteAutomationRuleRequest,
   DeleteAutomationRuleResponse,
   DeleteAutomationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomationRuleRequest,
   output: DeleteAutomationRuleResponse,
@@ -1736,7 +1735,7 @@ export const disassociateAccounts: API.OperationMethod<
   DisassociateAccountsRequest,
   DisassociateAccountsResponse,
   DisassociateAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAccountsRequest,
   output: DisassociateAccountsResponse,
@@ -1774,7 +1773,7 @@ export const getAutomationEvent: API.OperationMethod<
   GetAutomationEventRequest,
   GetAutomationEventResponse,
   GetAutomationEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomationEventRequest,
   output: GetAutomationEventResponse,
@@ -1810,7 +1809,7 @@ export const getAutomationRule: API.OperationMethod<
   GetAutomationRuleRequest,
   GetAutomationRuleResponse,
   GetAutomationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomationRuleRequest,
   output: GetAutomationRuleResponse,
@@ -1846,7 +1845,7 @@ export const getEnrollmentConfiguration: API.OperationMethod<
   GetEnrollmentConfigurationRequest,
   GetEnrollmentConfigurationResponse,
   GetEnrollmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnrollmentConfigurationRequest,
   output: GetEnrollmentConfigurationResponse,
@@ -1884,7 +1883,7 @@ export const listAccounts: API.PaginatedOperationMethod<
   ListAccountsRequest,
   ListAccountsResponse,
   ListAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsRequest,
@@ -1926,7 +1925,7 @@ export const listAutomationEvents: API.PaginatedOperationMethod<
   ListAutomationEventsRequest,
   ListAutomationEventsResponse,
   ListAutomationEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationEventsRequest,
@@ -1968,7 +1967,7 @@ export const listAutomationEventSteps: API.PaginatedOperationMethod<
   ListAutomationEventStepsRequest,
   ListAutomationEventStepsResponse,
   ListAutomationEventStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomationEventStep
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationEventStepsRequest,
@@ -2010,7 +2009,7 @@ export const listAutomationEventSummaries: API.PaginatedOperationMethod<
   ListAutomationEventSummariesRequest,
   ListAutomationEventSummariesResponse,
   ListAutomationEventSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomationEventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationEventSummariesRequest,
@@ -2051,7 +2050,7 @@ export const listAutomationRulePreview: API.PaginatedOperationMethod<
   ListAutomationRulePreviewRequest,
   ListAutomationRulePreviewResponse,
   ListAutomationRulePreviewError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PreviewResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationRulePreviewRequest,
@@ -2092,7 +2091,7 @@ export const listAutomationRulePreviewSummaries: API.PaginatedOperationMethod<
   ListAutomationRulePreviewSummariesRequest,
   ListAutomationRulePreviewSummariesResponse,
   ListAutomationRulePreviewSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PreviewResultSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationRulePreviewSummariesRequest,
@@ -2133,7 +2132,7 @@ export const listAutomationRules: API.PaginatedOperationMethod<
   ListAutomationRulesRequest,
   ListAutomationRulesResponse,
   ListAutomationRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomationRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomationRulesRequest,
@@ -2176,7 +2175,7 @@ export const listRecommendedActions: API.PaginatedOperationMethod<
   ListRecommendedActionsRequest,
   ListRecommendedActionsResponse,
   ListRecommendedActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendedAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendedActionsRequest,
@@ -2219,7 +2218,7 @@ export const listRecommendedActionSummaries: API.PaginatedOperationMethod<
   ListRecommendedActionSummariesRequest,
   ListRecommendedActionSummariesResponse,
   ListRecommendedActionSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendedActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendedActionSummariesRequest,
@@ -2261,7 +2260,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2301,7 +2300,7 @@ export const rollbackAutomationEvent: API.OperationMethod<
   RollbackAutomationEventRequest,
   RollbackAutomationEventResponse,
   RollbackAutomationEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackAutomationEventRequest,
   output: RollbackAutomationEventResponse,
@@ -2344,7 +2343,7 @@ export const startAutomationEvent: API.OperationMethod<
   StartAutomationEventRequest,
   StartAutomationEventResponse,
   StartAutomationEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutomationEventRequest,
   output: StartAutomationEventResponse,
@@ -2385,7 +2384,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2425,7 +2424,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2465,7 +2464,7 @@ export const updateAutomationRule: API.OperationMethod<
   UpdateAutomationRuleRequest,
   UpdateAutomationRuleResponse,
   UpdateAutomationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomationRuleRequest,
   output: UpdateAutomationRuleResponse,
@@ -2506,7 +2505,7 @@ export const updateEnrollmentConfiguration: API.OperationMethod<
   UpdateEnrollmentConfigurationRequest,
   UpdateEnrollmentConfigurationResponse,
   UpdateEnrollmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnrollmentConfigurationRequest,
   output: UpdateEnrollmentConfigurationResponse,

--- a/packages/aws/src/services/compute-optimizer.ts
+++ b/packages/aws/src/services/compute-optimizer.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Compute Optimizer",
   serviceShapeName: "ComputeOptimizerService",
@@ -4219,7 +4218,7 @@ export const deleteRecommendationPreferences: API.OperationMethod<
   DeleteRecommendationPreferencesRequest,
   DeleteRecommendationPreferencesResponse,
   DeleteRecommendationPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommendationPreferencesRequest,
   output: DeleteRecommendationPreferencesResponse,
@@ -4259,7 +4258,7 @@ export const describeRecommendationExportJobs: API.PaginatedOperationMethod<
   DescribeRecommendationExportJobsRequest,
   DescribeRecommendationExportJobsResponse,
   DescribeRecommendationExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationExportJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRecommendationExportJobsRequest,
@@ -4309,7 +4308,7 @@ export const exportAutoScalingGroupRecommendations: API.OperationMethod<
   ExportAutoScalingGroupRecommendationsRequest,
   ExportAutoScalingGroupRecommendationsResponse,
   ExportAutoScalingGroupRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportAutoScalingGroupRecommendationsRequest,
   output: ExportAutoScalingGroupRecommendationsResponse,
@@ -4352,7 +4351,7 @@ export const exportEBSVolumeRecommendations: API.OperationMethod<
   ExportEBSVolumeRecommendationsRequest,
   ExportEBSVolumeRecommendationsResponse,
   ExportEBSVolumeRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportEBSVolumeRecommendationsRequest,
   output: ExportEBSVolumeRecommendationsResponse,
@@ -4395,7 +4394,7 @@ export const exportEC2InstanceRecommendations: API.OperationMethod<
   ExportEC2InstanceRecommendationsRequest,
   ExportEC2InstanceRecommendationsResponse,
   ExportEC2InstanceRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportEC2InstanceRecommendationsRequest,
   output: ExportEC2InstanceRecommendationsResponse,
@@ -4438,7 +4437,7 @@ export const exportECSServiceRecommendations: API.OperationMethod<
   ExportECSServiceRecommendationsRequest,
   ExportECSServiceRecommendationsResponse,
   ExportECSServiceRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportECSServiceRecommendationsRequest,
   output: ExportECSServiceRecommendationsResponse,
@@ -4481,7 +4480,7 @@ export const exportIdleRecommendations: API.OperationMethod<
   ExportIdleRecommendationsRequest,
   ExportIdleRecommendationsResponse,
   ExportIdleRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportIdleRecommendationsRequest,
   output: ExportIdleRecommendationsResponse,
@@ -4524,7 +4523,7 @@ export const exportLambdaFunctionRecommendations: API.OperationMethod<
   ExportLambdaFunctionRecommendationsRequest,
   ExportLambdaFunctionRecommendationsResponse,
   ExportLambdaFunctionRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportLambdaFunctionRecommendationsRequest,
   output: ExportLambdaFunctionRecommendationsResponse,
@@ -4567,7 +4566,7 @@ export const exportLicenseRecommendations: API.OperationMethod<
   ExportLicenseRecommendationsRequest,
   ExportLicenseRecommendationsResponse,
   ExportLicenseRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportLicenseRecommendationsRequest,
   output: ExportLicenseRecommendationsResponse,
@@ -4610,7 +4609,7 @@ export const exportRDSDatabaseRecommendations: API.OperationMethod<
   ExportRDSDatabaseRecommendationsRequest,
   ExportRDSDatabaseRecommendationsResponse,
   ExportRDSDatabaseRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportRDSDatabaseRecommendationsRequest,
   output: ExportRDSDatabaseRecommendationsResponse,
@@ -4651,7 +4650,7 @@ export const getAutoScalingGroupRecommendations: API.OperationMethod<
   GetAutoScalingGroupRecommendationsRequest,
   GetAutoScalingGroupRecommendationsResponse,
   GetAutoScalingGroupRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoScalingGroupRecommendationsRequest,
   output: GetAutoScalingGroupRecommendationsResponse,
@@ -4692,7 +4691,7 @@ export const getEBSVolumeRecommendations: API.OperationMethod<
   GetEBSVolumeRecommendationsRequest,
   GetEBSVolumeRecommendationsResponse,
   GetEBSVolumeRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEBSVolumeRecommendationsRequest,
   output: GetEBSVolumeRecommendationsResponse,
@@ -4733,7 +4732,7 @@ export const getEC2InstanceRecommendations: API.OperationMethod<
   GetEC2InstanceRecommendationsRequest,
   GetEC2InstanceRecommendationsResponse,
   GetEC2InstanceRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEC2InstanceRecommendationsRequest,
   output: GetEC2InstanceRecommendationsResponse,
@@ -4775,7 +4774,7 @@ export const getEC2RecommendationProjectedMetrics: API.OperationMethod<
   GetEC2RecommendationProjectedMetricsRequest,
   GetEC2RecommendationProjectedMetricsResponse,
   GetEC2RecommendationProjectedMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEC2RecommendationProjectedMetricsRequest,
   output: GetEC2RecommendationProjectedMetricsResponse,
@@ -4811,7 +4810,7 @@ export const getECSServiceRecommendationProjectedMetrics: API.OperationMethod<
   GetECSServiceRecommendationProjectedMetricsRequest,
   GetECSServiceRecommendationProjectedMetricsResponse,
   GetECSServiceRecommendationProjectedMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetECSServiceRecommendationProjectedMetricsRequest,
   output: GetECSServiceRecommendationProjectedMetricsResponse,
@@ -4853,7 +4852,7 @@ export const getECSServiceRecommendations: API.OperationMethod<
   GetECSServiceRecommendationsRequest,
   GetECSServiceRecommendationsResponse,
   GetECSServiceRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetECSServiceRecommendationsRequest,
   output: GetECSServiceRecommendationsResponse,
@@ -4895,7 +4894,7 @@ export const getEffectiveRecommendationPreferences: API.OperationMethod<
   GetEffectiveRecommendationPreferencesRequest,
   GetEffectiveRecommendationPreferencesResponse,
   GetEffectiveRecommendationPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEffectiveRecommendationPreferencesRequest,
   output: GetEffectiveRecommendationPreferencesResponse,
@@ -4934,7 +4933,7 @@ export const getEnrollmentStatus: API.OperationMethod<
   GetEnrollmentStatusRequest,
   GetEnrollmentStatusResponse,
   GetEnrollmentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnrollmentStatusRequest,
   output: GetEnrollmentStatusResponse,
@@ -4969,7 +4968,7 @@ export const getEnrollmentStatusesForOrganization: API.PaginatedOperationMethod<
   GetEnrollmentStatusesForOrganizationRequest,
   GetEnrollmentStatusesForOrganizationResponse,
   GetEnrollmentStatusesForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountEnrollmentStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEnrollmentStatusesForOrganizationRequest,
@@ -5013,7 +5012,7 @@ export const getIdleRecommendations: API.OperationMethod<
   GetIdleRecommendationsRequest,
   GetIdleRecommendationsResponse,
   GetIdleRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdleRecommendationsRequest,
   output: GetIdleRecommendationsResponse,
@@ -5054,7 +5053,7 @@ export const getLambdaFunctionRecommendations: API.PaginatedOperationMethod<
   GetLambdaFunctionRecommendationsRequest,
   GetLambdaFunctionRecommendationsResponse,
   GetLambdaFunctionRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LambdaFunctionRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLambdaFunctionRecommendationsRequest,
@@ -5102,7 +5101,7 @@ export const getLicenseRecommendations: API.OperationMethod<
   GetLicenseRecommendationsRequest,
   GetLicenseRecommendationsResponse,
   GetLicenseRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseRecommendationsRequest,
   output: GetLicenseRecommendationsResponse,
@@ -5138,7 +5137,7 @@ export const getRDSDatabaseRecommendationProjectedMetrics: API.OperationMethod<
   GetRDSDatabaseRecommendationProjectedMetricsRequest,
   GetRDSDatabaseRecommendationProjectedMetricsResponse,
   GetRDSDatabaseRecommendationProjectedMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRDSDatabaseRecommendationProjectedMetricsRequest,
   output: GetRDSDatabaseRecommendationProjectedMetricsResponse,
@@ -5180,7 +5179,7 @@ export const getRDSDatabaseRecommendations: API.OperationMethod<
   GetRDSDatabaseRecommendationsRequest,
   GetRDSDatabaseRecommendationsResponse,
   GetRDSDatabaseRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRDSDatabaseRecommendationsRequest,
   output: GetRDSDatabaseRecommendationsResponse,
@@ -5225,7 +5224,7 @@ export const getRecommendationPreferences: API.PaginatedOperationMethod<
   GetRecommendationPreferencesRequest,
   GetRecommendationPreferencesResponse,
   GetRecommendationPreferencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationPreferencesDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRecommendationPreferencesRequest,
@@ -5291,7 +5290,7 @@ export const getRecommendationSummaries: API.PaginatedOperationMethod<
   GetRecommendationSummariesRequest,
   GetRecommendationSummariesResponse,
   GetRecommendationSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRecommendationSummariesRequest,
@@ -5338,7 +5337,7 @@ export const putRecommendationPreferences: API.OperationMethod<
   PutRecommendationPreferencesRequest,
   PutRecommendationPreferencesResponse,
   PutRecommendationPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecommendationPreferencesRequest,
   output: PutRecommendationPreferencesResponse,
@@ -5382,7 +5381,7 @@ export const updateEnrollmentStatus: API.OperationMethod<
   UpdateEnrollmentStatusRequest,
   UpdateEnrollmentStatusResponse,
   UpdateEnrollmentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnrollmentStatusRequest,
   output: UpdateEnrollmentStatusResponse,

--- a/packages/aws/src/services/config-service.ts
+++ b/packages/aws/src/services/config-service.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://config.amazonaws.com/doc/2014-11-12/");
 const svc = T.AwsApiService({
   sdkId: "Config Service",
@@ -6702,7 +6701,7 @@ export const associateResourceTypes: API.OperationMethod<
   AssociateResourceTypesRequest,
   AssociateResourceTypesResponse,
   AssociateResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceTypesRequest,
   output: AssociateResourceTypesResponse,
@@ -6732,7 +6731,7 @@ export const batchGetAggregateResourceConfig: API.OperationMethod<
   BatchGetAggregateResourceConfigRequest,
   BatchGetAggregateResourceConfigResponse,
   BatchGetAggregateResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAggregateResourceConfigRequest,
   output: BatchGetAggregateResourceConfigResponse,
@@ -6765,7 +6764,7 @@ export const batchGetResourceConfig: API.OperationMethod<
   BatchGetResourceConfigRequest,
   BatchGetResourceConfigResponse,
   BatchGetResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetResourceConfigRequest,
   output: BatchGetResourceConfigResponse,
@@ -6786,7 +6785,7 @@ export const deleteAggregationAuthorization: API.OperationMethod<
   DeleteAggregationAuthorizationRequest,
   DeleteAggregationAuthorizationResponse,
   DeleteAggregationAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAggregationAuthorizationRequest,
   output: DeleteAggregationAuthorizationResponse,
@@ -6829,7 +6828,7 @@ export const deleteConfigRule: API.OperationMethod<
   DeleteConfigRuleRequest,
   DeleteConfigRuleResponse,
   DeleteConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigRuleRequest,
   output: DeleteConfigRuleResponse,
@@ -6850,7 +6849,7 @@ export const deleteConfigurationAggregator: API.OperationMethod<
   DeleteConfigurationAggregatorRequest,
   DeleteConfigurationAggregatorResponse,
   DeleteConfigurationAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationAggregatorRequest,
   output: DeleteConfigurationAggregatorResponse,
@@ -6878,7 +6877,7 @@ export const deleteConfigurationRecorder: API.OperationMethod<
   DeleteConfigurationRecorderRequest,
   DeleteConfigurationRecorderResponse,
   DeleteConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationRecorderRequest,
   output: DeleteConfigurationRecorderResponse,
@@ -6915,7 +6914,7 @@ export const deleteConformancePack: API.OperationMethod<
   DeleteConformancePackRequest,
   DeleteConformancePackResponse,
   DeleteConformancePackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConformancePackRequest,
   output: DeleteConformancePackResponse,
@@ -6938,7 +6937,7 @@ export const deleteDeliveryChannel: API.OperationMethod<
   DeleteDeliveryChannelRequest,
   DeleteDeliveryChannelResponse,
   DeleteDeliveryChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliveryChannelRequest,
   output: DeleteDeliveryChannelResponse,
@@ -6965,7 +6964,7 @@ export const deleteEvaluationResults: API.OperationMethod<
   DeleteEvaluationResultsRequest,
   DeleteEvaluationResultsResponse,
   DeleteEvaluationResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEvaluationResultsRequest,
   output: DeleteEvaluationResultsResponse,
@@ -7006,7 +7005,7 @@ export const deleteOrganizationConfigRule: API.OperationMethod<
   DeleteOrganizationConfigRuleRequest,
   DeleteOrganizationConfigRuleResponse,
   DeleteOrganizationConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOrganizationConfigRuleRequest,
   output: DeleteOrganizationConfigRuleResponse,
@@ -7052,7 +7051,7 @@ export const deleteOrganizationConformancePack: API.OperationMethod<
   DeleteOrganizationConformancePackRequest,
   DeleteOrganizationConformancePackResponse,
   DeleteOrganizationConformancePackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOrganizationConformancePackRequest,
   output: DeleteOrganizationConformancePackResponse,
@@ -7077,7 +7076,7 @@ export const deletePendingAggregationRequest: API.OperationMethod<
   DeletePendingAggregationRequestRequest,
   DeletePendingAggregationRequestResponse,
   DeletePendingAggregationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePendingAggregationRequestRequest,
   output: DeletePendingAggregationRequestResponse,
@@ -7100,7 +7099,7 @@ export const deleteRemediationConfiguration: API.OperationMethod<
   DeleteRemediationConfigurationRequest,
   DeleteRemediationConfigurationResponse,
   DeleteRemediationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRemediationConfigurationRequest,
   output: DeleteRemediationConfigurationResponse,
@@ -7128,7 +7127,7 @@ export const deleteRemediationExceptions: API.OperationMethod<
   DeleteRemediationExceptionsRequest,
   DeleteRemediationExceptionsResponse,
   DeleteRemediationExceptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRemediationExceptionsRequest,
   output: DeleteRemediationExceptionsResponse,
@@ -7149,7 +7148,7 @@ export const deleteResourceConfig: API.OperationMethod<
   DeleteResourceConfigRequest,
   DeleteResourceConfigResponse,
   DeleteResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceConfigRequest,
   output: DeleteResourceConfigResponse,
@@ -7170,7 +7169,7 @@ export const deleteRetentionConfiguration: API.OperationMethod<
   DeleteRetentionConfigurationRequest,
   DeleteRetentionConfigurationResponse,
   DeleteRetentionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRetentionConfigurationRequest,
   output: DeleteRetentionConfigurationResponse,
@@ -7205,7 +7204,7 @@ export const deleteServiceLinkedConfigurationRecorder: API.OperationMethod<
   DeleteServiceLinkedConfigurationRecorderRequest,
   DeleteServiceLinkedConfigurationRecorderResponse,
   DeleteServiceLinkedConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceLinkedConfigurationRecorderRequest,
   output: DeleteServiceLinkedConfigurationRecorderResponse,
@@ -7230,7 +7229,7 @@ export const deleteStoredQuery: API.OperationMethod<
   DeleteStoredQueryRequest,
   DeleteStoredQueryResponse,
   DeleteStoredQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStoredQueryRequest,
   output: DeleteStoredQueryResponse,
@@ -7263,7 +7262,7 @@ export const deliverConfigSnapshot: API.OperationMethod<
   DeliverConfigSnapshotRequest,
   DeliverConfigSnapshotResponse,
   DeliverConfigSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeliverConfigSnapshotRequest,
   output: DeliverConfigSnapshotResponse,
@@ -7295,7 +7294,7 @@ export const describeAggregateComplianceByConfigRules: API.PaginatedOperationMet
   DescribeAggregateComplianceByConfigRulesRequest,
   DescribeAggregateComplianceByConfigRulesResponse,
   DescribeAggregateComplianceByConfigRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAggregateComplianceByConfigRulesRequest,
@@ -7332,7 +7331,7 @@ export const describeAggregateComplianceByConformancePacks: API.PaginatedOperati
   DescribeAggregateComplianceByConformancePacksRequest,
   DescribeAggregateComplianceByConformancePacksResponse,
   DescribeAggregateComplianceByConformancePacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregateComplianceByConformancePack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAggregateComplianceByConformancePacksRequest,
@@ -7367,7 +7366,7 @@ export const describeAggregationAuthorizations: API.PaginatedOperationMethod<
   DescribeAggregationAuthorizationsRequest,
   DescribeAggregationAuthorizationsResponse,
   DescribeAggregationAuthorizationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregationAuthorization
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAggregationAuthorizationsRequest,
@@ -7429,7 +7428,7 @@ export const describeComplianceByConfigRule: API.PaginatedOperationMethod<
   DescribeComplianceByConfigRuleRequest,
   DescribeComplianceByConfigRuleResponse,
   DescribeComplianceByConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComplianceByConfigRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeComplianceByConfigRuleRequest,
@@ -7489,7 +7488,7 @@ export const describeComplianceByResource: API.PaginatedOperationMethod<
   DescribeComplianceByResourceRequest,
   DescribeComplianceByResourceResponse,
   DescribeComplianceByResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComplianceByResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeComplianceByResourceRequest,
@@ -7519,7 +7518,7 @@ export const describeConfigRuleEvaluationStatus: API.PaginatedOperationMethod<
   DescribeConfigRuleEvaluationStatusRequest,
   DescribeConfigRuleEvaluationStatusResponse,
   DescribeConfigRuleEvaluationStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigRuleEvaluationStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigRuleEvaluationStatusRequest,
@@ -7552,7 +7551,7 @@ export const describeConfigRules: API.PaginatedOperationMethod<
   DescribeConfigRulesRequest,
   DescribeConfigRulesResponse,
   DescribeConfigRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigRulesRequest,
@@ -7588,7 +7587,7 @@ export const describeConfigurationAggregators: API.PaginatedOperationMethod<
   DescribeConfigurationAggregatorsRequest,
   DescribeConfigurationAggregatorsResponse,
   DescribeConfigurationAggregatorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationAggregator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigurationAggregatorsRequest,
@@ -7624,7 +7623,7 @@ export const describeConfigurationAggregatorSourcesStatus: API.PaginatedOperatio
   DescribeConfigurationAggregatorSourcesStatusRequest,
   DescribeConfigurationAggregatorSourcesStatusResponse,
   DescribeConfigurationAggregatorSourcesStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregatedSourceStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigurationAggregatorSourcesStatusRequest,
@@ -7662,7 +7661,7 @@ export const describeConfigurationRecorders: API.OperationMethod<
   DescribeConfigurationRecordersRequest,
   DescribeConfigurationRecordersResponse,
   DescribeConfigurationRecordersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRecordersRequest,
   output: DescribeConfigurationRecordersResponse,
@@ -7691,7 +7690,7 @@ export const describeConfigurationRecorderStatus: API.OperationMethod<
   DescribeConfigurationRecorderStatusRequest,
   DescribeConfigurationRecorderStatusResponse,
   DescribeConfigurationRecorderStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRecorderStatusRequest,
   output: DescribeConfigurationRecorderStatusResponse,
@@ -7717,7 +7716,7 @@ export const describeConformancePackCompliance: API.PaginatedOperationMethod<
   DescribeConformancePackComplianceRequest,
   DescribeConformancePackComplianceResponse,
   DescribeConformancePackComplianceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConformancePackRuleCompliance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConformancePackComplianceRequest,
@@ -7753,7 +7752,7 @@ export const describeConformancePacks: API.PaginatedOperationMethod<
   DescribeConformancePacksRequest,
   DescribeConformancePacksResponse,
   DescribeConformancePacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConformancePackDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConformancePacksRequest,
@@ -7789,7 +7788,7 @@ export const describeConformancePackStatus: API.PaginatedOperationMethod<
   DescribeConformancePackStatusRequest,
   DescribeConformancePackStatusResponse,
   DescribeConformancePackStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConformancePackStatusDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConformancePackStatusRequest,
@@ -7825,7 +7824,7 @@ export const describeDeliveryChannels: API.OperationMethod<
   DescribeDeliveryChannelsRequest,
   DescribeDeliveryChannelsResponse,
   DescribeDeliveryChannelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeliveryChannelsRequest,
   output: DescribeDeliveryChannelsResponse,
@@ -7851,7 +7850,7 @@ export const describeDeliveryChannelStatus: API.OperationMethod<
   DescribeDeliveryChannelStatusRequest,
   DescribeDeliveryChannelStatusResponse,
   DescribeDeliveryChannelStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeliveryChannelStatusRequest,
   output: DescribeDeliveryChannelStatusResponse,
@@ -7892,7 +7891,7 @@ export const describeOrganizationConfigRules: API.PaginatedOperationMethod<
   DescribeOrganizationConfigRulesRequest,
   DescribeOrganizationConfigRulesResponse,
   DescribeOrganizationConfigRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationConfigRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationConfigRulesRequest,
@@ -7934,7 +7933,7 @@ export const describeOrganizationConfigRuleStatuses: API.PaginatedOperationMetho
   DescribeOrganizationConfigRuleStatusesRequest,
   DescribeOrganizationConfigRuleStatusesResponse,
   DescribeOrganizationConfigRuleStatusesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationConfigRuleStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationConfigRuleStatusesRequest,
@@ -7987,7 +7986,7 @@ export const describeOrganizationConformancePacks: API.PaginatedOperationMethod<
   DescribeOrganizationConformancePacksRequest,
   DescribeOrganizationConformancePacksResponse,
   DescribeOrganizationConformancePacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationConformancePack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationConformancePacksRequest,
@@ -8029,7 +8028,7 @@ export const describeOrganizationConformancePackStatuses: API.PaginatedOperation
   DescribeOrganizationConformancePackStatusesRequest,
   DescribeOrganizationConformancePackStatusesResponse,
   DescribeOrganizationConformancePackStatusesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationConformancePackStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationConformancePackStatusesRequest,
@@ -8063,7 +8062,7 @@ export const describePendingAggregationRequests: API.PaginatedOperationMethod<
   DescribePendingAggregationRequestsRequest,
   DescribePendingAggregationRequestsResponse,
   DescribePendingAggregationRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PendingAggregationRequest
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePendingAggregationRequestsRequest,
@@ -8092,7 +8091,7 @@ export const describeRemediationConfigurations: API.OperationMethod<
   DescribeRemediationConfigurationsRequest,
   DescribeRemediationConfigurationsResponse,
   DescribeRemediationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRemediationConfigurationsRequest,
   output: DescribeRemediationConfigurationsResponse,
@@ -8121,7 +8120,7 @@ export const describeRemediationExceptions: API.PaginatedOperationMethod<
   DescribeRemediationExceptionsRequest,
   DescribeRemediationExceptionsResponse,
   DescribeRemediationExceptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRemediationExceptionsRequest,
@@ -8150,7 +8149,7 @@ export const describeRemediationExecutionStatus: API.PaginatedOperationMethod<
   DescribeRemediationExecutionStatusRequest,
   DescribeRemediationExecutionStatusResponse,
   DescribeRemediationExecutionStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RemediationExecutionStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRemediationExecutionStatusRequest,
@@ -8189,7 +8188,7 @@ export const describeRetentionConfigurations: API.PaginatedOperationMethod<
   DescribeRetentionConfigurationsRequest,
   DescribeRetentionConfigurationsResponse,
   DescribeRetentionConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RetentionConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRetentionConfigurationsRequest,
@@ -8223,7 +8222,7 @@ export const disassociateResourceTypes: API.OperationMethod<
   DisassociateResourceTypesRequest,
   DisassociateResourceTypesResponse,
   DisassociateResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceTypesRequest,
   output: DisassociateResourceTypesResponse,
@@ -8257,7 +8256,7 @@ export const getAggregateComplianceDetailsByConfigRule: API.PaginatedOperationMe
   GetAggregateComplianceDetailsByConfigRuleRequest,
   GetAggregateComplianceDetailsByConfigRuleResponse,
   GetAggregateComplianceDetailsByConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregateEvaluationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAggregateComplianceDetailsByConfigRuleRequest,
@@ -8297,7 +8296,7 @@ export const getAggregateConfigRuleComplianceSummary: API.PaginatedOperationMeth
   GetAggregateConfigRuleComplianceSummaryRequest,
   GetAggregateConfigRuleComplianceSummaryResponse,
   GetAggregateConfigRuleComplianceSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAggregateConfigRuleComplianceSummaryRequest,
@@ -8333,7 +8332,7 @@ export const getAggregateConformancePackComplianceSummary: API.PaginatedOperatio
   GetAggregateConformancePackComplianceSummaryRequest,
   GetAggregateConformancePackComplianceSummaryResponse,
   GetAggregateConformancePackComplianceSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAggregateConformancePackComplianceSummaryRequest,
@@ -8370,7 +8369,7 @@ export const getAggregateDiscoveredResourceCounts: API.PaginatedOperationMethod<
   GetAggregateDiscoveredResourceCountsRequest,
   GetAggregateDiscoveredResourceCountsResponse,
   GetAggregateDiscoveredResourceCountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAggregateDiscoveredResourceCountsRequest,
@@ -8406,7 +8405,7 @@ export const getAggregateResourceConfig: API.OperationMethod<
   GetAggregateResourceConfigRequest,
   GetAggregateResourceConfigResponse,
   GetAggregateResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAggregateResourceConfigRequest,
   output: GetAggregateResourceConfigResponse,
@@ -8436,7 +8435,7 @@ export const getComplianceDetailsByConfigRule: API.PaginatedOperationMethod<
   GetComplianceDetailsByConfigRuleRequest,
   GetComplianceDetailsByConfigRuleResponse,
   GetComplianceDetailsByConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetComplianceDetailsByConfigRuleRequest,
@@ -8470,7 +8469,7 @@ export const getComplianceDetailsByResource: API.PaginatedOperationMethod<
   GetComplianceDetailsByResourceRequest,
   GetComplianceDetailsByResourceResponse,
   GetComplianceDetailsByResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetComplianceDetailsByResourceRequest,
@@ -8495,7 +8494,7 @@ export const getComplianceSummaryByConfigRule: API.OperationMethod<
   GetComplianceSummaryByConfigRuleRequest,
   GetComplianceSummaryByConfigRuleResponse,
   GetComplianceSummaryByConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComplianceSummaryByConfigRuleRequest,
   output: GetComplianceSummaryByConfigRuleResponse,
@@ -8518,7 +8517,7 @@ export const getComplianceSummaryByResourceType: API.OperationMethod<
   GetComplianceSummaryByResourceTypeRequest,
   GetComplianceSummaryByResourceTypeResponse,
   GetComplianceSummaryByResourceTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComplianceSummaryByResourceTypeRequest,
   output: GetComplianceSummaryByResourceTypeResponse,
@@ -8542,7 +8541,7 @@ export const getConformancePackComplianceDetails: API.PaginatedOperationMethod<
   GetConformancePackComplianceDetailsRequest,
   GetConformancePackComplianceDetailsResponse,
   GetConformancePackComplianceDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConformancePackComplianceDetailsRequest,
@@ -8576,7 +8575,7 @@ export const getConformancePackComplianceSummary: API.PaginatedOperationMethod<
   GetConformancePackComplianceSummaryRequest,
   GetConformancePackComplianceSummaryResponse,
   GetConformancePackComplianceSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConformancePackComplianceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConformancePackComplianceSummaryRequest,
@@ -8605,7 +8604,7 @@ export const getCustomRulePolicy: API.OperationMethod<
   GetCustomRulePolicyRequest,
   GetCustomRulePolicyResponse,
   GetCustomRulePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomRulePolicyRequest,
   output: GetCustomRulePolicyResponse,
@@ -8669,7 +8668,7 @@ export const getDiscoveredResourceCounts: API.PaginatedOperationMethod<
   GetDiscoveredResourceCountsRequest,
   GetDiscoveredResourceCountsResponse,
   GetDiscoveredResourceCountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDiscoveredResourceCountsRequest,
@@ -8702,7 +8701,7 @@ export const getOrganizationConfigRuleDetailedStatus: API.PaginatedOperationMeth
   GetOrganizationConfigRuleDetailedStatusRequest,
   GetOrganizationConfigRuleDetailedStatusResponse,
   GetOrganizationConfigRuleDetailedStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemberAccountStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOrganizationConfigRuleDetailedStatusRequest,
@@ -8737,7 +8736,7 @@ export const getOrganizationConformancePackDetailedStatus: API.PaginatedOperatio
   GetOrganizationConformancePackDetailedStatusRequest,
   GetOrganizationConformancePackDetailedStatusResponse,
   GetOrganizationConformancePackDetailedStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationConformancePackDetailedStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOrganizationConformancePackDetailedStatusRequest,
@@ -8770,7 +8769,7 @@ export const getOrganizationCustomRulePolicy: API.OperationMethod<
   GetOrganizationCustomRulePolicyRequest,
   GetOrganizationCustomRulePolicyResponse,
   GetOrganizationCustomRulePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrganizationCustomRulePolicyRequest,
   output: GetOrganizationCustomRulePolicyResponse,
@@ -8826,7 +8825,7 @@ export const getResourceConfigHistory: API.PaginatedOperationMethod<
   GetResourceConfigHistoryRequest,
   GetResourceConfigHistoryResponse,
   GetResourceConfigHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceConfigHistoryRequest,
@@ -8865,7 +8864,7 @@ export const getResourceEvaluationSummary: API.OperationMethod<
   GetResourceEvaluationSummaryRequest,
   GetResourceEvaluationSummaryResponse,
   GetResourceEvaluationSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceEvaluationSummaryRequest,
   output: GetResourceEvaluationSummaryResponse,
@@ -8886,7 +8885,7 @@ export const getStoredQuery: API.OperationMethod<
   GetStoredQueryRequest,
   GetStoredQueryResponse,
   GetStoredQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStoredQueryRequest,
   output: GetStoredQueryResponse,
@@ -8913,7 +8912,7 @@ export const listAggregateDiscoveredResources: API.PaginatedOperationMethod<
   ListAggregateDiscoveredResourcesRequest,
   ListAggregateDiscoveredResourcesResponse,
   ListAggregateDiscoveredResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregateResourceIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAggregateDiscoveredResourcesRequest,
@@ -8945,7 +8944,7 @@ export const listConfigurationRecorders: API.PaginatedOperationMethod<
   ListConfigurationRecordersRequest,
   ListConfigurationRecordersResponse,
   ListConfigurationRecordersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationRecorderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationRecordersRequest,
@@ -8979,7 +8978,7 @@ export const listConformancePackComplianceScores: API.PaginatedOperationMethod<
   ListConformancePackComplianceScoresRequest,
   ListConformancePackComplianceScoresResponse,
   ListConformancePackComplianceScoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConformancePackComplianceScoresRequest,
@@ -9045,7 +9044,7 @@ export const listDiscoveredResources: API.PaginatedOperationMethod<
   ListDiscoveredResourcesRequest,
   ListDiscoveredResourcesResponse,
   ListDiscoveredResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDiscoveredResourcesRequest,
@@ -9079,7 +9078,7 @@ export const listResourceEvaluations: API.PaginatedOperationMethod<
   ListResourceEvaluationsRequest,
   ListResourceEvaluationsResponse,
   ListResourceEvaluationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceEvaluation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceEvaluationsRequest,
@@ -9111,7 +9110,7 @@ export const listStoredQueries: API.PaginatedOperationMethod<
   ListStoredQueriesRequest,
   ListStoredQueriesResponse,
   ListStoredQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStoredQueriesRequest,
@@ -9140,7 +9139,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -9180,7 +9179,7 @@ export const putAggregationAuthorization: API.OperationMethod<
   PutAggregationAuthorizationRequest,
   PutAggregationAuthorizationResponse,
   PutAggregationAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAggregationAuthorizationRequest,
   output: PutAggregationAuthorizationResponse,
@@ -9255,7 +9254,7 @@ export const putConfigRule: API.OperationMethod<
   PutConfigRuleRequest,
   PutConfigRuleResponse,
   PutConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigRuleRequest,
   output: PutConfigRuleResponse,
@@ -9307,7 +9306,7 @@ export const putConfigurationAggregator: API.OperationMethod<
   PutConfigurationAggregatorRequest,
   PutConfigurationAggregatorResponse,
   PutConfigurationAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationAggregatorRequest,
   output: PutConfigurationAggregatorResponse,
@@ -9364,7 +9363,7 @@ export const putConfigurationRecorder: API.OperationMethod<
   PutConfigurationRecorderRequest,
   PutConfigurationRecorderResponse,
   PutConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationRecorderRequest,
   output: PutConfigurationRecorderResponse,
@@ -9422,7 +9421,7 @@ export const putConformancePack: API.OperationMethod<
   PutConformancePackRequest,
   PutConformancePackResponse,
   PutConformancePackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConformancePackRequest,
   output: PutConformancePackResponse,
@@ -9467,7 +9466,7 @@ export const putDeliveryChannel: API.OperationMethod<
   PutDeliveryChannelRequest,
   PutDeliveryChannelResponse,
   PutDeliveryChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliveryChannelRequest,
   output: PutDeliveryChannelResponse,
@@ -9500,7 +9499,7 @@ export const putEvaluations: API.OperationMethod<
   PutEvaluationsRequest,
   PutEvaluationsResponse,
   PutEvaluationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEvaluationsRequest,
   output: PutEvaluationsResponse,
@@ -9526,7 +9525,7 @@ export const putExternalEvaluation: API.OperationMethod<
   PutExternalEvaluationRequest,
   PutExternalEvaluationResponse,
   PutExternalEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutExternalEvaluationRequest,
   output: PutExternalEvaluationResponse,
@@ -9594,7 +9593,7 @@ export const putOrganizationConfigRule: API.OperationMethod<
   PutOrganizationConfigRuleRequest,
   PutOrganizationConfigRuleResponse,
   PutOrganizationConfigRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOrganizationConfigRuleRequest,
   output: PutOrganizationConfigRuleResponse,
@@ -9664,7 +9663,7 @@ export const putOrganizationConformancePack: API.OperationMethod<
   PutOrganizationConformancePackRequest,
   PutOrganizationConformancePackResponse,
   PutOrganizationConformancePackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOrganizationConformancePackRequest,
   output: PutOrganizationConformancePackResponse,
@@ -9721,7 +9720,7 @@ export const putRemediationConfigurations: API.OperationMethod<
   PutRemediationConfigurationsRequest,
   PutRemediationConfigurationsResponse,
   PutRemediationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRemediationConfigurationsRequest,
   output: PutRemediationConfigurationsResponse,
@@ -9775,7 +9774,7 @@ export const putRemediationExceptions: API.OperationMethod<
   PutRemediationExceptionsRequest,
   PutRemediationExceptionsResponse,
   PutRemediationExceptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRemediationExceptionsRequest,
   output: PutRemediationExceptionsResponse,
@@ -9807,7 +9806,7 @@ export const putResourceConfig: API.OperationMethod<
   PutResourceConfigRequest,
   PutResourceConfigResponse,
   PutResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourceConfigRequest,
   output: PutResourceConfigResponse,
@@ -9842,7 +9841,7 @@ export const putRetentionConfiguration: API.OperationMethod<
   PutRetentionConfigurationRequest,
   PutRetentionConfigurationResponse,
   PutRetentionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRetentionConfigurationRequest,
   output: PutRetentionConfigurationResponse,
@@ -9884,7 +9883,7 @@ export const putServiceLinkedConfigurationRecorder: API.OperationMethod<
   PutServiceLinkedConfigurationRecorderRequest,
   PutServiceLinkedConfigurationRecorderResponse,
   PutServiceLinkedConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutServiceLinkedConfigurationRecorderRequest,
   output: PutServiceLinkedConfigurationRecorderResponse,
@@ -9917,7 +9916,7 @@ export const putStoredQuery: API.OperationMethod<
   PutStoredQueryRequest,
   PutStoredQueryResponse,
   PutStoredQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutStoredQueryRequest,
   output: PutStoredQueryResponse,
@@ -9956,7 +9955,7 @@ export const selectAggregateResourceConfig: API.PaginatedOperationMethod<
   SelectAggregateResourceConfigRequest,
   SelectAggregateResourceConfigResponse,
   SelectAggregateResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SelectAggregateResourceConfigRequest,
@@ -9995,7 +9994,7 @@ export const selectResourceConfig: API.PaginatedOperationMethod<
   SelectResourceConfigRequest,
   SelectResourceConfigResponse,
   SelectResourceConfigError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SelectResourceConfigRequest,
@@ -10068,7 +10067,7 @@ export const startConfigRulesEvaluation: API.OperationMethod<
   StartConfigRulesEvaluationRequest,
   StartConfigRulesEvaluationResponse,
   StartConfigRulesEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigRulesEvaluationRequest,
   output: StartConfigRulesEvaluationResponse,
@@ -10098,7 +10097,7 @@ export const startConfigurationRecorder: API.OperationMethod<
   StartConfigurationRecorderRequest,
   StartConfigurationRecorderResponse,
   StartConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigurationRecorderRequest,
   output: StartConfigurationRecorderResponse,
@@ -10126,7 +10125,7 @@ export const startRemediationExecution: API.OperationMethod<
   StartRemediationExecutionRequest,
   StartRemediationExecutionResponse,
   StartRemediationExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRemediationExecutionRequest,
   output: StartRemediationExecutionResponse,
@@ -10162,7 +10161,7 @@ export const startResourceEvaluation: API.OperationMethod<
   StartResourceEvaluationRequest,
   StartResourceEvaluationResponse,
   StartResourceEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceEvaluationRequest,
   output: StartResourceEvaluationResponse,
@@ -10183,7 +10182,7 @@ export const stopConfigurationRecorder: API.OperationMethod<
   StopConfigurationRecorderRequest,
   StopConfigurationRecorderResponse,
   StopConfigurationRecorderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopConfigurationRecorderRequest,
   output: StopConfigurationRecorderResponse,
@@ -10206,7 +10205,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10231,7 +10230,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/connect-contact-lens.ts
+++ b/packages/aws/src/services/connect-contact-lens.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Connect Contact Lens",
   serviceShapeName: "AmazonConnectContactLens",
@@ -346,7 +345,7 @@ export const listRealtimeContactAnalysisSegments: API.PaginatedOperationMethod<
   ListRealtimeContactAnalysisSegmentsRequest,
   ListRealtimeContactAnalysisSegmentsResponse,
   ListRealtimeContactAnalysisSegmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRealtimeContactAnalysisSegmentsRequest,

--- a/packages/aws/src/services/connect.ts
+++ b/packages/aws/src/services/connect.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Connect",
@@ -25568,7 +25567,7 @@ export const activateEvaluationForm: API.OperationMethod<
   ActivateEvaluationFormRequest,
   ActivateEvaluationFormResponse,
   ActivateEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateEvaluationFormRequest,
   output: ActivateEvaluationFormResponse,
@@ -25599,7 +25598,7 @@ export const associateAnalyticsDataSet: API.OperationMethod<
   AssociateAnalyticsDataSetRequest,
   AssociateAnalyticsDataSetResponse,
   AssociateAnalyticsDataSetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAnalyticsDataSetRequest,
   output: AssociateAnalyticsDataSetResponse,
@@ -25633,7 +25632,7 @@ export const associateApprovedOrigin: API.OperationMethod<
   AssociateApprovedOriginRequest,
   AssociateApprovedOriginResponse,
   AssociateApprovedOriginError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApprovedOriginRequest,
   output: AssociateApprovedOriginResponse,
@@ -25670,7 +25669,7 @@ export const associateBot: API.OperationMethod<
   AssociateBotRequest,
   AssociateBotResponse,
   AssociateBotError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateBotRequest,
   output: AssociateBotResponse,
@@ -25732,7 +25731,7 @@ export const associateContactWithUser: API.OperationMethod<
   AssociateContactWithUserRequest,
   AssociateContactWithUserResponse,
   AssociateContactWithUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateContactWithUserRequest,
   output: AssociateContactWithUserResponse,
@@ -25764,7 +25763,7 @@ export const associateDefaultVocabulary: API.OperationMethod<
   AssociateDefaultVocabularyRequest,
   AssociateDefaultVocabularyResponse,
   AssociateDefaultVocabularyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDefaultVocabularyRequest,
   output: AssociateDefaultVocabularyResponse,
@@ -25848,7 +25847,7 @@ export const associateEmailAddressAlias: API.OperationMethod<
   AssociateEmailAddressAliasRequest,
   AssociateEmailAddressAliasResponse,
   AssociateEmailAddressAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEmailAddressAliasRequest,
   output: AssociateEmailAddressAliasResponse,
@@ -25882,7 +25881,7 @@ export const associateFlow: API.OperationMethod<
   AssociateFlowRequest,
   AssociateFlowResponse,
   AssociateFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFlowRequest,
   output: AssociateFlowResponse,
@@ -25915,7 +25914,7 @@ export const associateHoursOfOperations: API.OperationMethod<
   AssociateHoursOfOperationsRequest,
   AssociateHoursOfOperationsResponse,
   AssociateHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateHoursOfOperationsRequest,
   output: AssociateHoursOfOperationsResponse,
@@ -25956,7 +25955,7 @@ export const associateInstanceStorageConfig: API.OperationMethod<
   AssociateInstanceStorageConfigRequest,
   AssociateInstanceStorageConfigResponse,
   AssociateInstanceStorageConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateInstanceStorageConfigRequest,
   output: AssociateInstanceStorageConfigResponse,
@@ -25991,7 +25990,7 @@ export const associateLambdaFunction: API.OperationMethod<
   AssociateLambdaFunctionRequest,
   AssociateLambdaFunctionResponse,
   AssociateLambdaFunctionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLambdaFunctionRequest,
   output: AssociateLambdaFunctionResponse,
@@ -26028,7 +26027,7 @@ export const associateLexBot: API.OperationMethod<
   AssociateLexBotRequest,
   AssociateLexBotResponse,
   AssociateLexBotError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLexBotRequest,
   output: AssociateLexBotResponse,
@@ -26067,7 +26066,7 @@ export const associatePhoneNumberContactFlow: API.OperationMethod<
   AssociatePhoneNumberContactFlowRequest,
   AssociatePhoneNumberContactFlowResponse,
   AssociatePhoneNumberContactFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePhoneNumberContactFlowRequest,
   output: AssociatePhoneNumberContactFlowResponse,
@@ -26111,7 +26110,7 @@ export const associateQueueEmailAddresses: API.OperationMethod<
   AssociateQueueEmailAddressesRequest,
   AssociateQueueEmailAddressesResponse,
   AssociateQueueEmailAddressesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateQueueEmailAddressesRequest,
   output: AssociateQueueEmailAddressesResponse,
@@ -26144,7 +26143,7 @@ export const associateQueueQuickConnects: API.OperationMethod<
   AssociateQueueQuickConnectsRequest,
   AssociateQueueQuickConnectsResponse,
   AssociateQueueQuickConnectsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateQueueQuickConnectsRequest,
   output: AssociateQueueQuickConnectsResponse,
@@ -26175,7 +26174,7 @@ export const associateRoutingProfileQueues: API.OperationMethod<
   AssociateRoutingProfileQueuesRequest,
   AssociateRoutingProfileQueuesResponse,
   AssociateRoutingProfileQueuesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateRoutingProfileQueuesRequest,
   output: AssociateRoutingProfileQueuesResponse,
@@ -26209,7 +26208,7 @@ export const associateSecurityKey: API.OperationMethod<
   AssociateSecurityKeyRequest,
   AssociateSecurityKeyResponse,
   AssociateSecurityKeyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSecurityKeyRequest,
   output: AssociateSecurityKeyResponse,
@@ -26243,7 +26242,7 @@ export const associateSecurityProfiles: API.OperationMethod<
   AssociateSecurityProfilesRequest,
   AssociateSecurityProfilesResponse,
   AssociateSecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSecurityProfilesRequest,
   output: AssociateSecurityProfilesResponse,
@@ -26277,7 +26276,7 @@ export const associateTrafficDistributionGroupUser: API.OperationMethod<
   AssociateTrafficDistributionGroupUserRequest,
   AssociateTrafficDistributionGroupUserResponse,
   AssociateTrafficDistributionGroupUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTrafficDistributionGroupUserRequest,
   output: AssociateTrafficDistributionGroupUserResponse,
@@ -26308,7 +26307,7 @@ export const associateUserProficiencies: API.OperationMethod<
   AssociateUserProficienciesRequest,
   AssociateUserProficienciesResponse,
   AssociateUserProficienciesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateUserProficienciesRequest,
   output: AssociateUserProficienciesResponse,
@@ -26341,7 +26340,7 @@ export const associateWorkspace: API.OperationMethod<
   AssociateWorkspaceRequest,
   AssociateWorkspaceResponse,
   AssociateWorkspaceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWorkspaceRequest,
   output: AssociateWorkspaceResponse,
@@ -26374,7 +26373,7 @@ export const batchAssociateAnalyticsDataSet: API.OperationMethod<
   BatchAssociateAnalyticsDataSetRequest,
   BatchAssociateAnalyticsDataSetResponse,
   BatchAssociateAnalyticsDataSetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateAnalyticsDataSetRequest,
   output: BatchAssociateAnalyticsDataSetResponse,
@@ -26413,7 +26412,7 @@ export const batchCreateDataTableValue: API.OperationMethod<
   BatchCreateDataTableValueRequest,
   BatchCreateDataTableValueResponse,
   BatchCreateDataTableValueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateDataTableValueRequest,
   output: BatchCreateDataTableValueResponse,
@@ -26451,7 +26450,7 @@ export const batchDeleteDataTableValue: API.OperationMethod<
   BatchDeleteDataTableValueRequest,
   BatchDeleteDataTableValueResponse,
   BatchDeleteDataTableValueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDataTableValueRequest,
   output: BatchDeleteDataTableValueResponse,
@@ -26486,7 +26485,7 @@ export const batchDescribeDataTableValue: API.OperationMethod<
   BatchDescribeDataTableValueRequest,
   BatchDescribeDataTableValueResponse,
   BatchDescribeDataTableValueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDescribeDataTableValueRequest,
   output: BatchDescribeDataTableValueResponse,
@@ -26518,7 +26517,7 @@ export const batchDisassociateAnalyticsDataSet: API.OperationMethod<
   BatchDisassociateAnalyticsDataSetRequest,
   BatchDisassociateAnalyticsDataSetResponse,
   BatchDisassociateAnalyticsDataSetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateAnalyticsDataSetRequest,
   output: BatchDisassociateAnalyticsDataSetResponse,
@@ -26549,7 +26548,7 @@ export const batchGetAttachedFileMetadata: API.OperationMethod<
   BatchGetAttachedFileMetadataRequest,
   BatchGetAttachedFileMetadataResponse,
   BatchGetAttachedFileMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAttachedFileMetadataRequest,
   output: BatchGetAttachedFileMetadataResponse,
@@ -26580,7 +26579,7 @@ export const batchGetFlowAssociation: API.OperationMethod<
   BatchGetFlowAssociationRequest,
   BatchGetFlowAssociationResponse,
   BatchGetFlowAssociationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFlowAssociationRequest,
   output: BatchGetFlowAssociationResponse,
@@ -26618,7 +26617,7 @@ export const batchPutContact: API.OperationMethod<
   BatchPutContactRequest,
   BatchPutContactResponse,
   BatchPutContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutContactRequest,
   output: BatchPutContactResponse,
@@ -26653,7 +26652,7 @@ export const batchUpdateDataTableValue: API.OperationMethod<
   BatchUpdateDataTableValueRequest,
   BatchUpdateDataTableValueResponse,
   BatchUpdateDataTableValueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateDataTableValueRequest,
   output: BatchUpdateDataTableValueResponse,
@@ -26712,7 +26711,7 @@ export const claimPhoneNumber: API.OperationMethod<
   ClaimPhoneNumberRequest,
   ClaimPhoneNumberResponse,
   ClaimPhoneNumberError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClaimPhoneNumberRequest,
   output: ClaimPhoneNumberResponse,
@@ -26744,7 +26743,7 @@ export const completeAttachedFileUpload: API.OperationMethod<
   CompleteAttachedFileUploadRequest,
   CompleteAttachedFileUploadResponse,
   CompleteAttachedFileUploadError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteAttachedFileUploadRequest,
   output: CompleteAttachedFileUploadResponse,
@@ -26776,7 +26775,7 @@ export const createAgentStatus: API.OperationMethod<
   CreateAgentStatusRequest,
   CreateAgentStatusResponse,
   CreateAgentStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentStatusRequest,
   output: CreateAgentStatusResponse,
@@ -26827,7 +26826,7 @@ export const createContact: API.OperationMethod<
   CreateContactRequest,
   CreateContactResponse,
   CreateContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactRequest,
   output: CreateContactResponse,
@@ -26867,7 +26866,7 @@ export const createContactFlow: API.OperationMethod<
   CreateContactFlowRequest,
   CreateContactFlowResponse,
   CreateContactFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactFlowRequest,
   output: CreateContactFlowResponse,
@@ -26905,7 +26904,7 @@ export const createContactFlowModule: API.OperationMethod<
   CreateContactFlowModuleRequest,
   CreateContactFlowModuleResponse,
   CreateContactFlowModuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactFlowModuleRequest,
   output: CreateContactFlowModuleResponse,
@@ -26943,7 +26942,7 @@ export const createContactFlowModuleAlias: API.OperationMethod<
   CreateContactFlowModuleAliasRequest,
   CreateContactFlowModuleAliasResponse,
   CreateContactFlowModuleAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactFlowModuleAliasRequest,
   output: CreateContactFlowModuleAliasResponse,
@@ -26979,7 +26978,7 @@ export const createContactFlowModuleVersion: API.OperationMethod<
   CreateContactFlowModuleVersionRequest,
   CreateContactFlowModuleVersionResponse,
   CreateContactFlowModuleVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactFlowModuleVersionRequest,
   output: CreateContactFlowModuleVersionResponse,
@@ -27016,7 +27015,7 @@ export const createContactFlowVersion: API.OperationMethod<
   CreateContactFlowVersionRequest,
   CreateContactFlowVersionResponse,
   CreateContactFlowVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactFlowVersionRequest,
   output: CreateContactFlowVersionResponse,
@@ -27054,7 +27053,7 @@ export const createDataTable: API.OperationMethod<
   CreateDataTableRequest,
   CreateDataTableResponse,
   CreateDataTableError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataTableRequest,
   output: CreateDataTableResponse,
@@ -27095,7 +27094,7 @@ export const createDataTableAttribute: API.OperationMethod<
   CreateDataTableAttributeRequest,
   CreateDataTableAttributeResponse,
   CreateDataTableAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataTableAttributeRequest,
   output: CreateDataTableAttributeResponse,
@@ -27136,7 +27135,7 @@ export const createEmailAddress: API.OperationMethod<
   CreateEmailAddressRequest,
   CreateEmailAddressResponse,
   CreateEmailAddressError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailAddressRequest,
   output: CreateEmailAddressResponse,
@@ -27174,7 +27173,7 @@ export const createEvaluationForm: API.OperationMethod<
   CreateEvaluationFormRequest,
   CreateEvaluationFormResponse,
   CreateEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEvaluationFormRequest,
   output: CreateEvaluationFormResponse,
@@ -27208,7 +27207,7 @@ export const createHoursOfOperation: API.OperationMethod<
   CreateHoursOfOperationRequest,
   CreateHoursOfOperationResponse,
   CreateHoursOfOperationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHoursOfOperationRequest,
   output: CreateHoursOfOperationResponse,
@@ -27243,7 +27242,7 @@ export const createHoursOfOperationOverride: API.OperationMethod<
   CreateHoursOfOperationOverrideRequest,
   CreateHoursOfOperationOverrideResponse,
   CreateHoursOfOperationOverrideError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHoursOfOperationOverrideRequest,
   output: CreateHoursOfOperationOverrideResponse,
@@ -27286,7 +27285,7 @@ export const createInstance: API.OperationMethod<
   CreateInstanceRequest,
   CreateInstanceResponse,
   CreateInstanceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceRequest,
   output: CreateInstanceResponse,
@@ -27316,7 +27315,7 @@ export const createIntegrationAssociation: API.OperationMethod<
   CreateIntegrationAssociationRequest,
   CreateIntegrationAssociationResponse,
   CreateIntegrationAssociationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationAssociationRequest,
   output: CreateIntegrationAssociationResponse,
@@ -27348,7 +27347,7 @@ export const createNotification: API.OperationMethod<
   CreateNotificationRequest,
   CreateNotificationResponse,
   CreateNotificationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationRequest,
   output: CreateNotificationResponse,
@@ -27383,7 +27382,7 @@ export const createParticipant: API.OperationMethod<
   CreateParticipantRequest,
   CreateParticipantResponse,
   CreateParticipantError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParticipantRequest,
   output: CreateParticipantResponse,
@@ -27417,7 +27416,7 @@ export const createPersistentContactAssociation: API.OperationMethod<
   CreatePersistentContactAssociationRequest,
   CreatePersistentContactAssociationResponse,
   CreatePersistentContactAssociationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePersistentContactAssociationRequest,
   output: CreatePersistentContactAssociationResponse,
@@ -27468,7 +27467,7 @@ export const createPredefinedAttribute: API.OperationMethod<
   CreatePredefinedAttributeRequest,
   CreatePredefinedAttributeResponse,
   CreatePredefinedAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePredefinedAttributeRequest,
   output: CreatePredefinedAttributeResponse,
@@ -27503,7 +27502,7 @@ export const createPrompt: API.OperationMethod<
   CreatePromptRequest,
   CreatePromptResponse,
   CreatePromptError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePromptRequest,
   output: CreatePromptResponse,
@@ -27536,7 +27535,7 @@ export const createPushNotificationRegistration: API.OperationMethod<
   CreatePushNotificationRegistrationRequest,
   CreatePushNotificationRegistrationResponse,
   CreatePushNotificationRegistrationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePushNotificationRegistrationRequest,
   output: CreatePushNotificationRegistrationResponse,
@@ -27583,7 +27582,7 @@ export const createQueue: API.OperationMethod<
   CreateQueueRequest,
   CreateQueueResponse,
   CreateQueueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueRequest,
   output: CreateQueueResponse,
@@ -27617,7 +27616,7 @@ export const createQuickConnect: API.OperationMethod<
   CreateQuickConnectRequest,
   CreateQuickConnectResponse,
   CreateQuickConnectError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuickConnectRequest,
   output: CreateQuickConnectResponse,
@@ -27651,7 +27650,7 @@ export const createRoutingProfile: API.OperationMethod<
   CreateRoutingProfileRequest,
   CreateRoutingProfileResponse,
   CreateRoutingProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoutingProfileRequest,
   output: CreateRoutingProfileResponse,
@@ -27688,7 +27687,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResponse,
   CreateRuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
@@ -27726,7 +27725,7 @@ export const createSecurityProfile: API.OperationMethod<
   CreateSecurityProfileRequest,
   CreateSecurityProfileResponse,
   CreateSecurityProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityProfileRequest,
   output: CreateSecurityProfileResponse,
@@ -27759,7 +27758,7 @@ export const createTaskTemplate: API.OperationMethod<
   CreateTaskTemplateRequest,
   CreateTaskTemplateResponse,
   CreateTaskTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTaskTemplateRequest,
   output: CreateTaskTemplateResponse,
@@ -27796,7 +27795,7 @@ export const createTestCase: API.OperationMethod<
   CreateTestCaseRequest,
   CreateTestCaseResponse,
   CreateTestCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTestCaseRequest,
   output: CreateTestCaseResponse,
@@ -27845,7 +27844,7 @@ export const createTrafficDistributionGroup: API.OperationMethod<
   CreateTrafficDistributionGroupRequest,
   CreateTrafficDistributionGroupResponse,
   CreateTrafficDistributionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficDistributionGroupRequest,
   output: CreateTrafficDistributionGroupResponse,
@@ -27878,7 +27877,7 @@ export const createUseCase: API.OperationMethod<
   CreateUseCaseRequest,
   CreateUseCaseResponse,
   CreateUseCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUseCaseRequest,
   output: CreateUseCaseResponse,
@@ -27929,7 +27928,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -27963,7 +27962,7 @@ export const createUserHierarchyGroup: API.OperationMethod<
   CreateUserHierarchyGroupRequest,
   CreateUserHierarchyGroupResponse,
   CreateUserHierarchyGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserHierarchyGroupRequest,
   output: CreateUserHierarchyGroupResponse,
@@ -28006,7 +28005,7 @@ export const createView: API.OperationMethod<
   CreateViewRequest,
   CreateViewResponse,
   CreateViewError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateViewRequest,
   output: CreateViewResponse,
@@ -28048,7 +28047,7 @@ export const createViewVersion: API.OperationMethod<
   CreateViewVersionRequest,
   CreateViewVersionResponse,
   CreateViewVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateViewVersionRequest,
   output: CreateViewVersionResponse,
@@ -28085,7 +28084,7 @@ export const createVocabulary: API.OperationMethod<
   CreateVocabularyRequest,
   CreateVocabularyResponse,
   CreateVocabularyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVocabularyRequest,
   output: CreateVocabularyResponse,
@@ -28122,7 +28121,7 @@ export const createWorkspace: API.OperationMethod<
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
   CreateWorkspaceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceRequest,
   output: CreateWorkspaceResponse,
@@ -28161,7 +28160,7 @@ export const createWorkspacePage: API.OperationMethod<
   CreateWorkspacePageRequest,
   CreateWorkspacePageResponse,
   CreateWorkspacePageError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspacePageRequest,
   output: CreateWorkspacePageResponse,
@@ -28197,7 +28196,7 @@ export const deactivateEvaluationForm: API.OperationMethod<
   DeactivateEvaluationFormRequest,
   DeactivateEvaluationFormResponse,
   DeactivateEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateEvaluationFormRequest,
   output: DeactivateEvaluationFormResponse,
@@ -28230,7 +28229,7 @@ export const deleteAttachedFile: API.OperationMethod<
   DeleteAttachedFileRequest,
   DeleteAttachedFileResponse,
   DeleteAttachedFileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttachedFileRequest,
   output: DeleteAttachedFileResponse,
@@ -28260,7 +28259,7 @@ export const deleteContactEvaluation: API.OperationMethod<
   DeleteContactEvaluationRequest,
   DeleteContactEvaluationResponse,
   DeleteContactEvaluationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactEvaluationRequest,
   output: DeleteContactEvaluationResponse,
@@ -28291,7 +28290,7 @@ export const deleteContactFlow: API.OperationMethod<
   DeleteContactFlowRequest,
   DeleteContactFlowResponse,
   DeleteContactFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactFlowRequest,
   output: DeleteContactFlowResponse,
@@ -28323,7 +28322,7 @@ export const deleteContactFlowModule: API.OperationMethod<
   DeleteContactFlowModuleRequest,
   DeleteContactFlowModuleResponse,
   DeleteContactFlowModuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactFlowModuleRequest,
   output: DeleteContactFlowModuleResponse,
@@ -28356,7 +28355,7 @@ export const deleteContactFlowModuleAlias: API.OperationMethod<
   DeleteContactFlowModuleAliasRequest,
   DeleteContactFlowModuleAliasResponse,
   DeleteContactFlowModuleAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactFlowModuleAliasRequest,
   output: DeleteContactFlowModuleAliasResponse,
@@ -28388,7 +28387,7 @@ export const deleteContactFlowModuleVersion: API.OperationMethod<
   DeleteContactFlowModuleVersionRequest,
   DeleteContactFlowModuleVersionResponse,
   DeleteContactFlowModuleVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactFlowModuleVersionRequest,
   output: DeleteContactFlowModuleVersionResponse,
@@ -28420,7 +28419,7 @@ export const deleteContactFlowVersion: API.OperationMethod<
   DeleteContactFlowVersionRequest,
   DeleteContactFlowVersionResponse,
   DeleteContactFlowVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactFlowVersionRequest,
   output: DeleteContactFlowVersionResponse,
@@ -28457,7 +28456,7 @@ export const deleteDataTable: API.OperationMethod<
   DeleteDataTableRequest,
   DeleteDataTableResponse,
   DeleteDataTableError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataTableRequest,
   output: DeleteDataTableResponse,
@@ -28491,7 +28490,7 @@ export const deleteDataTableAttribute: API.OperationMethod<
   DeleteDataTableAttributeRequest,
   DeleteDataTableAttributeResponse,
   DeleteDataTableAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataTableAttributeRequest,
   output: DeleteDataTableAttributeResponse,
@@ -28525,7 +28524,7 @@ export const deleteEmailAddress: API.OperationMethod<
   DeleteEmailAddressRequest,
   DeleteEmailAddressResponse,
   DeleteEmailAddressError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailAddressRequest,
   output: DeleteEmailAddressResponse,
@@ -28561,7 +28560,7 @@ export const deleteEvaluationForm: API.OperationMethod<
   DeleteEvaluationFormRequest,
   DeleteEvaluationFormResponse,
   DeleteEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEvaluationFormRequest,
   output: DeleteEvaluationFormResponse,
@@ -28591,7 +28590,7 @@ export const deleteHoursOfOperation: API.OperationMethod<
   DeleteHoursOfOperationRequest,
   DeleteHoursOfOperationResponse,
   DeleteHoursOfOperationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHoursOfOperationRequest,
   output: DeleteHoursOfOperationResponse,
@@ -28621,7 +28620,7 @@ export const deleteHoursOfOperationOverride: API.OperationMethod<
   DeleteHoursOfOperationOverrideRequest,
   DeleteHoursOfOperationOverrideResponse,
   DeleteHoursOfOperationOverrideError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHoursOfOperationOverrideRequest,
   output: DeleteHoursOfOperationOverrideResponse,
@@ -28656,7 +28655,7 @@ export const deleteInstance: API.OperationMethod<
   DeleteInstanceRequest,
   DeleteInstanceResponse,
   DeleteInstanceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceRequest,
   output: DeleteInstanceResponse,
@@ -28684,7 +28683,7 @@ export const deleteIntegrationAssociation: API.OperationMethod<
   DeleteIntegrationAssociationRequest,
   DeleteIntegrationAssociationResponse,
   DeleteIntegrationAssociationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationAssociationRequest,
   output: DeleteIntegrationAssociationResponse,
@@ -28714,7 +28713,7 @@ export const deleteNotification: API.OperationMethod<
   DeleteNotificationRequest,
   DeleteNotificationResponse,
   DeleteNotificationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationRequest,
   output: DeleteNotificationResponse,
@@ -28746,7 +28745,7 @@ export const deletePredefinedAttribute: API.OperationMethod<
   DeletePredefinedAttributeRequest,
   DeletePredefinedAttributeResponse,
   DeletePredefinedAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePredefinedAttributeRequest,
   output: DeletePredefinedAttributeResponse,
@@ -28777,7 +28776,7 @@ export const deletePrompt: API.OperationMethod<
   DeletePromptRequest,
   DeletePromptResponse,
   DeletePromptError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePromptRequest,
   output: DeletePromptResponse,
@@ -28807,7 +28806,7 @@ export const deletePushNotificationRegistration: API.OperationMethod<
   DeletePushNotificationRegistrationRequest,
   DeletePushNotificationRegistrationResponse,
   DeletePushNotificationRegistrationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePushNotificationRegistrationRequest,
   output: DeletePushNotificationRegistrationResponse,
@@ -28838,7 +28837,7 @@ export const deleteQueue: API.OperationMethod<
   DeleteQueueRequest,
   DeleteQueueResponse,
   DeleteQueueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueRequest,
   output: DeleteQueueResponse,
@@ -28879,7 +28878,7 @@ export const deleteQuickConnect: API.OperationMethod<
   DeleteQuickConnectRequest,
   DeleteQuickConnectResponse,
   DeleteQuickConnectError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuickConnectRequest,
   output: DeleteQuickConnectResponse,
@@ -28910,7 +28909,7 @@ export const deleteRoutingProfile: API.OperationMethod<
   DeleteRoutingProfileRequest,
   DeleteRoutingProfileResponse,
   DeleteRoutingProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoutingProfileRequest,
   output: DeleteRoutingProfileResponse,
@@ -28941,7 +28940,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -28973,7 +28972,7 @@ export const deleteSecurityProfile: API.OperationMethod<
   DeleteSecurityProfileRequest,
   DeleteSecurityProfileResponse,
   DeleteSecurityProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityProfileRequest,
   output: DeleteSecurityProfileResponse,
@@ -29005,7 +29004,7 @@ export const deleteTaskTemplate: API.OperationMethod<
   DeleteTaskTemplateRequest,
   DeleteTaskTemplateResponse,
   DeleteTaskTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTaskTemplateRequest,
   output: DeleteTaskTemplateResponse,
@@ -29036,7 +29035,7 @@ export const deleteTestCase: API.OperationMethod<
   DeleteTestCaseRequest,
   DeleteTestCaseResponse,
   DeleteTestCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTestCaseRequest,
   output: DeleteTestCaseResponse,
@@ -29070,7 +29069,7 @@ export const deleteTrafficDistributionGroup: API.OperationMethod<
   DeleteTrafficDistributionGroupRequest,
   DeleteTrafficDistributionGroupResponse,
   DeleteTrafficDistributionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficDistributionGroupRequest,
   output: DeleteTrafficDistributionGroupResponse,
@@ -29099,7 +29098,7 @@ export const deleteUseCase: API.OperationMethod<
   DeleteUseCaseRequest,
   DeleteUseCaseResponse,
   DeleteUseCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUseCaseRequest,
   output: DeleteUseCaseResponse,
@@ -29141,7 +29140,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -29173,7 +29172,7 @@ export const deleteUserHierarchyGroup: API.OperationMethod<
   DeleteUserHierarchyGroupRequest,
   DeleteUserHierarchyGroupResponse,
   DeleteUserHierarchyGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserHierarchyGroupRequest,
   output: DeleteUserHierarchyGroupResponse,
@@ -29206,7 +29205,7 @@ export const deleteView: API.OperationMethod<
   DeleteViewRequest,
   DeleteViewResponse,
   DeleteViewError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteViewRequest,
   output: DeleteViewResponse,
@@ -29240,7 +29239,7 @@ export const deleteViewVersion: API.OperationMethod<
   DeleteViewVersionRequest,
   DeleteViewVersionResponse,
   DeleteViewVersionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteViewVersionRequest,
   output: DeleteViewVersionResponse,
@@ -29273,7 +29272,7 @@ export const deleteVocabulary: API.OperationMethod<
   DeleteVocabularyRequest,
   DeleteVocabularyResponse,
   DeleteVocabularyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVocabularyRequest,
   output: DeleteVocabularyResponse,
@@ -29305,7 +29304,7 @@ export const deleteWorkspace: API.OperationMethod<
   DeleteWorkspaceRequest,
   DeleteWorkspaceResponse,
   DeleteWorkspaceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceRequest,
   output: DeleteWorkspaceResponse,
@@ -29336,7 +29335,7 @@ export const deleteWorkspaceMedia: API.OperationMethod<
   DeleteWorkspaceMediaRequest,
   DeleteWorkspaceMediaResponse,
   DeleteWorkspaceMediaError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceMediaRequest,
   output: DeleteWorkspaceMediaResponse,
@@ -29369,7 +29368,7 @@ export const deleteWorkspacePage: API.OperationMethod<
   DeleteWorkspacePageRequest,
   DeleteWorkspacePageResponse,
   DeleteWorkspacePageError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspacePageRequest,
   output: DeleteWorkspacePageResponse,
@@ -29401,7 +29400,7 @@ export const describeAgentStatus: API.OperationMethod<
   DescribeAgentStatusRequest,
   DescribeAgentStatusResponse,
   DescribeAgentStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgentStatusRequest,
   output: DescribeAgentStatusResponse,
@@ -29433,7 +29432,7 @@ export const describeAttachedFilesConfiguration: API.OperationMethod<
   DescribeAttachedFilesConfigurationRequest,
   DescribeAttachedFilesConfigurationResponse,
   DescribeAttachedFilesConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAttachedFilesConfigurationRequest,
   output: DescribeAttachedFilesConfigurationResponse,
@@ -29466,7 +29465,7 @@ export const describeAuthenticationProfile: API.OperationMethod<
   DescribeAuthenticationProfileRequest,
   DescribeAuthenticationProfileResponse,
   DescribeAuthenticationProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuthenticationProfileRequest,
   output: DescribeAuthenticationProfileResponse,
@@ -29523,7 +29522,7 @@ export const describeContact: API.OperationMethod<
   DescribeContactRequest,
   DescribeContactResponse,
   DescribeContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactRequest,
   output: DescribeContactResponse,
@@ -29552,7 +29551,7 @@ export const describeContactEvaluation: API.OperationMethod<
   DescribeContactEvaluationRequest,
   DescribeContactEvaluationResponse,
   DescribeContactEvaluationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactEvaluationRequest,
   output: DescribeContactEvaluationResponse,
@@ -29596,7 +29595,7 @@ export const describeContactFlow: API.OperationMethod<
   DescribeContactFlowRequest,
   DescribeContactFlowResponse,
   DescribeContactFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactFlowRequest,
   output: DescribeContactFlowResponse,
@@ -29632,7 +29631,7 @@ export const describeContactFlowModule: API.OperationMethod<
   DescribeContactFlowModuleRequest,
   DescribeContactFlowModuleResponse,
   DescribeContactFlowModuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactFlowModuleRequest,
   output: DescribeContactFlowModuleResponse,
@@ -29665,7 +29664,7 @@ export const describeContactFlowModuleAlias: API.OperationMethod<
   DescribeContactFlowModuleAliasRequest,
   DescribeContactFlowModuleAliasResponse,
   DescribeContactFlowModuleAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactFlowModuleAliasRequest,
   output: DescribeContactFlowModuleAliasResponse,
@@ -29699,7 +29698,7 @@ export const describeDataTable: API.OperationMethod<
   DescribeDataTableRequest,
   DescribeDataTableResponse,
   DescribeDataTableError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataTableRequest,
   output: DescribeDataTableResponse,
@@ -29732,7 +29731,7 @@ export const describeDataTableAttribute: API.OperationMethod<
   DescribeDataTableAttributeRequest,
   DescribeDataTableAttributeResponse,
   DescribeDataTableAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataTableAttributeRequest,
   output: DescribeDataTableAttributeResponse,
@@ -29764,7 +29763,7 @@ export const describeEmailAddress: API.OperationMethod<
   DescribeEmailAddressRequest,
   DescribeEmailAddressResponse,
   DescribeEmailAddressError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEmailAddressRequest,
   output: DescribeEmailAddressResponse,
@@ -29795,7 +29794,7 @@ export const describeEvaluationForm: API.OperationMethod<
   DescribeEvaluationFormRequest,
   DescribeEvaluationFormResponse,
   DescribeEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEvaluationFormRequest,
   output: DescribeEvaluationFormResponse,
@@ -29824,7 +29823,7 @@ export const describeHoursOfOperation: API.OperationMethod<
   DescribeHoursOfOperationRequest,
   DescribeHoursOfOperationResponse,
   DescribeHoursOfOperationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHoursOfOperationRequest,
   output: DescribeHoursOfOperationResponse,
@@ -29854,7 +29853,7 @@ export const describeHoursOfOperationOverride: API.OperationMethod<
   DescribeHoursOfOperationOverrideRequest,
   DescribeHoursOfOperationOverrideResponse,
   DescribeHoursOfOperationOverrideError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHoursOfOperationOverrideRequest,
   output: DescribeHoursOfOperationOverrideResponse,
@@ -29888,7 +29887,7 @@ export const describeInstance: API.OperationMethod<
   DescribeInstanceRequest,
   DescribeInstanceResponse,
   DescribeInstanceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceRequest,
   output: DescribeInstanceResponse,
@@ -29918,7 +29917,7 @@ export const describeInstanceAttribute: API.OperationMethod<
   DescribeInstanceAttributeRequest,
   DescribeInstanceAttributeResponse,
   DescribeInstanceAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceAttributeRequest,
   output: DescribeInstanceAttributeResponse,
@@ -29951,7 +29950,7 @@ export const describeInstanceStorageConfig: API.OperationMethod<
   DescribeInstanceStorageConfigRequest,
   DescribeInstanceStorageConfigResponse,
   DescribeInstanceStorageConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceStorageConfigRequest,
   output: DescribeInstanceStorageConfigResponse,
@@ -29982,7 +29981,7 @@ export const describeNotification: API.OperationMethod<
   DescribeNotificationRequest,
   DescribeNotificationResponse,
   DescribeNotificationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotificationRequest,
   output: DescribeNotificationResponse,
@@ -30019,7 +30018,7 @@ export const describePhoneNumber: API.OperationMethod<
   DescribePhoneNumberRequest,
   DescribePhoneNumberResponse,
   DescribePhoneNumberError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePhoneNumberRequest,
   output: DescribePhoneNumberResponse,
@@ -30062,7 +30061,7 @@ export const describePredefinedAttribute: API.OperationMethod<
   DescribePredefinedAttributeRequest,
   DescribePredefinedAttributeResponse,
   DescribePredefinedAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePredefinedAttributeRequest,
   output: DescribePredefinedAttributeResponse,
@@ -30092,7 +30091,7 @@ export const describePrompt: API.OperationMethod<
   DescribePromptRequest,
   DescribePromptResponse,
   DescribePromptError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePromptRequest,
   output: DescribePromptResponse,
@@ -30122,7 +30121,7 @@ export const describeQueue: API.OperationMethod<
   DescribeQueueRequest,
   DescribeQueueResponse,
   DescribeQueueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQueueRequest,
   output: DescribeQueueResponse,
@@ -30152,7 +30151,7 @@ export const describeQuickConnect: API.OperationMethod<
   DescribeQuickConnectRequest,
   DescribeQuickConnectResponse,
   DescribeQuickConnectError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQuickConnectRequest,
   output: DescribeQuickConnectResponse,
@@ -30186,7 +30185,7 @@ export const describeRoutingProfile: API.OperationMethod<
   DescribeRoutingProfileRequest,
   DescribeRoutingProfileResponse,
   DescribeRoutingProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRoutingProfileRequest,
   output: DescribeRoutingProfileResponse,
@@ -30216,7 +30215,7 @@ export const describeRule: API.OperationMethod<
   DescribeRuleRequest,
   DescribeRuleResponse,
   DescribeRuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleRequest,
   output: DescribeRuleResponse,
@@ -30250,7 +30249,7 @@ export const describeSecurityProfile: API.OperationMethod<
   DescribeSecurityProfileRequest,
   DescribeSecurityProfileResponse,
   DescribeSecurityProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityProfileRequest,
   output: DescribeSecurityProfileResponse,
@@ -30281,7 +30280,7 @@ export const describeTestCase: API.OperationMethod<
   DescribeTestCaseRequest,
   DescribeTestCaseResponse,
   DescribeTestCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTestCaseRequest,
   output: DescribeTestCaseResponse,
@@ -30312,7 +30311,7 @@ export const describeTrafficDistributionGroup: API.OperationMethod<
   DescribeTrafficDistributionGroupRequest,
   DescribeTrafficDistributionGroupResponse,
   DescribeTrafficDistributionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrafficDistributionGroupRequest,
   output: DescribeTrafficDistributionGroupResponse,
@@ -30344,7 +30343,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -30374,7 +30373,7 @@ export const describeUserHierarchyGroup: API.OperationMethod<
   DescribeUserHierarchyGroupRequest,
   DescribeUserHierarchyGroupResponse,
   DescribeUserHierarchyGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserHierarchyGroupRequest,
   output: DescribeUserHierarchyGroupResponse,
@@ -30404,7 +30403,7 @@ export const describeUserHierarchyStructure: API.OperationMethod<
   DescribeUserHierarchyStructureRequest,
   DescribeUserHierarchyStructureResponse,
   DescribeUserHierarchyStructureError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserHierarchyStructureRequest,
   output: DescribeUserHierarchyStructureResponse,
@@ -30444,7 +30443,7 @@ export const describeView: API.OperationMethod<
   DescribeViewRequest,
   DescribeViewResponse,
   DescribeViewError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeViewRequest,
   output: DescribeViewResponse,
@@ -30475,7 +30474,7 @@ export const describeVocabulary: API.OperationMethod<
   DescribeVocabularyRequest,
   DescribeVocabularyResponse,
   DescribeVocabularyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVocabularyRequest,
   output: DescribeVocabularyResponse,
@@ -30506,7 +30505,7 @@ export const describeWorkspace: API.OperationMethod<
   DescribeWorkspaceRequest,
   DescribeWorkspaceResponse,
   DescribeWorkspaceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceRequest,
   output: DescribeWorkspaceResponse,
@@ -30537,7 +30536,7 @@ export const disassociateAnalyticsDataSet: API.OperationMethod<
   DisassociateAnalyticsDataSetRequest,
   DisassociateAnalyticsDataSetResponse,
   DisassociateAnalyticsDataSetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAnalyticsDataSetRequest,
   output: DisassociateAnalyticsDataSetResponse,
@@ -30569,7 +30568,7 @@ export const disassociateApprovedOrigin: API.OperationMethod<
   DisassociateApprovedOriginRequest,
   DisassociateApprovedOriginResponse,
   DisassociateApprovedOriginError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApprovedOriginRequest,
   output: DisassociateApprovedOriginResponse,
@@ -30600,7 +30599,7 @@ export const disassociateBot: API.OperationMethod<
   DisassociateBotRequest,
   DisassociateBotResponse,
   DisassociateBotError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateBotRequest,
   output: DisassociateBotResponse,
@@ -30684,7 +30683,7 @@ export const disassociateEmailAddressAlias: API.OperationMethod<
   DisassociateEmailAddressAliasRequest,
   DisassociateEmailAddressAliasResponse,
   DisassociateEmailAddressAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEmailAddressAliasRequest,
   output: DisassociateEmailAddressAliasResponse,
@@ -30717,7 +30716,7 @@ export const disassociateFlow: API.OperationMethod<
   DisassociateFlowRequest,
   DisassociateFlowResponse,
   DisassociateFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFlowRequest,
   output: DisassociateFlowResponse,
@@ -30749,7 +30748,7 @@ export const disassociateHoursOfOperations: API.OperationMethod<
   DisassociateHoursOfOperationsRequest,
   DisassociateHoursOfOperationsResponse,
   DisassociateHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateHoursOfOperationsRequest,
   output: DisassociateHoursOfOperationsResponse,
@@ -30782,7 +30781,7 @@ export const disassociateInstanceStorageConfig: API.OperationMethod<
   DisassociateInstanceStorageConfigRequest,
   DisassociateInstanceStorageConfigResponse,
   DisassociateInstanceStorageConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateInstanceStorageConfigRequest,
   output: DisassociateInstanceStorageConfigResponse,
@@ -30814,7 +30813,7 @@ export const disassociateLambdaFunction: API.OperationMethod<
   DisassociateLambdaFunctionRequest,
   DisassociateLambdaFunctionResponse,
   DisassociateLambdaFunctionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLambdaFunctionRequest,
   output: DisassociateLambdaFunctionResponse,
@@ -30846,7 +30845,7 @@ export const disassociateLexBot: API.OperationMethod<
   DisassociateLexBotRequest,
   DisassociateLexBotResponse,
   DisassociateLexBotError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLexBotRequest,
   output: DisassociateLexBotResponse,
@@ -30882,7 +30881,7 @@ export const disassociatePhoneNumberContactFlow: API.OperationMethod<
   DisassociatePhoneNumberContactFlowRequest,
   DisassociatePhoneNumberContactFlowResponse,
   DisassociatePhoneNumberContactFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePhoneNumberContactFlowRequest,
   output: DisassociatePhoneNumberContactFlowResponse,
@@ -30921,7 +30920,7 @@ export const disassociateQueueEmailAddresses: API.OperationMethod<
   DisassociateQueueEmailAddressesRequest,
   DisassociateQueueEmailAddressesResponse,
   DisassociateQueueEmailAddressesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateQueueEmailAddressesRequest,
   output: DisassociateQueueEmailAddressesResponse,
@@ -30952,7 +30951,7 @@ export const disassociateQueueQuickConnects: API.OperationMethod<
   DisassociateQueueQuickConnectsRequest,
   DisassociateQueueQuickConnectsResponse,
   DisassociateQueueQuickConnectsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateQueueQuickConnectsRequest,
   output: DisassociateQueueQuickConnectsResponse,
@@ -30985,7 +30984,7 @@ export const disassociateRoutingProfileQueues: API.OperationMethod<
   DisassociateRoutingProfileQueuesRequest,
   DisassociateRoutingProfileQueuesResponse,
   DisassociateRoutingProfileQueuesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRoutingProfileQueuesRequest,
   output: DisassociateRoutingProfileQueuesResponse,
@@ -31017,7 +31016,7 @@ export const disassociateSecurityKey: API.OperationMethod<
   DisassociateSecurityKeyRequest,
   DisassociateSecurityKeyResponse,
   DisassociateSecurityKeyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSecurityKeyRequest,
   output: DisassociateSecurityKeyResponse,
@@ -31049,7 +31048,7 @@ export const disassociateSecurityProfiles: API.OperationMethod<
   DisassociateSecurityProfilesRequest,
   DisassociateSecurityProfilesResponse,
   DisassociateSecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSecurityProfilesRequest,
   output: DisassociateSecurityProfilesResponse,
@@ -31083,7 +31082,7 @@ export const disassociateTrafficDistributionGroupUser: API.OperationMethod<
   DisassociateTrafficDistributionGroupUserRequest,
   DisassociateTrafficDistributionGroupUserResponse,
   DisassociateTrafficDistributionGroupUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTrafficDistributionGroupUserRequest,
   output: DisassociateTrafficDistributionGroupUserResponse,
@@ -31114,7 +31113,7 @@ export const disassociateUserProficiencies: API.OperationMethod<
   DisassociateUserProficienciesRequest,
   DisassociateUserProficienciesResponse,
   DisassociateUserProficienciesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateUserProficienciesRequest,
   output: DisassociateUserProficienciesResponse,
@@ -31145,7 +31144,7 @@ export const disassociateWorkspace: API.OperationMethod<
   DisassociateWorkspaceRequest,
   DisassociateWorkspaceResponse,
   DisassociateWorkspaceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWorkspaceRequest,
   output: DisassociateWorkspaceResponse,
@@ -31179,7 +31178,7 @@ export const dismissUserContact: API.OperationMethod<
   DismissUserContactRequest,
   DismissUserContactResponse,
   DismissUserContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DismissUserContactRequest,
   output: DismissUserContactResponse,
@@ -31215,7 +31214,7 @@ export const evaluateDataTableValues: API.PaginatedOperationMethod<
   EvaluateDataTableValuesRequest,
   EvaluateDataTableValuesResponse,
   EvaluateDataTableValuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: EvaluateDataTableValuesRequest,
@@ -31253,7 +31252,7 @@ export const getAttachedFile: API.OperationMethod<
   GetAttachedFileRequest,
   GetAttachedFileResponse,
   GetAttachedFileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAttachedFileRequest,
   output: GetAttachedFileResponse,
@@ -31281,7 +31280,7 @@ export const getContactAttributes: API.OperationMethod<
   GetContactAttributesRequest,
   GetContactAttributesResponse,
   GetContactAttributesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactAttributesRequest,
   output: GetContactAttributesResponse,
@@ -31330,7 +31329,7 @@ export const getContactMetrics: API.OperationMethod<
   GetContactMetricsRequest,
   GetContactMetricsResponse,
   GetContactMetricsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactMetricsRequest,
   output: GetContactMetricsResponse,
@@ -31384,7 +31383,7 @@ export const getCurrentMetricData: API.PaginatedOperationMethod<
   GetCurrentMetricDataRequest,
   GetCurrentMetricDataResponse,
   GetCurrentMetricDataError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCurrentMetricDataRequest,
@@ -31420,7 +31419,7 @@ export const getCurrentUserData: API.PaginatedOperationMethod<
   GetCurrentUserDataRequest,
   GetCurrentUserDataResponse,
   GetCurrentUserDataError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCurrentUserDataRequest,
@@ -31456,7 +31455,7 @@ export const getEffectiveHoursOfOperations: API.OperationMethod<
   GetEffectiveHoursOfOperationsRequest,
   GetEffectiveHoursOfOperationsResponse,
   GetEffectiveHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEffectiveHoursOfOperationsRequest,
   output: GetEffectiveHoursOfOperationsResponse,
@@ -31489,7 +31488,7 @@ export const getEvaluationFormValidation: API.OperationMethod<
   GetEvaluationFormValidationRequest,
   GetEvaluationFormValidationResponse,
   GetEvaluationFormValidationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvaluationFormValidationRequest,
   output: GetEvaluationFormValidationResponse,
@@ -31527,7 +31526,7 @@ export const getFederationToken: API.OperationMethod<
   GetFederationTokenRequest,
   GetFederationTokenResponse,
   GetFederationTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFederationTokenRequest,
   output: GetFederationTokenResponse,
@@ -31559,7 +31558,7 @@ export const getFlowAssociation: API.OperationMethod<
   GetFlowAssociationRequest,
   GetFlowAssociationResponse,
   GetFlowAssociationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowAssociationRequest,
   output: GetFlowAssociationResponse,
@@ -31598,7 +31597,7 @@ export const getMetricData: API.PaginatedOperationMethod<
   GetMetricDataRequest,
   GetMetricDataResponse,
   GetMetricDataError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMetricDataRequest,
@@ -31665,7 +31664,7 @@ export const getMetricDataV2: API.PaginatedOperationMethod<
   GetMetricDataV2Request,
   GetMetricDataV2Response,
   GetMetricDataV2Error,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMetricDataV2Request,
@@ -31701,7 +31700,7 @@ export const getPromptFile: API.OperationMethod<
   GetPromptFileRequest,
   GetPromptFileResponse,
   GetPromptFileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPromptFileRequest,
   output: GetPromptFileResponse,
@@ -31731,7 +31730,7 @@ export const getTaskTemplate: API.OperationMethod<
   GetTaskTemplateRequest,
   GetTaskTemplateResponse,
   GetTaskTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaskTemplateRequest,
   output: GetTaskTemplateResponse,
@@ -31762,7 +31761,7 @@ export const getTestCaseExecutionSummary: API.OperationMethod<
   GetTestCaseExecutionSummaryRequest,
   GetTestCaseExecutionSummaryResponse,
   GetTestCaseExecutionSummaryError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTestCaseExecutionSummaryRequest,
   output: GetTestCaseExecutionSummaryResponse,
@@ -31793,7 +31792,7 @@ export const getTrafficDistribution: API.OperationMethod<
   GetTrafficDistributionRequest,
   GetTrafficDistributionResponse,
   GetTrafficDistributionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrafficDistributionRequest,
   output: GetTrafficDistributionResponse,
@@ -31840,7 +31839,7 @@ export const importPhoneNumber: API.OperationMethod<
   ImportPhoneNumberRequest,
   ImportPhoneNumberResponse,
   ImportPhoneNumberError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportPhoneNumberRequest,
   output: ImportPhoneNumberResponse,
@@ -31871,7 +31870,7 @@ export const importWorkspaceMedia: API.OperationMethod<
   ImportWorkspaceMediaRequest,
   ImportWorkspaceMediaResponse,
   ImportWorkspaceMediaError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportWorkspaceMediaRequest,
   output: ImportWorkspaceMediaResponse,
@@ -31901,7 +31900,7 @@ export const listAgentStatuses: API.PaginatedOperationMethod<
   ListAgentStatusRequest,
   ListAgentStatusResponse,
   ListAgentStatusesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AgentStatusSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentStatusRequest,
@@ -31938,7 +31937,7 @@ export const listAnalyticsDataAssociations: API.OperationMethod<
   ListAnalyticsDataAssociationsRequest,
   ListAnalyticsDataAssociationsResponse,
   ListAnalyticsDataAssociationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAnalyticsDataAssociationsRequest,
   output: ListAnalyticsDataAssociationsResponse,
@@ -31968,7 +31967,7 @@ export const listAnalyticsDataLakeDataSets: API.OperationMethod<
   ListAnalyticsDataLakeDataSetsRequest,
   ListAnalyticsDataLakeDataSetsResponse,
   ListAnalyticsDataLakeDataSetsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAnalyticsDataLakeDataSetsRequest,
   output: ListAnalyticsDataLakeDataSetsResponse,
@@ -32000,7 +31999,7 @@ export const listApprovedOrigins: API.PaginatedOperationMethod<
   ListApprovedOriginsRequest,
   ListApprovedOriginsResponse,
   ListApprovedOriginsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Origin
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApprovedOriginsRequest,
@@ -32037,7 +32036,7 @@ export const listAssociatedContacts: API.OperationMethod<
   ListAssociatedContactsRequest,
   ListAssociatedContactsResponse,
   ListAssociatedContactsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAssociatedContactsRequest,
   output: ListAssociatedContactsResponse,
@@ -32069,7 +32068,7 @@ export const listAttachedFilesConfigurations: API.PaginatedOperationMethod<
   ListAttachedFilesConfigurationsRequest,
   ListAttachedFilesConfigurationsResponse,
   ListAttachedFilesConfigurationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AttachedFilesConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedFilesConfigurationsRequest,
@@ -32110,7 +32109,7 @@ export const listAuthenticationProfiles: API.PaginatedOperationMethod<
   ListAuthenticationProfilesRequest,
   ListAuthenticationProfilesResponse,
   ListAuthenticationProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AuthenticationProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuthenticationProfilesRequest,
@@ -32150,7 +32149,7 @@ export const listBots: API.PaginatedOperationMethod<
   ListBotsRequest,
   ListBotsResponse,
   ListBotsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   LexBotConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotsRequest,
@@ -32189,7 +32188,7 @@ export const listChildHoursOfOperations: API.PaginatedOperationMethod<
   ListChildHoursOfOperationsRequest,
   ListChildHoursOfOperationsResponse,
   ListChildHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HoursOfOperationsIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChildHoursOfOperationsRequest,
@@ -32225,7 +32224,7 @@ export const listContactEvaluations: API.PaginatedOperationMethod<
   ListContactEvaluationsRequest,
   ListContactEvaluationsResponse,
   ListContactEvaluationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   EvaluationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactEvaluationsRequest,
@@ -32262,7 +32261,7 @@ export const listContactFlowModuleAliases: API.PaginatedOperationMethod<
   ListContactFlowModuleAliasesRequest,
   ListContactFlowModuleAliasesResponse,
   ListContactFlowModuleAliasesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowModuleAliasSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactFlowModuleAliasesRequest,
@@ -32301,7 +32300,7 @@ export const listContactFlowModules: API.PaginatedOperationMethod<
   ListContactFlowModulesRequest,
   ListContactFlowModulesResponse,
   ListContactFlowModulesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowModuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactFlowModulesRequest,
@@ -32340,7 +32339,7 @@ export const listContactFlowModuleVersions: API.PaginatedOperationMethod<
   ListContactFlowModuleVersionsRequest,
   ListContactFlowModuleVersionsResponse,
   ListContactFlowModuleVersionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowModuleVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactFlowModuleVersionsRequest,
@@ -32384,7 +32383,7 @@ export const listContactFlows: API.PaginatedOperationMethod<
   ListContactFlowsRequest,
   ListContactFlowsResponse,
   ListContactFlowsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactFlowsRequest,
@@ -32422,7 +32421,7 @@ export const listContactFlowVersions: API.PaginatedOperationMethod<
   ListContactFlowVersionsRequest,
   ListContactFlowVersionsResponse,
   ListContactFlowVersionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactFlowVersionsRequest,
@@ -32464,7 +32463,7 @@ export const listContactReferences: API.PaginatedOperationMethod<
   ListContactReferencesRequest,
   ListContactReferencesResponse,
   ListContactReferencesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ReferenceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactReferencesRequest,
@@ -32503,7 +32502,7 @@ export const listDataTableAttributes: API.PaginatedOperationMethod<
   ListDataTableAttributesRequest,
   ListDataTableAttributesResponse,
   ListDataTableAttributesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DataTableAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataTableAttributesRequest,
@@ -32543,7 +32542,7 @@ export const listDataTablePrimaryValues: API.PaginatedOperationMethod<
   ListDataTablePrimaryValuesRequest,
   ListDataTablePrimaryValuesResponse,
   ListDataTablePrimaryValuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RecordPrimaryValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataTablePrimaryValuesRequest,
@@ -32583,7 +32582,7 @@ export const listDataTables: API.PaginatedOperationMethod<
   ListDataTablesRequest,
   ListDataTablesResponse,
   ListDataTablesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DataTableSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataTablesRequest,
@@ -32623,7 +32622,7 @@ export const listDataTableValues: API.PaginatedOperationMethod<
   ListDataTableValuesRequest,
   ListDataTableValuesResponse,
   ListDataTableValuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DataTableValueSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataTableValuesRequest,
@@ -32660,7 +32659,7 @@ export const listDefaultVocabularies: API.PaginatedOperationMethod<
   ListDefaultVocabulariesRequest,
   ListDefaultVocabulariesResponse,
   ListDefaultVocabulariesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DefaultVocabulary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDefaultVocabulariesRequest,
@@ -32696,7 +32695,7 @@ export const listEntitySecurityProfiles: API.PaginatedOperationMethod<
   ListEntitySecurityProfilesRequest,
   ListEntitySecurityProfilesResponse,
   ListEntitySecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityProfileItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitySecurityProfilesRequest,
@@ -32732,7 +32731,7 @@ export const listEvaluationForms: API.PaginatedOperationMethod<
   ListEvaluationFormsRequest,
   ListEvaluationFormsResponse,
   ListEvaluationFormsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   EvaluationFormSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEvaluationFormsRequest,
@@ -32767,7 +32766,7 @@ export const listEvaluationFormVersions: API.PaginatedOperationMethod<
   ListEvaluationFormVersionsRequest,
   ListEvaluationFormVersionsResponse,
   ListEvaluationFormVersionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   EvaluationFormVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEvaluationFormVersionsRequest,
@@ -32804,7 +32803,7 @@ export const listFlowAssociations: API.PaginatedOperationMethod<
   ListFlowAssociationsRequest,
   ListFlowAssociationsResponse,
   ListFlowAssociationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   FlowAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowAssociationsRequest,
@@ -32842,7 +32841,7 @@ export const listHoursOfOperationOverrides: API.PaginatedOperationMethod<
   ListHoursOfOperationOverridesRequest,
   ListHoursOfOperationOverridesResponse,
   ListHoursOfOperationOverridesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HoursOfOperationOverride
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHoursOfOperationOverridesRequest,
@@ -32882,7 +32881,7 @@ export const listHoursOfOperations: API.PaginatedOperationMethod<
   ListHoursOfOperationsRequest,
   ListHoursOfOperationsResponse,
   ListHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HoursOfOperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHoursOfOperationsRequest,
@@ -32921,7 +32920,7 @@ export const listInstanceAttributes: API.PaginatedOperationMethod<
   ListInstanceAttributesRequest,
   ListInstanceAttributesResponse,
   ListInstanceAttributesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Attribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceAttributesRequest,
@@ -32959,7 +32958,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesRequest,
   ListInstancesResponse,
   ListInstancesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesRequest,
@@ -32992,7 +32991,7 @@ export const listInstanceStorageConfigs: API.PaginatedOperationMethod<
   ListInstanceStorageConfigsRequest,
   ListInstanceStorageConfigsResponse,
   ListInstanceStorageConfigsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceStorageConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceStorageConfigsRequest,
@@ -33028,7 +33027,7 @@ export const listIntegrationAssociations: API.PaginatedOperationMethod<
   ListIntegrationAssociationsRequest,
   ListIntegrationAssociationsResponse,
   ListIntegrationAssociationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   IntegrationAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntegrationAssociationsRequest,
@@ -33067,7 +33066,7 @@ export const listLambdaFunctions: API.PaginatedOperationMethod<
   ListLambdaFunctionsRequest,
   ListLambdaFunctionsResponse,
   ListLambdaFunctionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   FunctionArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLambdaFunctionsRequest,
@@ -33107,7 +33106,7 @@ export const listLexBots: API.PaginatedOperationMethod<
   ListLexBotsRequest,
   ListLexBotsResponse,
   ListLexBotsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   LexBot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLexBotsRequest,
@@ -33145,7 +33144,7 @@ export const listNotifications: API.OperationMethod<
   ListNotificationsRequest,
   ListNotificationsResponse,
   ListNotificationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListNotificationsRequest,
   output: ListNotificationsResponse,
@@ -33187,7 +33186,7 @@ export const listPhoneNumbers: API.PaginatedOperationMethod<
   ListPhoneNumbersRequest,
   ListPhoneNumbersResponse,
   ListPhoneNumbersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PhoneNumberSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumbersRequest,
@@ -33234,7 +33233,7 @@ export const listPhoneNumbersV2: API.PaginatedOperationMethod<
   ListPhoneNumbersV2Request,
   ListPhoneNumbersV2Response,
   ListPhoneNumbersV2Error,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ListPhoneNumbersSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumbersV2Request,
@@ -33284,7 +33283,7 @@ export const listPredefinedAttributes: API.PaginatedOperationMethod<
   ListPredefinedAttributesRequest,
   ListPredefinedAttributesResponse,
   ListPredefinedAttributesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PredefinedAttributeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPredefinedAttributesRequest,
@@ -33321,7 +33320,7 @@ export const listPrompts: API.PaginatedOperationMethod<
   ListPromptsRequest,
   ListPromptsResponse,
   ListPromptsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PromptSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPromptsRequest,
@@ -33369,7 +33368,7 @@ export const listQueueEmailAddresses: API.OperationMethod<
   ListQueueEmailAddressesRequest,
   ListQueueEmailAddressesResponse,
   ListQueueEmailAddressesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListQueueEmailAddressesRequest,
   output: ListQueueEmailAddressesResponse,
@@ -33400,7 +33399,7 @@ export const listQueueQuickConnects: API.PaginatedOperationMethod<
   ListQueueQuickConnectsRequest,
   ListQueueQuickConnectsResponse,
   ListQueueQuickConnectsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   QuickConnectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueueQuickConnectsRequest,
@@ -33444,7 +33443,7 @@ export const listQueues: API.PaginatedOperationMethod<
   ListQueuesRequest,
   ListQueuesResponse,
   ListQueuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   QueueSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuesRequest,
@@ -33481,7 +33480,7 @@ export const listQuickConnects: API.PaginatedOperationMethod<
   ListQuickConnectsRequest,
   ListQuickConnectsResponse,
   ListQuickConnectsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   QuickConnectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuickConnectsRequest,
@@ -33523,7 +33522,7 @@ export const listRealtimeContactAnalysisSegmentsV2: API.PaginatedOperationMethod
   ListRealtimeContactAnalysisSegmentsV2Request,
   ListRealtimeContactAnalysisSegmentsV2Response,
   ListRealtimeContactAnalysisSegmentsV2Error,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRealtimeContactAnalysisSegmentsV2Request,
@@ -33577,7 +33576,7 @@ export const listRoutingProfileManualAssignmentQueues: API.PaginatedOperationMet
   ListRoutingProfileManualAssignmentQueuesRequest,
   ListRoutingProfileManualAssignmentQueuesResponse,
   ListRoutingProfileManualAssignmentQueuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RoutingProfileManualAssignmentQueueConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingProfileManualAssignmentQueuesRequest,
@@ -33614,7 +33613,7 @@ export const listRoutingProfileQueues: API.PaginatedOperationMethod<
   ListRoutingProfileQueuesRequest,
   ListRoutingProfileQueuesResponse,
   ListRoutingProfileQueuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RoutingProfileQueueConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingProfileQueuesRequest,
@@ -33653,7 +33652,7 @@ export const listRoutingProfiles: API.PaginatedOperationMethod<
   ListRoutingProfilesRequest,
   ListRoutingProfilesResponse,
   ListRoutingProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RoutingProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingProfilesRequest,
@@ -33690,7 +33689,7 @@ export const listRules: API.PaginatedOperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesRequest,
@@ -33729,7 +33728,7 @@ export const listSecurityKeys: API.PaginatedOperationMethod<
   ListSecurityKeysRequest,
   ListSecurityKeysResponse,
   ListSecurityKeysError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityKeysRequest,
@@ -33766,7 +33765,7 @@ export const listSecurityProfileApplications: API.PaginatedOperationMethod<
   ListSecurityProfileApplicationsRequest,
   ListSecurityProfileApplicationsResponse,
   ListSecurityProfileApplicationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Application
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfileApplicationsRequest,
@@ -33803,7 +33802,7 @@ export const listSecurityProfileFlowModules: API.PaginatedOperationMethod<
   ListSecurityProfileFlowModulesRequest,
   ListSecurityProfileFlowModulesResponse,
   ListSecurityProfileFlowModulesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   FlowModule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfileFlowModulesRequest,
@@ -33844,7 +33843,7 @@ export const listSecurityProfilePermissions: API.PaginatedOperationMethod<
   ListSecurityProfilePermissionsRequest,
   ListSecurityProfilePermissionsResponse,
   ListSecurityProfilePermissionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityProfilePermission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfilePermissionsRequest,
@@ -33885,7 +33884,7 @@ export const listSecurityProfiles: API.PaginatedOperationMethod<
   ListSecurityProfilesRequest,
   ListSecurityProfilesResponse,
   ListSecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfilesRequest,
@@ -33925,7 +33924,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -33955,7 +33954,7 @@ export const listTaskTemplates: API.PaginatedOperationMethod<
   ListTaskTemplatesRequest,
   ListTaskTemplatesResponse,
   ListTaskTemplatesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TaskTemplateMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaskTemplatesRequest,
@@ -33993,7 +33992,7 @@ export const listTestCaseExecutionRecords: API.OperationMethod<
   ListTestCaseExecutionRecordsRequest,
   ListTestCaseExecutionRecordsResponse,
   ListTestCaseExecutionRecordsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTestCaseExecutionRecordsRequest,
   output: ListTestCaseExecutionRecordsResponse,
@@ -34025,7 +34024,7 @@ export const listTestCaseExecutions: API.OperationMethod<
   ListTestCaseExecutionsRequest,
   ListTestCaseExecutionsResponse,
   ListTestCaseExecutionsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTestCaseExecutionsRequest,
   output: ListTestCaseExecutionsResponse,
@@ -34057,7 +34056,7 @@ export const listTestCases: API.PaginatedOperationMethod<
   ListTestCasesRequest,
   ListTestCasesResponse,
   ListTestCasesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TestCaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestCasesRequest,
@@ -34094,7 +34093,7 @@ export const listTrafficDistributionGroups: API.PaginatedOperationMethod<
   ListTrafficDistributionGroupsRequest,
   ListTrafficDistributionGroupsResponse,
   ListTrafficDistributionGroupsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TrafficDistributionGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrafficDistributionGroupsRequest,
@@ -34130,7 +34129,7 @@ export const listTrafficDistributionGroupUsers: API.PaginatedOperationMethod<
   ListTrafficDistributionGroupUsersRequest,
   ListTrafficDistributionGroupUsersResponse,
   ListTrafficDistributionGroupUsersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TrafficDistributionGroupUserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrafficDistributionGroupUsersRequest,
@@ -34166,7 +34165,7 @@ export const listUseCases: API.PaginatedOperationMethod<
   ListUseCasesRequest,
   ListUseCasesResponse,
   ListUseCasesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   UseCase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUseCasesRequest,
@@ -34204,7 +34203,7 @@ export const listUserHierarchyGroups: API.PaginatedOperationMethod<
   ListUserHierarchyGroupsRequest,
   ListUserHierarchyGroupsResponse,
   ListUserHierarchyGroupsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HierarchyGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserHierarchyGroupsRequest,
@@ -34242,7 +34241,7 @@ export const listUserNotifications: API.OperationMethod<
   ListUserNotificationsRequest,
   ListUserNotificationsResponse,
   ListUserNotificationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUserNotificationsRequest,
   output: ListUserNotificationsResponse,
@@ -34273,7 +34272,7 @@ export const listUserProficiencies: API.PaginatedOperationMethod<
   ListUserProficienciesRequest,
   ListUserProficienciesResponse,
   ListUserProficienciesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   UserProficiency
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserProficienciesRequest,
@@ -34310,7 +34309,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   UserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -34350,7 +34349,7 @@ export const listViews: API.PaginatedOperationMethod<
   ListViewsRequest,
   ListViewsResponse,
   ListViewsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ViewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListViewsRequest,
@@ -34391,7 +34390,7 @@ export const listViewVersions: API.PaginatedOperationMethod<
   ListViewVersionsRequest,
   ListViewVersionsResponse,
   ListViewVersionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ViewVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListViewVersionsRequest,
@@ -34430,7 +34429,7 @@ export const listWorkspaceMedia: API.OperationMethod<
   ListWorkspaceMediaRequest,
   ListWorkspaceMediaResponse,
   ListWorkspaceMediaError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWorkspaceMediaRequest,
   output: ListWorkspaceMediaResponse,
@@ -34462,7 +34461,7 @@ export const listWorkspacePages: API.PaginatedOperationMethod<
   ListWorkspacePagesRequest,
   ListWorkspacePagesResponse,
   ListWorkspacePagesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   WorkspacePage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspacePagesRequest,
@@ -34501,7 +34500,7 @@ export const listWorkspaces: API.PaginatedOperationMethod<
   ListWorkspacesRequest,
   ListWorkspacesResponse,
   ListWorkspacesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   WorkspaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspacesRequest,
@@ -34542,7 +34541,7 @@ export const monitorContact: API.OperationMethod<
   MonitorContactRequest,
   MonitorContactResponse,
   MonitorContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MonitorContactRequest,
   output: MonitorContactResponse,
@@ -34577,7 +34576,7 @@ export const pauseContact: API.OperationMethod<
   PauseContactRequest,
   PauseContactResponse,
   PauseContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseContactRequest,
   output: PauseContactResponse,
@@ -34615,7 +34614,7 @@ export const putUserStatus: API.OperationMethod<
   PutUserStatusRequest,
   PutUserStatusResponse,
   PutUserStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutUserStatusRequest,
   output: PutUserStatusResponse,
@@ -34671,7 +34670,7 @@ export const releasePhoneNumber: API.OperationMethod<
   ReleasePhoneNumberRequest,
   ReleasePhoneNumberResponse,
   ReleasePhoneNumberError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleasePhoneNumberRequest,
   output: ReleasePhoneNumberResponse,
@@ -34710,7 +34709,7 @@ export const replicateInstance: API.OperationMethod<
   ReplicateInstanceRequest,
   ReplicateInstanceResponse,
   ReplicateInstanceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplicateInstanceRequest,
   output: ReplicateInstanceResponse,
@@ -34745,7 +34744,7 @@ export const resumeContact: API.OperationMethod<
   ResumeContactRequest,
   ResumeContactResponse,
   ResumeContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeContactRequest,
   output: ResumeContactResponse,
@@ -34780,7 +34779,7 @@ export const resumeContactRecording: API.OperationMethod<
   ResumeContactRecordingRequest,
   ResumeContactRecordingResponse,
   ResumeContactRecordingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeContactRecordingRequest,
   output: ResumeContactRecordingResponse,
@@ -34809,7 +34808,7 @@ export const searchAgentStatuses: API.PaginatedOperationMethod<
   SearchAgentStatusesRequest,
   SearchAgentStatusesResponse,
   SearchAgentStatusesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AgentStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAgentStatusesRequest,
@@ -34847,7 +34846,7 @@ export const searchAvailablePhoneNumbers: API.PaginatedOperationMethod<
   SearchAvailablePhoneNumbersRequest,
   SearchAvailablePhoneNumbersResponse,
   SearchAvailablePhoneNumbersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AvailableNumberSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAvailablePhoneNumbersRequest,
@@ -34899,7 +34898,7 @@ export const searchContactEvaluations: API.OperationMethod<
   SearchContactEvaluationsRequest,
   SearchContactEvaluationsResponse,
   SearchContactEvaluationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchContactEvaluationsRequest,
   output: SearchContactEvaluationsResponse,
@@ -34929,7 +34928,7 @@ export const searchContactFlowModules: API.PaginatedOperationMethod<
   SearchContactFlowModulesRequest,
   SearchContactFlowModulesResponse,
   SearchContactFlowModulesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlowModule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchContactFlowModulesRequest,
@@ -34966,7 +34965,7 @@ export const searchContactFlows: API.PaginatedOperationMethod<
   SearchContactFlowsRequest,
   SearchContactFlowsResponse,
   SearchContactFlowsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactFlow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchContactFlowsRequest,
@@ -35003,7 +35002,7 @@ export const searchContacts: API.PaginatedOperationMethod<
   SearchContactsRequest,
   SearchContactsResponse,
   SearchContactsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ContactSearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchContactsRequest,
@@ -35042,7 +35041,7 @@ export const searchDataTables: API.PaginatedOperationMethod<
   SearchDataTablesRequest,
   SearchDataTablesResponse,
   SearchDataTablesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DataTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDataTablesRequest,
@@ -35080,7 +35079,7 @@ export const searchEmailAddresses: API.OperationMethod<
   SearchEmailAddressesRequest,
   SearchEmailAddressesResponse,
   SearchEmailAddressesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchEmailAddressesRequest,
   output: SearchEmailAddressesResponse,
@@ -35129,7 +35128,7 @@ export const searchEvaluationForms: API.OperationMethod<
   SearchEvaluationFormsRequest,
   SearchEvaluationFormsResponse,
   SearchEvaluationFormsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchEvaluationFormsRequest,
   output: SearchEvaluationFormsResponse,
@@ -35159,7 +35158,7 @@ export const searchHoursOfOperationOverrides: API.PaginatedOperationMethod<
   SearchHoursOfOperationOverridesRequest,
   SearchHoursOfOperationOverridesResponse,
   SearchHoursOfOperationOverridesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HoursOfOperationOverride
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchHoursOfOperationOverridesRequest,
@@ -35196,7 +35195,7 @@ export const searchHoursOfOperations: API.PaginatedOperationMethod<
   SearchHoursOfOperationsRequest,
   SearchHoursOfOperationsResponse,
   SearchHoursOfOperationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HoursOfOperation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchHoursOfOperationsRequest,
@@ -35234,7 +35233,7 @@ export const searchNotifications: API.OperationMethod<
   SearchNotificationsRequest,
   SearchNotificationsResponse,
   SearchNotificationsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchNotificationsRequest,
   output: SearchNotificationsResponse,
@@ -35278,7 +35277,7 @@ export const searchPredefinedAttributes: API.PaginatedOperationMethod<
   SearchPredefinedAttributesRequest,
   SearchPredefinedAttributesResponse,
   SearchPredefinedAttributesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PredefinedAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchPredefinedAttributesRequest,
@@ -35315,7 +35314,7 @@ export const searchPrompts: API.PaginatedOperationMethod<
   SearchPromptsRequest,
   SearchPromptsResponse,
   SearchPromptsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Prompt
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchPromptsRequest,
@@ -35352,7 +35351,7 @@ export const searchQueues: API.PaginatedOperationMethod<
   SearchQueuesRequest,
   SearchQueuesResponse,
   SearchQueuesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Queue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchQueuesRequest,
@@ -35389,7 +35388,7 @@ export const searchQuickConnects: API.PaginatedOperationMethod<
   SearchQuickConnectsRequest,
   SearchQuickConnectsResponse,
   SearchQuickConnectsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   QuickConnect
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchQuickConnectsRequest,
@@ -35427,7 +35426,7 @@ export const searchResourceTags: API.PaginatedOperationMethod<
   SearchResourceTagsRequest,
   SearchResourceTagsResponse,
   SearchResourceTagsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TagSet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchResourceTagsRequest,
@@ -35468,7 +35467,7 @@ export const searchRoutingProfiles: API.PaginatedOperationMethod<
   SearchRoutingProfilesRequest,
   SearchRoutingProfilesResponse,
   SearchRoutingProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   RoutingProfile
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchRoutingProfilesRequest,
@@ -35509,7 +35508,7 @@ export const searchSecurityProfiles: API.PaginatedOperationMethod<
   SearchSecurityProfilesRequest,
   SearchSecurityProfilesResponse,
   SearchSecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityProfileSearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSecurityProfilesRequest,
@@ -35547,7 +35546,7 @@ export const searchTestCases: API.PaginatedOperationMethod<
   SearchTestCasesRequest,
   SearchTestCasesResponse,
   SearchTestCasesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   TestCase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTestCasesRequest,
@@ -35588,7 +35587,7 @@ export const searchUserHierarchyGroups: API.PaginatedOperationMethod<
   SearchUserHierarchyGroupsRequest,
   SearchUserHierarchyGroupsResponse,
   SearchUserHierarchyGroupsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   HierarchyGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchUserHierarchyGroupsRequest,
@@ -35627,7 +35626,7 @@ export const searchUsers: API.PaginatedOperationMethod<
   SearchUsersRequest,
   SearchUsersResponse,
   SearchUsersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   UserSearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchUsersRequest,
@@ -35665,7 +35664,7 @@ export const searchViews: API.PaginatedOperationMethod<
   SearchViewsRequest,
   SearchViewsResponse,
   SearchViewsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   View
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchViewsRequest,
@@ -35703,7 +35702,7 @@ export const searchVocabularies: API.PaginatedOperationMethod<
   SearchVocabulariesRequest,
   SearchVocabulariesResponse,
   SearchVocabulariesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   VocabularySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchVocabulariesRequest,
@@ -35740,7 +35739,7 @@ export const searchWorkspaceAssociations: API.PaginatedOperationMethod<
   SearchWorkspaceAssociationsRequest,
   SearchWorkspaceAssociationsResponse,
   SearchWorkspaceAssociationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   WorkspaceAssociationSearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchWorkspaceAssociationsRequest,
@@ -35779,7 +35778,7 @@ export const searchWorkspaces: API.PaginatedOperationMethod<
   SearchWorkspacesRequest,
   SearchWorkspacesResponse,
   SearchWorkspacesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   WorkspaceSearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchWorkspacesRequest,
@@ -35829,7 +35828,7 @@ export const sendChatIntegrationEvent: API.OperationMethod<
   SendChatIntegrationEventRequest,
   SendChatIntegrationEventResponse,
   SendChatIntegrationEventError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendChatIntegrationEventRequest,
   output: SendChatIntegrationEventResponse,
@@ -35865,7 +35864,7 @@ export const sendOutboundEmail: API.OperationMethod<
   SendOutboundEmailRequest,
   SendOutboundEmailResponse,
   SendOutboundEmailError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendOutboundEmailRequest,
   output: SendOutboundEmailResponse,
@@ -35900,7 +35899,7 @@ export const startAttachedFileUpload: API.OperationMethod<
   StartAttachedFileUploadRequest,
   StartAttachedFileUploadResponse,
   StartAttachedFileUploadError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAttachedFileUploadRequest,
   output: StartAttachedFileUploadResponse,
@@ -35953,7 +35952,7 @@ export const startChatContact: API.OperationMethod<
   StartChatContactRequest,
   StartChatContactResponse,
   StartChatContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartChatContactRequest,
   output: StartChatContactResponse,
@@ -35988,7 +35987,7 @@ export const startContactEvaluation: API.OperationMethod<
   StartContactEvaluationRequest,
   StartContactEvaluationResponse,
   StartContactEvaluationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContactEvaluationRequest,
   output: StartContactEvaluationResponse,
@@ -36022,7 +36021,7 @@ export const startContactMediaProcessing: API.OperationMethod<
   StartContactMediaProcessingRequest,
   StartContactMediaProcessingResponse,
   StartContactMediaProcessingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContactMediaProcessingRequest,
   output: StartContactMediaProcessingResponse,
@@ -36069,7 +36068,7 @@ export const startContactRecording: API.OperationMethod<
   StartContactRecordingRequest,
   StartContactRecordingResponse,
   StartContactRecordingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContactRecordingRequest,
   output: StartContactRecordingResponse,
@@ -36109,7 +36108,7 @@ export const startContactStreaming: API.OperationMethod<
   StartContactStreamingRequest,
   StartContactStreamingResponse,
   StartContactStreamingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContactStreamingRequest,
   output: StartContactStreamingResponse,
@@ -36142,7 +36141,7 @@ export const startEmailContact: API.OperationMethod<
   StartEmailContactRequest,
   StartEmailContactResponse,
   StartEmailContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEmailContactRequest,
   output: StartEmailContactResponse,
@@ -36179,7 +36178,7 @@ export const startEvaluationFormValidation: API.OperationMethod<
   StartEvaluationFormValidationRequest,
   StartEvaluationFormValidationResponse,
   StartEvaluationFormValidationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEvaluationFormValidationRequest,
   output: StartEvaluationFormValidationResponse,
@@ -36234,7 +36233,7 @@ export const startOutboundChatContact: API.OperationMethod<
   StartOutboundChatContactRequest,
   StartOutboundChatContactResponse,
   StartOutboundChatContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOutboundChatContactRequest,
   output: StartOutboundChatContactResponse,
@@ -36269,7 +36268,7 @@ export const startOutboundEmailContact: API.OperationMethod<
   StartOutboundEmailContactRequest,
   StartOutboundEmailContactResponse,
   StartOutboundEmailContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOutboundEmailContactRequest,
   output: StartOutboundEmailContactResponse,
@@ -36322,7 +36321,7 @@ export const startOutboundVoiceContact: API.OperationMethod<
   StartOutboundVoiceContactRequest,
   StartOutboundVoiceContactResponse,
   StartOutboundVoiceContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOutboundVoiceContactRequest,
   output: StartOutboundVoiceContactResponse,
@@ -36356,7 +36355,7 @@ export const startScreenSharing: API.OperationMethod<
   StartScreenSharingRequest,
   StartScreenSharingResponse,
   StartScreenSharingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartScreenSharingRequest,
   output: StartScreenSharingResponse,
@@ -36420,7 +36419,7 @@ export const startTaskContact: API.OperationMethod<
   StartTaskContactRequest,
   StartTaskContactResponse,
   StartTaskContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTaskContactRequest,
   output: StartTaskContactResponse,
@@ -36453,7 +36452,7 @@ export const startTestCaseExecution: API.OperationMethod<
   StartTestCaseExecutionRequest,
   StartTestCaseExecutionResponse,
   StartTestCaseExecutionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTestCaseExecutionRequest,
   output: StartTestCaseExecutionResponse,
@@ -36487,7 +36486,7 @@ export const startWebRTCContact: API.OperationMethod<
   StartWebRTCContactRequest,
   StartWebRTCContactResponse,
   StartWebRTCContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWebRTCContactRequest,
   output: StartWebRTCContactResponse,
@@ -36531,7 +36530,7 @@ export const stopContact: API.OperationMethod<
   StopContactRequest,
   StopContactResponse,
   StopContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopContactRequest,
   output: StopContactResponse,
@@ -36563,7 +36562,7 @@ export const stopContactMediaProcessing: API.OperationMethod<
   StopContactMediaProcessingRequest,
   StopContactMediaProcessingResponse,
   StopContactMediaProcessingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopContactMediaProcessingRequest,
   output: StopContactMediaProcessingResponse,
@@ -36598,7 +36597,7 @@ export const stopContactRecording: API.OperationMethod<
   StopContactRecordingRequest,
   StopContactRecordingResponse,
   StopContactRecordingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopContactRecordingRequest,
   output: StopContactRecordingResponse,
@@ -36627,7 +36626,7 @@ export const stopContactStreaming: API.OperationMethod<
   StopContactStreamingRequest,
   StopContactStreamingResponse,
   StopContactStreamingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopContactStreamingRequest,
   output: StopContactStreamingResponse,
@@ -36657,7 +36656,7 @@ export const stopTestCaseExecution: API.OperationMethod<
   StopTestCaseExecutionRequest,
   StopTestCaseExecutionResponse,
   StopTestCaseExecutionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTestCaseExecutionRequest,
   output: StopTestCaseExecutionResponse,
@@ -36693,7 +36692,7 @@ export const submitContactEvaluation: API.OperationMethod<
   SubmitContactEvaluationRequest,
   SubmitContactEvaluationResponse,
   SubmitContactEvaluationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitContactEvaluationRequest,
   output: SubmitContactEvaluationResponse,
@@ -36730,7 +36729,7 @@ export const suspendContactRecording: API.OperationMethod<
   SuspendContactRecordingRequest,
   SuspendContactRecordingResponse,
   SuspendContactRecordingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SuspendContactRecordingRequest,
   output: SuspendContactRecordingResponse,
@@ -36761,7 +36760,7 @@ export const tagContact: API.OperationMethod<
   TagContactRequest,
   TagContactResponse,
   TagContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagContactRequest,
   output: TagContactResponse,
@@ -36798,7 +36797,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -36847,7 +36846,7 @@ export const transferContact: API.OperationMethod<
   TransferContactRequest,
   TransferContactResponse,
   TransferContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransferContactRequest,
   output: TransferContactResponse,
@@ -36881,7 +36880,7 @@ export const untagContact: API.OperationMethod<
   UntagContactRequest,
   UntagContactResponse,
   UntagContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagContactRequest,
   output: UntagContactResponse,
@@ -36912,7 +36911,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -36944,7 +36943,7 @@ export const updateAgentStatus: API.OperationMethod<
   UpdateAgentStatusRequest,
   UpdateAgentStatusResponse,
   UpdateAgentStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentStatusRequest,
   output: UpdateAgentStatusResponse,
@@ -36978,7 +36977,7 @@ export const updateAttachedFilesConfiguration: API.OperationMethod<
   UpdateAttachedFilesConfigurationRequest,
   UpdateAttachedFilesConfigurationResponse,
   UpdateAttachedFilesConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAttachedFilesConfigurationRequest,
   output: UpdateAttachedFilesConfigurationResponse,
@@ -37011,7 +37010,7 @@ export const updateAuthenticationProfile: API.OperationMethod<
   UpdateAuthenticationProfileRequest,
   UpdateAuthenticationProfileResponse,
   UpdateAuthenticationProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuthenticationProfileRequest,
   output: UpdateAuthenticationProfileResponse,
@@ -37049,7 +37048,7 @@ export const updateContact: API.OperationMethod<
   UpdateContactRequest,
   UpdateContactResponse,
   UpdateContactError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactRequest,
   output: UpdateContactResponse,
@@ -37092,7 +37091,7 @@ export const updateContactAttributes: API.OperationMethod<
   UpdateContactAttributesRequest,
   UpdateContactAttributesResponse,
   UpdateContactAttributesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactAttributesRequest,
   output: UpdateContactAttributesResponse,
@@ -37124,7 +37123,7 @@ export const updateContactEvaluation: API.OperationMethod<
   UpdateContactEvaluationRequest,
   UpdateContactEvaluationResponse,
   UpdateContactEvaluationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactEvaluationRequest,
   output: UpdateContactEvaluationResponse,
@@ -37162,7 +37161,7 @@ export const updateContactFlowContent: API.OperationMethod<
   UpdateContactFlowContentRequest,
   UpdateContactFlowContentResponse,
   UpdateContactFlowContentError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowContentRequest,
   output: UpdateContactFlowContentResponse,
@@ -37194,7 +37193,7 @@ export const updateContactFlowMetadata: API.OperationMethod<
   UpdateContactFlowMetadataRequest,
   UpdateContactFlowMetadataResponse,
   UpdateContactFlowMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowMetadataRequest,
   output: UpdateContactFlowMetadataResponse,
@@ -37228,7 +37227,7 @@ export const updateContactFlowModuleAlias: API.OperationMethod<
   UpdateContactFlowModuleAliasRequest,
   UpdateContactFlowModuleAliasResponse,
   UpdateContactFlowModuleAliasError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowModuleAliasRequest,
   output: UpdateContactFlowModuleAliasResponse,
@@ -37266,7 +37265,7 @@ export const updateContactFlowModuleContent: API.OperationMethod<
   UpdateContactFlowModuleContentRequest,
   UpdateContactFlowModuleContentResponse,
   UpdateContactFlowModuleContentError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowModuleContentRequest,
   output: UpdateContactFlowModuleContentResponse,
@@ -37299,7 +37298,7 @@ export const updateContactFlowModuleMetadata: API.OperationMethod<
   UpdateContactFlowModuleMetadataRequest,
   UpdateContactFlowModuleMetadataResponse,
   UpdateContactFlowModuleMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowModuleMetadataRequest,
   output: UpdateContactFlowModuleMetadataResponse,
@@ -37335,7 +37334,7 @@ export const updateContactFlowName: API.OperationMethod<
   UpdateContactFlowNameRequest,
   UpdateContactFlowNameResponse,
   UpdateContactFlowNameError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactFlowNameRequest,
   output: UpdateContactFlowNameResponse,
@@ -37376,7 +37375,7 @@ export const updateContactRoutingData: API.OperationMethod<
   UpdateContactRoutingDataRequest,
   UpdateContactRoutingDataResponse,
   UpdateContactRoutingDataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactRoutingDataRequest,
   output: UpdateContactRoutingDataResponse,
@@ -37409,7 +37408,7 @@ export const updateContactSchedule: API.OperationMethod<
   UpdateContactScheduleRequest,
   UpdateContactScheduleResponse,
   UpdateContactScheduleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactScheduleRequest,
   output: UpdateContactScheduleResponse,
@@ -37447,7 +37446,7 @@ export const updateDataTableAttribute: API.OperationMethod<
   UpdateDataTableAttributeRequest,
   UpdateDataTableAttributeResponse,
   UpdateDataTableAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataTableAttributeRequest,
   output: UpdateDataTableAttributeResponse,
@@ -37486,7 +37485,7 @@ export const updateDataTableMetadata: API.OperationMethod<
   UpdateDataTableMetadataRequest,
   UpdateDataTableMetadataResponse,
   UpdateDataTableMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataTableMetadataRequest,
   output: UpdateDataTableMetadataResponse,
@@ -37523,7 +37522,7 @@ export const updateDataTablePrimaryValues: API.OperationMethod<
   UpdateDataTablePrimaryValuesRequest,
   UpdateDataTablePrimaryValuesResponse,
   UpdateDataTablePrimaryValuesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataTablePrimaryValuesRequest,
   output: UpdateDataTablePrimaryValuesResponse,
@@ -37558,7 +37557,7 @@ export const updateEmailAddressMetadata: API.OperationMethod<
   UpdateEmailAddressMetadataRequest,
   UpdateEmailAddressMetadataResponse,
   UpdateEmailAddressMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmailAddressMetadataRequest,
   output: UpdateEmailAddressMetadataResponse,
@@ -37595,7 +37594,7 @@ export const updateEvaluationForm: API.OperationMethod<
   UpdateEvaluationFormRequest,
   UpdateEvaluationFormResponse,
   UpdateEvaluationFormError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEvaluationFormRequest,
   output: UpdateEvaluationFormResponse,
@@ -37627,7 +37626,7 @@ export const updateHoursOfOperation: API.OperationMethod<
   UpdateHoursOfOperationRequest,
   UpdateHoursOfOperationResponse,
   UpdateHoursOfOperationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHoursOfOperationRequest,
   output: UpdateHoursOfOperationResponse,
@@ -37660,7 +37659,7 @@ export const updateHoursOfOperationOverride: API.OperationMethod<
   UpdateHoursOfOperationOverrideRequest,
   UpdateHoursOfOperationOverrideResponse,
   UpdateHoursOfOperationOverrideError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHoursOfOperationOverrideRequest,
   output: UpdateHoursOfOperationOverrideResponse,
@@ -37694,7 +37693,7 @@ export const updateInstanceAttribute: API.OperationMethod<
   UpdateInstanceAttributeRequest,
   UpdateInstanceAttributeResponse,
   UpdateInstanceAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceAttributeRequest,
   output: UpdateInstanceAttributeResponse,
@@ -37726,7 +37725,7 @@ export const updateInstanceStorageConfig: API.OperationMethod<
   UpdateInstanceStorageConfigRequest,
   UpdateInstanceStorageConfigResponse,
   UpdateInstanceStorageConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceStorageConfigRequest,
   output: UpdateInstanceStorageConfigResponse,
@@ -37757,7 +37756,7 @@ export const updateNotificationContent: API.OperationMethod<
   UpdateNotificationContentRequest,
   UpdateNotificationContentResponse,
   UpdateNotificationContentError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationContentRequest,
   output: UpdateNotificationContentResponse,
@@ -37799,7 +37798,7 @@ export const updateParticipantAuthentication: API.OperationMethod<
   UpdateParticipantAuthenticationRequest,
   UpdateParticipantAuthenticationResponse,
   UpdateParticipantAuthenticationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateParticipantAuthenticationRequest,
   output: UpdateParticipantAuthenticationResponse,
@@ -37843,7 +37842,7 @@ export const updateParticipantRoleConfig: API.OperationMethod<
   UpdateParticipantRoleConfigRequest,
   UpdateParticipantRoleConfigResponse,
   UpdateParticipantRoleConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateParticipantRoleConfigRequest,
   output: UpdateParticipantRoleConfigResponse,
@@ -37882,7 +37881,7 @@ export const updatePhoneNumber: API.OperationMethod<
   UpdatePhoneNumberRequest,
   UpdatePhoneNumberResponse,
   UpdatePhoneNumberError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberRequest,
   output: UpdatePhoneNumberResponse,
@@ -37919,7 +37918,7 @@ export const updatePhoneNumberMetadata: API.OperationMethod<
   UpdatePhoneNumberMetadataRequest,
   UpdatePhoneNumberMetadataResponse,
   UpdatePhoneNumberMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberMetadataRequest,
   output: UpdatePhoneNumberMetadataResponse,
@@ -37970,7 +37969,7 @@ export const updatePredefinedAttribute: API.OperationMethod<
   UpdatePredefinedAttributeRequest,
   UpdatePredefinedAttributeResponse,
   UpdatePredefinedAttributeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePredefinedAttributeRequest,
   output: UpdatePredefinedAttributeResponse,
@@ -38000,7 +37999,7 @@ export const updatePrompt: API.OperationMethod<
   UpdatePromptRequest,
   UpdatePromptResponse,
   UpdatePromptError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePromptRequest,
   output: UpdatePromptResponse,
@@ -38030,7 +38029,7 @@ export const updateQueueHoursOfOperation: API.OperationMethod<
   UpdateQueueHoursOfOperationRequest,
   UpdateQueueHoursOfOperationResponse,
   UpdateQueueHoursOfOperationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueHoursOfOperationRequest,
   output: UpdateQueueHoursOfOperationResponse,
@@ -38060,7 +38059,7 @@ export const updateQueueMaxContacts: API.OperationMethod<
   UpdateQueueMaxContactsRequest,
   UpdateQueueMaxContactsResponse,
   UpdateQueueMaxContactsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueMaxContactsRequest,
   output: UpdateQueueMaxContactsResponse,
@@ -38091,7 +38090,7 @@ export const updateQueueName: API.OperationMethod<
   UpdateQueueNameRequest,
   UpdateQueueNameResponse,
   UpdateQueueNameError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueNameRequest,
   output: UpdateQueueNameResponse,
@@ -38136,7 +38135,7 @@ export const updateQueueOutboundCallerConfig: API.OperationMethod<
   UpdateQueueOutboundCallerConfigRequest,
   UpdateQueueOutboundCallerConfigResponse,
   UpdateQueueOutboundCallerConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueOutboundCallerConfigRequest,
   output: UpdateQueueOutboundCallerConfigResponse,
@@ -38168,7 +38167,7 @@ export const updateQueueOutboundEmailConfig: API.OperationMethod<
   UpdateQueueOutboundEmailConfigRequest,
   UpdateQueueOutboundEmailConfigResponse,
   UpdateQueueOutboundEmailConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueOutboundEmailConfigRequest,
   output: UpdateQueueOutboundEmailConfigResponse,
@@ -38200,7 +38199,7 @@ export const updateQueueStatus: API.OperationMethod<
   UpdateQueueStatusRequest,
   UpdateQueueStatusResponse,
   UpdateQueueStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueStatusRequest,
   output: UpdateQueueStatusResponse,
@@ -38230,7 +38229,7 @@ export const updateQuickConnectConfig: API.OperationMethod<
   UpdateQuickConnectConfigRequest,
   UpdateQuickConnectConfigResponse,
   UpdateQuickConnectConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuickConnectConfigRequest,
   output: UpdateQuickConnectConfigResponse,
@@ -38260,7 +38259,7 @@ export const updateQuickConnectName: API.OperationMethod<
   UpdateQuickConnectNameRequest,
   UpdateQuickConnectNameResponse,
   UpdateQuickConnectNameError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuickConnectNameRequest,
   output: UpdateQuickConnectNameResponse,
@@ -38291,7 +38290,7 @@ export const updateRoutingProfileAgentAvailabilityTimer: API.OperationMethod<
   UpdateRoutingProfileAgentAvailabilityTimerRequest,
   UpdateRoutingProfileAgentAvailabilityTimerResponse,
   UpdateRoutingProfileAgentAvailabilityTimerError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingProfileAgentAvailabilityTimerRequest,
   output: UpdateRoutingProfileAgentAvailabilityTimerResponse,
@@ -38321,7 +38320,7 @@ export const updateRoutingProfileConcurrency: API.OperationMethod<
   UpdateRoutingProfileConcurrencyRequest,
   UpdateRoutingProfileConcurrencyResponse,
   UpdateRoutingProfileConcurrencyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingProfileConcurrencyRequest,
   output: UpdateRoutingProfileConcurrencyResponse,
@@ -38351,7 +38350,7 @@ export const updateRoutingProfileDefaultOutboundQueue: API.OperationMethod<
   UpdateRoutingProfileDefaultOutboundQueueRequest,
   UpdateRoutingProfileDefaultOutboundQueueResponse,
   UpdateRoutingProfileDefaultOutboundQueueError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingProfileDefaultOutboundQueueRequest,
   output: UpdateRoutingProfileDefaultOutboundQueueResponse,
@@ -38382,7 +38381,7 @@ export const updateRoutingProfileName: API.OperationMethod<
   UpdateRoutingProfileNameRequest,
   UpdateRoutingProfileNameResponse,
   UpdateRoutingProfileNameError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingProfileNameRequest,
   output: UpdateRoutingProfileNameResponse,
@@ -38413,7 +38412,7 @@ export const updateRoutingProfileQueues: API.OperationMethod<
   UpdateRoutingProfileQueuesRequest,
   UpdateRoutingProfileQueuesResponse,
   UpdateRoutingProfileQueuesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingProfileQueuesRequest,
   output: UpdateRoutingProfileQueuesResponse,
@@ -38447,7 +38446,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
   UpdateRuleResponse,
   UpdateRuleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,
@@ -38482,7 +38481,7 @@ export const updateSecurityProfile: API.OperationMethod<
   UpdateSecurityProfileRequest,
   UpdateSecurityProfileResponse,
   UpdateSecurityProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityProfileRequest,
   output: UpdateSecurityProfileResponse,
@@ -38514,7 +38513,7 @@ export const updateTaskTemplate: API.OperationMethod<
   UpdateTaskTemplateRequest,
   UpdateTaskTemplateResponse,
   UpdateTaskTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskTemplateRequest,
   output: UpdateTaskTemplateResponse,
@@ -38548,7 +38547,7 @@ export const updateTestCase: API.OperationMethod<
   UpdateTestCaseRequest,
   UpdateTestCaseResponse,
   UpdateTestCaseError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTestCaseRequest,
   output: UpdateTestCaseResponse,
@@ -38601,7 +38600,7 @@ export const updateTrafficDistribution: API.OperationMethod<
   UpdateTrafficDistributionRequest,
   UpdateTrafficDistributionResponse,
   UpdateTrafficDistributionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrafficDistributionRequest,
   output: UpdateTrafficDistributionResponse,
@@ -38635,7 +38634,7 @@ export const updateUserConfig: API.OperationMethod<
   UpdateUserConfigRequest,
   UpdateUserConfigResponse,
   UpdateUserConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserConfigRequest,
   output: UpdateUserConfigResponse,
@@ -38666,7 +38665,7 @@ export const updateUserHierarchy: API.OperationMethod<
   UpdateUserHierarchyRequest,
   UpdateUserHierarchyResponse,
   UpdateUserHierarchyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserHierarchyRequest,
   output: UpdateUserHierarchyResponse,
@@ -38697,7 +38696,7 @@ export const updateUserHierarchyGroupName: API.OperationMethod<
   UpdateUserHierarchyGroupNameRequest,
   UpdateUserHierarchyGroupNameResponse,
   UpdateUserHierarchyGroupNameError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserHierarchyGroupNameRequest,
   output: UpdateUserHierarchyGroupNameResponse,
@@ -38729,7 +38728,7 @@ export const updateUserHierarchyStructure: API.OperationMethod<
   UpdateUserHierarchyStructureRequest,
   UpdateUserHierarchyStructureResponse,
   UpdateUserHierarchyStructureError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserHierarchyStructureRequest,
   output: UpdateUserHierarchyStructureResponse,
@@ -38766,7 +38765,7 @@ export const updateUserIdentityInfo: API.OperationMethod<
   UpdateUserIdentityInfoRequest,
   UpdateUserIdentityInfoResponse,
   UpdateUserIdentityInfoError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserIdentityInfoRequest,
   output: UpdateUserIdentityInfoResponse,
@@ -38797,7 +38796,7 @@ export const updateUserNotificationStatus: API.OperationMethod<
   UpdateUserNotificationStatusRequest,
   UpdateUserNotificationStatusResponse,
   UpdateUserNotificationStatusError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserNotificationStatusRequest,
   output: UpdateUserNotificationStatusResponse,
@@ -38830,7 +38829,7 @@ export const updateUserPhoneConfig: API.OperationMethod<
   UpdateUserPhoneConfigRequest,
   UpdateUserPhoneConfigResponse,
   UpdateUserPhoneConfigError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserPhoneConfigRequest,
   output: UpdateUserPhoneConfigResponse,
@@ -38860,7 +38859,7 @@ export const updateUserProficiencies: API.OperationMethod<
   UpdateUserProficienciesRequest,
   UpdateUserProficienciesResponse,
   UpdateUserProficienciesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserProficienciesRequest,
   output: UpdateUserProficienciesResponse,
@@ -38890,7 +38889,7 @@ export const updateUserRoutingProfile: API.OperationMethod<
   UpdateUserRoutingProfileRequest,
   UpdateUserRoutingProfileResponse,
   UpdateUserRoutingProfileError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRoutingProfileRequest,
   output: UpdateUserRoutingProfileResponse,
@@ -38920,7 +38919,7 @@ export const updateUserSecurityProfiles: API.OperationMethod<
   UpdateUserSecurityProfilesRequest,
   UpdateUserSecurityProfilesResponse,
   UpdateUserSecurityProfilesError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserSecurityProfilesRequest,
   output: UpdateUserSecurityProfilesResponse,
@@ -38957,7 +38956,7 @@ export const updateViewContent: API.OperationMethod<
   UpdateViewContentRequest,
   UpdateViewContentResponse,
   UpdateViewContentError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateViewContentRequest,
   output: UpdateViewContentResponse,
@@ -38993,7 +38992,7 @@ export const updateViewMetadata: API.OperationMethod<
   UpdateViewMetadataRequest,
   UpdateViewMetadataResponse,
   UpdateViewMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateViewMetadataRequest,
   output: UpdateViewMetadataResponse,
@@ -39028,7 +39027,7 @@ export const updateWorkspaceMetadata: API.OperationMethod<
   UpdateWorkspaceMetadataRequest,
   UpdateWorkspaceMetadataResponse,
   UpdateWorkspaceMetadataError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceMetadataRequest,
   output: UpdateWorkspaceMetadataResponse,
@@ -39063,7 +39062,7 @@ export const updateWorkspacePage: API.OperationMethod<
   UpdateWorkspacePageRequest,
   UpdateWorkspacePageResponse,
   UpdateWorkspacePageError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspacePageRequest,
   output: UpdateWorkspacePageResponse,
@@ -39097,7 +39096,7 @@ export const updateWorkspaceTheme: API.OperationMethod<
   UpdateWorkspaceThemeRequest,
   UpdateWorkspaceThemeResponse,
   UpdateWorkspaceThemeError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceThemeRequest,
   output: UpdateWorkspaceThemeResponse,
@@ -39130,7 +39129,7 @@ export const updateWorkspaceVisibility: API.OperationMethod<
   UpdateWorkspaceVisibilityRequest,
   UpdateWorkspaceVisibilityResponse,
   UpdateWorkspaceVisibilityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceVisibilityRequest,
   output: UpdateWorkspaceVisibilityResponse,

--- a/packages/aws/src/services/connectcampaigns.ts
+++ b/packages/aws/src/services/connectcampaigns.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ConnectCampaigns",
@@ -1111,7 +1110,7 @@ export const createCampaign: API.OperationMethod<
   CreateCampaignRequest,
   CreateCampaignResponse,
   CreateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCampaignRequest,
   output: CreateCampaignResponse,
@@ -1142,7 +1141,7 @@ export const deleteCampaign: API.OperationMethod<
   DeleteCampaignRequest,
   DeleteCampaignResponse,
   DeleteCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignRequest,
   output: DeleteCampaignResponse,
@@ -1172,7 +1171,7 @@ export const deleteConnectInstanceConfig: API.OperationMethod<
   DeleteConnectInstanceConfigRequest,
   DeleteConnectInstanceConfigResponse,
   DeleteConnectInstanceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectInstanceConfigRequest,
   output: DeleteConnectInstanceConfigResponse,
@@ -1203,7 +1202,7 @@ export const deleteInstanceOnboardingJob: API.OperationMethod<
   DeleteInstanceOnboardingJobRequest,
   DeleteInstanceOnboardingJobResponse,
   DeleteInstanceOnboardingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceOnboardingJobRequest,
   output: DeleteInstanceOnboardingJobResponse,
@@ -1232,7 +1231,7 @@ export const describeCampaign: API.OperationMethod<
   DescribeCampaignRequest,
   DescribeCampaignResponse,
   DescribeCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCampaignRequest,
   output: DescribeCampaignResponse,
@@ -1261,7 +1260,7 @@ export const getCampaignState: API.OperationMethod<
   GetCampaignStateRequest,
   GetCampaignStateResponse,
   GetCampaignStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignStateRequest,
   output: GetCampaignStateResponse,
@@ -1290,7 +1289,7 @@ export const getCampaignStateBatch: API.OperationMethod<
   GetCampaignStateBatchRequest,
   GetCampaignStateBatchResponse,
   GetCampaignStateBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignStateBatchRequest,
   output: GetCampaignStateBatchResponse,
@@ -1318,7 +1317,7 @@ export const getConnectInstanceConfig: API.OperationMethod<
   GetConnectInstanceConfigRequest,
   GetConnectInstanceConfigResponse,
   GetConnectInstanceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectInstanceConfigRequest,
   output: GetConnectInstanceConfigResponse,
@@ -1346,7 +1345,7 @@ export const getInstanceOnboardingJobStatus: API.OperationMethod<
   GetInstanceOnboardingJobStatusRequest,
   GetInstanceOnboardingJobStatusResponse,
   GetInstanceOnboardingJobStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceOnboardingJobStatusRequest,
   output: GetInstanceOnboardingJobStatusResponse,
@@ -1373,7 +1372,7 @@ export const listCampaigns: API.PaginatedOperationMethod<
   ListCampaignsRequest,
   ListCampaignsResponse,
   ListCampaignsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CampaignSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCampaignsRequest,
@@ -1404,7 +1403,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1436,7 +1435,7 @@ export const pauseCampaign: API.OperationMethod<
   PauseCampaignRequest,
   PauseCampaignResponse,
   PauseCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseCampaignRequest,
   output: PauseCampaignResponse,
@@ -1470,7 +1469,7 @@ export const putDialRequestBatch: API.OperationMethod<
   PutDialRequestBatchRequest,
   PutDialRequestBatchResponse,
   PutDialRequestBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDialRequestBatchRequest,
   output: PutDialRequestBatchResponse,
@@ -1504,7 +1503,7 @@ export const resumeCampaign: API.OperationMethod<
   ResumeCampaignRequest,
   ResumeCampaignResponse,
   ResumeCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeCampaignRequest,
   output: ResumeCampaignResponse,
@@ -1538,7 +1537,7 @@ export const startCampaign: API.OperationMethod<
   StartCampaignRequest,
   StartCampaignResponse,
   StartCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCampaignRequest,
   output: StartCampaignResponse,
@@ -1571,7 +1570,7 @@ export const startInstanceOnboardingJob: API.OperationMethod<
   StartInstanceOnboardingJobRequest,
   StartInstanceOnboardingJobResponse,
   StartInstanceOnboardingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInstanceOnboardingJobRequest,
   output: StartInstanceOnboardingJobResponse,
@@ -1604,7 +1603,7 @@ export const stopCampaign: API.OperationMethod<
   StopCampaignRequest,
   StopCampaignResponse,
   StopCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCampaignRequest,
   output: StopCampaignResponse,
@@ -1636,7 +1635,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1666,7 +1665,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1696,7 +1695,7 @@ export const updateCampaignDialerConfig: API.OperationMethod<
   UpdateCampaignDialerConfigRequest,
   UpdateCampaignDialerConfigResponse,
   UpdateCampaignDialerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignDialerConfigRequest,
   output: UpdateCampaignDialerConfigResponse,
@@ -1726,7 +1725,7 @@ export const updateCampaignName: API.OperationMethod<
   UpdateCampaignNameRequest,
   UpdateCampaignNameResponse,
   UpdateCampaignNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignNameRequest,
   output: UpdateCampaignNameResponse,
@@ -1757,7 +1756,7 @@ export const updateCampaignOutboundCallConfig: API.OperationMethod<
   UpdateCampaignOutboundCallConfigRequest,
   UpdateCampaignOutboundCallConfigResponse,
   UpdateCampaignOutboundCallConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignOutboundCallConfigRequest,
   output: UpdateCampaignOutboundCallConfigResponse,

--- a/packages/aws/src/services/connectcampaignsv2.ts
+++ b/packages/aws/src/services/connectcampaignsv2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ConnectCampaignsV2",
@@ -2263,7 +2262,7 @@ export const createCampaign: API.OperationMethod<
   CreateCampaignRequest,
   CreateCampaignResponse,
   CreateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCampaignRequest,
   output: CreateCampaignResponse,
@@ -2294,7 +2293,7 @@ export const deleteCampaign: API.OperationMethod<
   DeleteCampaignRequest,
   DeleteCampaignResponse,
   DeleteCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignRequest,
   output: DeleteCampaignResponse,
@@ -2323,7 +2322,7 @@ export const deleteCampaignChannelSubtypeConfig: API.OperationMethod<
   DeleteCampaignChannelSubtypeConfigRequest,
   DeleteCampaignChannelSubtypeConfigResponse,
   DeleteCampaignChannelSubtypeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignChannelSubtypeConfigRequest,
   output: DeleteCampaignChannelSubtypeConfigResponse,
@@ -2354,7 +2353,7 @@ export const deleteCampaignCommunicationLimits: API.OperationMethod<
   DeleteCampaignCommunicationLimitsRequest,
   DeleteCampaignCommunicationLimitsResponse,
   DeleteCampaignCommunicationLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignCommunicationLimitsRequest,
   output: DeleteCampaignCommunicationLimitsResponse,
@@ -2386,7 +2385,7 @@ export const deleteCampaignCommunicationTime: API.OperationMethod<
   DeleteCampaignCommunicationTimeRequest,
   DeleteCampaignCommunicationTimeResponse,
   DeleteCampaignCommunicationTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignCommunicationTimeRequest,
   output: DeleteCampaignCommunicationTimeResponse,
@@ -2418,7 +2417,7 @@ export const deleteCampaignEntryLimits: API.OperationMethod<
   DeleteCampaignEntryLimitsRequest,
   DeleteCampaignEntryLimitsResponse,
   DeleteCampaignEntryLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignEntryLimitsRequest,
   output: DeleteCampaignEntryLimitsResponse,
@@ -2450,7 +2449,7 @@ export const deleteConnectInstanceConfig: API.OperationMethod<
   DeleteConnectInstanceConfigRequest,
   DeleteConnectInstanceConfigResponse,
   DeleteConnectInstanceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectInstanceConfigRequest,
   output: DeleteConnectInstanceConfigResponse,
@@ -2481,7 +2480,7 @@ export const deleteConnectInstanceIntegration: API.OperationMethod<
   DeleteConnectInstanceIntegrationRequest,
   DeleteConnectInstanceIntegrationResponse,
   DeleteConnectInstanceIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectInstanceIntegrationRequest,
   output: DeleteConnectInstanceIntegrationResponse,
@@ -2511,7 +2510,7 @@ export const deleteInstanceOnboardingJob: API.OperationMethod<
   DeleteInstanceOnboardingJobRequest,
   DeleteInstanceOnboardingJobResponse,
   DeleteInstanceOnboardingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceOnboardingJobRequest,
   output: DeleteInstanceOnboardingJobResponse,
@@ -2540,7 +2539,7 @@ export const describeCampaign: API.OperationMethod<
   DescribeCampaignRequest,
   DescribeCampaignResponse,
   DescribeCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCampaignRequest,
   output: DescribeCampaignResponse,
@@ -2569,7 +2568,7 @@ export const getCampaignState: API.OperationMethod<
   GetCampaignStateRequest,
   GetCampaignStateResponse,
   GetCampaignStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignStateRequest,
   output: GetCampaignStateResponse,
@@ -2598,7 +2597,7 @@ export const getCampaignStateBatch: API.OperationMethod<
   GetCampaignStateBatchRequest,
   GetCampaignStateBatchResponse,
   GetCampaignStateBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignStateBatchRequest,
   output: GetCampaignStateBatchResponse,
@@ -2626,7 +2625,7 @@ export const getConnectInstanceConfig: API.OperationMethod<
   GetConnectInstanceConfigRequest,
   GetConnectInstanceConfigResponse,
   GetConnectInstanceConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectInstanceConfigRequest,
   output: GetConnectInstanceConfigResponse,
@@ -2654,7 +2653,7 @@ export const getInstanceCommunicationLimits: API.OperationMethod<
   GetInstanceCommunicationLimitsRequest,
   GetInstanceCommunicationLimitsResponse,
   GetInstanceCommunicationLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceCommunicationLimitsRequest,
   output: GetInstanceCommunicationLimitsResponse,
@@ -2682,7 +2681,7 @@ export const getInstanceOnboardingJobStatus: API.OperationMethod<
   GetInstanceOnboardingJobStatusRequest,
   GetInstanceOnboardingJobStatusResponse,
   GetInstanceOnboardingJobStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceOnboardingJobStatusRequest,
   output: GetInstanceOnboardingJobStatusResponse,
@@ -2709,7 +2708,7 @@ export const listCampaigns: API.PaginatedOperationMethod<
   ListCampaignsRequest,
   ListCampaignsResponse,
   ListCampaignsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CampaignSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCampaignsRequest,
@@ -2740,7 +2739,7 @@ export const listConnectInstanceIntegrations: API.PaginatedOperationMethod<
   ListConnectInstanceIntegrationsRequest,
   ListConnectInstanceIntegrationsResponse,
   ListConnectInstanceIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IntegrationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectInstanceIntegrationsRequest,
@@ -2777,7 +2776,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2809,7 +2808,7 @@ export const pauseCampaign: API.OperationMethod<
   PauseCampaignRequest,
   PauseCampaignResponse,
   PauseCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseCampaignRequest,
   output: PauseCampaignResponse,
@@ -2842,7 +2841,7 @@ export const putConnectInstanceIntegration: API.OperationMethod<
   PutConnectInstanceIntegrationRequest,
   PutConnectInstanceIntegrationResponse,
   PutConnectInstanceIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConnectInstanceIntegrationRequest,
   output: PutConnectInstanceIntegrationResponse,
@@ -2873,7 +2872,7 @@ export const putInstanceCommunicationLimits: API.OperationMethod<
   PutInstanceCommunicationLimitsRequest,
   PutInstanceCommunicationLimitsResponse,
   PutInstanceCommunicationLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInstanceCommunicationLimitsRequest,
   output: PutInstanceCommunicationLimitsResponse,
@@ -2905,7 +2904,7 @@ export const putOutboundRequestBatch: API.OperationMethod<
   PutOutboundRequestBatchRequest,
   PutOutboundRequestBatchResponse,
   PutOutboundRequestBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOutboundRequestBatchRequest,
   output: PutOutboundRequestBatchResponse,
@@ -2939,7 +2938,7 @@ export const putProfileOutboundRequestBatch: API.OperationMethod<
   PutProfileOutboundRequestBatchRequest,
   PutProfileOutboundRequestBatchResponse,
   PutProfileOutboundRequestBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProfileOutboundRequestBatchRequest,
   output: PutProfileOutboundRequestBatchResponse,
@@ -2973,7 +2972,7 @@ export const resumeCampaign: API.OperationMethod<
   ResumeCampaignRequest,
   ResumeCampaignResponse,
   ResumeCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeCampaignRequest,
   output: ResumeCampaignResponse,
@@ -3007,7 +3006,7 @@ export const startCampaign: API.OperationMethod<
   StartCampaignRequest,
   StartCampaignResponse,
   StartCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCampaignRequest,
   output: StartCampaignResponse,
@@ -3040,7 +3039,7 @@ export const startInstanceOnboardingJob: API.OperationMethod<
   StartInstanceOnboardingJobRequest,
   StartInstanceOnboardingJobResponse,
   StartInstanceOnboardingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInstanceOnboardingJobRequest,
   output: StartInstanceOnboardingJobResponse,
@@ -3073,7 +3072,7 @@ export const stopCampaign: API.OperationMethod<
   StopCampaignRequest,
   StopCampaignResponse,
   StopCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCampaignRequest,
   output: StopCampaignResponse,
@@ -3105,7 +3104,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3135,7 +3134,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3165,7 +3164,7 @@ export const updateCampaignChannelSubtypeConfig: API.OperationMethod<
   UpdateCampaignChannelSubtypeConfigRequest,
   UpdateCampaignChannelSubtypeConfigResponse,
   UpdateCampaignChannelSubtypeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignChannelSubtypeConfigRequest,
   output: UpdateCampaignChannelSubtypeConfigResponse,
@@ -3196,7 +3195,7 @@ export const updateCampaignCommunicationLimits: API.OperationMethod<
   UpdateCampaignCommunicationLimitsRequest,
   UpdateCampaignCommunicationLimitsResponse,
   UpdateCampaignCommunicationLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignCommunicationLimitsRequest,
   output: UpdateCampaignCommunicationLimitsResponse,
@@ -3228,7 +3227,7 @@ export const updateCampaignCommunicationTime: API.OperationMethod<
   UpdateCampaignCommunicationTimeRequest,
   UpdateCampaignCommunicationTimeResponse,
   UpdateCampaignCommunicationTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignCommunicationTimeRequest,
   output: UpdateCampaignCommunicationTimeResponse,
@@ -3260,7 +3259,7 @@ export const updateCampaignEntryLimits: API.OperationMethod<
   UpdateCampaignEntryLimitsRequest,
   UpdateCampaignEntryLimitsResponse,
   UpdateCampaignEntryLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignEntryLimitsRequest,
   output: UpdateCampaignEntryLimitsResponse,
@@ -3292,7 +3291,7 @@ export const updateCampaignFlowAssociation: API.OperationMethod<
   UpdateCampaignFlowAssociationRequest,
   UpdateCampaignFlowAssociationResponse,
   UpdateCampaignFlowAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignFlowAssociationRequest,
   output: UpdateCampaignFlowAssociationResponse,
@@ -3323,7 +3322,7 @@ export const updateCampaignName: API.OperationMethod<
   UpdateCampaignNameRequest,
   UpdateCampaignNameResponse,
   UpdateCampaignNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignNameRequest,
   output: UpdateCampaignNameResponse,
@@ -3354,7 +3353,7 @@ export const updateCampaignSchedule: API.OperationMethod<
   UpdateCampaignScheduleRequest,
   UpdateCampaignScheduleResponse,
   UpdateCampaignScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignScheduleRequest,
   output: UpdateCampaignScheduleResponse,
@@ -3386,7 +3385,7 @@ export const updateCampaignSource: API.OperationMethod<
   UpdateCampaignSourceRequest,
   UpdateCampaignSourceResponse,
   UpdateCampaignSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignSourceRequest,
   output: UpdateCampaignSourceResponse,

--- a/packages/aws/src/services/connectcases.ts
+++ b/packages/aws/src/services/connectcases.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ConnectCases",
@@ -3021,7 +3020,7 @@ export const batchGetCaseRule: API.OperationMethod<
   BatchGetCaseRuleRequest,
   BatchGetCaseRuleResponse,
   BatchGetCaseRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCaseRuleRequest,
   output: BatchGetCaseRuleResponse,
@@ -3051,7 +3050,7 @@ export const batchGetField: API.OperationMethod<
   BatchGetFieldRequest,
   BatchGetFieldResponse,
   BatchGetFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFieldRequest,
   output: BatchGetFieldResponse,
@@ -3082,7 +3081,7 @@ export const batchPutFieldOptions: API.OperationMethod<
   BatchPutFieldOptionsRequest,
   BatchPutFieldOptionsResponse,
   BatchPutFieldOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutFieldOptionsRequest,
   output: BatchPutFieldOptionsResponse,
@@ -3124,7 +3123,7 @@ export const createCase: API.OperationMethod<
   CreateCaseRequest,
   CreateCaseResponse,
   CreateCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCaseRequest,
   output: CreateCaseResponse,
@@ -3157,7 +3156,7 @@ export const createCaseRule: API.OperationMethod<
   CreateCaseRuleRequest,
   CreateCaseRuleResponse,
   CreateCaseRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCaseRuleRequest,
   output: CreateCaseRuleResponse,
@@ -3192,7 +3191,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -3225,7 +3224,7 @@ export const createField: API.OperationMethod<
   CreateFieldRequest,
   CreateFieldResponse,
   CreateFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFieldRequest,
   output: CreateFieldResponse,
@@ -3265,7 +3264,7 @@ export const createLayout: API.OperationMethod<
   CreateLayoutRequest,
   CreateLayoutResponse,
   CreateLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLayoutRequest,
   output: CreateLayoutResponse,
@@ -3328,7 +3327,7 @@ export const createRelatedItem: API.OperationMethod<
   CreateRelatedItemRequest,
   CreateRelatedItemResponse,
   CreateRelatedItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelatedItemRequest,
   output: CreateRelatedItemResponse,
@@ -3371,7 +3370,7 @@ export const createTemplate: API.OperationMethod<
   CreateTemplateRequest,
   CreateTemplateResponse,
   CreateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateRequest,
   output: CreateTemplateResponse,
@@ -3411,7 +3410,7 @@ export const deleteCase: API.OperationMethod<
   DeleteCaseRequest,
   DeleteCaseResponse,
   DeleteCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCaseRequest,
   output: DeleteCaseResponse,
@@ -3441,7 +3440,7 @@ export const deleteCaseRule: API.OperationMethod<
   DeleteCaseRuleRequest,
   DeleteCaseRuleResponse,
   DeleteCaseRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCaseRuleRequest,
   output: DeleteCaseRuleResponse,
@@ -3474,7 +3473,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -3533,7 +3532,7 @@ export const deleteField: API.OperationMethod<
   DeleteFieldRequest,
   DeleteFieldResponse,
   DeleteFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFieldRequest,
   output: DeleteFieldResponse,
@@ -3574,7 +3573,7 @@ export const deleteLayout: API.OperationMethod<
   DeleteLayoutRequest,
   DeleteLayoutResponse,
   DeleteLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLayoutRequest,
   output: DeleteLayoutResponse,
@@ -3607,7 +3606,7 @@ export const deleteRelatedItem: API.OperationMethod<
   DeleteRelatedItemRequest,
   DeleteRelatedItemResponse,
   DeleteRelatedItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRelatedItemRequest,
   output: DeleteRelatedItemResponse,
@@ -3648,7 +3647,7 @@ export const deleteTemplate: API.OperationMethod<
   DeleteTemplateRequest,
   DeleteTemplateResponse,
   DeleteTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateRequest,
   output: DeleteTemplateResponse,
@@ -3679,7 +3678,7 @@ export const getCase: API.PaginatedOperationMethod<
   GetCaseRequest,
   GetCaseResponse,
   GetCaseError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCaseRequest,
@@ -3711,7 +3710,7 @@ export const getCaseAuditEvents: API.PaginatedOperationMethod<
   GetCaseAuditEventsRequest,
   GetCaseAuditEventsResponse,
   GetCaseAuditEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCaseAuditEventsRequest,
@@ -3747,7 +3746,7 @@ export const getCaseEventConfiguration: API.OperationMethod<
   GetCaseEventConfigurationRequest,
   GetCaseEventConfigurationResponse,
   GetCaseEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCaseEventConfigurationRequest,
   output: GetCaseEventConfigurationResponse,
@@ -3777,7 +3776,7 @@ export const getDomain: API.OperationMethod<
   GetDomainRequest,
   GetDomainResponse,
   GetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainRequest,
   output: GetDomainResponse,
@@ -3807,7 +3806,7 @@ export const getLayout: API.OperationMethod<
   GetLayoutRequest,
   GetLayoutResponse,
   GetLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLayoutRequest,
   output: GetLayoutResponse,
@@ -3845,7 +3844,7 @@ export const getTemplate: API.OperationMethod<
   GetTemplateRequest,
   GetTemplateResponse,
   GetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateRequest,
   output: GetTemplateResponse,
@@ -3875,7 +3874,7 @@ export const listCaseRules: API.PaginatedOperationMethod<
   ListCaseRulesRequest,
   ListCaseRulesResponse,
   ListCaseRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CaseRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCaseRulesRequest,
@@ -3912,7 +3911,7 @@ export const listCasesForContact: API.PaginatedOperationMethod<
   ListCasesForContactRequest,
   ListCasesForContactResponse,
   ListCasesForContactError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCasesForContactRequest,
@@ -3947,7 +3946,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -3982,7 +3981,7 @@ export const listFieldOptions: API.PaginatedOperationMethod<
   ListFieldOptionsRequest,
   ListFieldOptionsResponse,
   ListFieldOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFieldOptionsRequest,
@@ -4018,7 +4017,7 @@ export const listFields: API.PaginatedOperationMethod<
   ListFieldsRequest,
   ListFieldsResponse,
   ListFieldsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFieldsRequest,
@@ -4054,7 +4053,7 @@ export const listLayouts: API.PaginatedOperationMethod<
   ListLayoutsRequest,
   ListLayoutsResponse,
   ListLayoutsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLayoutsRequest,
@@ -4090,7 +4089,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4130,7 +4129,7 @@ export const listTemplates: API.PaginatedOperationMethod<
   ListTemplatesRequest,
   ListTemplatesResponse,
   ListTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplatesRequest,
@@ -4167,7 +4166,7 @@ export const putCaseEventConfiguration: API.OperationMethod<
   PutCaseEventConfigurationRequest,
   PutCaseEventConfigurationResponse,
   PutCaseEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCaseEventConfigurationRequest,
   output: PutCaseEventConfigurationResponse,
@@ -4216,7 +4215,7 @@ export const searchAllRelatedItems: API.PaginatedOperationMethod<
   SearchAllRelatedItemsRequest,
   SearchAllRelatedItemsResponse,
   SearchAllRelatedItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchAllRelatedItemsResponseItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAllRelatedItemsRequest,
@@ -4255,7 +4254,7 @@ export const searchCases: API.PaginatedOperationMethod<
   SearchCasesRequest,
   SearchCasesResponse,
   SearchCasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchCasesResponseItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchCasesRequest,
@@ -4294,7 +4293,7 @@ export const searchRelatedItems: API.PaginatedOperationMethod<
   SearchRelatedItemsRequest,
   SearchRelatedItemsResponse,
   SearchRelatedItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchRelatedItemsResponseItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchRelatedItemsRequest,
@@ -4331,7 +4330,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4361,7 +4360,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4395,7 +4394,7 @@ export const updateCase: API.OperationMethod<
   UpdateCaseRequest,
   UpdateCaseResponse,
   UpdateCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCaseRequest,
   output: UpdateCaseResponse,
@@ -4427,7 +4426,7 @@ export const updateCaseRule: API.OperationMethod<
   UpdateCaseRuleRequest,
   UpdateCaseRuleResponse,
   UpdateCaseRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCaseRuleRequest,
   output: UpdateCaseRuleResponse,
@@ -4460,7 +4459,7 @@ export const updateField: API.OperationMethod<
   UpdateFieldRequest,
   UpdateFieldResponse,
   UpdateFieldError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFieldRequest,
   output: UpdateFieldResponse,
@@ -4499,7 +4498,7 @@ export const updateLayout: API.OperationMethod<
   UpdateLayoutRequest,
   UpdateLayoutResponse,
   UpdateLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLayoutRequest,
   output: UpdateLayoutResponse,
@@ -4546,7 +4545,7 @@ export const updateRelatedItem: API.OperationMethod<
   UpdateRelatedItemRequest,
   UpdateRelatedItemResponse,
   UpdateRelatedItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelatedItemRequest,
   output: UpdateRelatedItemResponse,
@@ -4589,7 +4588,7 @@ export const updateTemplate: API.OperationMethod<
   UpdateTemplateRequest,
   UpdateTemplateResponse,
   UpdateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateRequest,
   output: UpdateTemplateResponse,

--- a/packages/aws/src/services/connecthealth.ts
+++ b/packages/aws/src/services/connecthealth.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ConnectHealth",
@@ -1371,7 +1370,7 @@ export const activateSubscription: API.OperationMethod<
   ActivateSubscriptionInput,
   ActivateSubscriptionOutput,
   ActivateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateSubscriptionInput,
   output: ActivateSubscriptionOutput,
@@ -1394,7 +1393,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainInput,
   CreateDomainOutput,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainInput,
   output: CreateDomainOutput,
@@ -1418,7 +1417,7 @@ export const createSubscription: API.OperationMethod<
   CreateSubscriptionInput,
   CreateSubscriptionOutput,
   CreateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionInput,
   output: CreateSubscriptionOutput,
@@ -1447,7 +1446,7 @@ export const deactivateSubscription: API.OperationMethod<
   DeactivateSubscriptionInput,
   DeactivateSubscriptionOutput,
   DeactivateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateSubscriptionInput,
   output: DeactivateSubscriptionOutput,
@@ -1470,7 +1469,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainInput,
   DeleteDomainOutput,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainInput,
   output: DeleteDomainOutput,
@@ -1488,7 +1487,7 @@ export const getDomain: API.OperationMethod<
   GetDomainInput,
   GetDomainOutput,
   GetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainInput,
   output: GetDomainOutput,
@@ -1512,7 +1511,7 @@ export const getMedicalScribeListeningSession: API.OperationMethod<
   GetMedicalScribeListeningSessionInput,
   GetMedicalScribeListeningSessionOutput,
   GetMedicalScribeListeningSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMedicalScribeListeningSessionInput,
   output: GetMedicalScribeListeningSessionOutput,
@@ -1543,7 +1542,7 @@ export const getPatientInsightsJob: API.OperationMethod<
   GetPatientInsightsJobRequest,
   GetPatientInsightsJobResponse,
   GetPatientInsightsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPatientInsightsJobRequest,
   output: GetPatientInsightsJobResponse,
@@ -1573,7 +1572,7 @@ export const getSubscription: API.OperationMethod<
   GetSubscriptionInput,
   GetSubscriptionOutput,
   GetSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionInput,
   output: GetSubscriptionOutput,
@@ -1596,7 +1595,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsInput,
   ListDomainsOutput,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsInput,
@@ -1626,7 +1625,7 @@ export const listSubscriptions: API.PaginatedOperationMethod<
   ListSubscriptionsInput,
   ListSubscriptionsOutput,
   ListSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsInput,
@@ -1656,7 +1655,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1681,7 +1680,7 @@ export const startMedicalScribeListeningSession: API.OperationMethod<
   StartMedicalScribeListeningSessionInput,
   StartMedicalScribeListeningSessionOutput,
   StartMedicalScribeListeningSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMedicalScribeListeningSessionInput,
   output: StartMedicalScribeListeningSessionOutput,
@@ -1714,7 +1713,7 @@ export const startPatientInsightsJob: API.OperationMethod<
   StartPatientInsightsJobRequest,
   StartPatientInsightsJobResponse,
   StartPatientInsightsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPatientInsightsJobRequest,
   output: StartPatientInsightsJobResponse,
@@ -1740,7 +1739,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -1758,7 +1757,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/connectparticipant.ts
+++ b/packages/aws/src/services/connectparticipant.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ConnectParticipant",
@@ -880,7 +879,7 @@ export const cancelParticipantAuthentication: API.OperationMethod<
   CancelParticipantAuthenticationRequest,
   CancelParticipantAuthenticationResponse,
   CancelParticipantAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelParticipantAuthenticationRequest,
   output: CancelParticipantAuthenticationResponse,
@@ -920,7 +919,7 @@ export const completeAttachmentUpload: API.OperationMethod<
   CompleteAttachmentUploadRequest,
   CompleteAttachmentUploadResponse,
   CompleteAttachmentUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteAttachmentUploadRequest,
   output: CompleteAttachmentUploadResponse,
@@ -1013,7 +1012,7 @@ export const createParticipantConnection: API.OperationMethod<
   CreateParticipantConnectionRequest,
   CreateParticipantConnectionResponse,
   CreateParticipantConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParticipantConnectionRequest,
   output: CreateParticipantConnectionResponse,
@@ -1044,7 +1043,7 @@ export const describeView: API.OperationMethod<
   DescribeViewRequest,
   DescribeViewResponse,
   DescribeViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeViewRequest,
   output: DescribeViewResponse,
@@ -1081,7 +1080,7 @@ export const disconnectParticipant: API.OperationMethod<
   DisconnectParticipantRequest,
   DisconnectParticipantResponse,
   DisconnectParticipantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectParticipantRequest,
   output: DisconnectParticipantResponse,
@@ -1123,7 +1122,7 @@ export const getAttachment: API.OperationMethod<
   GetAttachmentRequest,
   GetAttachmentResponse,
   GetAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAttachmentRequest,
   output: GetAttachmentResponse,
@@ -1166,7 +1165,7 @@ export const getAuthenticationUrl: API.OperationMethod<
   GetAuthenticationUrlRequest,
   GetAuthenticationUrlResponse,
   GetAuthenticationUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthenticationUrlRequest,
   output: GetAuthenticationUrlResponse,
@@ -1220,7 +1219,7 @@ export const getTranscript: API.PaginatedOperationMethod<
   GetTranscriptRequest,
   GetTranscriptResponse,
   GetTranscriptError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTranscriptRequest,
@@ -1270,7 +1269,7 @@ export const sendEvent: API.OperationMethod<
   SendEventRequest,
   SendEventResponse,
   SendEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEventRequest,
   output: SendEventResponse,
@@ -1307,7 +1306,7 @@ export const sendMessage: API.OperationMethod<
   SendMessageRequest,
   SendMessageResponse,
   SendMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessageRequest,
   output: SendMessageResponse,
@@ -1345,7 +1344,7 @@ export const startAttachmentUpload: API.OperationMethod<
   StartAttachmentUploadRequest,
   StartAttachmentUploadResponse,
   StartAttachmentUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAttachmentUploadRequest,
   output: StartAttachmentUploadResponse,

--- a/packages/aws/src/services/controlcatalog.ts
+++ b/packages/aws/src/services/controlcatalog.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ControlCatalog",
   serviceShapeName: "ControlCatalog",
@@ -729,7 +728,7 @@ export const getControl: API.OperationMethod<
   GetControlRequest,
   GetControlResponse,
   GetControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetControlRequest,
   output: GetControlResponse,
@@ -760,7 +759,7 @@ export const listCommonControls: API.PaginatedOperationMethod<
   ListCommonControlsRequest,
   ListCommonControlsResponse,
   ListCommonControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CommonControlSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommonControlsRequest,
@@ -795,7 +794,7 @@ export const listControlMappings: API.PaginatedOperationMethod<
   ListControlMappingsRequest,
   ListControlMappingsResponse,
   ListControlMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ControlMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlMappingsRequest,
@@ -830,7 +829,7 @@ export const listControls: API.PaginatedOperationMethod<
   ListControlsRequest,
   ListControlsResponse,
   ListControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ControlSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlsRequest,
@@ -865,7 +864,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -902,7 +901,7 @@ export const listObjectives: API.PaginatedOperationMethod<
   ListObjectivesRequest,
   ListObjectivesResponse,
   ListObjectivesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ObjectiveSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectivesRequest,

--- a/packages/aws/src/services/controltower.ts
+++ b/packages/aws/src/services/controltower.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ControlTower",
   serviceShapeName: "AWSControlTowerApis",
@@ -1601,7 +1600,7 @@ export const createLandingZone: API.OperationMethod<
   CreateLandingZoneInput,
   CreateLandingZoneOutput,
   CreateLandingZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLandingZoneInput,
   output: CreateLandingZoneOutput,
@@ -1636,7 +1635,7 @@ export const deleteLandingZone: API.OperationMethod<
   DeleteLandingZoneInput,
   DeleteLandingZoneOutput,
   DeleteLandingZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLandingZoneInput,
   output: DeleteLandingZoneOutput,
@@ -1671,7 +1670,7 @@ export const disableBaseline: API.OperationMethod<
   DisableBaselineInput,
   DisableBaselineOutput,
   DisableBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableBaselineInput,
   output: DisableBaselineOutput,
@@ -1706,7 +1705,7 @@ export const disableControl: API.OperationMethod<
   DisableControlInput,
   DisableControlOutput,
   DisableControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableControlInput,
   output: DisableControlOutput,
@@ -1741,7 +1740,7 @@ export const enableBaseline: API.OperationMethod<
   EnableBaselineInput,
   EnableBaselineOutput,
   EnableBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableBaselineInput,
   output: EnableBaselineOutput,
@@ -1776,7 +1775,7 @@ export const enableControl: API.OperationMethod<
   EnableControlInput,
   EnableControlOutput,
   EnableControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableControlInput,
   output: EnableControlOutput,
@@ -1809,7 +1808,7 @@ export const getBaseline: API.OperationMethod<
   GetBaselineInput,
   GetBaselineOutput,
   GetBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBaselineInput,
   output: GetBaselineOutput,
@@ -1841,7 +1840,7 @@ export const getBaselineOperation: API.OperationMethod<
   GetBaselineOperationInput,
   GetBaselineOperationOutput,
   GetBaselineOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBaselineOperationInput,
   output: GetBaselineOperationOutput,
@@ -1872,7 +1871,7 @@ export const getControlOperation: API.OperationMethod<
   GetControlOperationInput,
   GetControlOperationOutput,
   GetControlOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetControlOperationInput,
   output: GetControlOperationOutput,
@@ -1903,7 +1902,7 @@ export const getEnabledBaseline: API.OperationMethod<
   GetEnabledBaselineInput,
   GetEnabledBaselineOutput,
   GetEnabledBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnabledBaselineInput,
   output: GetEnabledBaselineOutput,
@@ -1934,7 +1933,7 @@ export const getEnabledControl: API.OperationMethod<
   GetEnabledControlInput,
   GetEnabledControlOutput,
   GetEnabledControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnabledControlInput,
   output: GetEnabledControlOutput,
@@ -1965,7 +1964,7 @@ export const getLandingZone: API.OperationMethod<
   GetLandingZoneInput,
   GetLandingZoneOutput,
   GetLandingZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLandingZoneInput,
   output: GetLandingZoneOutput,
@@ -1997,7 +1996,7 @@ export const getLandingZoneOperation: API.OperationMethod<
   GetLandingZoneOperationInput,
   GetLandingZoneOperationOutput,
   GetLandingZoneOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLandingZoneOperationInput,
   output: GetLandingZoneOperationOutput,
@@ -2028,7 +2027,7 @@ export const listBaselines: API.PaginatedOperationMethod<
   ListBaselinesInput,
   ListBaselinesOutput,
   ListBaselinesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BaselineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBaselinesInput,
@@ -2064,7 +2063,7 @@ export const listControlOperations: API.PaginatedOperationMethod<
   ListControlOperationsInput,
   ListControlOperationsOutput,
   ListControlOperationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ControlOperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlOperationsInput,
@@ -2100,7 +2099,7 @@ export const listEnabledBaselines: API.PaginatedOperationMethod<
   ListEnabledBaselinesInput,
   ListEnabledBaselinesOutput,
   ListEnabledBaselinesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnabledBaselineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnabledBaselinesInput,
@@ -2137,7 +2136,7 @@ export const listEnabledControls: API.PaginatedOperationMethod<
   ListEnabledControlsInput,
   ListEnabledControlsOutput,
   ListEnabledControlsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnabledControlSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnabledControlsInput,
@@ -2174,7 +2173,7 @@ export const listLandingZoneOperations: API.PaginatedOperationMethod<
   ListLandingZoneOperationsInput,
   ListLandingZoneOperationsOutput,
   ListLandingZoneOperationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LandingZoneOperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLandingZoneOperationsInput,
@@ -2213,7 +2212,7 @@ export const listLandingZones: API.PaginatedOperationMethod<
   ListLandingZonesInput,
   ListLandingZonesOutput,
   ListLandingZonesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LandingZoneSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLandingZonesInput,
@@ -2249,7 +2248,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2281,7 +2280,7 @@ export const resetEnabledBaseline: API.OperationMethod<
   ResetEnabledBaselineInput,
   ResetEnabledBaselineOutput,
   ResetEnabledBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetEnabledBaselineInput,
   output: ResetEnabledBaselineOutput,
@@ -2316,7 +2315,7 @@ export const resetEnabledControl: API.OperationMethod<
   ResetEnabledControlInput,
   ResetEnabledControlOutput,
   ResetEnabledControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetEnabledControlInput,
   output: ResetEnabledControlOutput,
@@ -2350,7 +2349,7 @@ export const resetLandingZone: API.OperationMethod<
   ResetLandingZoneInput,
   ResetLandingZoneOutput,
   ResetLandingZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetLandingZoneInput,
   output: ResetLandingZoneOutput,
@@ -2381,7 +2380,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2409,7 +2408,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2441,7 +2440,7 @@ export const updateEnabledBaseline: API.OperationMethod<
   UpdateEnabledBaselineInput,
   UpdateEnabledBaselineOutput,
   UpdateEnabledBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnabledBaselineInput,
   output: UpdateEnabledBaselineOutput,
@@ -2482,7 +2481,7 @@ export const updateEnabledControl: API.OperationMethod<
   UpdateEnabledControlInput,
   UpdateEnabledControlOutput,
   UpdateEnabledControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnabledControlInput,
   output: UpdateEnabledControlOutput,
@@ -2516,7 +2515,7 @@ export const updateLandingZone: API.OperationMethod<
   UpdateLandingZoneInput,
   UpdateLandingZoneOutput,
   UpdateLandingZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLandingZoneInput,
   output: UpdateLandingZoneOutput,

--- a/packages/aws/src/services/cost-and-usage-report-service.ts
+++ b/packages/aws/src/services/cost-and-usage-report-service.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Cost and Usage Report Service",
   serviceShapeName: "AWSOrigamiServiceGatewayService",
@@ -403,7 +402,7 @@ export const deleteReportDefinition: API.OperationMethod<
   DeleteReportDefinitionRequest,
   DeleteReportDefinitionResponse,
   DeleteReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReportDefinitionRequest,
   output: DeleteReportDefinitionResponse,
@@ -423,7 +422,7 @@ export const describeReportDefinitions: API.PaginatedOperationMethod<
   DescribeReportDefinitionsRequest,
   DescribeReportDefinitionsResponse,
   DescribeReportDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReportDefinitionsRequest,
@@ -451,7 +450,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -477,7 +476,7 @@ export const modifyReportDefinition: API.OperationMethod<
   ModifyReportDefinitionRequest,
   ModifyReportDefinitionResponse,
   ModifyReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReportDefinitionRequest,
   output: ModifyReportDefinitionResponse,
@@ -506,7 +505,7 @@ export const putReportDefinition: API.OperationMethod<
   PutReportDefinitionRequest,
   PutReportDefinitionResponse,
   PutReportDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutReportDefinitionRequest,
   output: PutReportDefinitionResponse,
@@ -535,7 +534,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -561,7 +560,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/cost-explorer.ts
+++ b/packages/aws/src/services/cost-explorer.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Cost Explorer",
   serviceShapeName: "AWSInsightsIndexService",
@@ -4072,7 +4071,7 @@ export const createAnomalyMonitor: API.OperationMethod<
   CreateAnomalyMonitorRequest,
   CreateAnomalyMonitorResponse,
   CreateAnomalyMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnomalyMonitorRequest,
   output: CreateAnomalyMonitorResponse,
@@ -4096,7 +4095,7 @@ export const createAnomalySubscription: API.OperationMethod<
   CreateAnomalySubscriptionRequest,
   CreateAnomalySubscriptionResponse,
   CreateAnomalySubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnomalySubscriptionRequest,
   output: CreateAnomalySubscriptionResponse,
@@ -4121,7 +4120,7 @@ export const createCostCategoryDefinition: API.OperationMethod<
   CreateCostCategoryDefinitionRequest,
   CreateCostCategoryDefinitionResponse,
   CreateCostCategoryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCostCategoryDefinitionRequest,
   output: CreateCostCategoryDefinitionResponse,
@@ -4142,7 +4141,7 @@ export const deleteAnomalyMonitor: API.OperationMethod<
   DeleteAnomalyMonitorRequest,
   DeleteAnomalyMonitorResponse,
   DeleteAnomalyMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnomalyMonitorRequest,
   output: DeleteAnomalyMonitorResponse,
@@ -4163,7 +4162,7 @@ export const deleteAnomalySubscription: API.OperationMethod<
   DeleteAnomalySubscriptionRequest,
   DeleteAnomalySubscriptionResponse,
   DeleteAnomalySubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnomalySubscriptionRequest,
   output: DeleteAnomalySubscriptionResponse,
@@ -4185,7 +4184,7 @@ export const deleteCostCategoryDefinition: API.OperationMethod<
   DeleteCostCategoryDefinitionRequest,
   DeleteCostCategoryDefinitionResponse,
   DeleteCostCategoryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCostCategoryDefinitionRequest,
   output: DeleteCostCategoryDefinitionResponse,
@@ -4212,7 +4211,7 @@ export const describeCostCategoryDefinition: API.OperationMethod<
   DescribeCostCategoryDefinitionRequest,
   DescribeCostCategoryDefinitionResponse,
   DescribeCostCategoryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCostCategoryDefinitionRequest,
   output: DescribeCostCategoryDefinitionResponse,
@@ -4235,7 +4234,7 @@ export const getAnomalies: API.PaginatedOperationMethod<
   GetAnomaliesRequest,
   GetAnomaliesResponse,
   GetAnomaliesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Anomaly
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAnomaliesRequest,
@@ -4265,7 +4264,7 @@ export const getAnomalyMonitors: API.PaginatedOperationMethod<
   GetAnomalyMonitorsRequest,
   GetAnomalyMonitorsResponse,
   GetAnomalyMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnomalyMonitor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAnomalyMonitorsRequest,
@@ -4299,7 +4298,7 @@ export const getAnomalySubscriptions: API.PaginatedOperationMethod<
   GetAnomalySubscriptionsRequest,
   GetAnomalySubscriptionsResponse,
   GetAnomalySubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnomalySubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAnomalySubscriptionsRequest,
@@ -4332,7 +4331,7 @@ export const getApproximateUsageRecords: API.OperationMethod<
   GetApproximateUsageRecordsRequest,
   GetApproximateUsageRecordsResponse,
   GetApproximateUsageRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApproximateUsageRecordsRequest,
   output: GetApproximateUsageRecordsResponse,
@@ -4355,7 +4354,7 @@ export const getCommitmentPurchaseAnalysis: API.OperationMethod<
   GetCommitmentPurchaseAnalysisRequest,
   GetCommitmentPurchaseAnalysisResponse,
   GetCommitmentPurchaseAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommitmentPurchaseAnalysisRequest,
   output: GetCommitmentPurchaseAnalysisResponse,
@@ -4392,7 +4391,7 @@ export const getCostAndUsage: API.OperationMethod<
   GetCostAndUsageRequest,
   GetCostAndUsageResponse,
   GetCostAndUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCostAndUsageRequest,
   output: GetCostAndUsageResponse,
@@ -4426,7 +4425,7 @@ export const getCostAndUsageComparisons: API.PaginatedOperationMethod<
   GetCostAndUsageComparisonsRequest,
   GetCostAndUsageComparisonsResponse,
   GetCostAndUsageComparisonsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostAndUsageComparison
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCostAndUsageComparisonsRequest,
@@ -4478,7 +4477,7 @@ export const getCostAndUsageWithResources: API.OperationMethod<
   GetCostAndUsageWithResourcesRequest,
   GetCostAndUsageWithResourcesResponse,
   GetCostAndUsageWithResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCostAndUsageWithResourcesRequest,
   output: GetCostAndUsageWithResourcesResponse,
@@ -4515,7 +4514,7 @@ export const getCostCategories: API.OperationMethod<
   GetCostCategoriesRequest,
   GetCostCategoriesResponse,
   GetCostCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCostCategoriesRequest,
   output: GetCostCategoriesResponse,
@@ -4549,7 +4548,7 @@ export const getCostComparisonDrivers: API.PaginatedOperationMethod<
   GetCostComparisonDriversRequest,
   GetCostComparisonDriversResponse,
   GetCostComparisonDriversError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostComparisonDriver
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCostComparisonDriversRequest,
@@ -4586,7 +4585,7 @@ export const getCostForecast: API.OperationMethod<
   GetCostForecastRequest,
   GetCostForecastResponse,
   GetCostForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCostForecastRequest,
   output: GetCostForecastResponse,
@@ -4618,7 +4617,7 @@ export const getDimensionValues: API.OperationMethod<
   GetDimensionValuesRequest,
   GetDimensionValuesResponse,
   GetDimensionValuesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDimensionValuesRequest,
   output: GetDimensionValuesResponse,
@@ -4680,7 +4679,7 @@ export const getReservationCoverage: API.OperationMethod<
   GetReservationCoverageRequest,
   GetReservationCoverageResponse,
   GetReservationCoverageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReservationCoverageRequest,
   output: GetReservationCoverageResponse,
@@ -4723,7 +4722,7 @@ export const getReservationPurchaseRecommendation: API.PaginatedOperationMethod<
   GetReservationPurchaseRecommendationRequest,
   GetReservationPurchaseRecommendationResponse,
   GetReservationPurchaseRecommendationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservationPurchaseRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetReservationPurchaseRecommendationRequest,
@@ -4759,7 +4758,7 @@ export const getReservationUtilization: API.OperationMethod<
   GetReservationUtilizationRequest,
   GetReservationUtilizationResponse,
   GetReservationUtilizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReservationUtilizationRequest,
   output: GetReservationUtilizationResponse,
@@ -4790,7 +4789,7 @@ export const getRightsizingRecommendation: API.PaginatedOperationMethod<
   GetRightsizingRecommendationRequest,
   GetRightsizingRecommendationResponse,
   GetRightsizingRecommendationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RightsizingRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRightsizingRecommendationRequest,
@@ -4823,7 +4822,7 @@ export const getSavingsPlanPurchaseRecommendationDetails: API.OperationMethod<
   GetSavingsPlanPurchaseRecommendationDetailsRequest,
   GetSavingsPlanPurchaseRecommendationDetailsResponse,
   GetSavingsPlanPurchaseRecommendationDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSavingsPlanPurchaseRecommendationDetailsRequest,
   output: GetSavingsPlanPurchaseRecommendationDetailsResponse,
@@ -4860,7 +4859,7 @@ export const getSavingsPlansCoverage: API.PaginatedOperationMethod<
   GetSavingsPlansCoverageRequest,
   GetSavingsPlansCoverageResponse,
   GetSavingsPlansCoverageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSavingsPlansCoverageRequest,
@@ -4894,7 +4893,7 @@ export const getSavingsPlansPurchaseRecommendation: API.OperationMethod<
   GetSavingsPlansPurchaseRecommendationRequest,
   GetSavingsPlansPurchaseRecommendationResponse,
   GetSavingsPlansPurchaseRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSavingsPlansPurchaseRecommendationRequest,
   output: GetSavingsPlansPurchaseRecommendationResponse,
@@ -4921,7 +4920,7 @@ export const getSavingsPlansUtilization: API.OperationMethod<
   GetSavingsPlansUtilizationRequest,
   GetSavingsPlansUtilizationResponse,
   GetSavingsPlansUtilizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSavingsPlansUtilizationRequest,
   output: GetSavingsPlansUtilizationResponse,
@@ -4952,7 +4951,7 @@ export const getSavingsPlansUtilizationDetails: API.PaginatedOperationMethod<
   GetSavingsPlansUtilizationDetailsRequest,
   GetSavingsPlansUtilizationDetailsResponse,
   GetSavingsPlansUtilizationDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSavingsPlansUtilizationDetailsRequest,
@@ -4989,7 +4988,7 @@ export const getTags: API.OperationMethod<
   GetTagsRequest,
   GetTagsResponse,
   GetTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagsRequest,
   output: GetTagsResponse,
@@ -5022,7 +5021,7 @@ export const getUsageForecast: API.OperationMethod<
   GetUsageForecastRequest,
   GetUsageForecastResponse,
   GetUsageForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsageForecastRequest,
   output: GetUsageForecastResponse,
@@ -5050,7 +5049,7 @@ export const listCommitmentPurchaseAnalyses: API.PaginatedOperationMethod<
   ListCommitmentPurchaseAnalysesRequest,
   ListCommitmentPurchaseAnalysesResponse,
   ListCommitmentPurchaseAnalysesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommitmentPurchaseAnalysesRequest,
@@ -5082,7 +5081,7 @@ export const listCostAllocationTagBackfillHistory: API.PaginatedOperationMethod<
   ListCostAllocationTagBackfillHistoryRequest,
   ListCostAllocationTagBackfillHistoryResponse,
   ListCostAllocationTagBackfillHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostAllocationTagBackfillRequest
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCostAllocationTagBackfillHistoryRequest,
@@ -5111,7 +5110,7 @@ export const listCostAllocationTags: API.PaginatedOperationMethod<
   ListCostAllocationTagsRequest,
   ListCostAllocationTagsResponse,
   ListCostAllocationTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostAllocationTag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCostAllocationTagsRequest,
@@ -5144,7 +5143,7 @@ export const listCostCategoryDefinitions: API.PaginatedOperationMethod<
   ListCostCategoryDefinitionsRequest,
   ListCostCategoryDefinitionsResponse,
   ListCostCategoryDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostCategoryReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCostCategoryDefinitionsRequest,
@@ -5172,7 +5171,7 @@ export const listCostCategoryResourceAssociations: API.PaginatedOperationMethod<
   ListCostCategoryResourceAssociationsRequest,
   ListCostCategoryResourceAssociationsResponse,
   ListCostCategoryResourceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CostCategoryResourceAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCostCategoryResourceAssociationsRequest,
@@ -5202,7 +5201,7 @@ export const listSavingsPlansPurchaseRecommendationGeneration: API.PaginatedOper
   ListSavingsPlansPurchaseRecommendationGenerationRequest,
   ListSavingsPlansPurchaseRecommendationGenerationResponse,
   ListSavingsPlansPurchaseRecommendationGenerationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GenerationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSavingsPlansPurchaseRecommendationGenerationRequest,
@@ -5235,7 +5234,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5253,7 +5252,7 @@ export const provideAnomalyFeedback: API.OperationMethod<
   ProvideAnomalyFeedbackRequest,
   ProvideAnomalyFeedbackResponse,
   ProvideAnomalyFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvideAnomalyFeedbackRequest,
   output: ProvideAnomalyFeedbackResponse,
@@ -5278,7 +5277,7 @@ export const startCommitmentPurchaseAnalysis: API.OperationMethod<
   StartCommitmentPurchaseAnalysisRequest,
   StartCommitmentPurchaseAnalysisResponse,
   StartCommitmentPurchaseAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCommitmentPurchaseAnalysisRequest,
   output: StartCommitmentPurchaseAnalysisResponse,
@@ -5306,7 +5305,7 @@ export const startCostAllocationTagBackfill: API.OperationMethod<
   StartCostAllocationTagBackfillRequest,
   StartCostAllocationTagBackfillResponse,
   StartCostAllocationTagBackfillError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCostAllocationTagBackfillRequest,
   output: StartCostAllocationTagBackfillResponse,
@@ -5335,7 +5334,7 @@ export const startSavingsPlansPurchaseRecommendationGeneration: API.OperationMet
   StartSavingsPlansPurchaseRecommendationGenerationRequest,
   StartSavingsPlansPurchaseRecommendationGenerationResponse,
   StartSavingsPlansPurchaseRecommendationGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSavingsPlansPurchaseRecommendationGenerationRequest,
   output: StartSavingsPlansPurchaseRecommendationGenerationResponse,
@@ -5370,7 +5369,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5396,7 +5395,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5418,7 +5417,7 @@ export const updateAnomalyMonitor: API.OperationMethod<
   UpdateAnomalyMonitorRequest,
   UpdateAnomalyMonitorResponse,
   UpdateAnomalyMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnomalyMonitorRequest,
   output: UpdateAnomalyMonitorResponse,
@@ -5444,7 +5443,7 @@ export const updateAnomalySubscription: API.OperationMethod<
   UpdateAnomalySubscriptionRequest,
   UpdateAnomalySubscriptionResponse,
   UpdateAnomalySubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnomalySubscriptionRequest,
   output: UpdateAnomalySubscriptionResponse,
@@ -5471,7 +5470,7 @@ export const updateCostAllocationTagsStatus: API.OperationMethod<
   UpdateCostAllocationTagsStatusRequest,
   UpdateCostAllocationTagsStatusResponse,
   UpdateCostAllocationTagsStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCostAllocationTagsStatusRequest,
   output: UpdateCostAllocationTagsStatusResponse,
@@ -5495,7 +5494,7 @@ export const updateCostCategoryDefinition: API.OperationMethod<
   UpdateCostCategoryDefinitionRequest,
   UpdateCostCategoryDefinitionResponse,
   UpdateCostCategoryDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCostCategoryDefinitionRequest,
   output: UpdateCostCategoryDefinitionResponse,

--- a/packages/aws/src/services/cost-optimization-hub.ts
+++ b/packages/aws/src/services/cost-optimization-hub.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Cost Optimization Hub",
   serviceShapeName: "CostOptimizationHubService",
@@ -2290,7 +2289,7 @@ export const getPreferences: API.OperationMethod<
   GetPreferencesRequest,
   GetPreferencesResponse,
   GetPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPreferencesRequest,
   output: GetPreferencesResponse,
@@ -2321,7 +2320,7 @@ export const getRecommendation: API.OperationMethod<
   GetRecommendationRequest,
   GetRecommendationResponse,
   GetRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationRequest,
   output: GetRecommendationResponse,
@@ -2352,7 +2351,7 @@ export const listEfficiencyMetrics: API.PaginatedOperationMethod<
   ListEfficiencyMetricsRequest,
   ListEfficiencyMetricsResponse,
   ListEfficiencyMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EfficiencyMetricsByGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEfficiencyMetricsRequest,
@@ -2387,7 +2386,7 @@ export const listEnrollmentStatuses: API.PaginatedOperationMethod<
   ListEnrollmentStatusesRequest,
   ListEnrollmentStatusesResponse,
   ListEnrollmentStatusesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountEnrollmentStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnrollmentStatusesRequest,
@@ -2422,7 +2421,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -2459,7 +2458,7 @@ export const listRecommendationSummaries: API.PaginatedOperationMethod<
   ListRecommendationSummariesRequest,
   ListRecommendationSummariesResponse,
   ListRecommendationSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationSummariesRequest,
@@ -2498,7 +2497,7 @@ export const updateEnrollmentStatus: API.OperationMethod<
   UpdateEnrollmentStatusRequest,
   UpdateEnrollmentStatusResponse,
   UpdateEnrollmentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnrollmentStatusRequest,
   output: UpdateEnrollmentStatusResponse,
@@ -2526,7 +2525,7 @@ export const updatePreferences: API.OperationMethod<
   UpdatePreferencesRequest,
   UpdatePreferencesResponse,
   UpdatePreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePreferencesRequest,
   output: UpdatePreferencesResponse,

--- a/packages/aws/src/services/customer-profiles.ts
+++ b/packages/aws/src/services/customer-profiles.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Customer Profiles",
@@ -7660,7 +7659,7 @@ export const addProfileKey: API.OperationMethod<
   AddProfileKeyRequest,
   AddProfileKeyResponse,
   AddProfileKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddProfileKeyRequest,
   output: AddProfileKeyResponse,
@@ -7690,7 +7689,7 @@ export const batchGetCalculatedAttributeForProfile: API.OperationMethod<
   BatchGetCalculatedAttributeForProfileRequest,
   BatchGetCalculatedAttributeForProfileResponse,
   BatchGetCalculatedAttributeForProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCalculatedAttributeForProfileRequest,
   output: BatchGetCalculatedAttributeForProfileResponse,
@@ -7720,7 +7719,7 @@ export const batchGetProfile: API.OperationMethod<
   BatchGetProfileRequest,
   BatchGetProfileResponse,
   BatchGetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetProfileRequest,
   output: BatchGetProfileResponse,
@@ -7762,7 +7761,7 @@ export const batchPutProfileObject: API.OperationMethod<
   BatchPutProfileObjectRequest,
   BatchPutProfileObjectResponse,
   BatchPutProfileObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutProfileObjectRequest,
   output: BatchPutProfileObjectResponse,
@@ -7797,7 +7796,7 @@ export const createCalculatedAttributeDefinition: API.OperationMethod<
   CreateCalculatedAttributeDefinitionRequest,
   CreateCalculatedAttributeDefinitionResponse,
   CreateCalculatedAttributeDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCalculatedAttributeDefinitionRequest,
   output: CreateCalculatedAttributeDefinitionResponse,
@@ -7846,7 +7845,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -7877,7 +7876,7 @@ export const createDomainLayout: API.OperationMethod<
   CreateDomainLayoutRequest,
   CreateDomainLayoutResponse,
   CreateDomainLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainLayoutRequest,
   output: CreateDomainLayoutResponse,
@@ -7911,7 +7910,7 @@ export const createEventStream: API.OperationMethod<
   CreateEventStreamRequest,
   CreateEventStreamResponse,
   CreateEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventStreamRequest,
   output: CreateEventStreamResponse,
@@ -7945,7 +7944,7 @@ export const createEventTrigger: API.OperationMethod<
   CreateEventTriggerRequest,
   CreateEventTriggerResponse,
   CreateEventTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventTriggerRequest,
   output: CreateEventTriggerResponse,
@@ -7976,7 +7975,7 @@ export const createIntegrationWorkflow: API.OperationMethod<
   CreateIntegrationWorkflowRequest,
   CreateIntegrationWorkflowResponse,
   CreateIntegrationWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationWorkflowRequest,
   output: CreateIntegrationWorkflowResponse,
@@ -8009,7 +8008,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileRequest,
   CreateProfileResponse,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileRequest,
   output: CreateProfileResponse,
@@ -8039,7 +8038,7 @@ export const createRecommender: API.OperationMethod<
   CreateRecommenderRequest,
   CreateRecommenderResponse,
   CreateRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommenderRequest,
   output: CreateRecommenderResponse,
@@ -8069,7 +8068,7 @@ export const createRecommenderFilter: API.OperationMethod<
   CreateRecommenderFilterRequest,
   CreateRecommenderFilterResponse,
   CreateRecommenderFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommenderFilterRequest,
   output: CreateRecommenderFilterResponse,
@@ -8099,7 +8098,7 @@ export const createRecommenderSchema: API.OperationMethod<
   CreateRecommenderSchemaRequest,
   CreateRecommenderSchemaResponse,
   CreateRecommenderSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommenderSchemaRequest,
   output: CreateRecommenderSchemaResponse,
@@ -8129,7 +8128,7 @@ export const createSegmentDefinition: API.OperationMethod<
   CreateSegmentDefinitionRequest,
   CreateSegmentDefinitionResponse,
   CreateSegmentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSegmentDefinitionRequest,
   output: CreateSegmentDefinitionResponse,
@@ -8159,7 +8158,7 @@ export const createSegmentEstimate: API.OperationMethod<
   CreateSegmentEstimateRequest,
   CreateSegmentEstimateResponse,
   CreateSegmentEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSegmentEstimateRequest,
   output: CreateSegmentEstimateResponse,
@@ -8189,7 +8188,7 @@ export const createSegmentSnapshot: API.OperationMethod<
   CreateSegmentSnapshotRequest,
   CreateSegmentSnapshotResponse,
   CreateSegmentSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSegmentSnapshotRequest,
   output: CreateSegmentSnapshotResponse,
@@ -8220,7 +8219,7 @@ export const createUploadJob: API.OperationMethod<
   CreateUploadJobRequest,
   CreateUploadJobResponse,
   CreateUploadJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUploadJobRequest,
   output: CreateUploadJobResponse,
@@ -8253,7 +8252,7 @@ export const deleteCalculatedAttributeDefinition: API.OperationMethod<
   DeleteCalculatedAttributeDefinitionRequest,
   DeleteCalculatedAttributeDefinitionResponse,
   DeleteCalculatedAttributeDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCalculatedAttributeDefinitionRequest,
   output: DeleteCalculatedAttributeDefinitionResponse,
@@ -8284,7 +8283,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -8315,7 +8314,7 @@ export const deleteDomainLayout: API.OperationMethod<
   DeleteDomainLayoutRequest,
   DeleteDomainLayoutResponse,
   DeleteDomainLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainLayoutRequest,
   output: DeleteDomainLayoutResponse,
@@ -8345,7 +8344,7 @@ export const deleteDomainObjectType: API.OperationMethod<
   DeleteDomainObjectTypeRequest,
   DeleteDomainObjectTypeResponse,
   DeleteDomainObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainObjectTypeRequest,
   output: DeleteDomainObjectTypeResponse,
@@ -8375,7 +8374,7 @@ export const deleteEventStream: API.OperationMethod<
   DeleteEventStreamRequest,
   DeleteEventStreamResponse,
   DeleteEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventStreamRequest,
   output: DeleteEventStreamResponse,
@@ -8407,7 +8406,7 @@ export const deleteEventTrigger: API.OperationMethod<
   DeleteEventTriggerRequest,
   DeleteEventTriggerResponse,
   DeleteEventTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventTriggerRequest,
   output: DeleteEventTriggerResponse,
@@ -8437,7 +8436,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationRequest,
   DeleteIntegrationResponse,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationRequest,
   output: DeleteIntegrationResponse,
@@ -8467,7 +8466,7 @@ export const deleteProfile: API.OperationMethod<
   DeleteProfileRequest,
   DeleteProfileResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileRequest,
   output: DeleteProfileResponse,
@@ -8497,7 +8496,7 @@ export const deleteProfileKey: API.OperationMethod<
   DeleteProfileKeyRequest,
   DeleteProfileKeyResponse,
   DeleteProfileKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileKeyRequest,
   output: DeleteProfileKeyResponse,
@@ -8527,7 +8526,7 @@ export const deleteProfileObject: API.OperationMethod<
   DeleteProfileObjectRequest,
   DeleteProfileObjectResponse,
   DeleteProfileObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileObjectRequest,
   output: DeleteProfileObjectResponse,
@@ -8560,7 +8559,7 @@ export const deleteProfileObjectType: API.OperationMethod<
   DeleteProfileObjectTypeRequest,
   DeleteProfileObjectTypeResponse,
   DeleteProfileObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileObjectTypeRequest,
   output: DeleteProfileObjectTypeResponse,
@@ -8590,7 +8589,7 @@ export const deleteRecommender: API.OperationMethod<
   DeleteRecommenderRequest,
   DeleteRecommenderResponse,
   DeleteRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommenderRequest,
   output: DeleteRecommenderResponse,
@@ -8620,7 +8619,7 @@ export const deleteRecommenderFilter: API.OperationMethod<
   DeleteRecommenderFilterRequest,
   DeleteRecommenderFilterResponse,
   DeleteRecommenderFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommenderFilterRequest,
   output: DeleteRecommenderFilterResponse,
@@ -8650,7 +8649,7 @@ export const deleteRecommenderSchema: API.OperationMethod<
   DeleteRecommenderSchemaRequest,
   DeleteRecommenderSchemaResponse,
   DeleteRecommenderSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommenderSchemaRequest,
   output: DeleteRecommenderSchemaResponse,
@@ -8680,7 +8679,7 @@ export const deleteSegmentDefinition: API.OperationMethod<
   DeleteSegmentDefinitionRequest,
   DeleteSegmentDefinitionResponse,
   DeleteSegmentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSegmentDefinitionRequest,
   output: DeleteSegmentDefinitionResponse,
@@ -8711,7 +8710,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -8741,7 +8740,7 @@ export const detectProfileObjectType: API.OperationMethod<
   DetectProfileObjectTypeRequest,
   DetectProfileObjectTypeResponse,
   DetectProfileObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectProfileObjectTypeRequest,
   output: DetectProfileObjectTypeResponse,
@@ -8783,7 +8782,7 @@ export const getAutoMergingPreview: API.OperationMethod<
   GetAutoMergingPreviewRequest,
   GetAutoMergingPreviewResponse,
   GetAutoMergingPreviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoMergingPreviewRequest,
   output: GetAutoMergingPreviewResponse,
@@ -8814,7 +8813,7 @@ export const getCalculatedAttributeDefinition: API.OperationMethod<
   GetCalculatedAttributeDefinitionRequest,
   GetCalculatedAttributeDefinitionResponse,
   GetCalculatedAttributeDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalculatedAttributeDefinitionRequest,
   output: GetCalculatedAttributeDefinitionResponse,
@@ -8844,7 +8843,7 @@ export const getCalculatedAttributeForProfile: API.OperationMethod<
   GetCalculatedAttributeForProfileRequest,
   GetCalculatedAttributeForProfileResponse,
   GetCalculatedAttributeForProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalculatedAttributeForProfileRequest,
   output: GetCalculatedAttributeForProfileResponse,
@@ -8874,7 +8873,7 @@ export const getDomain: API.OperationMethod<
   GetDomainRequest,
   GetDomainResponse,
   GetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainRequest,
   output: GetDomainResponse,
@@ -8905,7 +8904,7 @@ export const getDomainLayout: API.OperationMethod<
   GetDomainLayoutRequest,
   GetDomainLayoutResponse,
   GetDomainLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainLayoutRequest,
   output: GetDomainLayoutResponse,
@@ -8935,7 +8934,7 @@ export const getDomainObjectType: API.OperationMethod<
   GetDomainObjectTypeRequest,
   GetDomainObjectTypeResponse,
   GetDomainObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainObjectTypeRequest,
   output: GetDomainObjectTypeResponse,
@@ -8965,7 +8964,7 @@ export const getEventStream: API.OperationMethod<
   GetEventStreamRequest,
   GetEventStreamResponse,
   GetEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventStreamRequest,
   output: GetEventStreamResponse,
@@ -8995,7 +8994,7 @@ export const getEventTrigger: API.OperationMethod<
   GetEventTriggerRequest,
   GetEventTriggerResponse,
   GetEventTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventTriggerRequest,
   output: GetEventTriggerResponse,
@@ -9028,7 +9027,7 @@ export const getIdentityResolutionJob: API.OperationMethod<
   GetIdentityResolutionJobRequest,
   GetIdentityResolutionJobResponse,
   GetIdentityResolutionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityResolutionJobRequest,
   output: GetIdentityResolutionJobResponse,
@@ -9058,7 +9057,7 @@ export const getIntegration: API.OperationMethod<
   GetIntegrationRequest,
   GetIntegrationResponse,
   GetIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationRequest,
   output: GetIntegrationResponse,
@@ -9125,7 +9124,7 @@ export const getMatches: API.OperationMethod<
   GetMatchesRequest,
   GetMatchesResponse,
   GetMatchesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMatchesRequest,
   output: GetMatchesResponse,
@@ -9161,7 +9160,7 @@ export const getObjectTypeAttributeStatistics: API.OperationMethod<
   GetObjectTypeAttributeStatisticsRequest,
   GetObjectTypeAttributeStatisticsResponse,
   GetObjectTypeAttributeStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectTypeAttributeStatisticsRequest,
   output: GetObjectTypeAttributeStatisticsResponse,
@@ -9191,7 +9190,7 @@ export const getProfileHistoryRecord: API.OperationMethod<
   GetProfileHistoryRecordRequest,
   GetProfileHistoryRecordResponse,
   GetProfileHistoryRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileHistoryRecordRequest,
   output: GetProfileHistoryRecordResponse,
@@ -9221,7 +9220,7 @@ export const getProfileObjectType: API.OperationMethod<
   GetProfileObjectTypeRequest,
   GetProfileObjectTypeResponse,
   GetProfileObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileObjectTypeRequest,
   output: GetProfileObjectTypeResponse,
@@ -9256,7 +9255,7 @@ export const getProfileObjectTypeTemplate: API.OperationMethod<
   GetProfileObjectTypeTemplateRequest,
   GetProfileObjectTypeTemplateResponse,
   GetProfileObjectTypeTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileObjectTypeTemplateRequest,
   output: GetProfileObjectTypeTemplateResponse,
@@ -9286,7 +9285,7 @@ export const getProfileRecommendations: API.OperationMethod<
   GetProfileRecommendationsRequest,
   GetProfileRecommendationsResponse,
   GetProfileRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileRecommendationsRequest,
   output: GetProfileRecommendationsResponse,
@@ -9316,7 +9315,7 @@ export const getRecommender: API.OperationMethod<
   GetRecommenderRequest,
   GetRecommenderResponse,
   GetRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommenderRequest,
   output: GetRecommenderResponse,
@@ -9346,7 +9345,7 @@ export const getRecommenderFilter: API.OperationMethod<
   GetRecommenderFilterRequest,
   GetRecommenderFilterResponse,
   GetRecommenderFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommenderFilterRequest,
   output: GetRecommenderFilterResponse,
@@ -9376,7 +9375,7 @@ export const getRecommenderSchema: API.OperationMethod<
   GetRecommenderSchemaRequest,
   GetRecommenderSchemaResponse,
   GetRecommenderSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommenderSchemaRequest,
   output: GetRecommenderSchemaResponse,
@@ -9406,7 +9405,7 @@ export const getSegmentDefinition: API.OperationMethod<
   GetSegmentDefinitionRequest,
   GetSegmentDefinitionResponse,
   GetSegmentDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentDefinitionRequest,
   output: GetSegmentDefinitionResponse,
@@ -9436,7 +9435,7 @@ export const getSegmentEstimate: API.OperationMethod<
   GetSegmentEstimateRequest,
   GetSegmentEstimateResponse,
   GetSegmentEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentEstimateRequest,
   output: GetSegmentEstimateResponse,
@@ -9466,7 +9465,7 @@ export const getSegmentMembership: API.OperationMethod<
   GetSegmentMembershipRequest,
   GetSegmentMembershipResponse,
   GetSegmentMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentMembershipRequest,
   output: GetSegmentMembershipResponse,
@@ -9496,7 +9495,7 @@ export const getSegmentSnapshot: API.OperationMethod<
   GetSegmentSnapshotRequest,
   GetSegmentSnapshotResponse,
   GetSegmentSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentSnapshotRequest,
   output: GetSegmentSnapshotResponse,
@@ -9529,7 +9528,7 @@ export const getSimilarProfiles: API.PaginatedOperationMethod<
   GetSimilarProfilesRequest,
   GetSimilarProfilesResponse,
   GetSimilarProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Uuid
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSimilarProfilesRequest,
@@ -9566,7 +9565,7 @@ export const getUploadJob: API.OperationMethod<
   GetUploadJobRequest,
   GetUploadJobResponse,
   GetUploadJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUploadJobRequest,
   output: GetUploadJobResponse,
@@ -9597,7 +9596,7 @@ export const getUploadJobPath: API.OperationMethod<
   GetUploadJobPathRequest,
   GetUploadJobPathResponse,
   GetUploadJobPathError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUploadJobPathRequest,
   output: GetUploadJobPathResponse,
@@ -9627,7 +9626,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -9657,7 +9656,7 @@ export const getWorkflowSteps: API.OperationMethod<
   GetWorkflowStepsRequest,
   GetWorkflowStepsResponse,
   GetWorkflowStepsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowStepsRequest,
   output: GetWorkflowStepsResponse,
@@ -9687,7 +9686,7 @@ export const listAccountIntegrations: API.OperationMethod<
   ListAccountIntegrationsRequest,
   ListAccountIntegrationsResponse,
   ListAccountIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAccountIntegrationsRequest,
   output: ListAccountIntegrationsResponse,
@@ -9717,7 +9716,7 @@ export const listCalculatedAttributeDefinitions: API.OperationMethod<
   ListCalculatedAttributeDefinitionsRequest,
   ListCalculatedAttributeDefinitionsResponse,
   ListCalculatedAttributeDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCalculatedAttributeDefinitionsRequest,
   output: ListCalculatedAttributeDefinitionsResponse,
@@ -9747,7 +9746,7 @@ export const listCalculatedAttributesForProfile: API.OperationMethod<
   ListCalculatedAttributesForProfileRequest,
   ListCalculatedAttributesForProfileResponse,
   ListCalculatedAttributesForProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCalculatedAttributesForProfileRequest,
   output: ListCalculatedAttributesForProfileResponse,
@@ -9778,7 +9777,7 @@ export const listDomainLayouts: API.PaginatedOperationMethod<
   ListDomainLayoutsRequest,
   ListDomainLayoutsResponse,
   ListDomainLayoutsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LayoutItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainLayoutsRequest,
@@ -9815,7 +9814,7 @@ export const listDomainObjectTypes: API.PaginatedOperationMethod<
   ListDomainObjectTypesRequest,
   ListDomainObjectTypesResponse,
   ListDomainObjectTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainObjectTypesListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainObjectTypesRequest,
@@ -9852,7 +9851,7 @@ export const listDomains: API.OperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDomainsRequest,
   output: ListDomainsResponse,
@@ -9882,7 +9881,7 @@ export const listEventStreams: API.PaginatedOperationMethod<
   ListEventStreamsRequest,
   ListEventStreamsResponse,
   ListEventStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventStreamSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventStreamsRequest,
@@ -9919,7 +9918,7 @@ export const listEventTriggers: API.PaginatedOperationMethod<
   ListEventTriggersRequest,
   ListEventTriggersResponse,
   ListEventTriggersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventTriggerSummaryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventTriggersRequest,
@@ -9957,7 +9956,7 @@ export const listIdentityResolutionJobs: API.OperationMethod<
   ListIdentityResolutionJobsRequest,
   ListIdentityResolutionJobsResponse,
   ListIdentityResolutionJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIdentityResolutionJobsRequest,
   output: ListIdentityResolutionJobsResponse,
@@ -9987,7 +9986,7 @@ export const listIntegrations: API.OperationMethod<
   ListIntegrationsRequest,
   ListIntegrationsResponse,
   ListIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIntegrationsRequest,
   output: ListIntegrationsResponse,
@@ -10017,7 +10016,7 @@ export const listObjectTypeAttributes: API.PaginatedOperationMethod<
   ListObjectTypeAttributesRequest,
   ListObjectTypeAttributesResponse,
   ListObjectTypeAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListObjectTypeAttributeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectTypeAttributesRequest,
@@ -10054,7 +10053,7 @@ export const listObjectTypeAttributeValues: API.OperationMethod<
   ListObjectTypeAttributeValuesRequest,
   ListObjectTypeAttributeValuesResponse,
   ListObjectTypeAttributeValuesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListObjectTypeAttributeValuesRequest,
   output: ListObjectTypeAttributeValuesResponse,
@@ -10084,7 +10083,7 @@ export const listProfileAttributeValues: API.OperationMethod<
   ProfileAttributeValuesRequest,
   ProfileAttributeValuesResponse,
   ListProfileAttributeValuesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProfileAttributeValuesRequest,
   output: ProfileAttributeValuesResponse,
@@ -10114,7 +10113,7 @@ export const listProfileHistoryRecords: API.OperationMethod<
   ListProfileHistoryRecordsRequest,
   ListProfileHistoryRecordsResponse,
   ListProfileHistoryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProfileHistoryRecordsRequest,
   output: ListProfileHistoryRecordsResponse,
@@ -10144,7 +10143,7 @@ export const listProfileObjects: API.OperationMethod<
   ListProfileObjectsRequest,
   ListProfileObjectsResponse,
   ListProfileObjectsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProfileObjectsRequest,
   output: ListProfileObjectsResponse,
@@ -10174,7 +10173,7 @@ export const listProfileObjectTypes: API.OperationMethod<
   ListProfileObjectTypesRequest,
   ListProfileObjectTypesResponse,
   ListProfileObjectTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProfileObjectTypesRequest,
   output: ListProfileObjectTypesResponse,
@@ -10204,7 +10203,7 @@ export const listProfileObjectTypeTemplates: API.OperationMethod<
   ListProfileObjectTypeTemplatesRequest,
   ListProfileObjectTypeTemplatesResponse,
   ListProfileObjectTypeTemplatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProfileObjectTypeTemplatesRequest,
   output: ListProfileObjectTypeTemplatesResponse,
@@ -10234,7 +10233,7 @@ export const listRecommenderFilters: API.PaginatedOperationMethod<
   ListRecommenderFiltersRequest,
   ListRecommenderFiltersResponse,
   ListRecommenderFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommenderFilterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommenderFiltersRequest,
@@ -10270,7 +10269,7 @@ export const listRecommenderRecipes: API.PaginatedOperationMethod<
   ListRecommenderRecipesRequest,
   ListRecommenderRecipesResponse,
   ListRecommenderRecipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommenderRecipe
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommenderRecipesRequest,
@@ -10306,7 +10305,7 @@ export const listRecommenders: API.PaginatedOperationMethod<
   ListRecommendersRequest,
   ListRecommendersResponse,
   ListRecommendersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommenderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendersRequest,
@@ -10343,7 +10342,7 @@ export const listRecommenderSchemas: API.PaginatedOperationMethod<
   ListRecommenderSchemasRequest,
   ListRecommenderSchemasResponse,
   ListRecommenderSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommenderSchemaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommenderSchemasRequest,
@@ -10380,7 +10379,7 @@ export const listRuleBasedMatches: API.PaginatedOperationMethod<
   ListRuleBasedMatchesRequest,
   ListRuleBasedMatchesResponse,
   ListRuleBasedMatchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   String1To255
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRuleBasedMatchesRequest,
@@ -10417,7 +10416,7 @@ export const listSegmentDefinitions: API.PaginatedOperationMethod<
   ListSegmentDefinitionsRequest,
   ListSegmentDefinitionsResponse,
   ListSegmentDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SegmentDefinitionItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSegmentDefinitionsRequest,
@@ -10453,7 +10452,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -10481,7 +10480,7 @@ export const listUploadJobs: API.PaginatedOperationMethod<
   ListUploadJobsRequest,
   ListUploadJobsResponse,
   ListUploadJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UploadJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUploadJobsRequest,
@@ -10518,7 +10517,7 @@ export const listWorkflows: API.OperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWorkflowsRequest,
   output: ListWorkflowsResponse,
@@ -10575,7 +10574,7 @@ export const mergeProfiles: API.OperationMethod<
   MergeProfilesRequest,
   MergeProfilesResponse,
   MergeProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeProfilesRequest,
   output: MergeProfilesResponse,
@@ -10604,7 +10603,7 @@ export const putDomainObjectType: API.OperationMethod<
   PutDomainObjectTypeRequest,
   PutDomainObjectTypeResponse,
   PutDomainObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDomainObjectTypeRequest,
   output: PutDomainObjectTypeResponse,
@@ -10641,7 +10640,7 @@ export const putIntegration: API.OperationMethod<
   PutIntegrationRequest,
   PutIntegrationResponse,
   PutIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIntegrationRequest,
   output: PutIntegrationResponse,
@@ -10683,7 +10682,7 @@ export const putProfileObject: API.OperationMethod<
   PutProfileObjectRequest,
   PutProfileObjectResponse,
   PutProfileObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProfileObjectRequest,
   output: PutProfileObjectResponse,
@@ -10716,7 +10715,7 @@ export const putProfileObjectType: API.OperationMethod<
   PutProfileObjectTypeRequest,
   PutProfileObjectTypeResponse,
   PutProfileObjectTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProfileObjectTypeRequest,
   output: PutProfileObjectTypeResponse,
@@ -10752,7 +10751,7 @@ export const searchProfiles: API.OperationMethod<
   SearchProfilesRequest,
   SearchProfilesResponse,
   SearchProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchProfilesRequest,
   output: SearchProfilesResponse,
@@ -10782,7 +10781,7 @@ export const startRecommender: API.OperationMethod<
   StartRecommenderRequest,
   StartRecommenderResponse,
   StartRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecommenderRequest,
   output: StartRecommenderResponse,
@@ -10812,7 +10811,7 @@ export const startUploadJob: API.OperationMethod<
   StartUploadJobRequest,
   StartUploadJobResponse,
   StartUploadJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartUploadJobRequest,
   output: StartUploadJobResponse,
@@ -10842,7 +10841,7 @@ export const stopRecommender: API.OperationMethod<
   StopRecommenderRequest,
   StopRecommenderResponse,
   StopRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRecommenderRequest,
   output: StopRecommenderResponse,
@@ -10872,7 +10871,7 @@ export const stopUploadJob: API.OperationMethod<
   StopUploadJobRequest,
   StopUploadJobResponse,
   StopUploadJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopUploadJobRequest,
   output: StopUploadJobResponse,
@@ -10914,7 +10913,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10941,7 +10940,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10971,7 +10970,7 @@ export const updateCalculatedAttributeDefinition: API.OperationMethod<
   UpdateCalculatedAttributeDefinitionRequest,
   UpdateCalculatedAttributeDefinitionResponse,
   UpdateCalculatedAttributeDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCalculatedAttributeDefinitionRequest,
   output: UpdateCalculatedAttributeDefinitionResponse,
@@ -11013,7 +11012,7 @@ export const updateDomain: API.OperationMethod<
   UpdateDomainRequest,
   UpdateDomainResponse,
   UpdateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainRequest,
   output: UpdateDomainResponse,
@@ -11044,7 +11043,7 @@ export const updateDomainLayout: API.OperationMethod<
   UpdateDomainLayoutRequest,
   UpdateDomainLayoutResponse,
   UpdateDomainLayoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainLayoutRequest,
   output: UpdateDomainLayoutResponse,
@@ -11074,7 +11073,7 @@ export const updateEventTrigger: API.OperationMethod<
   UpdateEventTriggerRequest,
   UpdateEventTriggerResponse,
   UpdateEventTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventTriggerRequest,
   output: UpdateEventTriggerResponse,
@@ -11109,7 +11108,7 @@ export const updateProfile: API.OperationMethod<
   UpdateProfileRequest,
   UpdateProfileResponse,
   UpdateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileRequest,
   output: UpdateProfileResponse,
@@ -11139,7 +11138,7 @@ export const updateRecommender: API.OperationMethod<
   UpdateRecommenderRequest,
   UpdateRecommenderResponse,
   UpdateRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecommenderRequest,
   output: UpdateRecommenderResponse,

--- a/packages/aws/src/services/data-pipeline.ts
+++ b/packages/aws/src/services/data-pipeline.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://datapipeline.amazonaws.com/doc/2012-10-29/");
 const svc = T.AwsApiService({
   sdkId: "Data Pipeline",
@@ -942,7 +941,7 @@ export const activatePipeline: API.OperationMethod<
   ActivatePipelineInput,
   ActivatePipelineOutput,
   ActivatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivatePipelineInput,
   output: ActivatePipelineOutput,
@@ -970,7 +969,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -1016,7 +1015,7 @@ export const createPipeline: API.OperationMethod<
   CreatePipelineInput,
   CreatePipelineOutput,
   CreatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipelineInput,
   output: CreatePipelineOutput,
@@ -1043,7 +1042,7 @@ export const deactivatePipeline: API.OperationMethod<
   DeactivatePipelineInput,
   DeactivatePipelineOutput,
   DeactivatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivatePipelineInput,
   output: DeactivatePipelineOutput,
@@ -1092,7 +1091,7 @@ export const deletePipeline: API.OperationMethod<
   DeletePipelineInput,
   DeletePipelineResponse,
   DeletePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipelineInput,
   output: DeletePipelineResponse,
@@ -1167,7 +1166,7 @@ export const describeObjects: API.PaginatedOperationMethod<
   DescribeObjectsInput,
   DescribeObjectsOutput,
   DescribeObjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineObject
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeObjectsInput,
@@ -1254,7 +1253,7 @@ export const describePipelines: API.OperationMethod<
   DescribePipelinesInput,
   DescribePipelinesOutput,
   DescribePipelinesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePipelinesInput,
   output: DescribePipelinesOutput,
@@ -1303,7 +1302,7 @@ export const evaluateExpression: API.OperationMethod<
   EvaluateExpressionInput,
   EvaluateExpressionOutput,
   EvaluateExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluateExpressionInput,
   output: EvaluateExpressionOutput,
@@ -1386,7 +1385,7 @@ export const getPipelineDefinition: API.OperationMethod<
   GetPipelineDefinitionInput,
   GetPipelineDefinitionOutput,
   GetPipelineDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineDefinitionInput,
   output: GetPipelineDefinitionOutput,
@@ -1437,7 +1436,7 @@ export const listPipelines: API.PaginatedOperationMethod<
   ListPipelinesInput,
   ListPipelinesOutput,
   ListPipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineIdName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelinesInput,
@@ -1533,7 +1532,7 @@ export const pollForTask: API.OperationMethod<
   PollForTaskInput,
   PollForTaskOutput,
   PollForTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PollForTaskInput,
   output: PollForTaskOutput,
@@ -1699,7 +1698,7 @@ export const putPipelineDefinition: API.OperationMethod<
   PutPipelineDefinitionInput,
   PutPipelineDefinitionOutput,
   PutPipelineDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPipelineDefinitionInput,
   output: PutPipelineDefinitionOutput,
@@ -1755,7 +1754,7 @@ export const queryObjects: API.PaginatedOperationMethod<
   QueryObjectsInput,
   QueryObjectsOutput,
   QueryObjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Id
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryObjectsInput,
@@ -1790,7 +1789,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsInput,
   RemoveTagsOutput,
   RemoveTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsInput,
   output: RemoveTagsOutput,
@@ -1848,7 +1847,7 @@ export const reportTaskProgress: API.OperationMethod<
   ReportTaskProgressInput,
   ReportTaskProgressOutput,
   ReportTaskProgressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReportTaskProgressInput,
   output: ReportTaskProgressOutput,
@@ -1897,7 +1896,7 @@ export const reportTaskRunnerHeartbeat: API.OperationMethod<
   ReportTaskRunnerHeartbeatInput,
   ReportTaskRunnerHeartbeatOutput,
   ReportTaskRunnerHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReportTaskRunnerHeartbeatInput,
   output: ReportTaskRunnerHeartbeatOutput,
@@ -1942,7 +1941,7 @@ export const setStatus: API.OperationMethod<
   SetStatusInput,
   SetStatusResponse,
   SetStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetStatusInput,
   output: SetStatusResponse,
@@ -1991,7 +1990,7 @@ export const setTaskStatus: API.OperationMethod<
   SetTaskStatusInput,
   SetTaskStatusOutput,
   SetTaskStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTaskStatusInput,
   output: SetTaskStatusOutput,
@@ -2151,7 +2150,7 @@ export const validatePipelineDefinition: API.OperationMethod<
   ValidatePipelineDefinitionInput,
   ValidatePipelineDefinitionOutput,
   ValidatePipelineDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidatePipelineDefinitionInput,
   output: ValidatePipelineDefinitionOutput,

--- a/packages/aws/src/services/database-migration-service.ts
+++ b/packages/aws/src/services/database-migration-service.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://dms.amazonaws.com/doc/2016-01-01/");
 const svc = T.AwsApiService({
@@ -7959,7 +7958,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceMessage,
   AddTagsToResourceResponse,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceMessage,
   output: AddTagsToResourceResponse,
@@ -7980,7 +7979,7 @@ export const applyPendingMaintenanceAction: API.OperationMethod<
   ApplyPendingMaintenanceActionMessage,
   ApplyPendingMaintenanceActionResponse,
   ApplyPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyPendingMaintenanceActionMessage,
   output: ApplyPendingMaintenanceActionResponse,
@@ -8010,7 +8009,7 @@ export const batchStartRecommendations: API.OperationMethod<
   BatchStartRecommendationsRequest,
   BatchStartRecommendationsResponse,
   BatchStartRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStartRecommendationsRequest,
   output: BatchStartRecommendationsResponse,
@@ -8032,7 +8031,7 @@ export const cancelMetadataModelConversion: API.OperationMethod<
   CancelMetadataModelConversionMessage,
   CancelMetadataModelConversionResponse,
   CancelMetadataModelConversionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMetadataModelConversionMessage,
   output: CancelMetadataModelConversionResponse,
@@ -8054,7 +8053,7 @@ export const cancelMetadataModelCreation: API.OperationMethod<
   CancelMetadataModelCreationMessage,
   CancelMetadataModelCreationResponse,
   CancelMetadataModelCreationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMetadataModelCreationMessage,
   output: CancelMetadataModelCreationResponse,
@@ -8080,7 +8079,7 @@ export const cancelReplicationTaskAssessmentRun: API.OperationMethod<
   CancelReplicationTaskAssessmentRunMessage,
   CancelReplicationTaskAssessmentRunResponse,
   CancelReplicationTaskAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelReplicationTaskAssessmentRunMessage,
   output: CancelReplicationTaskAssessmentRunResponse,
@@ -8104,7 +8103,7 @@ export const createDataMigration: API.OperationMethod<
   CreateDataMigrationMessage,
   CreateDataMigrationResponse,
   CreateDataMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataMigrationMessage,
   output: CreateDataMigrationResponse,
@@ -8134,7 +8133,7 @@ export const createDataProvider: API.OperationMethod<
   CreateDataProviderMessage,
   CreateDataProviderResponse,
   CreateDataProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataProviderMessage,
   output: CreateDataProviderResponse,
@@ -8172,7 +8171,7 @@ export const createEndpoint: API.OperationMethod<
   CreateEndpointMessage,
   CreateEndpointResponse,
   CreateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointMessage,
   output: CreateEndpointResponse,
@@ -8224,7 +8223,7 @@ export const createEventSubscription: API.OperationMethod<
   CreateEventSubscriptionMessage,
   CreateEventSubscriptionResponse,
   CreateEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSubscriptionMessage,
   output: CreateEventSubscriptionResponse,
@@ -8261,7 +8260,7 @@ export const createFleetAdvisorCollector: API.OperationMethod<
   CreateFleetAdvisorCollectorRequest,
   CreateFleetAdvisorCollectorResponse,
   CreateFleetAdvisorCollectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetAdvisorCollectorRequest,
   output: CreateFleetAdvisorCollectorResponse,
@@ -8295,7 +8294,7 @@ export const createInstanceProfile: API.OperationMethod<
   CreateInstanceProfileMessage,
   CreateInstanceProfileResponse,
   CreateInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceProfileMessage,
   output: CreateInstanceProfileResponse,
@@ -8334,7 +8333,7 @@ export const createMigrationProject: API.OperationMethod<
   CreateMigrationProjectMessage,
   CreateMigrationProjectResponse,
   CreateMigrationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMigrationProjectMessage,
   output: CreateMigrationProjectResponse,
@@ -8371,7 +8370,7 @@ export const createReplicationConfig: API.OperationMethod<
   CreateReplicationConfigMessage,
   CreateReplicationConfigResponse,
   CreateReplicationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationConfigMessage,
   output: CreateReplicationConfigResponse,
@@ -8418,7 +8417,7 @@ export const createReplicationInstance: API.OperationMethod<
   CreateReplicationInstanceMessage,
   CreateReplicationInstanceResponse,
   CreateReplicationInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationInstanceMessage,
   output: CreateReplicationInstanceResponse,
@@ -8464,7 +8463,7 @@ export const createReplicationSubnetGroup: API.OperationMethod<
   CreateReplicationSubnetGroupMessage,
   CreateReplicationSubnetGroupResponse,
   CreateReplicationSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationSubnetGroupMessage,
   output: CreateReplicationSubnetGroupResponse,
@@ -8496,7 +8495,7 @@ export const createReplicationTask: API.OperationMethod<
   CreateReplicationTaskMessage,
   CreateReplicationTaskResponse,
   CreateReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationTaskMessage,
   output: CreateReplicationTaskResponse,
@@ -8524,7 +8523,7 @@ export const deleteCertificate: API.OperationMethod<
   DeleteCertificateMessage,
   DeleteCertificateResponse,
   DeleteCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateMessage,
   output: DeleteCertificateResponse,
@@ -8546,7 +8545,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionMessage,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionMessage,
   output: DeleteConnectionResponse,
@@ -8568,7 +8567,7 @@ export const deleteDataMigration: API.OperationMethod<
   DeleteDataMigrationMessage,
   DeleteDataMigrationResponse,
   DeleteDataMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataMigrationMessage,
   output: DeleteDataMigrationResponse,
@@ -8598,7 +8597,7 @@ export const deleteDataProvider: API.OperationMethod<
   DeleteDataProviderMessage,
   DeleteDataProviderResponse,
   DeleteDataProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataProviderMessage,
   output: DeleteDataProviderResponse,
@@ -8627,7 +8626,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointMessage,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointMessage,
   output: DeleteEndpointResponse,
@@ -8649,7 +8648,7 @@ export const deleteEventSubscription: API.OperationMethod<
   DeleteEventSubscriptionMessage,
   DeleteEventSubscriptionResponse,
   DeleteEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSubscriptionMessage,
   output: DeleteEventSubscriptionResponse,
@@ -8673,7 +8672,7 @@ export const deleteFleetAdvisorCollector: API.OperationMethod<
   DeleteCollectorRequest,
   DeleteFleetAdvisorCollectorResponse,
   DeleteFleetAdvisorCollectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCollectorRequest,
   output: DeleteFleetAdvisorCollectorResponse,
@@ -8701,7 +8700,7 @@ export const deleteFleetAdvisorDatabases: API.OperationMethod<
   DeleteFleetAdvisorDatabasesRequest,
   DeleteFleetAdvisorDatabasesResponse,
   DeleteFleetAdvisorDatabasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetAdvisorDatabasesRequest,
   output: DeleteFleetAdvisorDatabasesResponse,
@@ -8727,7 +8726,7 @@ export const deleteInstanceProfile: API.OperationMethod<
   DeleteInstanceProfileMessage,
   DeleteInstanceProfileResponse,
   DeleteInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceProfileMessage,
   output: DeleteInstanceProfileResponse,
@@ -8757,7 +8756,7 @@ export const deleteMigrationProject: API.OperationMethod<
   DeleteMigrationProjectMessage,
   DeleteMigrationProjectResponse,
   DeleteMigrationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMigrationProjectMessage,
   output: DeleteMigrationProjectResponse,
@@ -8787,7 +8786,7 @@ export const deleteReplicationConfig: API.OperationMethod<
   DeleteReplicationConfigMessage,
   DeleteReplicationConfigResponse,
   DeleteReplicationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationConfigMessage,
   output: DeleteReplicationConfigResponse,
@@ -8811,7 +8810,7 @@ export const deleteReplicationInstance: API.OperationMethod<
   DeleteReplicationInstanceMessage,
   DeleteReplicationInstanceResponse,
   DeleteReplicationInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationInstanceMessage,
   output: DeleteReplicationInstanceResponse,
@@ -8833,7 +8832,7 @@ export const deleteReplicationSubnetGroup: API.OperationMethod<
   DeleteReplicationSubnetGroupMessage,
   DeleteReplicationSubnetGroupResponse,
   DeleteReplicationSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationSubnetGroupMessage,
   output: DeleteReplicationSubnetGroupResponse,
@@ -8854,7 +8853,7 @@ export const deleteReplicationTask: API.OperationMethod<
   DeleteReplicationTaskMessage,
   DeleteReplicationTaskResponse,
   DeleteReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationTaskMessage,
   output: DeleteReplicationTaskResponse,
@@ -8880,7 +8879,7 @@ export const deleteReplicationTaskAssessmentRun: API.OperationMethod<
   DeleteReplicationTaskAssessmentRunMessage,
   DeleteReplicationTaskAssessmentRunResponse,
   DeleteReplicationTaskAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationTaskAssessmentRunMessage,
   output: DeleteReplicationTaskAssessmentRunResponse,
@@ -8905,7 +8904,7 @@ export const describeAccountAttributes: API.OperationMethod<
   DescribeAccountAttributesMessage,
   DescribeAccountAttributesResponse,
   DescribeAccountAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAttributesMessage,
   output: DescribeAccountAttributesResponse,
@@ -8945,7 +8944,7 @@ export const describeApplicableIndividualAssessments: API.PaginatedOperationMeth
   DescribeApplicableIndividualAssessmentsMessage,
   DescribeApplicableIndividualAssessmentsResponse,
   DescribeApplicableIndividualAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeApplicableIndividualAssessmentsMessage,
@@ -8969,7 +8968,7 @@ export const describeCertificates: API.PaginatedOperationMethod<
   DescribeCertificatesMessage,
   DescribeCertificatesResponse,
   DescribeCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCertificatesMessage,
@@ -8994,7 +8993,7 @@ export const describeConnections: API.PaginatedOperationMethod<
   DescribeConnectionsMessage,
   DescribeConnectionsResponse,
   DescribeConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConnectionsMessage,
@@ -9020,7 +9019,7 @@ export const describeConversionConfiguration: API.OperationMethod<
   DescribeConversionConfigurationMessage,
   DescribeConversionConfigurationResponse,
   DescribeConversionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConversionConfigurationMessage,
   output: DescribeConversionConfigurationResponse,
@@ -9042,7 +9041,7 @@ export const describeDataMigrations: API.PaginatedOperationMethod<
   DescribeDataMigrationsMessage,
   DescribeDataMigrationsResponse,
   DescribeDataMigrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataMigration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataMigrationsMessage,
@@ -9076,7 +9075,7 @@ export const describeDataProviders: API.PaginatedOperationMethod<
   DescribeDataProvidersMessage,
   DescribeDataProvidersResponse,
   DescribeDataProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataProvidersMessage,
@@ -9100,7 +9099,7 @@ export const describeEndpoints: API.PaginatedOperationMethod<
   DescribeEndpointsMessage,
   DescribeEndpointsResponse,
   DescribeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointsMessage,
@@ -9125,7 +9124,7 @@ export const describeEndpointSettings: API.PaginatedOperationMethod<
   DescribeEndpointSettingsMessage,
   DescribeEndpointSettingsResponse,
   DescribeEndpointSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointSettingsMessage,
@@ -9149,7 +9148,7 @@ export const describeEndpointTypes: API.PaginatedOperationMethod<
   DescribeEndpointTypesMessage,
   DescribeEndpointTypesResponse,
   DescribeEndpointTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointTypesMessage,
@@ -9173,7 +9172,7 @@ export const describeEngineVersions: API.PaginatedOperationMethod<
   DescribeEngineVersionsMessage,
   DescribeEngineVersionsResponse,
   DescribeEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineVersionsMessage,
@@ -9199,7 +9198,7 @@ export const describeEventCategories: API.OperationMethod<
   DescribeEventCategoriesMessage,
   DescribeEventCategoriesResponse,
   DescribeEventCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventCategoriesMessage,
   output: DescribeEventCategoriesResponse,
@@ -9219,7 +9218,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   DescribeEventsResponse,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -9251,7 +9250,7 @@ export const describeEventSubscriptions: API.PaginatedOperationMethod<
   DescribeEventSubscriptionsMessage,
   DescribeEventSubscriptionsResponse,
   DescribeEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventSubscriptionsMessage,
@@ -9277,7 +9276,7 @@ export const describeExtensionPackAssociations: API.PaginatedOperationMethod<
   DescribeExtensionPackAssociationsMessage,
   DescribeExtensionPackAssociationsResponse,
   DescribeExtensionPackAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeExtensionPackAssociationsMessage,
@@ -9305,7 +9304,7 @@ export const describeFleetAdvisorCollectors: API.PaginatedOperationMethod<
   DescribeFleetAdvisorCollectorsRequest,
   DescribeFleetAdvisorCollectorsResponse,
   DescribeFleetAdvisorCollectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAdvisorCollectorsRequest,
@@ -9333,7 +9332,7 @@ export const describeFleetAdvisorDatabases: API.PaginatedOperationMethod<
   DescribeFleetAdvisorDatabasesRequest,
   DescribeFleetAdvisorDatabasesResponse,
   DescribeFleetAdvisorDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAdvisorDatabasesRequest,
@@ -9362,7 +9361,7 @@ export const describeFleetAdvisorLsaAnalysis: API.PaginatedOperationMethod<
   DescribeFleetAdvisorLsaAnalysisRequest,
   DescribeFleetAdvisorLsaAnalysisResponse,
   DescribeFleetAdvisorLsaAnalysisError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAdvisorLsaAnalysisRequest,
@@ -9391,7 +9390,7 @@ export const describeFleetAdvisorSchemaObjectSummary: API.PaginatedOperationMeth
   DescribeFleetAdvisorSchemaObjectSummaryRequest,
   DescribeFleetAdvisorSchemaObjectSummaryResponse,
   DescribeFleetAdvisorSchemaObjectSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAdvisorSchemaObjectSummaryRequest,
@@ -9419,7 +9418,7 @@ export const describeFleetAdvisorSchemas: API.PaginatedOperationMethod<
   DescribeFleetAdvisorSchemasRequest,
   DescribeFleetAdvisorSchemasResponse,
   DescribeFleetAdvisorSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAdvisorSchemasRequest,
@@ -9448,7 +9447,7 @@ export const describeInstanceProfiles: API.PaginatedOperationMethod<
   DescribeInstanceProfilesMessage,
   DescribeInstanceProfilesResponse,
   DescribeInstanceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceProfilesMessage,
@@ -9475,7 +9474,7 @@ export const describeMetadataModel: API.OperationMethod<
   DescribeMetadataModelMessage,
   DescribeMetadataModelResponse,
   DescribeMetadataModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMetadataModelMessage,
   output: DescribeMetadataModelResponse,
@@ -9496,7 +9495,7 @@ export const describeMetadataModelAssessments: API.PaginatedOperationMethod<
   DescribeMetadataModelAssessmentsMessage,
   DescribeMetadataModelAssessmentsResponse,
   DescribeMetadataModelAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelAssessmentsMessage,
@@ -9523,7 +9522,7 @@ export const describeMetadataModelChildren: API.PaginatedOperationMethod<
   DescribeMetadataModelChildrenMessage,
   DescribeMetadataModelChildrenResponse,
   DescribeMetadataModelChildrenError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetadataModelReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelChildrenMessage,
@@ -9550,7 +9549,7 @@ export const describeMetadataModelConversions: API.PaginatedOperationMethod<
   DescribeMetadataModelConversionsMessage,
   DescribeMetadataModelConversionsResponse,
   DescribeMetadataModelConversionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelConversionsMessage,
@@ -9577,7 +9576,7 @@ export const describeMetadataModelCreations: API.PaginatedOperationMethod<
   DescribeMetadataModelCreationsMessage,
   DescribeMetadataModelCreationsResponse,
   DescribeMetadataModelCreationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaConversionRequest
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelCreationsMessage,
@@ -9604,7 +9603,7 @@ export const describeMetadataModelExportsAsScript: API.PaginatedOperationMethod<
   DescribeMetadataModelExportsAsScriptMessage,
   DescribeMetadataModelExportsAsScriptResponse,
   DescribeMetadataModelExportsAsScriptError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelExportsAsScriptMessage,
@@ -9630,7 +9629,7 @@ export const describeMetadataModelExportsToTarget: API.PaginatedOperationMethod<
   DescribeMetadataModelExportsToTargetMessage,
   DescribeMetadataModelExportsToTargetResponse,
   DescribeMetadataModelExportsToTargetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelExportsToTargetMessage,
@@ -9656,7 +9655,7 @@ export const describeMetadataModelImports: API.PaginatedOperationMethod<
   DescribeMetadataModelImportsMessage,
   DescribeMetadataModelImportsResponse,
   DescribeMetadataModelImportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMetadataModelImportsMessage,
@@ -9685,7 +9684,7 @@ export const describeMigrationProjects: API.PaginatedOperationMethod<
   DescribeMigrationProjectsMessage,
   DescribeMigrationProjectsResponse,
   DescribeMigrationProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMigrationProjectsMessage,
@@ -9710,7 +9709,7 @@ export const describeOrderableReplicationInstances: API.PaginatedOperationMethod
   DescribeOrderableReplicationInstancesMessage,
   DescribeOrderableReplicationInstancesResponse,
   DescribeOrderableReplicationInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrderableReplicationInstancesMessage,
@@ -9737,7 +9736,7 @@ export const describePendingMaintenanceActions: API.PaginatedOperationMethod<
   DescribePendingMaintenanceActionsMessage,
   DescribePendingMaintenanceActionsResponse,
   DescribePendingMaintenanceActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePendingMaintenanceActionsMessage,
@@ -9767,7 +9766,7 @@ export const describeRecommendationLimitations: API.PaginatedOperationMethod<
   DescribeRecommendationLimitationsRequest,
   DescribeRecommendationLimitationsResponse,
   DescribeRecommendationLimitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRecommendationLimitationsRequest,
@@ -9797,7 +9796,7 @@ export const describeRecommendations: API.PaginatedOperationMethod<
   DescribeRecommendationsRequest,
   DescribeRecommendationsResponse,
   DescribeRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRecommendationsRequest,
@@ -9824,7 +9823,7 @@ export const describeRefreshSchemasStatus: API.OperationMethod<
   DescribeRefreshSchemasStatusMessage,
   DescribeRefreshSchemasStatusResponse,
   DescribeRefreshSchemasStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRefreshSchemasStatusMessage,
   output: DescribeRefreshSchemasStatusResponse,
@@ -9845,7 +9844,7 @@ export const describeReplicationConfigs: API.PaginatedOperationMethod<
   DescribeReplicationConfigsMessage,
   DescribeReplicationConfigsResponse,
   DescribeReplicationConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationConfigsMessage,
@@ -9872,7 +9871,7 @@ export const describeReplicationInstances: API.PaginatedOperationMethod<
   DescribeReplicationInstancesMessage,
   DescribeReplicationInstancesResponse,
   DescribeReplicationInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationInstancesMessage,
@@ -9899,7 +9898,7 @@ export const describeReplicationInstanceTaskLogs: API.PaginatedOperationMethod<
   DescribeReplicationInstanceTaskLogsMessage,
   DescribeReplicationInstanceTaskLogsResponse,
   DescribeReplicationInstanceTaskLogsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationInstanceTaskLogsMessage,
@@ -9924,7 +9923,7 @@ export const describeReplications: API.PaginatedOperationMethod<
   DescribeReplicationsMessage,
   DescribeReplicationsResponse,
   DescribeReplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationsMessage,
@@ -9950,7 +9949,7 @@ export const describeReplicationSubnetGroups: API.PaginatedOperationMethod<
   DescribeReplicationSubnetGroupsMessage,
   DescribeReplicationSubnetGroupsResponse,
   DescribeReplicationSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationSubnetGroupsMessage,
@@ -9978,7 +9977,7 @@ export const describeReplicationTableStatistics: API.PaginatedOperationMethod<
   DescribeReplicationTableStatisticsMessage,
   DescribeReplicationTableStatisticsResponse,
   DescribeReplicationTableStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationTableStatisticsMessage,
@@ -10008,7 +10007,7 @@ export const describeReplicationTaskAssessmentResults: API.PaginatedOperationMet
   DescribeReplicationTaskAssessmentResultsMessage,
   DescribeReplicationTaskAssessmentResultsResponse,
   DescribeReplicationTaskAssessmentResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationTaskAssessmentResultsMessage,
@@ -10042,7 +10041,7 @@ export const describeReplicationTaskAssessmentRuns: API.PaginatedOperationMethod
   DescribeReplicationTaskAssessmentRunsMessage,
   DescribeReplicationTaskAssessmentRunsResponse,
   DescribeReplicationTaskAssessmentRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationTaskAssessmentRunsMessage,
@@ -10071,7 +10070,7 @@ export const describeReplicationTaskIndividualAssessments: API.PaginatedOperatio
   DescribeReplicationTaskIndividualAssessmentsMessage,
   DescribeReplicationTaskIndividualAssessmentsResponse,
   DescribeReplicationTaskIndividualAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationTaskIndividualAssessmentsMessage,
@@ -10098,7 +10097,7 @@ export const describeReplicationTasks: API.PaginatedOperationMethod<
   DescribeReplicationTasksMessage,
   DescribeReplicationTasksResponse,
   DescribeReplicationTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationTasksMessage,
@@ -10125,7 +10124,7 @@ export const describeSchemas: API.PaginatedOperationMethod<
   DescribeSchemasMessage,
   DescribeSchemasResponse,
   DescribeSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSchemasMessage,
@@ -10158,7 +10157,7 @@ export const describeTableStatistics: API.PaginatedOperationMethod<
   DescribeTableStatisticsMessage,
   DescribeTableStatisticsResponse,
   DescribeTableStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTableStatisticsMessage,
@@ -10185,7 +10184,7 @@ export const exportMetadataModelAssessment: API.OperationMethod<
   ExportMetadataModelAssessmentMessage,
   ExportMetadataModelAssessmentResponse,
   ExportMetadataModelAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportMetadataModelAssessmentMessage,
   output: ExportMetadataModelAssessmentResponse,
@@ -10207,7 +10206,7 @@ export const getTargetSelectionRules: API.OperationMethod<
   GetTargetSelectionRulesMessage,
   GetTargetSelectionRulesResponse,
   GetTargetSelectionRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTargetSelectionRulesMessage,
   output: GetTargetSelectionRulesResponse,
@@ -10230,7 +10229,7 @@ export const importCertificate: API.OperationMethod<
   ImportCertificateMessage,
   ImportCertificateResponse,
   ImportCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCertificateMessage,
   output: ImportCertificateResponse,
@@ -10260,7 +10259,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: ListTagsForResourceResponse,
@@ -10281,7 +10280,7 @@ export const modifyConversionConfiguration: API.OperationMethod<
   ModifyConversionConfigurationMessage,
   ModifyConversionConfigurationResponse,
   ModifyConversionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyConversionConfigurationMessage,
   output: ModifyConversionConfigurationResponse,
@@ -10303,7 +10302,7 @@ export const modifyDataMigration: API.OperationMethod<
   ModifyDataMigrationMessage,
   ModifyDataMigrationResponse,
   ModifyDataMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDataMigrationMessage,
   output: ModifyDataMigrationResponse,
@@ -10333,7 +10332,7 @@ export const modifyDataProvider: API.OperationMethod<
   ModifyDataProviderMessage,
   ModifyDataProviderResponse,
   ModifyDataProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDataProviderMessage,
   output: ModifyDataProviderResponse,
@@ -10369,7 +10368,7 @@ export const modifyEndpoint: API.OperationMethod<
   ModifyEndpointMessage,
   ModifyEndpointResponse,
   ModifyEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEndpointMessage,
   output: ModifyEndpointResponse,
@@ -10404,7 +10403,7 @@ export const modifyEventSubscription: API.OperationMethod<
   ModifyEventSubscriptionMessage,
   ModifyEventSubscriptionResponse,
   ModifyEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEventSubscriptionMessage,
   output: ModifyEventSubscriptionResponse,
@@ -10444,7 +10443,7 @@ export const modifyInstanceProfile: API.OperationMethod<
   ModifyInstanceProfileMessage,
   ModifyInstanceProfileResponse,
   ModifyInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceProfileMessage,
   output: ModifyInstanceProfileResponse,
@@ -10479,7 +10478,7 @@ export const modifyMigrationProject: API.OperationMethod<
   ModifyMigrationProjectMessage,
   ModifyMigrationProjectResponse,
   ModifyMigrationProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyMigrationProjectMessage,
   output: ModifyMigrationProjectResponse,
@@ -10519,7 +10518,7 @@ export const modifyReplicationConfig: API.OperationMethod<
   ModifyReplicationConfigMessage,
   ModifyReplicationConfigResponse,
   ModifyReplicationConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationConfigMessage,
   output: ModifyReplicationConfigResponse,
@@ -10555,7 +10554,7 @@ export const modifyReplicationInstance: API.OperationMethod<
   ModifyReplicationInstanceMessage,
   ModifyReplicationInstanceResponse,
   ModifyReplicationInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationInstanceMessage,
   output: ModifyReplicationInstanceResponse,
@@ -10588,7 +10587,7 @@ export const modifyReplicationSubnetGroup: API.OperationMethod<
   ModifyReplicationSubnetGroupMessage,
   ModifyReplicationSubnetGroupResponse,
   ModifyReplicationSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationSubnetGroupMessage,
   output: ModifyReplicationSubnetGroupResponse,
@@ -10623,7 +10622,7 @@ export const modifyReplicationTask: API.OperationMethod<
   ModifyReplicationTaskMessage,
   ModifyReplicationTaskResponse,
   ModifyReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationTaskMessage,
   output: ModifyReplicationTaskResponse,
@@ -10654,7 +10653,7 @@ export const moveReplicationTask: API.OperationMethod<
   MoveReplicationTaskMessage,
   MoveReplicationTaskResponse,
   MoveReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MoveReplicationTaskMessage,
   output: MoveReplicationTaskResponse,
@@ -10682,7 +10681,7 @@ export const rebootReplicationInstance: API.OperationMethod<
   RebootReplicationInstanceMessage,
   RebootReplicationInstanceResponse,
   RebootReplicationInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootReplicationInstanceMessage,
   output: RebootReplicationInstanceResponse,
@@ -10707,7 +10706,7 @@ export const refreshSchemas: API.OperationMethod<
   RefreshSchemasMessage,
   RefreshSchemasResponse,
   RefreshSchemasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RefreshSchemasMessage,
   output: RefreshSchemasResponse,
@@ -10737,7 +10736,7 @@ export const reloadReplicationTables: API.OperationMethod<
   ReloadReplicationTablesMessage,
   ReloadReplicationTablesResponse,
   ReloadReplicationTablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReloadReplicationTablesMessage,
   output: ReloadReplicationTablesResponse,
@@ -10761,7 +10760,7 @@ export const reloadTables: API.OperationMethod<
   ReloadTablesMessage,
   ReloadTablesResponse,
   ReloadTablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReloadTablesMessage,
   output: ReloadTablesResponse,
@@ -10786,7 +10785,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceMessage,
   RemoveTagsFromResourceResponse,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceMessage,
   output: RemoveTagsFromResourceResponse,
@@ -10809,7 +10808,7 @@ export const runFleetAdvisorLsaAnalysis: API.OperationMethod<
   RunFleetAdvisorLsaAnalysisRequest,
   RunFleetAdvisorLsaAnalysisResponse,
   RunFleetAdvisorLsaAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunFleetAdvisorLsaAnalysisRequest,
   output: RunFleetAdvisorLsaAnalysisResponse,
@@ -10833,7 +10832,7 @@ export const startDataMigration: API.OperationMethod<
   StartDataMigrationMessage,
   StartDataMigrationResponse,
   StartDataMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataMigrationMessage,
   output: StartDataMigrationResponse,
@@ -10868,7 +10867,7 @@ export const startExtensionPackAssociation: API.OperationMethod<
   StartExtensionPackAssociationMessage,
   StartExtensionPackAssociationResponse,
   StartExtensionPackAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExtensionPackAssociationMessage,
   output: StartExtensionPackAssociationResponse,
@@ -10907,7 +10906,7 @@ export const startMetadataModelAssessment: API.OperationMethod<
   StartMetadataModelAssessmentMessage,
   StartMetadataModelAssessmentResponse,
   StartMetadataModelAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelAssessmentMessage,
   output: StartMetadataModelAssessmentResponse,
@@ -10943,7 +10942,7 @@ export const startMetadataModelConversion: API.OperationMethod<
   StartMetadataModelConversionMessage,
   StartMetadataModelConversionResponse,
   StartMetadataModelConversionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelConversionMessage,
   output: StartMetadataModelConversionResponse,
@@ -10977,7 +10976,7 @@ export const startMetadataModelCreation: API.OperationMethod<
   StartMetadataModelCreationMessage,
   StartMetadataModelCreationResponse,
   StartMetadataModelCreationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelCreationMessage,
   output: StartMetadataModelCreationResponse,
@@ -11010,7 +11009,7 @@ export const startMetadataModelExportAsScript: API.OperationMethod<
   StartMetadataModelExportAsScriptMessage,
   StartMetadataModelExportAsScriptResponse,
   StartMetadataModelExportAsScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelExportAsScriptMessage,
   output: StartMetadataModelExportAsScriptResponse,
@@ -11046,7 +11045,7 @@ export const startMetadataModelExportToTarget: API.OperationMethod<
   StartMetadataModelExportToTargetMessage,
   StartMetadataModelExportToTargetResponse,
   StartMetadataModelExportToTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelExportToTargetMessage,
   output: StartMetadataModelExportToTargetResponse,
@@ -11085,7 +11084,7 @@ export const startMetadataModelImport: API.OperationMethod<
   StartMetadataModelImportMessage,
   StartMetadataModelImportResponse,
   StartMetadataModelImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataModelImportMessage,
   output: StartMetadataModelImportResponse,
@@ -11121,7 +11120,7 @@ export const startRecommendations: API.OperationMethod<
   StartRecommendationsRequest,
   StartRecommendationsResponse,
   StartRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecommendationsRequest,
   output: StartRecommendationsResponse,
@@ -11147,7 +11146,7 @@ export const startReplication: API.OperationMethod<
   StartReplicationMessage,
   StartReplicationResponse,
   StartReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationMessage,
   output: StartReplicationResponse,
@@ -11172,7 +11171,7 @@ export const startReplicationTask: API.OperationMethod<
   StartReplicationTaskMessage,
   StartReplicationTaskResponse,
   StartReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationTaskMessage,
   output: StartReplicationTaskResponse,
@@ -11206,7 +11205,7 @@ export const startReplicationTaskAssessment: API.OperationMethod<
   StartReplicationTaskAssessmentMessage,
   StartReplicationTaskAssessmentResponse,
   StartReplicationTaskAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationTaskAssessmentMessage,
   output: StartReplicationTaskAssessmentResponse,
@@ -11244,7 +11243,7 @@ export const startReplicationTaskAssessmentRun: API.OperationMethod<
   StartReplicationTaskAssessmentRunMessage,
   StartReplicationTaskAssessmentRunResponse,
   StartReplicationTaskAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationTaskAssessmentRunMessage,
   output: StartReplicationTaskAssessmentRunResponse,
@@ -11279,7 +11278,7 @@ export const stopDataMigration: API.OperationMethod<
   StopDataMigrationMessage,
   StopDataMigrationResponse,
   StopDataMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDataMigrationMessage,
   output: StopDataMigrationResponse,
@@ -11307,7 +11306,7 @@ export const stopReplication: API.OperationMethod<
   StopReplicationMessage,
   StopReplicationResponse,
   StopReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopReplicationMessage,
   output: StopReplicationResponse,
@@ -11328,7 +11327,7 @@ export const stopReplicationTask: API.OperationMethod<
   StopReplicationTaskMessage,
   StopReplicationTaskResponse,
   StopReplicationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopReplicationTaskMessage,
   output: StopReplicationTaskResponse,
@@ -11352,7 +11351,7 @@ export const testConnection: API.OperationMethod<
   TestConnectionMessage,
   TestConnectionResponse,
   TestConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestConnectionMessage,
   output: TestConnectionResponse,
@@ -11390,7 +11389,7 @@ export const updateSubscriptionsToEventBridge: API.OperationMethod<
   UpdateSubscriptionsToEventBridgeMessage,
   UpdateSubscriptionsToEventBridgeResponse,
   UpdateSubscriptionsToEventBridgeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionsToEventBridgeMessage,
   output: UpdateSubscriptionsToEventBridgeResponse,

--- a/packages/aws/src/services/databrew.ts
+++ b/packages/aws/src/services/databrew.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DataBrew",
@@ -2793,7 +2792,7 @@ export const batchDeleteRecipeVersion: API.OperationMethod<
   BatchDeleteRecipeVersionRequest,
   BatchDeleteRecipeVersionResponse,
   BatchDeleteRecipeVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteRecipeVersionRequest,
   output: BatchDeleteRecipeVersionResponse,
@@ -2822,7 +2821,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -2854,7 +2853,7 @@ export const createProfileJob: API.OperationMethod<
   CreateProfileJobRequest,
   CreateProfileJobResponse,
   CreateProfileJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileJobRequest,
   output: CreateProfileJobResponse,
@@ -2887,7 +2886,7 @@ export const createProject: API.OperationMethod<
   CreateProjectRequest,
   CreateProjectResponse,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectRequest,
   output: CreateProjectResponse,
@@ -2917,7 +2916,7 @@ export const createRecipe: API.OperationMethod<
   CreateRecipeRequest,
   CreateRecipeResponse,
   CreateRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecipeRequest,
   output: CreateRecipeResponse,
@@ -2948,7 +2947,7 @@ export const createRecipeJob: API.OperationMethod<
   CreateRecipeJobRequest,
   CreateRecipeJobResponse,
   CreateRecipeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecipeJobRequest,
   output: CreateRecipeJobResponse,
@@ -2980,7 +2979,7 @@ export const createRuleset: API.OperationMethod<
   CreateRulesetRequest,
   CreateRulesetResponse,
   CreateRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRulesetRequest,
   output: CreateRulesetResponse,
@@ -3009,7 +3008,7 @@ export const createSchedule: API.OperationMethod<
   CreateScheduleRequest,
   CreateScheduleResponse,
   CreateScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduleRequest,
   output: CreateScheduleResponse,
@@ -3037,7 +3036,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -3065,7 +3064,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -3093,7 +3092,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectRequest,
   DeleteProjectResponse,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectRequest,
   output: DeleteProjectResponse,
@@ -3121,7 +3120,7 @@ export const deleteRecipeVersion: API.OperationMethod<
   DeleteRecipeVersionRequest,
   DeleteRecipeVersionResponse,
   DeleteRecipeVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecipeVersionRequest,
   output: DeleteRecipeVersionResponse,
@@ -3149,7 +3148,7 @@ export const deleteRuleset: API.OperationMethod<
   DeleteRulesetRequest,
   DeleteRulesetResponse,
   DeleteRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRulesetRequest,
   output: DeleteRulesetResponse,
@@ -3176,7 +3175,7 @@ export const deleteSchedule: API.OperationMethod<
   DeleteScheduleRequest,
   DeleteScheduleResponse,
   DeleteScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduleRequest,
   output: DeleteScheduleResponse,
@@ -3202,7 +3201,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -3228,7 +3227,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobRequest,
   DescribeJobResponse,
   DescribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRequest,
   output: DescribeJobResponse,
@@ -3254,7 +3253,7 @@ export const describeJobRun: API.OperationMethod<
   DescribeJobRunRequest,
   DescribeJobRunResponse,
   DescribeJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRunRequest,
   output: DescribeJobRunResponse,
@@ -3280,7 +3279,7 @@ export const describeProject: API.OperationMethod<
   DescribeProjectRequest,
   DescribeProjectResponse,
   DescribeProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProjectRequest,
   output: DescribeProjectResponse,
@@ -3307,7 +3306,7 @@ export const describeRecipe: API.OperationMethod<
   DescribeRecipeRequest,
   DescribeRecipeResponse,
   DescribeRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecipeRequest,
   output: DescribeRecipeResponse,
@@ -3333,7 +3332,7 @@ export const describeRuleset: API.OperationMethod<
   DescribeRulesetRequest,
   DescribeRulesetResponse,
   DescribeRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRulesetRequest,
   output: DescribeRulesetResponse,
@@ -3359,7 +3358,7 @@ export const describeSchedule: API.OperationMethod<
   DescribeScheduleRequest,
   DescribeScheduleResponse,
   DescribeScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScheduleRequest,
   output: DescribeScheduleResponse,
@@ -3384,7 +3383,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Dataset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -3413,7 +3412,7 @@ export const listJobRuns: API.PaginatedOperationMethod<
   ListJobRunsRequest,
   ListJobRunsResponse,
   ListJobRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunsRequest,
@@ -3445,7 +3444,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -3473,7 +3472,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsRequest,
   ListProjectsResponse,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Project
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsRequest,
@@ -3501,7 +3500,7 @@ export const listRecipes: API.PaginatedOperationMethod<
   ListRecipesRequest,
   ListRecipesResponse,
   ListRecipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recipe
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecipesRequest,
@@ -3531,7 +3530,7 @@ export const listRecipeVersions: API.PaginatedOperationMethod<
   ListRecipeVersionsRequest,
   ListRecipeVersionsResponse,
   ListRecipeVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recipe
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecipeVersionsRequest,
@@ -3565,7 +3564,7 @@ export const listRulesets: API.PaginatedOperationMethod<
   ListRulesetsRequest,
   ListRulesetsResponse,
   ListRulesetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RulesetItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesetsRequest,
@@ -3597,7 +3596,7 @@ export const listSchedules: API.PaginatedOperationMethod<
   ListSchedulesRequest,
   ListSchedulesResponse,
   ListSchedulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Schedule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchedulesRequest,
@@ -3627,7 +3626,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3655,7 +3654,7 @@ export const publishRecipe: API.OperationMethod<
   PublishRecipeRequest,
   PublishRecipeResponse,
   PublishRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishRecipeRequest,
   output: PublishRecipeResponse,
@@ -3683,7 +3682,7 @@ export const sendProjectSessionAction: API.OperationMethod<
   SendProjectSessionActionRequest,
   SendProjectSessionActionResponse,
   SendProjectSessionActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendProjectSessionActionRequest,
   output: SendProjectSessionActionResponse,
@@ -3707,7 +3706,7 @@ export const startJobRun: API.OperationMethod<
   StartJobRunRequest,
   StartJobRunResponse,
   StartJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRunRequest,
   output: StartJobRunResponse,
@@ -3737,7 +3736,7 @@ export const startProjectSession: API.OperationMethod<
   StartProjectSessionRequest,
   StartProjectSessionResponse,
   StartProjectSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProjectSessionRequest,
   output: StartProjectSessionResponse,
@@ -3764,7 +3763,7 @@ export const stopJobRun: API.OperationMethod<
   StopJobRunRequest,
   StopJobRunResponse,
   StopJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopJobRunRequest,
   output: StopJobRunResponse,
@@ -3792,7 +3791,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3820,7 +3819,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3848,7 +3847,7 @@ export const updateDataset: API.OperationMethod<
   UpdateDatasetRequest,
   UpdateDatasetResponse,
   UpdateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetRequest,
   output: UpdateDatasetResponse,
@@ -3877,7 +3876,7 @@ export const updateProfileJob: API.OperationMethod<
   UpdateProfileJobRequest,
   UpdateProfileJobResponse,
   UpdateProfileJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileJobRequest,
   output: UpdateProfileJobResponse,
@@ -3906,7 +3905,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectRequest,
   UpdateProjectResponse,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectRequest,
   output: UpdateProjectResponse,
@@ -3934,7 +3933,7 @@ export const updateRecipe: API.OperationMethod<
   UpdateRecipeRequest,
   UpdateRecipeResponse,
   UpdateRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecipeRequest,
   output: UpdateRecipeResponse,
@@ -3962,7 +3961,7 @@ export const updateRecipeJob: API.OperationMethod<
   UpdateRecipeJobRequest,
   UpdateRecipeJobResponse,
   UpdateRecipeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecipeJobRequest,
   output: UpdateRecipeJobResponse,
@@ -3990,7 +3989,7 @@ export const updateRuleset: API.OperationMethod<
   UpdateRulesetRequest,
   UpdateRulesetResponse,
   UpdateRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRulesetRequest,
   output: UpdateRulesetResponse,
@@ -4017,7 +4016,7 @@ export const updateSchedule: API.OperationMethod<
   UpdateScheduleRequest,
   UpdateScheduleResponse,
   UpdateScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduleRequest,
   output: UpdateScheduleResponse,

--- a/packages/aws/src/services/dataexchange.ts
+++ b/packages/aws/src/services/dataexchange.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DataExchange",
@@ -2930,7 +2929,7 @@ export const acceptDataGrant: API.OperationMethod<
   AcceptDataGrantRequest,
   AcceptDataGrantResponse,
   AcceptDataGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptDataGrantRequest,
   output: AcceptDataGrantResponse,
@@ -2961,7 +2960,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -2992,7 +2991,7 @@ export const createDataGrant: API.OperationMethod<
   CreateDataGrantRequest,
   CreateDataGrantResponse,
   CreateDataGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataGrantRequest,
   output: CreateDataGrantResponse,
@@ -3023,7 +3022,7 @@ export const createDataSet: API.OperationMethod<
   CreateDataSetRequest,
   CreateDataSetResponse,
   CreateDataSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSetRequest,
   output: CreateDataSetResponse,
@@ -3053,7 +3052,7 @@ export const createEventAction: API.OperationMethod<
   CreateEventActionRequest,
   CreateEventActionResponse,
   CreateEventActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventActionRequest,
   output: CreateEventActionResponse,
@@ -3084,7 +3083,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -3115,7 +3114,7 @@ export const createRevision: API.OperationMethod<
   CreateRevisionRequest,
   CreateRevisionResponse,
   CreateRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRevisionRequest,
   output: CreateRevisionResponse,
@@ -3146,7 +3145,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetRequest,
   DeleteAssetResponse,
   DeleteAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetRequest,
   output: DeleteAssetResponse,
@@ -3177,7 +3176,7 @@ export const deleteDataGrant: API.OperationMethod<
   DeleteDataGrantRequest,
   DeleteDataGrantResponse,
   DeleteDataGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataGrantRequest,
   output: DeleteDataGrantResponse,
@@ -3208,7 +3207,7 @@ export const deleteDataSet: API.OperationMethod<
   DeleteDataSetRequest,
   DeleteDataSetResponse,
   DeleteDataSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSetRequest,
   output: DeleteDataSetResponse,
@@ -3238,7 +3237,7 @@ export const deleteEventAction: API.OperationMethod<
   DeleteEventActionRequest,
   DeleteEventActionResponse,
   DeleteEventActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventActionRequest,
   output: DeleteEventActionResponse,
@@ -3268,7 +3267,7 @@ export const deleteRevision: API.OperationMethod<
   DeleteRevisionRequest,
   DeleteRevisionResponse,
   DeleteRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRevisionRequest,
   output: DeleteRevisionResponse,
@@ -3298,7 +3297,7 @@ export const getAsset: API.OperationMethod<
   GetAssetRequest,
   GetAssetResponse,
   GetAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetRequest,
   output: GetAssetResponse,
@@ -3327,7 +3326,7 @@ export const getDataGrant: API.OperationMethod<
   GetDataGrantRequest,
   GetDataGrantResponse,
   GetDataGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataGrantRequest,
   output: GetDataGrantResponse,
@@ -3356,7 +3355,7 @@ export const getDataSet: API.OperationMethod<
   GetDataSetRequest,
   GetDataSetResponse,
   GetDataSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSetRequest,
   output: GetDataSetResponse,
@@ -3384,7 +3383,7 @@ export const getEventAction: API.OperationMethod<
   GetEventActionRequest,
   GetEventActionResponse,
   GetEventActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventActionRequest,
   output: GetEventActionResponse,
@@ -3412,7 +3411,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -3441,7 +3440,7 @@ export const getReceivedDataGrant: API.OperationMethod<
   GetReceivedDataGrantRequest,
   GetReceivedDataGrantResponse,
   GetReceivedDataGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReceivedDataGrantRequest,
   output: GetReceivedDataGrantResponse,
@@ -3470,7 +3469,7 @@ export const getRevision: API.OperationMethod<
   GetRevisionRequest,
   GetRevisionResponse,
   GetRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevisionRequest,
   output: GetRevisionResponse,
@@ -3499,7 +3498,7 @@ export const listDataGrants: API.PaginatedOperationMethod<
   ListDataGrantsRequest,
   ListDataGrantsResponse,
   ListDataGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataGrantSummaryEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataGrantsRequest,
@@ -3535,7 +3534,7 @@ export const listDataSetRevisions: API.PaginatedOperationMethod<
   ListDataSetRevisionsRequest,
   ListDataSetRevisionsResponse,
   ListDataSetRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RevisionEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetRevisionsRequest,
@@ -3570,7 +3569,7 @@ export const listDataSets: API.PaginatedOperationMethod<
   ListDataSetsRequest,
   ListDataSetsResponse,
   ListDataSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetsRequest,
@@ -3605,7 +3604,7 @@ export const listEventActions: API.PaginatedOperationMethod<
   ListEventActionsRequest,
   ListEventActionsResponse,
   ListEventActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventActionEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventActionsRequest,
@@ -3640,7 +3639,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -3676,7 +3675,7 @@ export const listReceivedDataGrants: API.PaginatedOperationMethod<
   ListReceivedDataGrantsRequest,
   ListReceivedDataGrantsResponse,
   ListReceivedDataGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReceivedDataGrantSummariesEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReceivedDataGrantsRequest,
@@ -3712,7 +3711,7 @@ export const listRevisionAssets: API.PaginatedOperationMethod<
   ListRevisionAssetsRequest,
   ListRevisionAssetsResponse,
   ListRevisionAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRevisionAssetsRequest,
@@ -3742,7 +3741,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3767,7 +3766,7 @@ export const revokeRevision: API.OperationMethod<
   RevokeRevisionRequest,
   RevokeRevisionResponse,
   RevokeRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeRevisionRequest,
   output: RevokeRevisionResponse,
@@ -3798,7 +3797,7 @@ export const sendApiAsset: API.OperationMethod<
   SendApiAssetRequest,
   SendApiAssetResponse,
   SendApiAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendApiAssetRequest,
   output: SendApiAssetResponse,
@@ -3830,7 +3829,7 @@ export const sendDataSetNotification: API.OperationMethod<
   SendDataSetNotificationRequest,
   SendDataSetNotificationResponse,
   SendDataSetNotificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDataSetNotificationRequest,
   output: SendDataSetNotificationResponse,
@@ -3862,7 +3861,7 @@ export const startJob: API.OperationMethod<
   StartJobRequest,
   StartJobResponse,
   StartJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRequest,
   output: StartJobResponse,
@@ -3887,7 +3886,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3905,7 +3904,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3930,7 +3929,7 @@ export const updateAsset: API.OperationMethod<
   UpdateAssetRequest,
   UpdateAssetResponse,
   UpdateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetRequest,
   output: UpdateAssetResponse,
@@ -3961,7 +3960,7 @@ export const updateDataSet: API.OperationMethod<
   UpdateDataSetRequest,
   UpdateDataSetResponse,
   UpdateDataSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSetRequest,
   output: UpdateDataSetResponse,
@@ -3991,7 +3990,7 @@ export const updateEventAction: API.OperationMethod<
   UpdateEventActionRequest,
   UpdateEventActionResponse,
   UpdateEventActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventActionRequest,
   output: UpdateEventActionResponse,
@@ -4022,7 +4021,7 @@ export const updateRevision: API.OperationMethod<
   UpdateRevisionRequest,
   UpdateRevisionResponse,
   UpdateRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRevisionRequest,
   output: UpdateRevisionResponse,

--- a/packages/aws/src/services/datasync.ts
+++ b/packages/aws/src/services/datasync.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DataSync",
@@ -2698,7 +2697,7 @@ export const cancelTaskExecution: API.OperationMethod<
   CancelTaskExecutionRequest,
   CancelTaskExecutionResponse,
   CancelTaskExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTaskExecutionRequest,
   output: CancelTaskExecutionResponse,
@@ -2723,7 +2722,7 @@ export const createAgent: API.OperationMethod<
   CreateAgentRequest,
   CreateAgentResponse,
   CreateAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentRequest,
   output: CreateAgentResponse,
@@ -2749,7 +2748,7 @@ export const createLocationAzureBlob: API.OperationMethod<
   CreateLocationAzureBlobRequest,
   CreateLocationAzureBlobResponse,
   CreateLocationAzureBlobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationAzureBlobRequest,
   output: CreateLocationAzureBlobResponse,
@@ -2778,7 +2777,7 @@ export const createLocationEfs: API.OperationMethod<
   CreateLocationEfsRequest,
   CreateLocationEfsResponse,
   CreateLocationEfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationEfsRequest,
   output: CreateLocationEfsResponse,
@@ -2809,7 +2808,7 @@ export const createLocationFsxLustre: API.OperationMethod<
   CreateLocationFsxLustreRequest,
   CreateLocationFsxLustreResponse,
   CreateLocationFsxLustreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationFsxLustreRequest,
   output: CreateLocationFsxLustreResponse,
@@ -2835,7 +2834,7 @@ export const createLocationFsxOntap: API.OperationMethod<
   CreateLocationFsxOntapRequest,
   CreateLocationFsxOntapResponse,
   CreateLocationFsxOntapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationFsxOntapRequest,
   output: CreateLocationFsxOntapResponse,
@@ -2865,7 +2864,7 @@ export const createLocationFsxOpenZfs: API.OperationMethod<
   CreateLocationFsxOpenZfsRequest,
   CreateLocationFsxOpenZfsResponse,
   CreateLocationFsxOpenZfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationFsxOpenZfsRequest,
   output: CreateLocationFsxOpenZfsResponse,
@@ -2892,7 +2891,7 @@ export const createLocationFsxWindows: API.OperationMethod<
   CreateLocationFsxWindowsRequest,
   CreateLocationFsxWindowsResponse,
   CreateLocationFsxWindowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationFsxWindowsRequest,
   output: CreateLocationFsxWindowsResponse,
@@ -2919,7 +2918,7 @@ export const createLocationHdfs: API.OperationMethod<
   CreateLocationHdfsRequest,
   CreateLocationHdfsResponse,
   CreateLocationHdfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationHdfsRequest,
   output: CreateLocationHdfsResponse,
@@ -2946,7 +2945,7 @@ export const createLocationNfs: API.OperationMethod<
   CreateLocationNfsRequest,
   CreateLocationNfsResponse,
   CreateLocationNfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationNfsRequest,
   output: CreateLocationNfsResponse,
@@ -2971,7 +2970,7 @@ export const createLocationObjectStorage: API.OperationMethod<
   CreateLocationObjectStorageRequest,
   CreateLocationObjectStorageResponse,
   CreateLocationObjectStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationObjectStorageRequest,
   output: CreateLocationObjectStorageResponse,
@@ -3006,7 +3005,7 @@ export const createLocationS3: API.OperationMethod<
   CreateLocationS3Request,
   CreateLocationS3Response,
   CreateLocationS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationS3Request,
   output: CreateLocationS3Response,
@@ -3037,7 +3036,7 @@ export const createLocationSmb: API.OperationMethod<
   CreateLocationSmbRequest,
   CreateLocationSmbResponse,
   CreateLocationSmbError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationSmbRequest,
   output: CreateLocationSmbResponse,
@@ -3068,7 +3067,7 @@ export const createTask: API.OperationMethod<
   CreateTaskRequest,
   CreateTaskResponse,
   CreateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTaskRequest,
   output: CreateTaskResponse,
@@ -3098,7 +3097,7 @@ export const deleteAgent: API.OperationMethod<
   DeleteAgentRequest,
   DeleteAgentResponse,
   DeleteAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentRequest,
   output: DeleteAgentResponse,
@@ -3120,7 +3119,7 @@ export const deleteLocation: API.OperationMethod<
   DeleteLocationRequest,
   DeleteLocationResponse,
   DeleteLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocationRequest,
   output: DeleteLocationResponse,
@@ -3142,7 +3141,7 @@ export const deleteTask: API.OperationMethod<
   DeleteTaskRequest,
   DeleteTaskResponse,
   DeleteTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTaskRequest,
   output: DeleteTaskResponse,
@@ -3164,7 +3163,7 @@ export const describeAgent: API.OperationMethod<
   DescribeAgentRequest,
   DescribeAgentResponse,
   DescribeAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgentRequest,
   output: DescribeAgentResponse,
@@ -3186,7 +3185,7 @@ export const describeLocationAzureBlob: API.OperationMethod<
   DescribeLocationAzureBlobRequest,
   DescribeLocationAzureBlobResponse,
   DescribeLocationAzureBlobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationAzureBlobRequest,
   output: DescribeLocationAzureBlobResponse,
@@ -3208,7 +3207,7 @@ export const describeLocationEfs: API.OperationMethod<
   DescribeLocationEfsRequest,
   DescribeLocationEfsResponse,
   DescribeLocationEfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationEfsRequest,
   output: DescribeLocationEfsResponse,
@@ -3229,7 +3228,7 @@ export const describeLocationFsxLustre: API.OperationMethod<
   DescribeLocationFsxLustreRequest,
   DescribeLocationFsxLustreResponse,
   DescribeLocationFsxLustreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationFsxLustreRequest,
   output: DescribeLocationFsxLustreResponse,
@@ -3253,7 +3252,7 @@ export const describeLocationFsxOntap: API.OperationMethod<
   DescribeLocationFsxOntapRequest,
   DescribeLocationFsxOntapResponse,
   DescribeLocationFsxOntapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationFsxOntapRequest,
   output: DescribeLocationFsxOntapResponse,
@@ -3277,7 +3276,7 @@ export const describeLocationFsxOpenZfs: API.OperationMethod<
   DescribeLocationFsxOpenZfsRequest,
   DescribeLocationFsxOpenZfsResponse,
   DescribeLocationFsxOpenZfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationFsxOpenZfsRequest,
   output: DescribeLocationFsxOpenZfsResponse,
@@ -3298,7 +3297,7 @@ export const describeLocationFsxWindows: API.OperationMethod<
   DescribeLocationFsxWindowsRequest,
   DescribeLocationFsxWindowsResponse,
   DescribeLocationFsxWindowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationFsxWindowsRequest,
   output: DescribeLocationFsxWindowsResponse,
@@ -3320,7 +3319,7 @@ export const describeLocationHdfs: API.OperationMethod<
   DescribeLocationHdfsRequest,
   DescribeLocationHdfsResponse,
   DescribeLocationHdfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationHdfsRequest,
   output: DescribeLocationHdfsResponse,
@@ -3342,7 +3341,7 @@ export const describeLocationNfs: API.OperationMethod<
   DescribeLocationNfsRequest,
   DescribeLocationNfsResponse,
   DescribeLocationNfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationNfsRequest,
   output: DescribeLocationNfsResponse,
@@ -3364,7 +3363,7 @@ export const describeLocationObjectStorage: API.OperationMethod<
   DescribeLocationObjectStorageRequest,
   DescribeLocationObjectStorageResponse,
   DescribeLocationObjectStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationObjectStorageRequest,
   output: DescribeLocationObjectStorageResponse,
@@ -3387,7 +3386,7 @@ export const describeLocationS3: API.OperationMethod<
   DescribeLocationS3Request,
   DescribeLocationS3Response,
   DescribeLocationS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationS3Request,
   output: DescribeLocationS3Response,
@@ -3409,7 +3408,7 @@ export const describeLocationSmb: API.OperationMethod<
   DescribeLocationSmbRequest,
   DescribeLocationSmbResponse,
   DescribeLocationSmbError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationSmbRequest,
   output: DescribeLocationSmbResponse,
@@ -3432,7 +3431,7 @@ export const describeTask: API.OperationMethod<
   DescribeTaskRequest,
   DescribeTaskResponse,
   DescribeTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTaskRequest,
   output: DescribeTaskResponse,
@@ -3459,7 +3458,7 @@ export const describeTaskExecution: API.OperationMethod<
   DescribeTaskExecutionRequest,
   DescribeTaskExecutionResponse,
   DescribeTaskExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTaskExecutionRequest,
   output: DescribeTaskExecutionResponse,
@@ -3491,7 +3490,7 @@ export const listAgents: API.PaginatedOperationMethod<
   ListAgentsRequest,
   ListAgentsResponse,
   ListAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentsRequest,
@@ -3523,7 +3522,7 @@ export const listLocations: API.PaginatedOperationMethod<
   ListLocationsRequest,
   ListLocationsResponse,
   ListLocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocationListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLocationsRequest,
@@ -3551,7 +3550,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -3579,7 +3578,7 @@ export const listTaskExecutions: API.PaginatedOperationMethod<
   ListTaskExecutionsRequest,
   ListTaskExecutionsResponse,
   ListTaskExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskExecutionListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaskExecutionsRequest,
@@ -3607,7 +3606,7 @@ export const listTasks: API.PaginatedOperationMethod<
   ListTasksRequest,
   ListTasksResponse,
   ListTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTasksRequest,
@@ -3644,7 +3643,7 @@ export const startTaskExecution: API.OperationMethod<
   StartTaskExecutionRequest,
   StartTaskExecutionResponse,
   StartTaskExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTaskExecutionRequest,
   output: StartTaskExecutionResponse,
@@ -3673,7 +3672,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3694,7 +3693,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3715,7 +3714,7 @@ export const updateAgent: API.OperationMethod<
   UpdateAgentRequest,
   UpdateAgentResponse,
   UpdateAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentRequest,
   output: UpdateAgentResponse,
@@ -3739,7 +3738,7 @@ export const updateLocationAzureBlob: API.OperationMethod<
   UpdateLocationAzureBlobRequest,
   UpdateLocationAzureBlobResponse,
   UpdateLocationAzureBlobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationAzureBlobRequest,
   output: UpdateLocationAzureBlobResponse,
@@ -3764,7 +3763,7 @@ export const updateLocationEfs: API.OperationMethod<
   UpdateLocationEfsRequest,
   UpdateLocationEfsResponse,
   UpdateLocationEfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationEfsRequest,
   output: UpdateLocationEfsResponse,
@@ -3789,7 +3788,7 @@ export const updateLocationFsxLustre: API.OperationMethod<
   UpdateLocationFsxLustreRequest,
   UpdateLocationFsxLustreResponse,
   UpdateLocationFsxLustreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationFsxLustreRequest,
   output: UpdateLocationFsxLustreResponse,
@@ -3814,7 +3813,7 @@ export const updateLocationFsxOntap: API.OperationMethod<
   UpdateLocationFsxOntapRequest,
   UpdateLocationFsxOntapResponse,
   UpdateLocationFsxOntapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationFsxOntapRequest,
   output: UpdateLocationFsxOntapResponse,
@@ -3842,7 +3841,7 @@ export const updateLocationFsxOpenZfs: API.OperationMethod<
   UpdateLocationFsxOpenZfsRequest,
   UpdateLocationFsxOpenZfsResponse,
   UpdateLocationFsxOpenZfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationFsxOpenZfsRequest,
   output: UpdateLocationFsxOpenZfsResponse,
@@ -3867,7 +3866,7 @@ export const updateLocationFsxWindows: API.OperationMethod<
   UpdateLocationFsxWindowsRequest,
   UpdateLocationFsxWindowsResponse,
   UpdateLocationFsxWindowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationFsxWindowsRequest,
   output: UpdateLocationFsxWindowsResponse,
@@ -3892,7 +3891,7 @@ export const updateLocationHdfs: API.OperationMethod<
   UpdateLocationHdfsRequest,
   UpdateLocationHdfsResponse,
   UpdateLocationHdfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationHdfsRequest,
   output: UpdateLocationHdfsResponse,
@@ -3917,7 +3916,7 @@ export const updateLocationNfs: API.OperationMethod<
   UpdateLocationNfsRequest,
   UpdateLocationNfsResponse,
   UpdateLocationNfsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationNfsRequest,
   output: UpdateLocationNfsResponse,
@@ -3942,7 +3941,7 @@ export const updateLocationObjectStorage: API.OperationMethod<
   UpdateLocationObjectStorageRequest,
   UpdateLocationObjectStorageResponse,
   UpdateLocationObjectStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationObjectStorageRequest,
   output: UpdateLocationObjectStorageResponse,
@@ -3971,7 +3970,7 @@ export const updateLocationS3: API.OperationMethod<
   UpdateLocationS3Request,
   UpdateLocationS3Response,
   UpdateLocationS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationS3Request,
   output: UpdateLocationS3Response,
@@ -3996,7 +3995,7 @@ export const updateLocationSmb: API.OperationMethod<
   UpdateLocationSmbRequest,
   UpdateLocationSmbResponse,
   UpdateLocationSmbError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLocationSmbRequest,
   output: UpdateLocationSmbResponse,
@@ -4019,7 +4018,7 @@ export const updateTask: API.OperationMethod<
   UpdateTaskRequest,
   UpdateTaskResponse,
   UpdateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskRequest,
   output: UpdateTaskResponse,
@@ -4046,7 +4045,7 @@ export const updateTaskExecution: API.OperationMethod<
   UpdateTaskExecutionRequest,
   UpdateTaskExecutionResponse,
   UpdateTaskExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskExecutionRequest,
   output: UpdateTaskExecutionResponse,

--- a/packages/aws/src/services/datazone.ts
+++ b/packages/aws/src/services/datazone.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DataZone",
@@ -16996,7 +16995,7 @@ export const acceptPredictions: API.OperationMethod<
   AcceptPredictionsInput,
   AcceptPredictionsOutput,
   AcceptPredictionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptPredictionsInput,
   output: AcceptPredictionsOutput,
@@ -17029,7 +17028,7 @@ export const acceptSubscriptionRequest: API.OperationMethod<
   AcceptSubscriptionRequestInput,
   AcceptSubscriptionRequestOutput,
   AcceptSubscriptionRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptSubscriptionRequestInput,
   output: AcceptSubscriptionRequestOutput,
@@ -17063,7 +17062,7 @@ export const addEntityOwner: API.OperationMethod<
   AddEntityOwnerInput,
   AddEntityOwnerOutput,
   AddEntityOwnerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddEntityOwnerInput,
   output: AddEntityOwnerOutput,
@@ -17096,7 +17095,7 @@ export const addPolicyGrant: API.OperationMethod<
   AddPolicyGrantInput,
   AddPolicyGrantOutput,
   AddPolicyGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddPolicyGrantInput,
   output: AddPolicyGrantOutput,
@@ -17128,7 +17127,7 @@ export const associateEnvironmentRole: API.OperationMethod<
   AssociateEnvironmentRoleInput,
   AssociateEnvironmentRoleOutput,
   AssociateEnvironmentRoleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEnvironmentRoleInput,
   output: AssociateEnvironmentRoleOutput,
@@ -17160,7 +17159,7 @@ export const associateGovernedTerms: API.OperationMethod<
   AssociateGovernedTermsInput,
   AssociateGovernedTermsOutput,
   AssociateGovernedTermsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateGovernedTermsInput,
   output: AssociateGovernedTermsOutput,
@@ -17191,7 +17190,7 @@ export const batchGetAttributesMetadata: API.OperationMethod<
   BatchGetAttributesMetadataInput,
   BatchGetAttributesMetadataOutput,
   BatchGetAttributesMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAttributesMetadataInput,
   output: BatchGetAttributesMetadataOutput,
@@ -17222,7 +17221,7 @@ export const batchPutAttributesMetadata: API.OperationMethod<
   BatchPutAttributesMetadataInput,
   BatchPutAttributesMetadataOutput,
   BatchPutAttributesMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutAttributesMetadataInput,
   output: BatchPutAttributesMetadataOutput,
@@ -17262,7 +17261,7 @@ export const cancelMetadataGenerationRun: API.OperationMethod<
   CancelMetadataGenerationRunInput,
   CancelMetadataGenerationRunOutput,
   CancelMetadataGenerationRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMetadataGenerationRunInput,
   output: CancelMetadataGenerationRunOutput,
@@ -17294,7 +17293,7 @@ export const cancelSubscription: API.OperationMethod<
   CancelSubscriptionInput,
   CancelSubscriptionOutput,
   CancelSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSubscriptionInput,
   output: CancelSubscriptionOutput,
@@ -17327,7 +17326,7 @@ export const createAccountPool: API.OperationMethod<
   CreateAccountPoolInput,
   CreateAccountPoolOutput,
   CreateAccountPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountPoolInput,
   output: CreateAccountPoolOutput,
@@ -17381,7 +17380,7 @@ export const createAsset: API.OperationMethod<
   CreateAssetInput,
   CreateAssetOutput,
   CreateAssetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetInput,
   output: CreateAssetOutput,
@@ -17427,7 +17426,7 @@ export const createAssetFilter: API.OperationMethod<
   CreateAssetFilterInput,
   CreateAssetFilterOutput,
   CreateAssetFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetFilterInput,
   output: CreateAssetFilterOutput,
@@ -17474,7 +17473,7 @@ export const createAssetRevision: API.OperationMethod<
   CreateAssetRevisionInput,
   CreateAssetRevisionOutput,
   CreateAssetRevisionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetRevisionInput,
   output: CreateAssetRevisionOutput,
@@ -17518,7 +17517,7 @@ export const createAssetType: API.OperationMethod<
   CreateAssetTypeInput,
   CreateAssetTypeOutput,
   CreateAssetTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetTypeInput,
   output: CreateAssetTypeOutput,
@@ -17551,7 +17550,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionInput,
   CreateConnectionOutput,
   CreateConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionInput,
   output: CreateConnectionOutput,
@@ -17597,7 +17596,7 @@ export const createDataProduct: API.OperationMethod<
   CreateDataProductInput,
   CreateDataProductOutput,
   CreateDataProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataProductInput,
   output: CreateDataProductOutput,
@@ -17640,7 +17639,7 @@ export const createDataProductRevision: API.OperationMethod<
   CreateDataProductRevisionInput,
   CreateDataProductRevisionOutput,
   CreateDataProductRevisionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataProductRevisionInput,
   output: CreateDataProductRevisionOutput,
@@ -17673,7 +17672,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceInput,
   CreateDataSourceOutput,
   CreateDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceInput,
   output: CreateDataSourceOutput,
@@ -17707,7 +17706,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainInput,
   CreateDomainOutput,
   CreateDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainInput,
   output: CreateDomainOutput,
@@ -17740,7 +17739,7 @@ export const createDomainUnit: API.OperationMethod<
   CreateDomainUnitInput,
   CreateDomainUnitOutput,
   CreateDomainUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainUnitInput,
   output: CreateDomainUnitOutput,
@@ -17772,7 +17771,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentInput,
   CreateEnvironmentOutput,
   CreateEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentInput,
   output: CreateEnvironmentOutput,
@@ -17804,7 +17803,7 @@ export const createEnvironmentAction: API.OperationMethod<
   CreateEnvironmentActionInput,
   CreateEnvironmentActionOutput,
   CreateEnvironmentActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentActionInput,
   output: CreateEnvironmentActionOutput,
@@ -17837,7 +17836,7 @@ export const createEnvironmentBlueprint: API.OperationMethod<
   CreateEnvironmentBlueprintInput,
   CreateEnvironmentBlueprintOutput,
   CreateEnvironmentBlueprintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentBlueprintInput,
   output: CreateEnvironmentBlueprintOutput,
@@ -17871,7 +17870,7 @@ export const createEnvironmentProfile: API.OperationMethod<
   CreateEnvironmentProfileInput,
   CreateEnvironmentProfileOutput,
   CreateEnvironmentProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentProfileInput,
   output: CreateEnvironmentProfileOutput,
@@ -17916,7 +17915,7 @@ export const createFormType: API.OperationMethod<
   CreateFormTypeInput,
   CreateFormTypeOutput,
   CreateFormTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFormTypeInput,
   output: CreateFormTypeOutput,
@@ -17960,7 +17959,7 @@ export const createGlossary: API.OperationMethod<
   CreateGlossaryInput,
   CreateGlossaryOutput,
   CreateGlossaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlossaryInput,
   output: CreateGlossaryOutput,
@@ -18005,7 +18004,7 @@ export const createGlossaryTerm: API.OperationMethod<
   CreateGlossaryTermInput,
   CreateGlossaryTermOutput,
   CreateGlossaryTermError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlossaryTermInput,
   output: CreateGlossaryTermOutput,
@@ -18036,7 +18035,7 @@ export const createGroupProfile: API.OperationMethod<
   CreateGroupProfileInput,
   CreateGroupProfileOutput,
   CreateGroupProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupProfileInput,
   output: CreateGroupProfileOutput,
@@ -18067,7 +18066,7 @@ export const createListingChangeSet: API.OperationMethod<
   CreateListingChangeSetInput,
   CreateListingChangeSetOutput,
   CreateListingChangeSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateListingChangeSetInput,
   output: CreateListingChangeSetOutput,
@@ -18101,7 +18100,7 @@ export const createNotebook: API.OperationMethod<
   CreateNotebookInput,
   CreateNotebookOutput,
   CreateNotebookError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotebookInput,
   output: CreateNotebookOutput,
@@ -18135,7 +18134,7 @@ export const createProject: API.OperationMethod<
   CreateProjectInput,
   CreateProjectOutput,
   CreateProjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectInput,
   output: CreateProjectOutput,
@@ -18166,7 +18165,7 @@ export const createProjectMembership: API.OperationMethod<
   CreateProjectMembershipInput,
   CreateProjectMembershipOutput,
   CreateProjectMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectMembershipInput,
   output: CreateProjectMembershipOutput,
@@ -18197,7 +18196,7 @@ export const createProjectProfile: API.OperationMethod<
   CreateProjectProfileInput,
   CreateProjectProfileOutput,
   CreateProjectProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectProfileInput,
   output: CreateProjectProfileOutput,
@@ -18231,7 +18230,7 @@ export const createRule: API.OperationMethod<
   CreateRuleInput,
   CreateRuleOutput,
   CreateRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleInput,
   output: CreateRuleOutput,
@@ -18264,7 +18263,7 @@ export const createSubscriptionGrant: API.OperationMethod<
   CreateSubscriptionGrantInput,
   CreateSubscriptionGrantOutput,
   CreateSubscriptionGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionGrantInput,
   output: CreateSubscriptionGrantOutput,
@@ -18297,7 +18296,7 @@ export const createSubscriptionRequest: API.OperationMethod<
   CreateSubscriptionRequestInput,
   CreateSubscriptionRequestOutput,
   CreateSubscriptionRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionRequestInput,
   output: CreateSubscriptionRequestOutput,
@@ -18330,7 +18329,7 @@ export const createSubscriptionTarget: API.OperationMethod<
   CreateSubscriptionTargetInput,
   CreateSubscriptionTargetOutput,
   CreateSubscriptionTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionTargetInput,
   output: CreateSubscriptionTargetOutput,
@@ -18360,7 +18359,7 @@ export const createUserProfile: API.OperationMethod<
   CreateUserProfileInput,
   CreateUserProfileOutput,
   CreateUserProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserProfileInput,
   output: CreateUserProfileOutput,
@@ -18389,7 +18388,7 @@ export const deleteAccountPool: API.OperationMethod<
   DeleteAccountPoolInput,
   DeleteAccountPoolOutput,
   DeleteAccountPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountPoolInput,
   output: DeleteAccountPoolOutput,
@@ -18430,7 +18429,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetInput,
   DeleteAssetOutput,
   DeleteAssetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetInput,
   output: DeleteAssetOutput,
@@ -18470,7 +18469,7 @@ export const deleteAssetFilter: API.OperationMethod<
   DeleteAssetFilterInput,
   DeleteAssetFilterResponse,
   DeleteAssetFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetFilterInput,
   output: DeleteAssetFilterResponse,
@@ -18512,7 +18511,7 @@ export const deleteAssetType: API.OperationMethod<
   DeleteAssetTypeInput,
   DeleteAssetTypeOutput,
   DeleteAssetTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetTypeInput,
   output: DeleteAssetTypeOutput,
@@ -18543,7 +18542,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionInput,
   DeleteConnectionOutput,
   DeleteConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionInput,
   output: DeleteConnectionOutput,
@@ -18578,7 +18577,7 @@ export const deleteDataExportConfiguration: API.OperationMethod<
   DeleteDataExportConfigurationInput,
   DeleteDataExportConfigurationOutput,
   DeleteDataExportConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataExportConfigurationInput,
   output: DeleteDataExportConfigurationOutput,
@@ -18618,7 +18617,7 @@ export const deleteDataProduct: API.OperationMethod<
   DeleteDataProductInput,
   DeleteDataProductOutput,
   DeleteDataProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataProductInput,
   output: DeleteDataProductOutput,
@@ -18651,7 +18650,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceInput,
   DeleteDataSourceOutput,
   DeleteDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceInput,
   output: DeleteDataSourceOutput,
@@ -18684,7 +18683,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainInput,
   DeleteDomainOutput,
   DeleteDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainInput,
   output: DeleteDomainOutput,
@@ -18716,7 +18715,7 @@ export const deleteDomainUnit: API.OperationMethod<
   DeleteDomainUnitInput,
   DeleteDomainUnitOutput,
   DeleteDomainUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainUnitInput,
   output: DeleteDomainUnitOutput,
@@ -18747,7 +18746,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentInput,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentInput,
   output: DeleteEnvironmentResponse,
@@ -18778,7 +18777,7 @@ export const deleteEnvironmentAction: API.OperationMethod<
   DeleteEnvironmentActionInput,
   DeleteEnvironmentActionResponse,
   DeleteEnvironmentActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentActionInput,
   output: DeleteEnvironmentActionResponse,
@@ -18810,7 +18809,7 @@ export const deleteEnvironmentBlueprint: API.OperationMethod<
   DeleteEnvironmentBlueprintInput,
   DeleteEnvironmentBlueprintResponse,
   DeleteEnvironmentBlueprintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentBlueprintInput,
   output: DeleteEnvironmentBlueprintResponse,
@@ -18840,7 +18839,7 @@ export const deleteEnvironmentBlueprintConfiguration: API.OperationMethod<
   DeleteEnvironmentBlueprintConfigurationInput,
   DeleteEnvironmentBlueprintConfigurationOutput,
   DeleteEnvironmentBlueprintConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentBlueprintConfigurationInput,
   output: DeleteEnvironmentBlueprintConfigurationOutput,
@@ -18869,7 +18868,7 @@ export const deleteEnvironmentProfile: API.OperationMethod<
   DeleteEnvironmentProfileInput,
   DeleteEnvironmentProfileResponse,
   DeleteEnvironmentProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentProfileInput,
   output: DeleteEnvironmentProfileResponse,
@@ -18912,7 +18911,7 @@ export const deleteFormType: API.OperationMethod<
   DeleteFormTypeInput,
   DeleteFormTypeOutput,
   DeleteFormTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFormTypeInput,
   output: DeleteFormTypeOutput,
@@ -18956,7 +18955,7 @@ export const deleteGlossary: API.OperationMethod<
   DeleteGlossaryInput,
   DeleteGlossaryOutput,
   DeleteGlossaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlossaryInput,
   output: DeleteGlossaryOutput,
@@ -18998,7 +18997,7 @@ export const deleteGlossaryTerm: API.OperationMethod<
   DeleteGlossaryTermInput,
   DeleteGlossaryTermOutput,
   DeleteGlossaryTermError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlossaryTermInput,
   output: DeleteGlossaryTermOutput,
@@ -19029,7 +19028,7 @@ export const deleteLineageEvent: API.OperationMethod<
   DeleteLineageEventInput,
   DeleteLineageEventOutput,
   DeleteLineageEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLineageEventInput,
   output: DeleteLineageEventOutput,
@@ -19060,7 +19059,7 @@ export const deleteListing: API.OperationMethod<
   DeleteListingInput,
   DeleteListingOutput,
   DeleteListingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteListingInput,
   output: DeleteListingOutput,
@@ -19091,7 +19090,7 @@ export const deleteNotebook: API.OperationMethod<
   DeleteNotebookInput,
   DeleteNotebookOutput,
   DeleteNotebookError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotebookInput,
   output: DeleteNotebookOutput,
@@ -19121,7 +19120,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectInput,
   DeleteProjectOutput,
   DeleteProjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectInput,
   output: DeleteProjectOutput,
@@ -19152,7 +19151,7 @@ export const deleteProjectMembership: API.OperationMethod<
   DeleteProjectMembershipInput,
   DeleteProjectMembershipOutput,
   DeleteProjectMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectMembershipInput,
   output: DeleteProjectMembershipOutput,
@@ -19183,7 +19182,7 @@ export const deleteProjectProfile: API.OperationMethod<
   DeleteProjectProfileInput,
   DeleteProjectProfileOutput,
   DeleteProjectProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectProfileInput,
   output: DeleteProjectProfileOutput,
@@ -19214,7 +19213,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleInput,
   DeleteRuleOutput,
   DeleteRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleInput,
   output: DeleteRuleOutput,
@@ -19246,7 +19245,7 @@ export const deleteSubscriptionGrant: API.OperationMethod<
   DeleteSubscriptionGrantInput,
   DeleteSubscriptionGrantOutput,
   DeleteSubscriptionGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionGrantInput,
   output: DeleteSubscriptionGrantOutput,
@@ -19278,7 +19277,7 @@ export const deleteSubscriptionRequest: API.OperationMethod<
   DeleteSubscriptionRequestInput,
   DeleteSubscriptionRequestResponse,
   DeleteSubscriptionRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionRequestInput,
   output: DeleteSubscriptionRequestResponse,
@@ -19310,7 +19309,7 @@ export const deleteSubscriptionTarget: API.OperationMethod<
   DeleteSubscriptionTargetInput,
   DeleteSubscriptionTargetResponse,
   DeleteSubscriptionTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionTargetInput,
   output: DeleteSubscriptionTargetResponse,
@@ -19341,7 +19340,7 @@ export const deleteTimeSeriesDataPoints: API.OperationMethod<
   DeleteTimeSeriesDataPointsInput,
   DeleteTimeSeriesDataPointsOutput,
   DeleteTimeSeriesDataPointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTimeSeriesDataPointsInput,
   output: DeleteTimeSeriesDataPointsOutput,
@@ -19372,7 +19371,7 @@ export const disassociateEnvironmentRole: API.OperationMethod<
   DisassociateEnvironmentRoleInput,
   DisassociateEnvironmentRoleOutput,
   DisassociateEnvironmentRoleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEnvironmentRoleInput,
   output: DisassociateEnvironmentRoleOutput,
@@ -19404,7 +19403,7 @@ export const disassociateGovernedTerms: API.OperationMethod<
   DisassociateGovernedTermsInput,
   DisassociateGovernedTermsOutput,
   DisassociateGovernedTermsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateGovernedTermsInput,
   output: DisassociateGovernedTermsOutput,
@@ -19435,7 +19434,7 @@ export const getAccountPool: API.OperationMethod<
   GetAccountPoolInput,
   GetAccountPoolOutput,
   GetAccountPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountPoolInput,
   output: GetAccountPoolOutput,
@@ -19475,7 +19474,7 @@ export const getAsset: API.OperationMethod<
   GetAssetInput,
   GetAssetOutput,
   GetAssetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetInput,
   output: GetAssetOutput,
@@ -19513,7 +19512,7 @@ export const getAssetFilter: API.OperationMethod<
   GetAssetFilterInput,
   GetAssetFilterOutput,
   GetAssetFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetFilterInput,
   output: GetAssetFilterOutput,
@@ -19553,7 +19552,7 @@ export const getAssetType: API.OperationMethod<
   GetAssetTypeInput,
   GetAssetTypeOutput,
   GetAssetTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetTypeInput,
   output: GetAssetTypeOutput,
@@ -19583,7 +19582,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionInput,
   GetConnectionOutput,
   GetConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionInput,
   output: GetConnectionOutput,
@@ -19613,7 +19612,7 @@ export const getDataExportConfiguration: API.OperationMethod<
   GetDataExportConfigurationInput,
   GetDataExportConfigurationOutput,
   GetDataExportConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataExportConfigurationInput,
   output: GetDataExportConfigurationOutput,
@@ -19651,7 +19650,7 @@ export const getDataProduct: API.OperationMethod<
   GetDataProductInput,
   GetDataProductOutput,
   GetDataProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataProductInput,
   output: GetDataProductOutput,
@@ -19683,7 +19682,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceInput,
   GetDataSourceOutput,
   GetDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceInput,
   output: GetDataSourceOutput,
@@ -19717,7 +19716,7 @@ export const getDataSourceRun: API.OperationMethod<
   GetDataSourceRunInput,
   GetDataSourceRunOutput,
   GetDataSourceRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceRunInput,
   output: GetDataSourceRunOutput,
@@ -19750,7 +19749,7 @@ export const getDomain: API.OperationMethod<
   GetDomainInput,
   GetDomainOutput,
   GetDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainInput,
   output: GetDomainOutput,
@@ -19781,7 +19780,7 @@ export const getDomainUnit: API.OperationMethod<
   GetDomainUnitInput,
   GetDomainUnitOutput,
   GetDomainUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainUnitInput,
   output: GetDomainUnitOutput,
@@ -19811,7 +19810,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentInput,
   GetEnvironmentOutput,
   GetEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentInput,
   output: GetEnvironmentOutput,
@@ -19841,7 +19840,7 @@ export const getEnvironmentAction: API.OperationMethod<
   GetEnvironmentActionInput,
   GetEnvironmentActionOutput,
   GetEnvironmentActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentActionInput,
   output: GetEnvironmentActionOutput,
@@ -19871,7 +19870,7 @@ export const getEnvironmentBlueprint: API.OperationMethod<
   GetEnvironmentBlueprintInput,
   GetEnvironmentBlueprintOutput,
   GetEnvironmentBlueprintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentBlueprintInput,
   output: GetEnvironmentBlueprintOutput,
@@ -19900,7 +19899,7 @@ export const getEnvironmentBlueprintConfiguration: API.OperationMethod<
   GetEnvironmentBlueprintConfigurationInput,
   GetEnvironmentBlueprintConfigurationOutput,
   GetEnvironmentBlueprintConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentBlueprintConfigurationInput,
   output: GetEnvironmentBlueprintConfigurationOutput,
@@ -19929,7 +19928,7 @@ export const getEnvironmentCredentials: API.OperationMethod<
   GetEnvironmentCredentialsInput,
   GetEnvironmentCredentialsOutput,
   GetEnvironmentCredentialsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentCredentialsInput,
   output: GetEnvironmentCredentialsOutput,
@@ -19959,7 +19958,7 @@ export const getEnvironmentProfile: API.OperationMethod<
   GetEnvironmentProfileInput,
   GetEnvironmentProfileOutput,
   GetEnvironmentProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentProfileInput,
   output: GetEnvironmentProfileOutput,
@@ -20005,7 +20004,7 @@ export const getFormType: API.OperationMethod<
   GetFormTypeInput,
   GetFormTypeOutput,
   GetFormTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFormTypeInput,
   output: GetFormTypeOutput,
@@ -20041,7 +20040,7 @@ export const getGlossary: API.OperationMethod<
   GetGlossaryInput,
   GetGlossaryOutput,
   GetGlossaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlossaryInput,
   output: GetGlossaryOutput,
@@ -20079,7 +20078,7 @@ export const getGlossaryTerm: API.OperationMethod<
   GetGlossaryTermInput,
   GetGlossaryTermOutput,
   GetGlossaryTermError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlossaryTermInput,
   output: GetGlossaryTermOutput,
@@ -20108,7 +20107,7 @@ export const getGroupProfile: API.OperationMethod<
   GetGroupProfileInput,
   GetGroupProfileOutput,
   GetGroupProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupProfileInput,
   output: GetGroupProfileOutput,
@@ -20138,7 +20137,7 @@ export const getIamPortalLoginUrl: API.OperationMethod<
   GetIamPortalLoginUrlInput,
   GetIamPortalLoginUrlOutput,
   GetIamPortalLoginUrlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIamPortalLoginUrlInput,
   output: GetIamPortalLoginUrlOutput,
@@ -20169,7 +20168,7 @@ export const getJobRun: API.OperationMethod<
   GetJobRunInput,
   GetJobRunOutput,
   GetJobRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRunInput,
   output: GetJobRunOutput,
@@ -20199,7 +20198,7 @@ export const getLineageEvent: API.OperationMethod<
   GetLineageEventInput,
   GetLineageEventOutput,
   GetLineageEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLineageEventInput,
   output: GetLineageEventOutput,
@@ -20229,7 +20228,7 @@ export const getLineageNode: API.OperationMethod<
   GetLineageNodeInput,
   GetLineageNodeOutput,
   GetLineageNodeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLineageNodeInput,
   output: GetLineageNodeOutput,
@@ -20259,7 +20258,7 @@ export const getListing: API.OperationMethod<
   GetListingInput,
   GetListingOutput,
   GetListingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetListingInput,
   output: GetListingOutput,
@@ -20297,7 +20296,7 @@ export const getMetadataGenerationRun: API.OperationMethod<
   GetMetadataGenerationRunInput,
   GetMetadataGenerationRunOutput,
   GetMetadataGenerationRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetadataGenerationRunInput,
   output: GetMetadataGenerationRunOutput,
@@ -20327,7 +20326,7 @@ export const getNotebook: API.OperationMethod<
   GetNotebookInput,
   GetNotebookOutput,
   GetNotebookError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotebookInput,
   output: GetNotebookOutput,
@@ -20357,7 +20356,7 @@ export const getNotebookExport: API.OperationMethod<
   GetNotebookExportInput,
   GetNotebookExportOutput,
   GetNotebookExportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotebookExportInput,
   output: GetNotebookExportOutput,
@@ -20387,7 +20386,7 @@ export const getNotebookRun: API.OperationMethod<
   GetNotebookRunInput,
   GetNotebookRunOutput,
   GetNotebookRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotebookRunInput,
   output: GetNotebookRunOutput,
@@ -20417,7 +20416,7 @@ export const getProject: API.OperationMethod<
   GetProjectInput,
   GetProjectOutput,
   GetProjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProjectInput,
   output: GetProjectOutput,
@@ -20447,7 +20446,7 @@ export const getProjectProfile: API.OperationMethod<
   GetProjectProfileInput,
   GetProjectProfileOutput,
   GetProjectProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProjectProfileInput,
   output: GetProjectProfileOutput,
@@ -20477,7 +20476,7 @@ export const getRule: API.OperationMethod<
   GetRuleInput,
   GetRuleOutput,
   GetRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleInput,
   output: GetRuleOutput,
@@ -20507,7 +20506,7 @@ export const getSubscription: API.OperationMethod<
   GetSubscriptionInput,
   GetSubscriptionOutput,
   GetSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionInput,
   output: GetSubscriptionOutput,
@@ -20537,7 +20536,7 @@ export const getSubscriptionGrant: API.OperationMethod<
   GetSubscriptionGrantInput,
   GetSubscriptionGrantOutput,
   GetSubscriptionGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionGrantInput,
   output: GetSubscriptionGrantOutput,
@@ -20567,7 +20566,7 @@ export const getSubscriptionRequestDetails: API.OperationMethod<
   GetSubscriptionRequestDetailsInput,
   GetSubscriptionRequestDetailsOutput,
   GetSubscriptionRequestDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionRequestDetailsInput,
   output: GetSubscriptionRequestDetailsOutput,
@@ -20597,7 +20596,7 @@ export const getSubscriptionTarget: API.OperationMethod<
   GetSubscriptionTargetInput,
   GetSubscriptionTargetOutput,
   GetSubscriptionTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionTargetInput,
   output: GetSubscriptionTargetOutput,
@@ -20627,7 +20626,7 @@ export const getTimeSeriesDataPoint: API.OperationMethod<
   GetTimeSeriesDataPointInput,
   GetTimeSeriesDataPointOutput,
   GetTimeSeriesDataPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTimeSeriesDataPointInput,
   output: GetTimeSeriesDataPointOutput,
@@ -20656,7 +20655,7 @@ export const getUserProfile: API.OperationMethod<
   GetUserProfileInput,
   GetUserProfileOutput,
   GetUserProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserProfileInput,
   output: GetUserProfileOutput,
@@ -20684,7 +20683,7 @@ export const listAccountPools: API.PaginatedOperationMethod<
   ListAccountPoolsInput,
   ListAccountPoolsOutput,
   ListAccountPoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountPoolSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountPoolsInput,
@@ -20720,7 +20719,7 @@ export const listAccountsInAccountPool: API.PaginatedOperationMethod<
   ListAccountsInAccountPoolInput,
   ListAccountsInAccountPoolOutput,
   ListAccountsInAccountPoolError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsInAccountPoolInput,
@@ -20763,7 +20762,7 @@ export const listAssetFilters: API.PaginatedOperationMethod<
   ListAssetFiltersInput,
   ListAssetFiltersOutput,
   ListAssetFiltersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetFilterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetFiltersInput,
@@ -20810,7 +20809,7 @@ export const listAssetRevisions: API.PaginatedOperationMethod<
   ListAssetRevisionsInput,
   ListAssetRevisionsOutput,
   ListAssetRevisionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetRevision
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetRevisionsInput,
@@ -20846,7 +20845,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsInput,
   ListConnectionsOutput,
   ListConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsInput,
@@ -20890,7 +20889,7 @@ export const listDataProductRevisions: API.PaginatedOperationMethod<
   ListDataProductRevisionsInput,
   ListDataProductRevisionsOutput,
   ListDataProductRevisionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataProductRevision
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataProductRevisionsInput,
@@ -20929,7 +20928,7 @@ export const listDataSourceRunActivities: API.PaginatedOperationMethod<
   ListDataSourceRunActivitiesInput,
   ListDataSourceRunActivitiesOutput,
   ListDataSourceRunActivitiesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceRunActivity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourceRunActivitiesInput,
@@ -20970,7 +20969,7 @@ export const listDataSourceRuns: API.PaginatedOperationMethod<
   ListDataSourceRunsInput,
   ListDataSourceRunsOutput,
   ListDataSourceRunsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourceRunsInput,
@@ -21011,7 +21010,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesInput,
   ListDataSourcesOutput,
   ListDataSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesInput,
@@ -21052,7 +21051,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsInput,
   ListDomainsOutput,
   ListDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsInput,
@@ -21090,7 +21089,7 @@ export const listDomainUnitsForParent: API.PaginatedOperationMethod<
   ListDomainUnitsForParentInput,
   ListDomainUnitsForParentOutput,
   ListDomainUnitsForParentError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainUnitSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainUnitsForParentInput,
@@ -21125,7 +21124,7 @@ export const listEntityOwners: API.PaginatedOperationMethod<
   ListEntityOwnersInput,
   ListEntityOwnersOutput,
   ListEntityOwnersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OwnerPropertiesOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntityOwnersInput,
@@ -21160,7 +21159,7 @@ export const listEnvironmentActions: API.PaginatedOperationMethod<
   ListEnvironmentActionsInput,
   ListEnvironmentActionsOutput,
   ListEnvironmentActionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentActionsInput,
@@ -21195,7 +21194,7 @@ export const listEnvironmentBlueprintConfigurations: API.PaginatedOperationMetho
   ListEnvironmentBlueprintConfigurationsInput,
   ListEnvironmentBlueprintConfigurationsOutput,
   ListEnvironmentBlueprintConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentBlueprintConfigurationItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentBlueprintConfigurationsInput,
@@ -21231,7 +21230,7 @@ export const listEnvironmentBlueprints: API.PaginatedOperationMethod<
   ListEnvironmentBlueprintsInput,
   ListEnvironmentBlueprintsOutput,
   ListEnvironmentBlueprintsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentBlueprintSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentBlueprintsInput,
@@ -21267,7 +21266,7 @@ export const listEnvironmentProfiles: API.PaginatedOperationMethod<
   ListEnvironmentProfilesInput,
   ListEnvironmentProfilesOutput,
   ListEnvironmentProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentProfilesInput,
@@ -21303,7 +21302,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsInput,
   ListEnvironmentsOutput,
   ListEnvironmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsInput,
@@ -21340,7 +21339,7 @@ export const listJobRuns: API.PaginatedOperationMethod<
   ListJobRunsInput,
   ListJobRunsOutput,
   ListJobRunsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunsInput,
@@ -21376,7 +21375,7 @@ export const listLineageEvents: API.PaginatedOperationMethod<
   ListLineageEventsInput,
   ListLineageEventsOutput,
   ListLineageEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LineageEventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLineageEventsInput,
@@ -21412,7 +21411,7 @@ export const listLineageNodeHistory: API.PaginatedOperationMethod<
   ListLineageNodeHistoryInput,
   ListLineageNodeHistoryOutput,
   ListLineageNodeHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LineageNodeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLineageNodeHistoryInput,
@@ -21457,7 +21456,7 @@ export const listMetadataGenerationRuns: API.PaginatedOperationMethod<
   ListMetadataGenerationRunsInput,
   ListMetadataGenerationRunsOutput,
   ListMetadataGenerationRunsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetadataGenerationRunItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetadataGenerationRunsInput,
@@ -21493,7 +21492,7 @@ export const listNotebookRuns: API.PaginatedOperationMethod<
   ListNotebookRunsInput,
   ListNotebookRunsOutput,
   ListNotebookRunsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotebookRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotebookRunsInput,
@@ -21528,7 +21527,7 @@ export const listNotebooks: API.PaginatedOperationMethod<
   ListNotebooksInput,
   ListNotebooksOutput,
   ListNotebooksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotebookSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotebooksInput,
@@ -21563,7 +21562,7 @@ export const listNotifications: API.PaginatedOperationMethod<
   ListNotificationsInput,
   ListNotificationsOutput,
   ListNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationsInput,
@@ -21598,7 +21597,7 @@ export const listPolicyGrants: API.PaginatedOperationMethod<
   ListPolicyGrantsInput,
   ListPolicyGrantsOutput,
   ListPolicyGrantsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyGrantMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyGrantsInput,
@@ -21634,7 +21633,7 @@ export const listProjectMemberships: API.PaginatedOperationMethod<
   ListProjectMembershipsInput,
   ListProjectMembershipsOutput,
   ListProjectMembershipsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectMembershipsInput,
@@ -21670,7 +21669,7 @@ export const listProjectProfiles: API.PaginatedOperationMethod<
   ListProjectProfilesInput,
   ListProjectProfilesOutput,
   ListProjectProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectProfilesInput,
@@ -21706,7 +21705,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsInput,
   ListProjectsOutput,
   ListProjectsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsInput,
@@ -21743,7 +21742,7 @@ export const listRules: API.PaginatedOperationMethod<
   ListRulesInput,
   ListRulesOutput,
   ListRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesInput,
@@ -21780,7 +21779,7 @@ export const listSubscriptionGrants: API.PaginatedOperationMethod<
   ListSubscriptionGrantsInput,
   ListSubscriptionGrantsOutput,
   ListSubscriptionGrantsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionGrantSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionGrantsInput,
@@ -21817,7 +21816,7 @@ export const listSubscriptionRequests: API.PaginatedOperationMethod<
   ListSubscriptionRequestsInput,
   ListSubscriptionRequestsOutput,
   ListSubscriptionRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionRequestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionRequestsInput,
@@ -21854,7 +21853,7 @@ export const listSubscriptions: API.PaginatedOperationMethod<
   ListSubscriptionsInput,
   ListSubscriptionsOutput,
   ListSubscriptionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsInput,
@@ -21891,7 +21890,7 @@ export const listSubscriptionTargets: API.PaginatedOperationMethod<
   ListSubscriptionTargetsInput,
   ListSubscriptionTargetsOutput,
   ListSubscriptionTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionTargetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionTargetsInput,
@@ -21926,7 +21925,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -21954,7 +21953,7 @@ export const listTimeSeriesDataPoints: API.PaginatedOperationMethod<
   ListTimeSeriesDataPointsInput,
   ListTimeSeriesDataPointsOutput,
   ListTimeSeriesDataPointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TimeSeriesDataPointSummaryFormOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTimeSeriesDataPointsInput,
@@ -21993,7 +21992,7 @@ export const postLineageEvent: API.OperationMethod<
   PostLineageEventInput,
   PostLineageEventOutput,
   PostLineageEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostLineageEventInput,
   output: PostLineageEventOutput,
@@ -22027,7 +22026,7 @@ export const postTimeSeriesDataPoints: API.OperationMethod<
   PostTimeSeriesDataPointsInput,
   PostTimeSeriesDataPointsOutput,
   PostTimeSeriesDataPointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostTimeSeriesDataPointsInput,
   output: PostTimeSeriesDataPointsOutput,
@@ -22071,7 +22070,7 @@ export const putDataExportConfiguration: API.OperationMethod<
   PutDataExportConfigurationInput,
   PutDataExportConfigurationOutput,
   PutDataExportConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataExportConfigurationInput,
   output: PutDataExportConfigurationOutput,
@@ -22103,7 +22102,7 @@ export const putEnvironmentBlueprintConfiguration: API.OperationMethod<
   PutEnvironmentBlueprintConfigurationInput,
   PutEnvironmentBlueprintConfigurationOutput,
   PutEnvironmentBlueprintConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEnvironmentBlueprintConfigurationInput,
   output: PutEnvironmentBlueprintConfigurationOutput,
@@ -22132,7 +22131,7 @@ export const queryGraph: API.PaginatedOperationMethod<
   QueryGraphInput,
   QueryGraphOutput,
   QueryGraphError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryGraphInput,
@@ -22169,7 +22168,7 @@ export const rejectPredictions: API.OperationMethod<
   RejectPredictionsInput,
   RejectPredictionsOutput,
   RejectPredictionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectPredictionsInput,
   output: RejectPredictionsOutput,
@@ -22201,7 +22200,7 @@ export const rejectSubscriptionRequest: API.OperationMethod<
   RejectSubscriptionRequestInput,
   RejectSubscriptionRequestOutput,
   RejectSubscriptionRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectSubscriptionRequestInput,
   output: RejectSubscriptionRequestOutput,
@@ -22232,7 +22231,7 @@ export const removeEntityOwner: API.OperationMethod<
   RemoveEntityOwnerInput,
   RemoveEntityOwnerOutput,
   RemoveEntityOwnerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveEntityOwnerInput,
   output: RemoveEntityOwnerOutput,
@@ -22261,7 +22260,7 @@ export const removePolicyGrant: API.OperationMethod<
   RemovePolicyGrantInput,
   RemovePolicyGrantOutput,
   RemovePolicyGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePolicyGrantInput,
   output: RemovePolicyGrantOutput,
@@ -22291,7 +22290,7 @@ export const revokeSubscription: API.OperationMethod<
   RevokeSubscriptionInput,
   RevokeSubscriptionOutput,
   RevokeSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSubscriptionInput,
   output: RevokeSubscriptionOutput,
@@ -22343,7 +22342,7 @@ export const search: API.PaginatedOperationMethod<
   SearchInput,
   SearchOutput,
   SearchError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchInventoryResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchInput,
@@ -22378,7 +22377,7 @@ export const searchGroupProfiles: API.PaginatedOperationMethod<
   SearchGroupProfilesInput,
   SearchGroupProfilesOutput,
   SearchGroupProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchGroupProfilesInput,
@@ -22425,7 +22424,7 @@ export const searchListings: API.PaginatedOperationMethod<
   SearchListingsInput,
   SearchListingsOutput,
   SearchListingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchListingsInput,
@@ -22474,7 +22473,7 @@ export const searchTypes: API.PaginatedOperationMethod<
   SearchTypesInput,
   SearchTypesOutput,
   SearchTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchTypesResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTypesInput,
@@ -22509,7 +22508,7 @@ export const searchUserProfiles: API.PaginatedOperationMethod<
   SearchUserProfilesInput,
   SearchUserProfilesOutput,
   SearchUserProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchUserProfilesInput,
@@ -22547,7 +22546,7 @@ export const startDataSourceRun: API.OperationMethod<
   StartDataSourceRunInput,
   StartDataSourceRunOutput,
   StartDataSourceRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataSourceRunInput,
   output: StartDataSourceRunOutput,
@@ -22593,7 +22592,7 @@ export const startMetadataGenerationRun: API.OperationMethod<
   StartMetadataGenerationRunInput,
   StartMetadataGenerationRunOutput,
   StartMetadataGenerationRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetadataGenerationRunInput,
   output: StartMetadataGenerationRunOutput,
@@ -22627,7 +22626,7 @@ export const startNotebookExport: API.OperationMethod<
   StartNotebookExportInput,
   StartNotebookExportOutput,
   StartNotebookExportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNotebookExportInput,
   output: StartNotebookExportOutput,
@@ -22661,7 +22660,7 @@ export const startNotebookImport: API.OperationMethod<
   StartNotebookImportInput,
   StartNotebookImportOutput,
   StartNotebookImportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNotebookImportInput,
   output: StartNotebookImportOutput,
@@ -22695,7 +22694,7 @@ export const startNotebookRun: API.OperationMethod<
   StartNotebookRunInput,
   StartNotebookRunOutput,
   StartNotebookRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNotebookRunInput,
   output: StartNotebookRunOutput,
@@ -22728,7 +22727,7 @@ export const stopNotebookRun: API.OperationMethod<
   StopNotebookRunInput,
   StopNotebookRunOutput,
   StopNotebookRunError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopNotebookRunInput,
   output: StopNotebookRunOutput,
@@ -22757,7 +22756,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -22782,7 +22781,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -22808,7 +22807,7 @@ export const updateAccountPool: API.OperationMethod<
   UpdateAccountPoolInput,
   UpdateAccountPoolOutput,
   UpdateAccountPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountPoolInput,
   output: UpdateAccountPoolOutput,
@@ -22849,7 +22848,7 @@ export const updateAssetFilter: API.OperationMethod<
   UpdateAssetFilterInput,
   UpdateAssetFilterOutput,
   UpdateAssetFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetFilterInput,
   output: UpdateAssetFilterOutput,
@@ -22882,7 +22881,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionInput,
   UpdateConnectionOutput,
   UpdateConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionInput,
   output: UpdateConnectionOutput,
@@ -22916,7 +22915,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceInput,
   UpdateDataSourceOutput,
   UpdateDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceInput,
   output: UpdateDataSourceOutput,
@@ -22950,7 +22949,7 @@ export const updateDomain: API.OperationMethod<
   UpdateDomainInput,
   UpdateDomainOutput,
   UpdateDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainInput,
   output: UpdateDomainOutput,
@@ -22983,7 +22982,7 @@ export const updateDomainUnit: API.OperationMethod<
   UpdateDomainUnitInput,
   UpdateDomainUnitOutput,
   UpdateDomainUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainUnitInput,
   output: UpdateDomainUnitOutput,
@@ -23015,7 +23014,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentInput,
   UpdateEnvironmentOutput,
   UpdateEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentInput,
   output: UpdateEnvironmentOutput,
@@ -23047,7 +23046,7 @@ export const updateEnvironmentAction: API.OperationMethod<
   UpdateEnvironmentActionInput,
   UpdateEnvironmentActionOutput,
   UpdateEnvironmentActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentActionInput,
   output: UpdateEnvironmentActionOutput,
@@ -23080,7 +23079,7 @@ export const updateEnvironmentBlueprint: API.OperationMethod<
   UpdateEnvironmentBlueprintInput,
   UpdateEnvironmentBlueprintOutput,
   UpdateEnvironmentBlueprintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentBlueprintInput,
   output: UpdateEnvironmentBlueprintOutput,
@@ -23114,7 +23113,7 @@ export const updateEnvironmentProfile: API.OperationMethod<
   UpdateEnvironmentProfileInput,
   UpdateEnvironmentProfileOutput,
   UpdateEnvironmentProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentProfileInput,
   output: UpdateEnvironmentProfileOutput,
@@ -23157,7 +23156,7 @@ export const updateGlossary: API.OperationMethod<
   UpdateGlossaryInput,
   UpdateGlossaryOutput,
   UpdateGlossaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlossaryInput,
   output: UpdateGlossaryOutput,
@@ -23199,7 +23198,7 @@ export const updateGlossaryTerm: API.OperationMethod<
   UpdateGlossaryTermInput,
   UpdateGlossaryTermOutput,
   UpdateGlossaryTermError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlossaryTermInput,
   output: UpdateGlossaryTermOutput,
@@ -23229,7 +23228,7 @@ export const updateGroupProfile: API.OperationMethod<
   UpdateGroupProfileInput,
   UpdateGroupProfileOutput,
   UpdateGroupProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupProfileInput,
   output: UpdateGroupProfileOutput,
@@ -23259,7 +23258,7 @@ export const updateNotebook: API.OperationMethod<
   UpdateNotebookInput,
   UpdateNotebookOutput,
   UpdateNotebookError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotebookInput,
   output: UpdateNotebookOutput,
@@ -23292,7 +23291,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectInput,
   UpdateProjectOutput,
   UpdateProjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectInput,
   output: UpdateProjectOutput,
@@ -23326,7 +23325,7 @@ export const updateProjectProfile: API.OperationMethod<
   UpdateProjectProfileInput,
   UpdateProjectProfileOutput,
   UpdateProjectProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectProfileInput,
   output: UpdateProjectProfileOutput,
@@ -23359,7 +23358,7 @@ export const updateRootDomainUnitOwner: API.OperationMethod<
   UpdateRootDomainUnitOwnerInput,
   UpdateRootDomainUnitOwnerOutput,
   UpdateRootDomainUnitOwnerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRootDomainUnitOwnerInput,
   output: UpdateRootDomainUnitOwnerOutput,
@@ -23392,7 +23391,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleInput,
   UpdateRuleOutput,
   UpdateRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleInput,
   output: UpdateRuleOutput,
@@ -23425,7 +23424,7 @@ export const updateSubscriptionGrantStatus: API.OperationMethod<
   UpdateSubscriptionGrantStatusInput,
   UpdateSubscriptionGrantStatusOutput,
   UpdateSubscriptionGrantStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionGrantStatusInput,
   output: UpdateSubscriptionGrantStatusOutput,
@@ -23457,7 +23456,7 @@ export const updateSubscriptionRequest: API.OperationMethod<
   UpdateSubscriptionRequestInput,
   UpdateSubscriptionRequestOutput,
   UpdateSubscriptionRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionRequestInput,
   output: UpdateSubscriptionRequestOutput,
@@ -23489,7 +23488,7 @@ export const updateSubscriptionTarget: API.OperationMethod<
   UpdateSubscriptionTargetInput,
   UpdateSubscriptionTargetOutput,
   UpdateSubscriptionTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionTargetInput,
   output: UpdateSubscriptionTargetOutput,
@@ -23519,7 +23518,7 @@ export const updateUserProfile: API.OperationMethod<
   UpdateUserProfileInput,
   UpdateUserProfileOutput,
   UpdateUserProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserProfileInput,
   output: UpdateUserProfileOutput,

--- a/packages/aws/src/services/dax.ts
+++ b/packages/aws/src/services/dax.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://dax.amazonaws.com/doc/2017-04-19/");
 const svc = T.AwsApiService({ sdkId: "DAX", serviceShapeName: "AmazonDAXV3" });
 const auth = T.AwsAuthSigv4({ name: "dax" });
@@ -1414,7 +1413,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -1456,7 +1455,7 @@ export const createParameterGroup: API.OperationMethod<
   CreateParameterGroupRequest,
   CreateParameterGroupResponse,
   CreateParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParameterGroupRequest,
   output: CreateParameterGroupResponse,
@@ -1488,7 +1487,7 @@ export const createSubnetGroup: API.OperationMethod<
   CreateSubnetGroupRequest,
   CreateSubnetGroupResponse,
   CreateSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubnetGroupRequest,
   output: CreateSubnetGroupResponse,
@@ -1524,7 +1523,7 @@ export const decreaseReplicationFactor: API.OperationMethod<
   DecreaseReplicationFactorRequest,
   DecreaseReplicationFactorResponse,
   DecreaseReplicationFactorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecreaseReplicationFactorRequest,
   output: DecreaseReplicationFactorResponse,
@@ -1559,7 +1558,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -1590,7 +1589,7 @@ export const deleteParameterGroup: API.OperationMethod<
   DeleteParameterGroupRequest,
   DeleteParameterGroupResponse,
   DeleteParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteParameterGroupRequest,
   output: DeleteParameterGroupResponse,
@@ -1621,7 +1620,7 @@ export const deleteSubnetGroup: API.OperationMethod<
   DeleteSubnetGroupRequest,
   DeleteSubnetGroupResponse,
   DeleteSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubnetGroupRequest,
   output: DeleteSubnetGroupResponse,
@@ -1664,7 +1663,7 @@ export const describeClusters: API.OperationMethod<
   DescribeClustersRequest,
   DescribeClustersResponse,
   DescribeClustersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClustersRequest,
   output: DescribeClustersResponse,
@@ -1692,7 +1691,7 @@ export const describeDefaultParameters: API.OperationMethod<
   DescribeDefaultParametersRequest,
   DescribeDefaultParametersResponse,
   DescribeDefaultParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDefaultParametersRequest,
   output: DescribeDefaultParametersResponse,
@@ -1723,7 +1722,7 @@ export const describeEvents: API.OperationMethod<
   DescribeEventsRequest,
   DescribeEventsResponse,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventsRequest,
   output: DescribeEventsResponse,
@@ -1751,7 +1750,7 @@ export const describeParameterGroups: API.OperationMethod<
   DescribeParameterGroupsRequest,
   DescribeParameterGroupsResponse,
   DescribeParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeParameterGroupsRequest,
   output: DescribeParameterGroupsResponse,
@@ -1779,7 +1778,7 @@ export const describeParameters: API.OperationMethod<
   DescribeParametersRequest,
   DescribeParametersResponse,
   DescribeParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeParametersRequest,
   output: DescribeParametersResponse,
@@ -1806,7 +1805,7 @@ export const describeSubnetGroups: API.OperationMethod<
   DescribeSubnetGroupsRequest,
   DescribeSubnetGroupsResponse,
   DescribeSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSubnetGroupsRequest,
   output: DescribeSubnetGroupsResponse,
@@ -1834,7 +1833,7 @@ export const increaseReplicationFactor: API.OperationMethod<
   IncreaseReplicationFactorRequest,
   IncreaseReplicationFactorResponse,
   IncreaseReplicationFactorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IncreaseReplicationFactorRequest,
   output: IncreaseReplicationFactorResponse,
@@ -1870,7 +1869,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -1907,7 +1906,7 @@ export const rebootNode: API.OperationMethod<
   RebootNodeRequest,
   RebootNodeResponse,
   RebootNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootNodeRequest,
   output: RebootNodeResponse,
@@ -1942,7 +1941,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1977,7 +1976,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2013,7 +2012,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -2046,7 +2045,7 @@ export const updateParameterGroup: API.OperationMethod<
   UpdateParameterGroupRequest,
   UpdateParameterGroupResponse,
   UpdateParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateParameterGroupRequest,
   output: UpdateParameterGroupResponse,
@@ -2077,7 +2076,7 @@ export const updateSubnetGroup: API.OperationMethod<
   UpdateSubnetGroupRequest,
   UpdateSubnetGroupResponse,
   UpdateSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubnetGroupRequest,
   output: UpdateSubnetGroupResponse,

--- a/packages/aws/src/services/deadline.ts
+++ b/packages/aws/src/services/deadline.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "deadline",
@@ -9144,7 +9143,7 @@ export const associateMemberToFarm: API.OperationMethod<
   AssociateMemberToFarmRequest,
   AssociateMemberToFarmResponse,
   AssociateMemberToFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberToFarmRequest,
   output: AssociateMemberToFarmResponse,
@@ -9177,7 +9176,7 @@ export const associateMemberToFleet: API.OperationMethod<
   AssociateMemberToFleetRequest,
   AssociateMemberToFleetResponse,
   AssociateMemberToFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberToFleetRequest,
   output: AssociateMemberToFleetResponse,
@@ -9210,7 +9209,7 @@ export const associateMemberToJob: API.OperationMethod<
   AssociateMemberToJobRequest,
   AssociateMemberToJobResponse,
   AssociateMemberToJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberToJobRequest,
   output: AssociateMemberToJobResponse,
@@ -9243,7 +9242,7 @@ export const associateMemberToQueue: API.OperationMethod<
   AssociateMemberToQueueRequest,
   AssociateMemberToQueueResponse,
   AssociateMemberToQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberToQueueRequest,
   output: AssociateMemberToQueueResponse,
@@ -9275,7 +9274,7 @@ export const assumeFleetRoleForRead: API.OperationMethod<
   AssumeFleetRoleForReadRequest,
   AssumeFleetRoleForReadResponse,
   AssumeFleetRoleForReadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeFleetRoleForReadRequest,
   output: AssumeFleetRoleForReadResponse,
@@ -9307,7 +9306,7 @@ export const assumeFleetRoleForWorker: API.OperationMethod<
   AssumeFleetRoleForWorkerRequest,
   AssumeFleetRoleForWorkerResponse,
   AssumeFleetRoleForWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeFleetRoleForWorkerRequest,
   output: AssumeFleetRoleForWorkerResponse,
@@ -9339,7 +9338,7 @@ export const assumeQueueRoleForRead: API.OperationMethod<
   AssumeQueueRoleForReadRequest,
   AssumeQueueRoleForReadResponse,
   AssumeQueueRoleForReadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeQueueRoleForReadRequest,
   output: AssumeQueueRoleForReadResponse,
@@ -9370,7 +9369,7 @@ export const assumeQueueRoleForUser: API.OperationMethod<
   AssumeQueueRoleForUserRequest,
   AssumeQueueRoleForUserResponse,
   AssumeQueueRoleForUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeQueueRoleForUserRequest,
   output: AssumeQueueRoleForUserResponse,
@@ -9402,7 +9401,7 @@ export const assumeQueueRoleForWorker: API.OperationMethod<
   AssumeQueueRoleForWorkerRequest,
   AssumeQueueRoleForWorkerResponse,
   AssumeQueueRoleForWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeQueueRoleForWorkerRequest,
   output: AssumeQueueRoleForWorkerResponse,
@@ -9435,7 +9434,7 @@ export const batchGetJob: API.OperationMethod<
   BatchGetJobRequest,
   BatchGetJobResponse,
   BatchGetJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetJobRequest,
   output: BatchGetJobResponse,
@@ -9465,7 +9464,7 @@ export const batchGetJobEntity: API.OperationMethod<
   BatchGetJobEntityRequest,
   BatchGetJobEntityResponse,
   BatchGetJobEntityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetJobEntityRequest,
   output: BatchGetJobEntityResponse,
@@ -9497,7 +9496,7 @@ export const batchGetSession: API.OperationMethod<
   BatchGetSessionRequest,
   BatchGetSessionResponse,
   BatchGetSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSessionRequest,
   output: BatchGetSessionResponse,
@@ -9528,7 +9527,7 @@ export const batchGetSessionAction: API.OperationMethod<
   BatchGetSessionActionRequest,
   BatchGetSessionActionResponse,
   BatchGetSessionActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSessionActionRequest,
   output: BatchGetSessionActionResponse,
@@ -9559,7 +9558,7 @@ export const batchGetStep: API.OperationMethod<
   BatchGetStepRequest,
   BatchGetStepResponse,
   BatchGetStepError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetStepRequest,
   output: BatchGetStepResponse,
@@ -9590,7 +9589,7 @@ export const batchGetTask: API.OperationMethod<
   BatchGetTaskRequest,
   BatchGetTaskResponse,
   BatchGetTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTaskRequest,
   output: BatchGetTaskResponse,
@@ -9621,7 +9620,7 @@ export const batchGetWorker: API.OperationMethod<
   BatchGetWorkerRequest,
   BatchGetWorkerResponse,
   BatchGetWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetWorkerRequest,
   output: BatchGetWorkerResponse,
@@ -9656,7 +9655,7 @@ export const batchUpdateJob: API.OperationMethod<
   BatchUpdateJobRequest,
   BatchUpdateJobResponse,
   BatchUpdateJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateJobRequest,
   output: BatchUpdateJobResponse,
@@ -9687,7 +9686,7 @@ export const batchUpdateTask: API.OperationMethod<
   BatchUpdateTaskRequest,
   BatchUpdateTaskResponse,
   BatchUpdateTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateTaskRequest,
   output: BatchUpdateTaskResponse,
@@ -9717,7 +9716,7 @@ export const copyJobTemplate: API.OperationMethod<
   CopyJobTemplateRequest,
   CopyJobTemplateResponse,
   CopyJobTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyJobTemplateRequest,
   output: CopyJobTemplateResponse,
@@ -9750,7 +9749,7 @@ export const createBudget: API.OperationMethod<
   CreateBudgetRequest,
   CreateBudgetResponse,
   CreateBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBudgetRequest,
   output: CreateBudgetResponse,
@@ -9784,7 +9783,7 @@ export const createFarm: API.OperationMethod<
   CreateFarmRequest,
   CreateFarmResponse,
   CreateFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFarmRequest,
   output: CreateFarmResponse,
@@ -9818,7 +9817,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetRequest,
   CreateFleetResponse,
   CreateFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetRequest,
   output: CreateFleetResponse,
@@ -9852,7 +9851,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -9885,7 +9884,7 @@ export const createLicenseEndpoint: API.OperationMethod<
   CreateLicenseEndpointRequest,
   CreateLicenseEndpointResponse,
   CreateLicenseEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseEndpointRequest,
   output: CreateLicenseEndpointResponse,
@@ -9920,7 +9919,7 @@ export const createLimit: API.OperationMethod<
   CreateLimitRequest,
   CreateLimitResponse,
   CreateLimitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLimitRequest,
   output: CreateLimitResponse,
@@ -9953,7 +9952,7 @@ export const createMonitor: API.OperationMethod<
   CreateMonitorRequest,
   CreateMonitorResponse,
   CreateMonitorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitorRequest,
   output: CreateMonitorResponse,
@@ -9987,7 +9986,7 @@ export const createQueue: API.OperationMethod<
   CreateQueueRequest,
   CreateQueueResponse,
   CreateQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueRequest,
   output: CreateQueueResponse,
@@ -10021,7 +10020,7 @@ export const createQueueEnvironment: API.OperationMethod<
   CreateQueueEnvironmentRequest,
   CreateQueueEnvironmentResponse,
   CreateQueueEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueEnvironmentRequest,
   output: CreateQueueEnvironmentResponse,
@@ -10053,7 +10052,7 @@ export const createQueueFleetAssociation: API.OperationMethod<
   CreateQueueFleetAssociationRequest,
   CreateQueueFleetAssociationResponse,
   CreateQueueFleetAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueFleetAssociationRequest,
   output: CreateQueueFleetAssociationResponse,
@@ -10084,7 +10083,7 @@ export const createQueueLimitAssociation: API.OperationMethod<
   CreateQueueLimitAssociationRequest,
   CreateQueueLimitAssociationResponse,
   CreateQueueLimitAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueLimitAssociationRequest,
   output: CreateQueueLimitAssociationResponse,
@@ -10117,7 +10116,7 @@ export const createStorageProfile: API.OperationMethod<
   CreateStorageProfileRequest,
   CreateStorageProfileResponse,
   CreateStorageProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorageProfileRequest,
   output: CreateStorageProfileResponse,
@@ -10153,7 +10152,7 @@ export const createWorker: API.OperationMethod<
   CreateWorkerRequest,
   CreateWorkerResponse,
   CreateWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkerRequest,
   output: CreateWorkerResponse,
@@ -10186,7 +10185,7 @@ export const deleteBudget: API.OperationMethod<
   DeleteBudgetRequest,
   DeleteBudgetResponse,
   DeleteBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBudgetRequest,
   output: DeleteBudgetResponse,
@@ -10219,7 +10218,7 @@ export const deleteFarm: API.OperationMethod<
   DeleteFarmRequest,
   DeleteFarmResponse,
   DeleteFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFarmRequest,
   output: DeleteFarmResponse,
@@ -10252,7 +10251,7 @@ export const deleteFleet: API.OperationMethod<
   DeleteFleetRequest,
   DeleteFleetResponse,
   DeleteFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetRequest,
   output: DeleteFleetResponse,
@@ -10285,7 +10284,7 @@ export const deleteLicenseEndpoint: API.OperationMethod<
   DeleteLicenseEndpointRequest,
   DeleteLicenseEndpointResponse,
   DeleteLicenseEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseEndpointRequest,
   output: DeleteLicenseEndpointResponse,
@@ -10316,7 +10315,7 @@ export const deleteLimit: API.OperationMethod<
   DeleteLimitRequest,
   DeleteLimitResponse,
   DeleteLimitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLimitRequest,
   output: DeleteLimitResponse,
@@ -10346,7 +10345,7 @@ export const deleteMeteredProduct: API.OperationMethod<
   DeleteMeteredProductRequest,
   DeleteMeteredProductResponse,
   DeleteMeteredProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMeteredProductRequest,
   output: DeleteMeteredProductResponse,
@@ -10378,7 +10377,7 @@ export const deleteMonitor: API.OperationMethod<
   DeleteMonitorRequest,
   DeleteMonitorResponse,
   DeleteMonitorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitorRequest,
   output: DeleteMonitorResponse,
@@ -10413,7 +10412,7 @@ export const deleteQueue: API.OperationMethod<
   DeleteQueueRequest,
   DeleteQueueResponse,
   DeleteQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueRequest,
   output: DeleteQueueResponse,
@@ -10444,7 +10443,7 @@ export const deleteQueueEnvironment: API.OperationMethod<
   DeleteQueueEnvironmentRequest,
   DeleteQueueEnvironmentResponse,
   DeleteQueueEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueEnvironmentRequest,
   output: DeleteQueueEnvironmentResponse,
@@ -10475,7 +10474,7 @@ export const deleteQueueFleetAssociation: API.OperationMethod<
   DeleteQueueFleetAssociationRequest,
   DeleteQueueFleetAssociationResponse,
   DeleteQueueFleetAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueFleetAssociationRequest,
   output: DeleteQueueFleetAssociationResponse,
@@ -10508,7 +10507,7 @@ export const deleteQueueLimitAssociation: API.OperationMethod<
   DeleteQueueLimitAssociationRequest,
   DeleteQueueLimitAssociationResponse,
   DeleteQueueLimitAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueLimitAssociationRequest,
   output: DeleteQueueLimitAssociationResponse,
@@ -10541,7 +10540,7 @@ export const deleteStorageProfile: API.OperationMethod<
   DeleteStorageProfileRequest,
   DeleteStorageProfileResponse,
   DeleteStorageProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageProfileRequest,
   output: DeleteStorageProfileResponse,
@@ -10574,7 +10573,7 @@ export const deleteVolume: API.OperationMethod<
   DeleteVolumeRequest,
   DeleteVolumeResponse,
   DeleteVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVolumeRequest,
   output: DeleteVolumeResponse,
@@ -10607,7 +10606,7 @@ export const deleteWorker: API.OperationMethod<
   DeleteWorkerRequest,
   DeleteWorkerResponse,
   DeleteWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkerRequest,
   output: DeleteWorkerResponse,
@@ -10639,7 +10638,7 @@ export const disassociateMemberFromFarm: API.OperationMethod<
   DisassociateMemberFromFarmRequest,
   DisassociateMemberFromFarmResponse,
   DisassociateMemberFromFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberFromFarmRequest,
   output: DisassociateMemberFromFarmResponse,
@@ -10671,7 +10670,7 @@ export const disassociateMemberFromFleet: API.OperationMethod<
   DisassociateMemberFromFleetRequest,
   DisassociateMemberFromFleetResponse,
   DisassociateMemberFromFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberFromFleetRequest,
   output: DisassociateMemberFromFleetResponse,
@@ -10703,7 +10702,7 @@ export const disassociateMemberFromJob: API.OperationMethod<
   DisassociateMemberFromJobRequest,
   DisassociateMemberFromJobResponse,
   DisassociateMemberFromJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberFromJobRequest,
   output: DisassociateMemberFromJobResponse,
@@ -10735,7 +10734,7 @@ export const disassociateMemberFromQueue: API.OperationMethod<
   DisassociateMemberFromQueueRequest,
   DisassociateMemberFromQueueResponse,
   DisassociateMemberFromQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberFromQueueRequest,
   output: DisassociateMemberFromQueueResponse,
@@ -10767,7 +10766,7 @@ export const getBudget: API.OperationMethod<
   GetBudgetRequest,
   GetBudgetResponse,
   GetBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBudgetRequest,
   output: GetBudgetResponse,
@@ -10798,7 +10797,7 @@ export const getFarm: API.OperationMethod<
   GetFarmRequest,
   GetFarmResponse,
   GetFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFarmRequest,
   output: GetFarmResponse,
@@ -10829,7 +10828,7 @@ export const getFleet: API.OperationMethod<
   GetFleetRequest,
   GetFleetResponse,
   GetFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFleetRequest,
   output: GetFleetResponse,
@@ -10860,7 +10859,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -10891,7 +10890,7 @@ export const getLicenseEndpoint: API.OperationMethod<
   GetLicenseEndpointRequest,
   GetLicenseEndpointResponse,
   GetLicenseEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseEndpointRequest,
   output: GetLicenseEndpointResponse,
@@ -10922,7 +10921,7 @@ export const getLimit: API.OperationMethod<
   GetLimitRequest,
   GetLimitResponse,
   GetLimitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLimitRequest,
   output: GetLimitResponse,
@@ -10953,7 +10952,7 @@ export const getMonitor: API.OperationMethod<
   GetMonitorRequest,
   GetMonitorResponse,
   GetMonitorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitorRequest,
   output: GetMonitorResponse,
@@ -10984,7 +10983,7 @@ export const getMonitorSettings: API.OperationMethod<
   GetMonitorSettingsRequest,
   GetMonitorSettingsResponse,
   GetMonitorSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitorSettingsRequest,
   output: GetMonitorSettingsResponse,
@@ -11015,7 +11014,7 @@ export const getQueue: API.OperationMethod<
   GetQueueRequest,
   GetQueueResponse,
   GetQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueRequest,
   output: GetQueueResponse,
@@ -11046,7 +11045,7 @@ export const getQueueEnvironment: API.OperationMethod<
   GetQueueEnvironmentRequest,
   GetQueueEnvironmentResponse,
   GetQueueEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueEnvironmentRequest,
   output: GetQueueEnvironmentResponse,
@@ -11077,7 +11076,7 @@ export const getQueueFleetAssociation: API.OperationMethod<
   GetQueueFleetAssociationRequest,
   GetQueueFleetAssociationResponse,
   GetQueueFleetAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueFleetAssociationRequest,
   output: GetQueueFleetAssociationResponse,
@@ -11108,7 +11107,7 @@ export const getQueueLimitAssociation: API.OperationMethod<
   GetQueueLimitAssociationRequest,
   GetQueueLimitAssociationResponse,
   GetQueueLimitAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueLimitAssociationRequest,
   output: GetQueueLimitAssociationResponse,
@@ -11139,7 +11138,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -11170,7 +11169,7 @@ export const getSessionAction: API.OperationMethod<
   GetSessionActionRequest,
   GetSessionActionResponse,
   GetSessionActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionActionRequest,
   output: GetSessionActionResponse,
@@ -11201,7 +11200,7 @@ export const getSessionsStatisticsAggregation: API.PaginatedOperationMethod<
   GetSessionsStatisticsAggregationRequest,
   GetSessionsStatisticsAggregationResponse,
   GetSessionsStatisticsAggregationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Statistics
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSessionsStatisticsAggregationRequest,
@@ -11239,7 +11238,7 @@ export const getStep: API.OperationMethod<
   GetStepRequest,
   GetStepResponse,
   GetStepError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStepRequest,
   output: GetStepResponse,
@@ -11270,7 +11269,7 @@ export const getStorageProfile: API.OperationMethod<
   GetStorageProfileRequest,
   GetStorageProfileResponse,
   GetStorageProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageProfileRequest,
   output: GetStorageProfileResponse,
@@ -11301,7 +11300,7 @@ export const getStorageProfileForQueue: API.OperationMethod<
   GetStorageProfileForQueueRequest,
   GetStorageProfileForQueueResponse,
   GetStorageProfileForQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageProfileForQueueRequest,
   output: GetStorageProfileForQueueResponse,
@@ -11332,7 +11331,7 @@ export const getTask: API.OperationMethod<
   GetTaskRequest,
   GetTaskResponse,
   GetTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaskRequest,
   output: GetTaskResponse,
@@ -11363,7 +11362,7 @@ export const getVolume: API.OperationMethod<
   GetVolumeRequest,
   GetVolumeResponse,
   GetVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVolumeRequest,
   output: GetVolumeResponse,
@@ -11394,7 +11393,7 @@ export const getWorker: API.OperationMethod<
   GetWorkerRequest,
   GetWorkerResponse,
   GetWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkerRequest,
   output: GetWorkerResponse,
@@ -11422,7 +11421,7 @@ export const listAvailableMeteredProducts: API.PaginatedOperationMethod<
   ListAvailableMeteredProductsRequest,
   ListAvailableMeteredProductsResponse,
   ListAvailableMeteredProductsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MeteredProductSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAvailableMeteredProductsRequest,
@@ -11454,7 +11453,7 @@ export const listBudgets: API.PaginatedOperationMethod<
   ListBudgetsRequest,
   ListBudgetsResponse,
   ListBudgetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BudgetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBudgetsRequest,
@@ -11492,7 +11491,7 @@ export const listFarmMembers: API.PaginatedOperationMethod<
   ListFarmMembersRequest,
   ListFarmMembersResponse,
   ListFarmMembersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FarmMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFarmMembersRequest,
@@ -11529,7 +11528,7 @@ export const listFarms: API.PaginatedOperationMethod<
   ListFarmsRequest,
   ListFarmsResponse,
   ListFarmsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FarmSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFarmsRequest,
@@ -11566,7 +11565,7 @@ export const listFleetMembers: API.PaginatedOperationMethod<
   ListFleetMembersRequest,
   ListFleetMembersResponse,
   ListFleetMembersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetMembersRequest,
@@ -11604,7 +11603,7 @@ export const listFleets: API.PaginatedOperationMethod<
   ListFleetsRequest,
   ListFleetsResponse,
   ListFleetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetsRequest,
@@ -11642,7 +11641,7 @@ export const listJobMembers: API.PaginatedOperationMethod<
   ListJobMembersRequest,
   ListJobMembersResponse,
   ListJobMembersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobMembersRequest,
@@ -11680,7 +11679,7 @@ export const listJobParameterDefinitions: API.PaginatedOperationMethod<
   ListJobParameterDefinitionsRequest,
   ListJobParameterDefinitionsResponse,
   ListJobParameterDefinitionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobParameterDefinitionsRequest,
@@ -11718,7 +11717,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -11756,7 +11755,7 @@ export const listLicenseEndpoints: API.PaginatedOperationMethod<
   ListLicenseEndpointsRequest,
   ListLicenseEndpointsResponse,
   ListLicenseEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LicenseEndpointSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLicenseEndpointsRequest,
@@ -11794,7 +11793,7 @@ export const listLimits: API.PaginatedOperationMethod<
   ListLimitsRequest,
   ListLimitsResponse,
   ListLimitsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LimitSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLimitsRequest,
@@ -11832,7 +11831,7 @@ export const listMeteredProducts: API.PaginatedOperationMethod<
   ListMeteredProductsRequest,
   ListMeteredProductsResponse,
   ListMeteredProductsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MeteredProductSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMeteredProductsRequest,
@@ -11869,7 +11868,7 @@ export const listMonitors: API.PaginatedOperationMethod<
   ListMonitorsRequest,
   ListMonitorsResponse,
   ListMonitorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorsRequest,
@@ -11906,7 +11905,7 @@ export const listQueueEnvironments: API.PaginatedOperationMethod<
   ListQueueEnvironmentsRequest,
   ListQueueEnvironmentsResponse,
   ListQueueEnvironmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueEnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueueEnvironmentsRequest,
@@ -11943,7 +11942,7 @@ export const listQueueFleetAssociations: API.PaginatedOperationMethod<
   ListQueueFleetAssociationsRequest,
   ListQueueFleetAssociationsResponse,
   ListQueueFleetAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueFleetAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueueFleetAssociationsRequest,
@@ -11979,7 +11978,7 @@ export const listQueueLimitAssociations: API.PaginatedOperationMethod<
   ListQueueLimitAssociationsRequest,
   ListQueueLimitAssociationsResponse,
   ListQueueLimitAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueLimitAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueueLimitAssociationsRequest,
@@ -12016,7 +12015,7 @@ export const listQueueMembers: API.PaginatedOperationMethod<
   ListQueueMembersRequest,
   ListQueueMembersResponse,
   ListQueueMembersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueueMembersRequest,
@@ -12054,7 +12053,7 @@ export const listQueues: API.PaginatedOperationMethod<
   ListQueuesRequest,
   ListQueuesResponse,
   ListQueuesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuesRequest,
@@ -12092,7 +12091,7 @@ export const listSessionActions: API.PaginatedOperationMethod<
   ListSessionActionsRequest,
   ListSessionActionsResponse,
   ListSessionActionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionActionsRequest,
@@ -12130,7 +12129,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -12168,7 +12167,7 @@ export const listSessionsForWorker: API.PaginatedOperationMethod<
   ListSessionsForWorkerRequest,
   ListSessionsForWorkerResponse,
   ListSessionsForWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkerSessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsForWorkerRequest,
@@ -12206,7 +12205,7 @@ export const listStepConsumers: API.PaginatedOperationMethod<
   ListStepConsumersRequest,
   ListStepConsumersResponse,
   ListStepConsumersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StepConsumer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStepConsumersRequest,
@@ -12244,7 +12243,7 @@ export const listStepDependencies: API.PaginatedOperationMethod<
   ListStepDependenciesRequest,
   ListStepDependenciesResponse,
   ListStepDependenciesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StepDependency
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStepDependenciesRequest,
@@ -12282,7 +12281,7 @@ export const listSteps: API.PaginatedOperationMethod<
   ListStepsRequest,
   ListStepsResponse,
   ListStepsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StepSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStepsRequest,
@@ -12320,7 +12319,7 @@ export const listStorageProfiles: API.PaginatedOperationMethod<
   ListStorageProfilesRequest,
   ListStorageProfilesResponse,
   ListStorageProfilesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StorageProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStorageProfilesRequest,
@@ -12358,7 +12357,7 @@ export const listStorageProfilesForQueue: API.PaginatedOperationMethod<
   ListStorageProfilesForQueueRequest,
   ListStorageProfilesForQueueResponse,
   ListStorageProfilesForQueueError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StorageProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStorageProfilesForQueueRequest,
@@ -12396,7 +12395,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -12427,7 +12426,7 @@ export const listTasks: API.PaginatedOperationMethod<
   ListTasksRequest,
   ListTasksResponse,
   ListTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTasksRequest,
@@ -12465,7 +12464,7 @@ export const listVolumes: API.PaginatedOperationMethod<
   ListVolumesRequest,
   ListVolumesResponse,
   ListVolumesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VolumeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVolumesRequest,
@@ -12503,7 +12502,7 @@ export const listWorkers: API.PaginatedOperationMethod<
   ListWorkersRequest,
   ListWorkersResponse,
   ListWorkersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkersRequest,
@@ -12541,7 +12540,7 @@ export const putMeteredProduct: API.OperationMethod<
   PutMeteredProductRequest,
   PutMeteredProductResponse,
   PutMeteredProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMeteredProductRequest,
   output: PutMeteredProductResponse,
@@ -12572,7 +12571,7 @@ export const searchJobs: API.OperationMethod<
   SearchJobsRequest,
   SearchJobsResponse,
   SearchJobsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchJobsRequest,
   output: SearchJobsResponse,
@@ -12603,7 +12602,7 @@ export const searchSteps: API.OperationMethod<
   SearchStepsRequest,
   SearchStepsResponse,
   SearchStepsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchStepsRequest,
   output: SearchStepsResponse,
@@ -12634,7 +12633,7 @@ export const searchTasks: API.OperationMethod<
   SearchTasksRequest,
   SearchTasksResponse,
   SearchTasksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchTasksRequest,
   output: SearchTasksResponse,
@@ -12665,7 +12664,7 @@ export const searchWorkers: API.OperationMethod<
   SearchWorkersRequest,
   SearchWorkersResponse,
   SearchWorkersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchWorkersRequest,
   output: SearchWorkersResponse,
@@ -12696,7 +12695,7 @@ export const startSessionsStatisticsAggregation: API.OperationMethod<
   StartSessionsStatisticsAggregationRequest,
   StartSessionsStatisticsAggregationResponse,
   StartSessionsStatisticsAggregationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionsStatisticsAggregationRequest,
   output: StartSessionsStatisticsAggregationResponse,
@@ -12728,7 +12727,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -12761,7 +12760,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -12795,7 +12794,7 @@ export const updateBudget: API.OperationMethod<
   UpdateBudgetRequest,
   UpdateBudgetResponse,
   UpdateBudgetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBudgetRequest,
   output: UpdateBudgetResponse,
@@ -12829,7 +12828,7 @@ export const updateFarm: API.OperationMethod<
   UpdateFarmRequest,
   UpdateFarmResponse,
   UpdateFarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFarmRequest,
   output: UpdateFarmResponse,
@@ -12862,7 +12861,7 @@ export const updateFleet: API.OperationMethod<
   UpdateFleetRequest,
   UpdateFleetResponse,
   UpdateFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetRequest,
   output: UpdateFleetResponse,
@@ -12899,7 +12898,7 @@ export const updateJob: API.OperationMethod<
   UpdateJobRequest,
   UpdateJobResponse,
   UpdateJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobRequest,
   output: UpdateJobResponse,
@@ -12931,7 +12930,7 @@ export const updateLimit: API.OperationMethod<
   UpdateLimitRequest,
   UpdateLimitResponse,
   UpdateLimitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLimitRequest,
   output: UpdateLimitResponse,
@@ -12963,7 +12962,7 @@ export const updateMonitor: API.OperationMethod<
   UpdateMonitorRequest,
   UpdateMonitorResponse,
   UpdateMonitorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitorRequest,
   output: UpdateMonitorResponse,
@@ -12995,7 +12994,7 @@ export const updateMonitorSettings: API.OperationMethod<
   UpdateMonitorSettingsRequest,
   UpdateMonitorSettingsResponse,
   UpdateMonitorSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitorSettingsRequest,
   output: UpdateMonitorSettingsResponse,
@@ -13026,7 +13025,7 @@ export const updateQueue: API.OperationMethod<
   UpdateQueueRequest,
   UpdateQueueResponse,
   UpdateQueueError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueRequest,
   output: UpdateQueueResponse,
@@ -13057,7 +13056,7 @@ export const updateQueueEnvironment: API.OperationMethod<
   UpdateQueueEnvironmentRequest,
   UpdateQueueEnvironmentResponse,
   UpdateQueueEnvironmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueEnvironmentRequest,
   output: UpdateQueueEnvironmentResponse,
@@ -13088,7 +13087,7 @@ export const updateQueueFleetAssociation: API.OperationMethod<
   UpdateQueueFleetAssociationRequest,
   UpdateQueueFleetAssociationResponse,
   UpdateQueueFleetAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueFleetAssociationRequest,
   output: UpdateQueueFleetAssociationResponse,
@@ -13119,7 +13118,7 @@ export const updateQueueLimitAssociation: API.OperationMethod<
   UpdateQueueLimitAssociationRequest,
   UpdateQueueLimitAssociationResponse,
   UpdateQueueLimitAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueLimitAssociationRequest,
   output: UpdateQueueLimitAssociationResponse,
@@ -13151,7 +13150,7 @@ export const updateSession: API.OperationMethod<
   UpdateSessionRequest,
   UpdateSessionResponse,
   UpdateSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSessionRequest,
   output: UpdateSessionResponse,
@@ -13184,7 +13183,7 @@ export const updateStep: API.OperationMethod<
   UpdateStepRequest,
   UpdateStepResponse,
   UpdateStepError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStepRequest,
   output: UpdateStepResponse,
@@ -13217,7 +13216,7 @@ export const updateStorageProfile: API.OperationMethod<
   UpdateStorageProfileRequest,
   UpdateStorageProfileResponse,
   UpdateStorageProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStorageProfileRequest,
   output: UpdateStorageProfileResponse,
@@ -13250,7 +13249,7 @@ export const updateTask: API.OperationMethod<
   UpdateTaskRequest,
   UpdateTaskResponse,
   UpdateTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskRequest,
   output: UpdateTaskResponse,
@@ -13283,7 +13282,7 @@ export const updateWorker: API.OperationMethod<
   UpdateWorkerRequest,
   UpdateWorkerResponse,
   UpdateWorkerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkerRequest,
   output: UpdateWorkerResponse,
@@ -13316,7 +13315,7 @@ export const updateWorkerSchedule: API.OperationMethod<
   UpdateWorkerScheduleRequest,
   UpdateWorkerScheduleResponse,
   UpdateWorkerScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkerScheduleRequest,
   output: UpdateWorkerScheduleResponse,

--- a/packages/aws/src/services/detective.ts
+++ b/packages/aws/src/services/detective.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Detective",
@@ -1633,7 +1632,7 @@ export const acceptInvitation: API.OperationMethod<
   AcceptInvitationRequest,
   AcceptInvitationResponse,
   AcceptInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInvitationRequest,
   output: AcceptInvitationResponse,
@@ -1662,7 +1661,7 @@ export const batchGetGraphMemberDatasources: API.OperationMethod<
   BatchGetGraphMemberDatasourcesRequest,
   BatchGetGraphMemberDatasourcesResponse,
   BatchGetGraphMemberDatasourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetGraphMemberDatasourcesRequest,
   output: BatchGetGraphMemberDatasourcesResponse,
@@ -1690,7 +1689,7 @@ export const batchGetMembershipDatasources: API.OperationMethod<
   BatchGetMembershipDatasourcesRequest,
   BatchGetMembershipDatasourcesResponse,
   BatchGetMembershipDatasourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetMembershipDatasourcesRequest,
   output: BatchGetMembershipDatasourcesResponse,
@@ -1729,7 +1728,7 @@ export const createGraph: API.OperationMethod<
   CreateGraphRequest,
   CreateGraphResponse,
   CreateGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGraphRequest,
   output: CreateGraphResponse,
@@ -1788,7 +1787,7 @@ export const createMembers: API.OperationMethod<
   CreateMembersRequest,
   CreateMembersResponse,
   CreateMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembersRequest,
   output: CreateMembersResponse,
@@ -1821,7 +1820,7 @@ export const deleteGraph: API.OperationMethod<
   DeleteGraphRequest,
   DeleteGraphResponse,
   DeleteGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGraphRequest,
   output: DeleteGraphResponse,
@@ -1865,7 +1864,7 @@ export const deleteMembers: API.OperationMethod<
   DeleteMembersRequest,
   DeleteMembersResponse,
   DeleteMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMembersRequest,
   output: DeleteMembersResponse,
@@ -1898,7 +1897,7 @@ export const describeOrganizationConfiguration: API.OperationMethod<
   DescribeOrganizationConfigurationRequest,
   DescribeOrganizationConfigurationResponse,
   DescribeOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationConfigurationRequest,
   output: DescribeOrganizationConfigurationResponse,
@@ -1934,7 +1933,7 @@ export const disableOrganizationAdminAccount: API.OperationMethod<
   DisableOrganizationAdminAccountRequest,
   DisableOrganizationAdminAccountResponse,
   DisableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationAdminAccountRequest,
   output: DisableOrganizationAdminAccountResponse,
@@ -1969,7 +1968,7 @@ export const disassociateMembership: API.OperationMethod<
   DisassociateMembershipRequest,
   DisassociateMembershipResponse,
   DisassociateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMembershipRequest,
   output: DisassociateMembershipResponse,
@@ -2013,7 +2012,7 @@ export const enableOrganizationAdminAccount: API.OperationMethod<
   EnableOrganizationAdminAccountRequest,
   EnableOrganizationAdminAccountResponse,
   EnableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationAdminAccountRequest,
   output: EnableOrganizationAdminAccountResponse,
@@ -2042,7 +2041,7 @@ export const getInvestigation: API.OperationMethod<
   GetInvestigationRequest,
   GetInvestigationResponse,
   GetInvestigationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvestigationRequest,
   output: GetInvestigationResponse,
@@ -2072,7 +2071,7 @@ export const getMembers: API.OperationMethod<
   GetMembersRequest,
   GetMembersResponse,
   GetMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMembersRequest,
   output: GetMembersResponse,
@@ -2100,7 +2099,7 @@ export const listDatasourcePackages: API.PaginatedOperationMethod<
   ListDatasourcePackagesRequest,
   ListDatasourcePackagesResponse,
   ListDatasourcePackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasourcePackagesRequest,
@@ -2137,7 +2136,7 @@ export const listGraphs: API.PaginatedOperationMethod<
   ListGraphsRequest,
   ListGraphsResponse,
   ListGraphsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGraphsRequest,
@@ -2167,7 +2166,7 @@ export const listIndicators: API.OperationMethod<
   ListIndicatorsRequest,
   ListIndicatorsResponse,
   ListIndicatorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIndicatorsRequest,
   output: ListIndicatorsResponse,
@@ -2202,7 +2201,7 @@ export const listInvestigations: API.OperationMethod<
   ListInvestigationsRequest,
   ListInvestigationsResponse,
   ListInvestigationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInvestigationsRequest,
   output: ListInvestigationsResponse,
@@ -2237,7 +2236,7 @@ export const listInvitations: API.PaginatedOperationMethod<
   ListInvitationsRequest,
   ListInvitationsResponse,
   ListInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvitationsRequest,
@@ -2273,7 +2272,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersRequest,
   ListMembersResponse,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersRequest,
@@ -2308,7 +2307,7 @@ export const listOrganizationAdminAccounts: API.PaginatedOperationMethod<
   ListOrganizationAdminAccountsRequest,
   ListOrganizationAdminAccountsResponse,
   ListOrganizationAdminAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationAdminAccountsRequest,
@@ -2342,7 +2341,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2377,7 +2376,7 @@ export const rejectInvitation: API.OperationMethod<
   RejectInvitationRequest,
   RejectInvitationResponse,
   RejectInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectInvitationRequest,
   output: RejectInvitationResponse,
@@ -2407,7 +2406,7 @@ export const startInvestigation: API.OperationMethod<
   StartInvestigationRequest,
   StartInvestigationResponse,
   StartInvestigationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInvestigationRequest,
   output: StartInvestigationResponse,
@@ -2447,7 +2446,7 @@ export const startMonitoringMember: API.OperationMethod<
   StartMonitoringMemberRequest,
   StartMonitoringMemberResponse,
   StartMonitoringMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMonitoringMemberRequest,
   output: StartMonitoringMemberResponse,
@@ -2477,7 +2476,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2505,7 +2504,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2534,7 +2533,7 @@ export const updateDatasourcePackages: API.OperationMethod<
   UpdateDatasourcePackagesRequest,
   UpdateDatasourcePackagesResponse,
   UpdateDatasourcePackagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasourcePackagesRequest,
   output: UpdateDatasourcePackagesResponse,
@@ -2564,7 +2563,7 @@ export const updateInvestigationState: API.OperationMethod<
   UpdateInvestigationStateRequest,
   UpdateInvestigationStateResponse,
   UpdateInvestigationStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInvestigationStateRequest,
   output: UpdateInvestigationStateResponse,
@@ -2595,7 +2594,7 @@ export const updateOrganizationConfiguration: API.OperationMethod<
   UpdateOrganizationConfigurationRequest,
   UpdateOrganizationConfigurationResponse,
   UpdateOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationConfigurationRequest,
   output: UpdateOrganizationConfigurationResponse,

--- a/packages/aws/src/services/device-farm.ts
+++ b/packages/aws/src/services/device-farm.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://devicefarm.amazonaws.com/doc/2015-06-23/");
 const svc = T.AwsApiService({
@@ -3938,7 +3937,7 @@ export const createDevicePool: API.OperationMethod<
   CreateDevicePoolRequest,
   CreateDevicePoolResult,
   CreateDevicePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDevicePoolRequest,
   output: CreateDevicePoolResult,
@@ -3967,7 +3966,7 @@ export const createInstanceProfile: API.OperationMethod<
   CreateInstanceProfileRequest,
   CreateInstanceProfileResult,
   CreateInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceProfileRequest,
   output: CreateInstanceProfileResult,
@@ -3995,7 +3994,7 @@ export const createNetworkProfile: API.OperationMethod<
   CreateNetworkProfileRequest,
   CreateNetworkProfileResult,
   CreateNetworkProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkProfileRequest,
   output: CreateNetworkProfileResult,
@@ -4024,7 +4023,7 @@ export const createProject: API.OperationMethod<
   CreateProjectRequest,
   CreateProjectResult,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectRequest,
   output: CreateProjectResult,
@@ -4053,7 +4052,7 @@ export const createRemoteAccessSession: API.OperationMethod<
   CreateRemoteAccessSessionRequest,
   CreateRemoteAccessSessionResult,
   CreateRemoteAccessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRemoteAccessSessionRequest,
   output: CreateRemoteAccessSessionResult,
@@ -4081,7 +4080,7 @@ export const createTestGridProject: API.OperationMethod<
   CreateTestGridProjectRequest,
   CreateTestGridProjectResult,
   CreateTestGridProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTestGridProjectRequest,
   output: CreateTestGridProjectResult,
@@ -4104,7 +4103,7 @@ export const createTestGridUrl: API.OperationMethod<
   CreateTestGridUrlRequest,
   CreateTestGridUrlResult,
   CreateTestGridUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTestGridUrlRequest,
   output: CreateTestGridUrlResult,
@@ -4127,7 +4126,7 @@ export const createUpload: API.OperationMethod<
   CreateUploadRequest,
   CreateUploadResult,
   CreateUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUploadRequest,
   output: CreateUploadResult,
@@ -4155,7 +4154,7 @@ export const createVPCEConfiguration: API.OperationMethod<
   CreateVPCEConfigurationRequest,
   CreateVPCEConfigurationResult,
   CreateVPCEConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVPCEConfigurationRequest,
   output: CreateVPCEConfigurationResult,
@@ -4179,7 +4178,7 @@ export const deleteDevicePool: API.OperationMethod<
   DeleteDevicePoolRequest,
   DeleteDevicePoolResult,
   DeleteDevicePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDevicePoolRequest,
   output: DeleteDevicePoolResult,
@@ -4207,7 +4206,7 @@ export const deleteInstanceProfile: API.OperationMethod<
   DeleteInstanceProfileRequest,
   DeleteInstanceProfileResult,
   DeleteInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceProfileRequest,
   output: DeleteInstanceProfileResult,
@@ -4235,7 +4234,7 @@ export const deleteNetworkProfile: API.OperationMethod<
   DeleteNetworkProfileRequest,
   DeleteNetworkProfileResult,
   DeleteNetworkProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkProfileRequest,
   output: DeleteNetworkProfileResult,
@@ -4265,7 +4264,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectRequest,
   DeleteProjectResult,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectRequest,
   output: DeleteProjectResult,
@@ -4295,7 +4294,7 @@ export const deleteRemoteAccessSession: API.OperationMethod<
   DeleteRemoteAccessSessionRequest,
   DeleteRemoteAccessSessionResult,
   DeleteRemoteAccessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRemoteAccessSessionRequest,
   output: DeleteRemoteAccessSessionResult,
@@ -4325,7 +4324,7 @@ export const deleteRun: API.OperationMethod<
   DeleteRunRequest,
   DeleteRunResult,
   DeleteRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRunRequest,
   output: DeleteRunResult,
@@ -4355,7 +4354,7 @@ export const deleteTestGridProject: API.OperationMethod<
   DeleteTestGridProjectRequest,
   DeleteTestGridProjectResult,
   DeleteTestGridProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTestGridProjectRequest,
   output: DeleteTestGridProjectResult,
@@ -4383,7 +4382,7 @@ export const deleteUpload: API.OperationMethod<
   DeleteUploadRequest,
   DeleteUploadResult,
   DeleteUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUploadRequest,
   output: DeleteUploadResult,
@@ -4411,7 +4410,7 @@ export const deleteVPCEConfiguration: API.OperationMethod<
   DeleteVPCEConfigurationRequest,
   DeleteVPCEConfigurationResult,
   DeleteVPCEConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVPCEConfigurationRequest,
   output: DeleteVPCEConfigurationResult,
@@ -4440,7 +4439,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsResult,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsResult,
@@ -4468,7 +4467,7 @@ export const getDevice: API.OperationMethod<
   GetDeviceRequest,
   GetDeviceResult,
   GetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceRequest,
   output: GetDeviceResult,
@@ -4496,7 +4495,7 @@ export const getDeviceInstance: API.OperationMethod<
   GetDeviceInstanceRequest,
   GetDeviceInstanceResult,
   GetDeviceInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceInstanceRequest,
   output: GetDeviceInstanceResult,
@@ -4524,7 +4523,7 @@ export const getDevicePool: API.OperationMethod<
   GetDevicePoolRequest,
   GetDevicePoolResult,
   GetDevicePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDevicePoolRequest,
   output: GetDevicePoolResult,
@@ -4552,7 +4551,7 @@ export const getDevicePoolCompatibility: API.OperationMethod<
   GetDevicePoolCompatibilityRequest,
   GetDevicePoolCompatibilityResult,
   GetDevicePoolCompatibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDevicePoolCompatibilityRequest,
   output: GetDevicePoolCompatibilityResult,
@@ -4580,7 +4579,7 @@ export const getInstanceProfile: API.OperationMethod<
   GetInstanceProfileRequest,
   GetInstanceProfileResult,
   GetInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceProfileRequest,
   output: GetInstanceProfileResult,
@@ -4608,7 +4607,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResult,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResult,
@@ -4636,7 +4635,7 @@ export const getNetworkProfile: API.OperationMethod<
   GetNetworkProfileRequest,
   GetNetworkProfileResult,
   GetNetworkProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkProfileRequest,
   output: GetNetworkProfileResult,
@@ -4668,7 +4667,7 @@ export const getOfferingStatus: API.PaginatedOperationMethod<
   GetOfferingStatusRequest,
   GetOfferingStatusResult,
   GetOfferingStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOfferingStatusRequest,
@@ -4699,7 +4698,7 @@ export const getProject: API.OperationMethod<
   GetProjectRequest,
   GetProjectResult,
   GetProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProjectRequest,
   output: GetProjectResult,
@@ -4727,7 +4726,7 @@ export const getRemoteAccessSession: API.OperationMethod<
   GetRemoteAccessSessionRequest,
   GetRemoteAccessSessionResult,
   GetRemoteAccessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRemoteAccessSessionRequest,
   output: GetRemoteAccessSessionResult,
@@ -4755,7 +4754,7 @@ export const getRun: API.OperationMethod<
   GetRunRequest,
   GetRunResult,
   GetRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRunRequest,
   output: GetRunResult,
@@ -4783,7 +4782,7 @@ export const getSuite: API.OperationMethod<
   GetSuiteRequest,
   GetSuiteResult,
   GetSuiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSuiteRequest,
   output: GetSuiteResult,
@@ -4811,7 +4810,7 @@ export const getTest: API.OperationMethod<
   GetTestRequest,
   GetTestResult,
   GetTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTestRequest,
   output: GetTestResult,
@@ -4838,7 +4837,7 @@ export const getTestGridProject: API.OperationMethod<
   GetTestGridProjectRequest,
   GetTestGridProjectResult,
   GetTestGridProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTestGridProjectRequest,
   output: GetTestGridProjectResult,
@@ -4864,7 +4863,7 @@ export const getTestGridSession: API.OperationMethod<
   GetTestGridSessionRequest,
   GetTestGridSessionResult,
   GetTestGridSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTestGridSessionRequest,
   output: GetTestGridSessionResult,
@@ -4887,7 +4886,7 @@ export const getUpload: API.OperationMethod<
   GetUploadRequest,
   GetUploadResult,
   GetUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUploadRequest,
   output: GetUploadResult,
@@ -4915,7 +4914,7 @@ export const getVPCEConfiguration: API.OperationMethod<
   GetVPCEConfigurationRequest,
   GetVPCEConfigurationResult,
   GetVPCEConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVPCEConfigurationRequest,
   output: GetVPCEConfigurationResult,
@@ -4940,7 +4939,7 @@ export const installToRemoteAccessSession: API.OperationMethod<
   InstallToRemoteAccessSessionRequest,
   InstallToRemoteAccessSessionResult,
   InstallToRemoteAccessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InstallToRemoteAccessSessionRequest,
   output: InstallToRemoteAccessSessionResult,
@@ -4968,7 +4967,7 @@ export const listArtifacts: API.PaginatedOperationMethod<
   ListArtifactsRequest,
   ListArtifactsResult,
   ListArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Artifact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArtifactsRequest,
@@ -5003,7 +5002,7 @@ export const listDeviceInstances: API.OperationMethod<
   ListDeviceInstancesRequest,
   ListDeviceInstancesResult,
   ListDeviceInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeviceInstancesRequest,
   output: ListDeviceInstancesResult,
@@ -5031,7 +5030,7 @@ export const listDevicePools: API.PaginatedOperationMethod<
   ListDevicePoolsRequest,
   ListDevicePoolsResult,
   ListDevicePoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DevicePool
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicePoolsRequest,
@@ -5065,7 +5064,7 @@ export const listDevices: API.PaginatedOperationMethod<
   ListDevicesRequest,
   ListDevicesResult,
   ListDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Device
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesRequest,
@@ -5099,7 +5098,7 @@ export const listInstanceProfiles: API.OperationMethod<
   ListInstanceProfilesRequest,
   ListInstanceProfilesResult,
   ListInstanceProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInstanceProfilesRequest,
   output: ListInstanceProfilesResult,
@@ -5127,7 +5126,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResult,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -5161,7 +5160,7 @@ export const listNetworkProfiles: API.OperationMethod<
   ListNetworkProfilesRequest,
   ListNetworkProfilesResult,
   ListNetworkProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListNetworkProfilesRequest,
   output: ListNetworkProfilesResult,
@@ -5192,7 +5191,7 @@ export const listOfferingPromotions: API.OperationMethod<
   ListOfferingPromotionsRequest,
   ListOfferingPromotionsResult,
   ListOfferingPromotionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOfferingPromotionsRequest,
   output: ListOfferingPromotionsResult,
@@ -5225,7 +5224,7 @@ export const listOfferings: API.PaginatedOperationMethod<
   ListOfferingsRequest,
   ListOfferingsResult,
   ListOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Offering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOfferingsRequest,
@@ -5264,7 +5263,7 @@ export const listOfferingTransactions: API.PaginatedOperationMethod<
   ListOfferingTransactionsRequest,
   ListOfferingTransactionsResult,
   ListOfferingTransactionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OfferingTransaction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOfferingTransactionsRequest,
@@ -5299,7 +5298,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsRequest,
   ListProjectsResult,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Project
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsRequest,
@@ -5333,7 +5332,7 @@ export const listRemoteAccessSessions: API.OperationMethod<
   ListRemoteAccessSessionsRequest,
   ListRemoteAccessSessionsResult,
   ListRemoteAccessSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRemoteAccessSessionsRequest,
   output: ListRemoteAccessSessionsResult,
@@ -5361,7 +5360,7 @@ export const listRuns: API.PaginatedOperationMethod<
   ListRunsRequest,
   ListRunsResult,
   ListRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Run
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunsRequest,
@@ -5395,7 +5394,7 @@ export const listSamples: API.PaginatedOperationMethod<
   ListSamplesRequest,
   ListSamplesResult,
   ListSamplesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Sample
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSamplesRequest,
@@ -5429,7 +5428,7 @@ export const listSuites: API.PaginatedOperationMethod<
   ListSuitesRequest,
   ListSuitesResult,
   ListSuitesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Suite
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSuitesRequest,
@@ -5462,7 +5461,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5483,7 +5482,7 @@ export const listTestGridProjects: API.PaginatedOperationMethod<
   ListTestGridProjectsRequest,
   ListTestGridProjectsResult,
   ListTestGridProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestGridProjectsRequest,
@@ -5511,7 +5510,7 @@ export const listTestGridSessionActions: API.PaginatedOperationMethod<
   ListTestGridSessionActionsRequest,
   ListTestGridSessionActionsResult,
   ListTestGridSessionActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestGridSessionActionsRequest,
@@ -5539,7 +5538,7 @@ export const listTestGridSessionArtifacts: API.PaginatedOperationMethod<
   ListTestGridSessionArtifactsRequest,
   ListTestGridSessionArtifactsResult,
   ListTestGridSessionArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestGridSessionArtifactsRequest,
@@ -5567,7 +5566,7 @@ export const listTestGridSessions: API.PaginatedOperationMethod<
   ListTestGridSessionsRequest,
   ListTestGridSessionsResult,
   ListTestGridSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestGridSessionsRequest,
@@ -5596,7 +5595,7 @@ export const listTests: API.PaginatedOperationMethod<
   ListTestsRequest,
   ListTestsResult,
   ListTestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Test
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestsRequest,
@@ -5635,7 +5634,7 @@ export const listUniqueProblems: API.PaginatedOperationMethod<
   ListUniqueProblemsRequest,
   ListUniqueProblemsResult,
   ListUniqueProblemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUniqueProblemsRequest,
@@ -5669,7 +5668,7 @@ export const listUploads: API.PaginatedOperationMethod<
   ListUploadsRequest,
   ListUploadsResult,
   ListUploadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Upload
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUploadsRequest,
@@ -5702,7 +5701,7 @@ export const listVPCEConfigurations: API.OperationMethod<
   ListVPCEConfigurationsRequest,
   ListVPCEConfigurationsResult,
   ListVPCEConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVPCEConfigurationsRequest,
   output: ListVPCEConfigurationsResult,
@@ -5729,7 +5728,7 @@ export const purchaseOffering: API.OperationMethod<
   PurchaseOfferingRequest,
   PurchaseOfferingResult,
   PurchaseOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseOfferingRequest,
   output: PurchaseOfferingResult,
@@ -5761,7 +5760,7 @@ export const renewOffering: API.OperationMethod<
   RenewOfferingRequest,
   RenewOfferingResult,
   RenewOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenewOfferingRequest,
   output: RenewOfferingResult,
@@ -5791,7 +5790,7 @@ export const scheduleRun: API.OperationMethod<
   ScheduleRunRequest,
   ScheduleRunResult,
   ScheduleRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScheduleRunRequest,
   output: ScheduleRunResult,
@@ -5823,7 +5822,7 @@ export const stopJob: API.OperationMethod<
   StopJobRequest,
   StopJobResult,
   StopJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopJobRequest,
   output: StopJobResult,
@@ -5851,7 +5850,7 @@ export const stopRemoteAccessSession: API.OperationMethod<
   StopRemoteAccessSessionRequest,
   StopRemoteAccessSessionResult,
   StopRemoteAccessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRemoteAccessSessionRequest,
   output: StopRemoteAccessSessionResult,
@@ -5882,7 +5881,7 @@ export const stopRun: API.OperationMethod<
   StopRunRequest,
   StopRunResult,
   StopRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRunRequest,
   output: StopRunResult,
@@ -5913,7 +5912,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5941,7 +5940,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5964,7 +5963,7 @@ export const updateDeviceInstance: API.OperationMethod<
   UpdateDeviceInstanceRequest,
   UpdateDeviceInstanceResult,
   UpdateDeviceInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceInstanceRequest,
   output: UpdateDeviceInstanceResult,
@@ -5994,7 +5993,7 @@ export const updateDevicePool: API.OperationMethod<
   UpdateDevicePoolRequest,
   UpdateDevicePoolResult,
   UpdateDevicePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDevicePoolRequest,
   output: UpdateDevicePoolResult,
@@ -6022,7 +6021,7 @@ export const updateInstanceProfile: API.OperationMethod<
   UpdateInstanceProfileRequest,
   UpdateInstanceProfileResult,
   UpdateInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceProfileRequest,
   output: UpdateInstanceProfileResult,
@@ -6050,7 +6049,7 @@ export const updateNetworkProfile: API.OperationMethod<
   UpdateNetworkProfileRequest,
   UpdateNetworkProfileResult,
   UpdateNetworkProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkProfileRequest,
   output: UpdateNetworkProfileResult,
@@ -6079,7 +6078,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectRequest,
   UpdateProjectResult,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectRequest,
   output: UpdateProjectResult,
@@ -6107,7 +6106,7 @@ export const updateTestGridProject: API.OperationMethod<
   UpdateTestGridProjectRequest,
   UpdateTestGridProjectResult,
   UpdateTestGridProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTestGridProjectRequest,
   output: UpdateTestGridProjectResult,
@@ -6135,7 +6134,7 @@ export const updateUpload: API.OperationMethod<
   UpdateUploadRequest,
   UpdateUploadResult,
   UpdateUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUploadRequest,
   output: UpdateUploadResult,
@@ -6163,7 +6162,7 @@ export const updateVPCEConfiguration: API.OperationMethod<
   UpdateVPCEConfigurationRequest,
   UpdateVPCEConfigurationResult,
   UpdateVPCEConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVPCEConfigurationRequest,
   output: UpdateVPCEConfigurationResult,

--- a/packages/aws/src/services/devops-agent.ts
+++ b/packages/aws/src/services/devops-agent.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DevOps Agent",
@@ -5563,7 +5562,7 @@ export const associateService: API.OperationMethod<
   AssociateServiceInput,
   AssociateServiceOutput,
   AssociateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateServiceInput,
   output: AssociateServiceOutput,
@@ -5596,7 +5595,7 @@ export const createAgentSpace: API.OperationMethod<
   CreateAgentSpaceInput,
   CreateAgentSpaceOutput,
   CreateAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentSpaceInput,
   output: CreateAgentSpaceOutput,
@@ -5628,7 +5627,7 @@ export const createAsset: API.OperationMethod<
   CreateAssetRequest,
   CreateAssetResponse,
   CreateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetRequest,
   output: CreateAssetResponse,
@@ -5661,7 +5660,7 @@ export const createAssetFile: API.OperationMethod<
   CreateAssetFileRequest,
   CreateAssetFileResponse,
   CreateAssetFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetFileRequest,
   output: CreateAssetFileResponse,
@@ -5695,7 +5694,7 @@ export const createBacklogTask: API.OperationMethod<
   CreateBacklogTaskRequest,
   CreateBacklogTaskResponse,
   CreateBacklogTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBacklogTaskRequest,
   output: CreateBacklogTaskResponse,
@@ -5726,7 +5725,7 @@ export const createChat: API.OperationMethod<
   CreateChatRequest,
   CreateChatResponse,
   CreateChatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChatRequest,
   output: CreateChatResponse,
@@ -5755,7 +5754,7 @@ export const createPrivateConnection: API.OperationMethod<
   CreatePrivateConnectionInput,
   CreatePrivateConnectionOutput,
   CreatePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivateConnectionInput,
   output: CreatePrivateConnectionOutput,
@@ -5786,7 +5785,7 @@ export const createTrigger: API.OperationMethod<
   CreateTriggerRequest,
   CreateTriggerResponse,
   CreateTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTriggerRequest,
   output: CreateTriggerResponse,
@@ -5818,7 +5817,7 @@ export const deleteAgentSpace: API.OperationMethod<
   DeleteAgentSpaceInput,
   DeleteAgentSpaceOutput,
   DeleteAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentSpaceInput,
   output: DeleteAgentSpaceOutput,
@@ -5850,7 +5849,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetRequest,
   DeleteAssetResponse,
   DeleteAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetRequest,
   output: DeleteAssetResponse,
@@ -5882,7 +5881,7 @@ export const deleteAssetFile: API.OperationMethod<
   DeleteAssetFileRequest,
   DeleteAssetFileResponse,
   DeleteAssetFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetFileRequest,
   output: DeleteAssetFileResponse,
@@ -5913,7 +5912,7 @@ export const deletePrivateConnection: API.OperationMethod<
   DeletePrivateConnectionInput,
   DeletePrivateConnectionOutput,
   DeletePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrivateConnectionInput,
   output: DeletePrivateConnectionOutput,
@@ -5945,7 +5944,7 @@ export const deleteTrigger: API.OperationMethod<
   DeleteTriggerRequest,
   DeleteTriggerResponse,
   DeleteTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTriggerRequest,
   output: DeleteTriggerResponse,
@@ -5977,7 +5976,7 @@ export const deregisterService: API.OperationMethod<
   DeregisterServiceInput,
   DeregisterServiceOutput,
   DeregisterServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterServiceInput,
   output: DeregisterServiceOutput,
@@ -6008,7 +6007,7 @@ export const describePrivateConnection: API.OperationMethod<
   DescribePrivateConnectionInput,
   DescribePrivateConnectionOutput,
   DescribePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePrivateConnectionInput,
   output: DescribePrivateConnectionOutput,
@@ -6038,7 +6037,7 @@ export const disableOperatorApp: API.OperationMethod<
   DisableOperatorAppInput,
   DisableOperatorAppResponse,
   DisableOperatorAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOperatorAppInput,
   output: DisableOperatorAppResponse,
@@ -6067,7 +6066,7 @@ export const disassociateService: API.OperationMethod<
   DisassociateServiceInput,
   DisassociateServiceOutput,
   DisassociateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateServiceInput,
   output: DisassociateServiceOutput,
@@ -6096,7 +6095,7 @@ export const enableOperatorApp: API.OperationMethod<
   EnableOperatorAppInput,
   EnableOperatorAppOutput,
   EnableOperatorAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOperatorAppInput,
   output: EnableOperatorAppOutput,
@@ -6126,7 +6125,7 @@ export const getAccountUsage: API.OperationMethod<
   GetAccountUsageInput,
   GetAccountUsageOutput,
   GetAccountUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountUsageInput,
   output: GetAccountUsageOutput,
@@ -6156,7 +6155,7 @@ export const getAgentSpace: API.OperationMethod<
   GetAgentSpaceInput,
   GetAgentSpaceOutput,
   GetAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentSpaceInput,
   output: GetAgentSpaceOutput,
@@ -6186,7 +6185,7 @@ export const getAsset: API.OperationMethod<
   GetAssetRequest,
   GetAssetResponse,
   GetAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetRequest,
   output: GetAssetResponse,
@@ -6217,7 +6216,7 @@ export const getAssetContent: API.OperationMethod<
   GetAssetContentRequest,
   GetAssetContentResponse,
   GetAssetContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetContentRequest,
   output: GetAssetContentResponse,
@@ -6248,7 +6247,7 @@ export const getAssetFile: API.OperationMethod<
   GetAssetFileRequest,
   GetAssetFileResponse,
   GetAssetFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetFileRequest,
   output: GetAssetFileResponse,
@@ -6278,7 +6277,7 @@ export const getAssociation: API.OperationMethod<
   GetAssociationInput,
   GetAssociationOutput,
   GetAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociationInput,
   output: GetAssociationOutput,
@@ -6309,7 +6308,7 @@ export const getBacklogTask: API.OperationMethod<
   GetBacklogTaskRequest,
   GetBacklogTaskResponse,
   GetBacklogTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBacklogTaskRequest,
   output: GetBacklogTaskResponse,
@@ -6339,7 +6338,7 @@ export const getOperatorApp: API.OperationMethod<
   GetOperatorAppInput,
   GetOperatorAppOutput,
   GetOperatorAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperatorAppInput,
   output: GetOperatorAppOutput,
@@ -6364,7 +6363,7 @@ export const getRecommendation: API.OperationMethod<
   GetRecommendationRequest,
   GetRecommendationResponse,
   GetRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationRequest,
   output: GetRecommendationResponse,
@@ -6394,7 +6393,7 @@ export const getService: API.OperationMethod<
   GetServiceInput,
   GetServiceOutput,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceInput,
   output: GetServiceOutput,
@@ -6424,7 +6423,7 @@ export const getTrigger: API.OperationMethod<
   GetTriggerRequest,
   GetTriggerResponse,
   GetTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTriggerRequest,
   output: GetTriggerResponse,
@@ -6453,7 +6452,7 @@ export const listAgentSpaces: API.PaginatedOperationMethod<
   ListAgentSpacesInput,
   ListAgentSpacesOutput,
   ListAgentSpacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentSpace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentSpacesInput,
@@ -6485,7 +6484,7 @@ export const listAssetFiles: API.PaginatedOperationMethod<
   ListAssetFilesRequest,
   ListAssetFilesResponse,
   ListAssetFilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetFileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetFilesRequest,
@@ -6522,7 +6521,7 @@ export const listAssets: API.PaginatedOperationMethod<
   ListAssetsRequest,
   ListAssetsResponse,
   ListAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Asset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetsRequest,
@@ -6558,7 +6557,7 @@ export const listAssetTypes: API.PaginatedOperationMethod<
   ListAssetTypesRequest,
   ListAssetTypesResponse,
   ListAssetTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetTypeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetTypesRequest,
@@ -6595,7 +6594,7 @@ export const listAssetVersions: API.PaginatedOperationMethod<
   ListAssetVersionsRequest,
   ListAssetVersionsResponse,
   ListAssetVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetVersionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetVersionsRequest,
@@ -6632,7 +6631,7 @@ export const listAssociations: API.PaginatedOperationMethod<
   ListAssociationsInput,
   ListAssociationsOutput,
   ListAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Association
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociationsInput,
@@ -6668,7 +6667,7 @@ export const listBacklogTasks: API.PaginatedOperationMethod<
   ListBacklogTasksRequest,
   ListBacklogTasksResponse,
   ListBacklogTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Task
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBacklogTasksRequest,
@@ -6704,7 +6703,7 @@ export const listChats: API.OperationMethod<
   ListChatsRequest,
   ListChatsResponse,
   ListChatsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListChatsRequest,
   output: ListChatsResponse,
@@ -6734,7 +6733,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsRequest,
   ListExecutionsResponse,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Execution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsRequest,
@@ -6771,7 +6770,7 @@ export const listGoals: API.PaginatedOperationMethod<
   ListGoalsRequest,
   ListGoalsResponse,
   ListGoalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Goal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGoalsRequest,
@@ -6808,7 +6807,7 @@ export const listJournalRecords: API.PaginatedOperationMethod<
   ListJournalRecordsRequest,
   ListJournalRecordsResponse,
   ListJournalRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JournalRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJournalRecordsRequest,
@@ -6846,7 +6845,7 @@ export const listPendingMessages: API.OperationMethod<
   ListPendingMessagesRequest,
   ListPendingMessagesResponse,
   ListPendingMessagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPendingMessagesRequest,
   output: ListPendingMessagesResponse,
@@ -6876,7 +6875,7 @@ export const listPrivateConnections: API.OperationMethod<
   ListPrivateConnectionsInput,
   ListPrivateConnectionsOutput,
   ListPrivateConnectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPrivateConnectionsInput,
   output: ListPrivateConnectionsOutput,
@@ -6905,7 +6904,7 @@ export const listRecommendations: API.OperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRecommendationsRequest,
   output: ListRecommendationsResponse,
@@ -6933,7 +6932,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesInput,
   ListServicesOutput,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegisteredService
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesInput,
@@ -6964,7 +6963,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6994,7 +6993,7 @@ export const listTriggers: API.PaginatedOperationMethod<
   ListTriggersRequest,
   ListTriggersResponse,
   ListTriggersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Trigger
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTriggersRequest,
@@ -7031,7 +7030,7 @@ export const listWebhooks: API.OperationMethod<
   ListWebhooksInput,
   ListWebhooksOutput,
   ListWebhooksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebhooksInput,
   output: ListWebhooksOutput,
@@ -7060,7 +7059,7 @@ export const registerService: API.OperationMethod<
   RegisterServiceInput,
   RegisterServiceOutput,
   RegisterServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterServiceInput,
   output: RegisterServiceOutput,
@@ -7091,7 +7090,7 @@ export const sendMessage: API.OperationMethod<
   SendMessageRequest,
   SendMessageResponse,
   SendMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessageRequest,
   output: SendMessageResponse,
@@ -7122,7 +7121,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7151,7 +7150,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7181,7 +7180,7 @@ export const updateAgentSpace: API.OperationMethod<
   UpdateAgentSpaceInput,
   UpdateAgentSpaceOutput,
   UpdateAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentSpaceInput,
   output: UpdateAgentSpaceOutput,
@@ -7213,7 +7212,7 @@ export const updateAsset: API.OperationMethod<
   UpdateAssetRequest,
   UpdateAssetResponse,
   UpdateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetRequest,
   output: UpdateAssetResponse,
@@ -7247,7 +7246,7 @@ export const updateAssetFile: API.OperationMethod<
   UpdateAssetFileRequest,
   UpdateAssetFileResponse,
   UpdateAssetFileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetFileRequest,
   output: UpdateAssetFileResponse,
@@ -7279,7 +7278,7 @@ export const updateAssociation: API.OperationMethod<
   UpdateAssociationInput,
   UpdateAssociationOutput,
   UpdateAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssociationInput,
   output: UpdateAssociationOutput,
@@ -7310,7 +7309,7 @@ export const updateBacklogTask: API.OperationMethod<
   UpdateBacklogTaskRequest,
   UpdateBacklogTaskResponse,
   UpdateBacklogTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBacklogTaskRequest,
   output: UpdateBacklogTaskResponse,
@@ -7343,7 +7342,7 @@ export const updateGoal: API.OperationMethod<
   UpdateGoalRequest,
   UpdateGoalResponse,
   UpdateGoalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGoalRequest,
   output: UpdateGoalResponse,
@@ -7374,7 +7373,7 @@ export const updateOperatorAppIdpConfig: API.OperationMethod<
   UpdateOperatorAppIdpConfigInput,
   UpdateOperatorAppIdpConfigOutput,
   UpdateOperatorAppIdpConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOperatorAppIdpConfigInput,
   output: UpdateOperatorAppIdpConfigOutput,
@@ -7404,7 +7403,7 @@ export const updatePrivateConnectionCertificate: API.OperationMethod<
   UpdatePrivateConnectionCertificateInput,
   UpdatePrivateConnectionCertificateOutput,
   UpdatePrivateConnectionCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrivateConnectionCertificateInput,
   output: UpdatePrivateConnectionCertificateOutput,
@@ -7436,7 +7435,7 @@ export const updateRecommendation: API.OperationMethod<
   UpdateRecommendationRequest,
   UpdateRecommendationResponse,
   UpdateRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecommendationRequest,
   output: UpdateRecommendationResponse,
@@ -7468,7 +7467,7 @@ export const updateTrigger: API.OperationMethod<
   UpdateTriggerRequest,
   UpdateTriggerResponse,
   UpdateTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTriggerRequest,
   output: UpdateTriggerResponse,
@@ -7498,7 +7497,7 @@ export const validateAwsAssociations: API.OperationMethod<
   ValidateAwsAssociationsInput,
   ValidateAwsAssociationsOutput,
   ValidateAwsAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateAwsAssociationsInput,
   output: ValidateAwsAssociationsOutput,

--- a/packages/aws/src/services/devops-guru.ts
+++ b/packages/aws/src/services/devops-guru.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "DevOps Guru",
   serviceShapeName: "CapstoneControlPlaneService",
@@ -2951,7 +2950,7 @@ export const addNotificationChannel: API.OperationMethod<
   AddNotificationChannelRequest,
   AddNotificationChannelResponse,
   AddNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddNotificationChannelRequest,
   output: AddNotificationChannelResponse,
@@ -2984,7 +2983,7 @@ export const deleteInsight: API.OperationMethod<
   DeleteInsightRequest,
   DeleteInsightResponse,
   DeleteInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInsightRequest,
   output: DeleteInsightResponse,
@@ -3016,7 +3015,7 @@ export const describeAccountHealth: API.OperationMethod<
   DescribeAccountHealthRequest,
   DescribeAccountHealthResponse,
   DescribeAccountHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountHealthRequest,
   output: DescribeAccountHealthResponse,
@@ -3046,7 +3045,7 @@ export const describeAccountOverview: API.OperationMethod<
   DescribeAccountOverviewRequest,
   DescribeAccountOverviewResponse,
   DescribeAccountOverviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountOverviewRequest,
   output: DescribeAccountOverviewResponse,
@@ -3075,7 +3074,7 @@ export const describeAnomaly: API.OperationMethod<
   DescribeAnomalyRequest,
   DescribeAnomalyResponse,
   DescribeAnomalyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnomalyRequest,
   output: DescribeAnomalyResponse,
@@ -3107,7 +3106,7 @@ export const describeEventSourcesConfig: API.OperationMethod<
   DescribeEventSourcesConfigRequest,
   DescribeEventSourcesConfigResponse,
   DescribeEventSourcesConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventSourcesConfigRequest,
   output: DescribeEventSourcesConfigResponse,
@@ -3136,7 +3135,7 @@ export const describeFeedback: API.OperationMethod<
   DescribeFeedbackRequest,
   DescribeFeedbackResponse,
   DescribeFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFeedbackRequest,
   output: DescribeFeedbackResponse,
@@ -3166,7 +3165,7 @@ export const describeInsight: API.OperationMethod<
   DescribeInsightRequest,
   DescribeInsightResponse,
   DescribeInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInsightRequest,
   output: DescribeInsightResponse,
@@ -3196,7 +3195,7 @@ export const describeOrganizationHealth: API.OperationMethod<
   DescribeOrganizationHealthRequest,
   DescribeOrganizationHealthResponse,
   DescribeOrganizationHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationHealthRequest,
   output: DescribeOrganizationHealthResponse,
@@ -3225,7 +3224,7 @@ export const describeOrganizationOverview: API.OperationMethod<
   DescribeOrganizationOverviewRequest,
   DescribeOrganizationOverviewResponse,
   DescribeOrganizationOverviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationOverviewRequest,
   output: DescribeOrganizationOverviewResponse,
@@ -3255,7 +3254,7 @@ export const describeOrganizationResourceCollectionHealth: API.PaginatedOperatio
   DescribeOrganizationResourceCollectionHealthRequest,
   DescribeOrganizationResourceCollectionHealthResponse,
   DescribeOrganizationResourceCollectionHealthError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationResourceCollectionHealthRequest,
@@ -3289,7 +3288,7 @@ export const describeResourceCollectionHealth: API.PaginatedOperationMethod<
   DescribeResourceCollectionHealthRequest,
   DescribeResourceCollectionHealthResponse,
   DescribeResourceCollectionHealthError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeResourceCollectionHealthRequest,
@@ -3322,7 +3321,7 @@ export const describeServiceIntegration: API.OperationMethod<
   DescribeServiceIntegrationRequest,
   DescribeServiceIntegrationResponse,
   DescribeServiceIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceIntegrationRequest,
   output: DescribeServiceIntegrationResponse,
@@ -3356,7 +3355,7 @@ export const getCostEstimation: API.PaginatedOperationMethod<
   GetCostEstimationRequest,
   GetCostEstimationResponse,
   GetCostEstimationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCostEstimationRequest,
@@ -3391,7 +3390,7 @@ export const getResourceCollection: API.PaginatedOperationMethod<
   GetResourceCollectionRequest,
   GetResourceCollectionResponse,
   GetResourceCollectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceCollectionRequest,
@@ -3424,7 +3423,7 @@ export const listAnomaliesForInsight: API.PaginatedOperationMethod<
   ListAnomaliesForInsightRequest,
   ListAnomaliesForInsightResponse,
   ListAnomaliesForInsightError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnomaliesForInsightRequest,
@@ -3460,7 +3459,7 @@ export const listAnomalousLogGroups: API.PaginatedOperationMethod<
   ListAnomalousLogGroupsRequest,
   ListAnomalousLogGroupsResponse,
   ListAnomalousLogGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnomalousLogGroupsRequest,
@@ -3497,7 +3496,7 @@ export const listEvents: API.PaginatedOperationMethod<
   ListEventsRequest,
   ListEventsResponse,
   ListEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventsRequest,
@@ -3535,7 +3534,7 @@ export const listInsights: API.PaginatedOperationMethod<
   ListInsightsRequest,
   ListInsightsResponse,
   ListInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInsightsRequest,
@@ -3569,7 +3568,7 @@ export const listMonitoredResources: API.PaginatedOperationMethod<
   ListMonitoredResourcesRequest,
   ListMonitoredResourcesResponse,
   ListMonitoredResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitoredResourcesRequest,
@@ -3606,7 +3605,7 @@ export const listNotificationChannels: API.PaginatedOperationMethod<
   ListNotificationChannelsRequest,
   ListNotificationChannelsResponse,
   ListNotificationChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationChannel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationChannelsRequest,
@@ -3640,7 +3639,7 @@ export const listOrganizationInsights: API.PaginatedOperationMethod<
   ListOrganizationInsightsRequest,
   ListOrganizationInsightsResponse,
   ListOrganizationInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationInsightsRequest,
@@ -3676,7 +3675,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -3713,7 +3712,7 @@ export const putFeedback: API.OperationMethod<
   PutFeedbackRequest,
   PutFeedbackResponse,
   PutFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFeedbackRequest,
   output: PutFeedbackResponse,
@@ -3747,7 +3746,7 @@ export const removeNotificationChannel: API.OperationMethod<
   RemoveNotificationChannelRequest,
   RemoveNotificationChannelResponse,
   RemoveNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveNotificationChannelRequest,
   output: RemoveNotificationChannelResponse,
@@ -3784,7 +3783,7 @@ export const searchInsights: API.PaginatedOperationMethod<
   SearchInsightsRequest,
   SearchInsightsResponse,
   SearchInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchInsightsRequest,
@@ -3826,7 +3825,7 @@ export const searchOrganizationInsights: API.PaginatedOperationMethod<
   SearchOrganizationInsightsRequest,
   SearchOrganizationInsightsResponse,
   SearchOrganizationInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchOrganizationInsightsRequest,
@@ -3863,7 +3862,7 @@ export const startCostEstimation: API.OperationMethod<
   StartCostEstimationRequest,
   StartCostEstimationResponse,
   StartCostEstimationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCostEstimationRequest,
   output: StartCostEstimationResponse,
@@ -3895,7 +3894,7 @@ export const updateEventSourcesConfig: API.OperationMethod<
   UpdateEventSourcesConfigRequest,
   UpdateEventSourcesConfigResponse,
   UpdateEventSourcesConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventSourcesConfigRequest,
   output: UpdateEventSourcesConfigResponse,
@@ -3928,7 +3927,7 @@ export const updateResourceCollection: API.OperationMethod<
   UpdateResourceCollectionRequest,
   UpdateResourceCollectionResponse,
   UpdateResourceCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceCollectionRequest,
   output: UpdateResourceCollectionResponse,
@@ -3960,7 +3959,7 @@ export const updateServiceIntegration: API.OperationMethod<
   UpdateServiceIntegrationRequest,
   UpdateServiceIntegrationResponse,
   UpdateServiceIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceIntegrationRequest,
   output: UpdateServiceIntegrationResponse,

--- a/packages/aws/src/services/direct-connect.ts
+++ b/packages/aws/src/services/direct-connect.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const ns = T.XmlNamespace("http://directconnect.amazonaws.com/doc/2012-10-25/");
 const svc = T.AwsApiService({
   sdkId: "Direct Connect",
@@ -3020,7 +3019,7 @@ export const acceptDirectConnectGatewayAssociationProposal: API.OperationMethod<
   AcceptDirectConnectGatewayAssociationProposalRequest,
   AcceptDirectConnectGatewayAssociationProposalResult,
   AcceptDirectConnectGatewayAssociationProposalError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptDirectConnectGatewayAssociationProposalRequest,
   output: AcceptDirectConnectGatewayAssociationProposalResult,
@@ -3047,7 +3046,7 @@ export const allocateConnectionOnInterconnect: API.OperationMethod<
   AllocateConnectionOnInterconnectRequest,
   Connection,
   AllocateConnectionOnInterconnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateConnectionOnInterconnectRequest,
   output: Connection,
@@ -3075,7 +3074,7 @@ export const allocateHostedConnection: API.OperationMethod<
   AllocateHostedConnectionRequest,
   Connection,
   AllocateHostedConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateHostedConnectionRequest,
   output: Connection,
@@ -3107,7 +3106,7 @@ export const allocatePrivateVirtualInterface: API.OperationMethod<
   AllocatePrivateVirtualInterfaceRequest,
   VirtualInterface,
   AllocatePrivateVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocatePrivateVirtualInterfaceRequest,
   output: VirtualInterface,
@@ -3145,7 +3144,7 @@ export const allocatePublicVirtualInterface: API.OperationMethod<
   AllocatePublicVirtualInterfaceRequest,
   VirtualInterface,
   AllocatePublicVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocatePublicVirtualInterfaceRequest,
   output: VirtualInterface,
@@ -3179,7 +3178,7 @@ export const allocateTransitVirtualInterface: API.OperationMethod<
   AllocateTransitVirtualInterfaceRequest,
   AllocateTransitVirtualInterfaceResult,
   AllocateTransitVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateTransitVirtualInterfaceRequest,
   output: AllocateTransitVirtualInterfaceResult,
@@ -3222,7 +3221,7 @@ export const associateConnectionWithLag: API.OperationMethod<
   AssociateConnectionWithLagRequest,
   Connection,
   AssociateConnectionWithLagError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateConnectionWithLagRequest,
   output: Connection,
@@ -3253,7 +3252,7 @@ export const associateHostedConnection: API.OperationMethod<
   AssociateHostedConnectionRequest,
   Connection,
   AssociateHostedConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateHostedConnectionRequest,
   output: Connection,
@@ -3278,7 +3277,7 @@ export const associateMacSecKey: API.OperationMethod<
   AssociateMacSecKeyRequest,
   AssociateMacSecKeyResponse,
   AssociateMacSecKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMacSecKeyRequest,
   output: AssociateMacSecKeyResponse,
@@ -3310,7 +3309,7 @@ export const associateVirtualInterface: API.OperationMethod<
   AssociateVirtualInterfaceRequest,
   VirtualInterface,
   AssociateVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateVirtualInterfaceRequest,
   output: VirtualInterface,
@@ -3334,7 +3333,7 @@ export const confirmConnection: API.OperationMethod<
   ConfirmConnectionRequest,
   ConfirmConnectionResponse,
   ConfirmConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmConnectionRequest,
   output: ConfirmConnectionResponse,
@@ -3355,7 +3354,7 @@ export const confirmCustomerAgreement: API.OperationMethod<
   ConfirmCustomerAgreementRequest,
   ConfirmCustomerAgreementResponse,
   ConfirmCustomerAgreementError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmCustomerAgreementRequest,
   output: ConfirmCustomerAgreementResponse,
@@ -3380,7 +3379,7 @@ export const confirmPrivateVirtualInterface: API.OperationMethod<
   ConfirmPrivateVirtualInterfaceRequest,
   ConfirmPrivateVirtualInterfaceResponse,
   ConfirmPrivateVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmPrivateVirtualInterfaceRequest,
   output: ConfirmPrivateVirtualInterfaceResponse,
@@ -3404,7 +3403,7 @@ export const confirmPublicVirtualInterface: API.OperationMethod<
   ConfirmPublicVirtualInterfaceRequest,
   ConfirmPublicVirtualInterfaceResponse,
   ConfirmPublicVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmPublicVirtualInterfaceRequest,
   output: ConfirmPublicVirtualInterfaceResponse,
@@ -3427,7 +3426,7 @@ export const confirmTransitVirtualInterface: API.OperationMethod<
   ConfirmTransitVirtualInterfaceRequest,
   ConfirmTransitVirtualInterfaceResponse,
   ConfirmTransitVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmTransitVirtualInterfaceRequest,
   output: ConfirmTransitVirtualInterfaceResponse,
@@ -3466,7 +3465,7 @@ export const createBGPPeer: API.OperationMethod<
   CreateBGPPeerRequest,
   CreateBGPPeerResponse,
   CreateBGPPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBGPPeerRequest,
   output: CreateBGPPeerResponse,
@@ -3499,7 +3498,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   Connection,
   CreateConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: Connection,
@@ -3530,7 +3529,7 @@ export const createDirectConnectGateway: API.OperationMethod<
   CreateDirectConnectGatewayRequest,
   CreateDirectConnectGatewayResult,
   CreateDirectConnectGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectConnectGatewayRequest,
   output: CreateDirectConnectGatewayResult,
@@ -3552,7 +3551,7 @@ export const createDirectConnectGatewayAssociation: API.OperationMethod<
   CreateDirectConnectGatewayAssociationRequest,
   CreateDirectConnectGatewayAssociationResult,
   CreateDirectConnectGatewayAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectConnectGatewayAssociationRequest,
   output: CreateDirectConnectGatewayAssociationResult,
@@ -3575,7 +3574,7 @@ export const createDirectConnectGatewayAssociationProposal: API.OperationMethod<
   CreateDirectConnectGatewayAssociationProposalRequest,
   CreateDirectConnectGatewayAssociationProposalResult,
   CreateDirectConnectGatewayAssociationProposalError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectConnectGatewayAssociationProposalRequest,
   output: CreateDirectConnectGatewayAssociationProposalResult,
@@ -3615,7 +3614,7 @@ export const createInterconnect: API.OperationMethod<
   CreateInterconnectRequest,
   Interconnect,
   CreateInterconnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInterconnectRequest,
   output: Interconnect,
@@ -3665,7 +3664,7 @@ export const createLag: API.OperationMethod<
   CreateLagRequest,
   Lag,
   CreateLagError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLagRequest,
   output: Lag,
@@ -3705,7 +3704,7 @@ export const createPrivateVirtualInterface: API.OperationMethod<
   CreatePrivateVirtualInterfaceRequest,
   VirtualInterface,
   CreatePrivateVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivateVirtualInterfaceRequest,
   output: VirtualInterface,
@@ -3739,7 +3738,7 @@ export const createPublicVirtualInterface: API.OperationMethod<
   CreatePublicVirtualInterfaceRequest,
   VirtualInterface,
   CreatePublicVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePublicVirtualInterfaceRequest,
   output: VirtualInterface,
@@ -3778,7 +3777,7 @@ export const createTransitVirtualInterface: API.OperationMethod<
   CreateTransitVirtualInterfaceRequest,
   CreateTransitVirtualInterfaceResult,
   CreateTransitVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitVirtualInterfaceRequest,
   output: CreateTransitVirtualInterfaceResult,
@@ -3807,7 +3806,7 @@ export const deleteBGPPeer: API.OperationMethod<
   DeleteBGPPeerRequest,
   DeleteBGPPeerResponse,
   DeleteBGPPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBGPPeerRequest,
   output: DeleteBGPPeerResponse,
@@ -3832,7 +3831,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   Connection,
   DeleteConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: Connection,
@@ -3855,7 +3854,7 @@ export const deleteDirectConnectGateway: API.OperationMethod<
   DeleteDirectConnectGatewayRequest,
   DeleteDirectConnectGatewayResult,
   DeleteDirectConnectGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectConnectGatewayRequest,
   output: DeleteDirectConnectGatewayResult,
@@ -3878,7 +3877,7 @@ export const deleteDirectConnectGatewayAssociation: API.OperationMethod<
   DeleteDirectConnectGatewayAssociationRequest,
   DeleteDirectConnectGatewayAssociationResult,
   DeleteDirectConnectGatewayAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectConnectGatewayAssociationRequest,
   output: DeleteDirectConnectGatewayAssociationResult,
@@ -3899,7 +3898,7 @@ export const deleteDirectConnectGatewayAssociationProposal: API.OperationMethod<
   DeleteDirectConnectGatewayAssociationProposalRequest,
   DeleteDirectConnectGatewayAssociationProposalResult,
   DeleteDirectConnectGatewayAssociationProposalError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectConnectGatewayAssociationProposalRequest,
   output: DeleteDirectConnectGatewayAssociationProposalResult,
@@ -3923,7 +3922,7 @@ export const deleteInterconnect: API.OperationMethod<
   DeleteInterconnectRequest,
   DeleteInterconnectResponse,
   DeleteInterconnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInterconnectRequest,
   output: DeleteInterconnectResponse,
@@ -3945,7 +3944,7 @@ export const deleteLag: API.OperationMethod<
   DeleteLagRequest,
   Lag,
   DeleteLagError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLagRequest,
   output: Lag,
@@ -3966,7 +3965,7 @@ export const deleteVirtualInterface: API.OperationMethod<
   DeleteVirtualInterfaceRequest,
   DeleteVirtualInterfaceResponse,
   DeleteVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualInterfaceRequest,
   output: DeleteVirtualInterfaceResponse,
@@ -3994,7 +3993,7 @@ export const describeConnectionLoa: API.OperationMethod<
   DescribeConnectionLoaRequest,
   DescribeConnectionLoaResponse,
   DescribeConnectionLoaError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionLoaRequest,
   output: DescribeConnectionLoaResponse,
@@ -4015,7 +4014,7 @@ export const describeConnections: API.OperationMethod<
   DescribeConnectionsRequest,
   Connections,
   DescribeConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionsRequest,
   output: Connections,
@@ -4040,7 +4039,7 @@ export const describeConnectionsOnInterconnect: API.OperationMethod<
   DescribeConnectionsOnInterconnectRequest,
   Connections,
   DescribeConnectionsOnInterconnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionsOnInterconnectRequest,
   output: Connections,
@@ -4061,7 +4060,7 @@ export const describeCustomerMetadata: API.OperationMethod<
   DescribeCustomerMetadataRequest,
   DescribeCustomerMetadataResponse,
   DescribeCustomerMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomerMetadataRequest,
   output: DescribeCustomerMetadataResponse,
@@ -4082,7 +4081,7 @@ export const describeDirectConnectGatewayAssociationProposals: API.OperationMeth
   DescribeDirectConnectGatewayAssociationProposalsRequest,
   DescribeDirectConnectGatewayAssociationProposalsResult,
   DescribeDirectConnectGatewayAssociationProposalsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectConnectGatewayAssociationProposalsRequest,
   output: DescribeDirectConnectGatewayAssociationProposalsResult,
@@ -4131,7 +4130,7 @@ export const describeDirectConnectGatewayAssociations: API.OperationMethod<
   DescribeDirectConnectGatewayAssociationsRequest,
   DescribeDirectConnectGatewayAssociationsResult,
   DescribeDirectConnectGatewayAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectConnectGatewayAssociationsRequest,
   output: DescribeDirectConnectGatewayAssociationsResult,
@@ -4156,7 +4155,7 @@ export const describeDirectConnectGatewayAttachments: API.OperationMethod<
   DescribeDirectConnectGatewayAttachmentsRequest,
   DescribeDirectConnectGatewayAttachmentsResult,
   DescribeDirectConnectGatewayAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectConnectGatewayAttachmentsRequest,
   output: DescribeDirectConnectGatewayAttachmentsResult,
@@ -4177,7 +4176,7 @@ export const describeDirectConnectGateways: API.OperationMethod<
   DescribeDirectConnectGatewaysRequest,
   DescribeDirectConnectGatewaysResult,
   DescribeDirectConnectGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectConnectGatewaysRequest,
   output: DescribeDirectConnectGatewaysResult,
@@ -4201,7 +4200,7 @@ export const describeHostedConnections: API.OperationMethod<
   DescribeHostedConnectionsRequest,
   Connections,
   DescribeHostedConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHostedConnectionsRequest,
   output: Connections,
@@ -4228,7 +4227,7 @@ export const describeInterconnectLoa: API.OperationMethod<
   DescribeInterconnectLoaRequest,
   DescribeInterconnectLoaResponse,
   DescribeInterconnectLoaError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInterconnectLoaRequest,
   output: DescribeInterconnectLoaResponse,
@@ -4249,7 +4248,7 @@ export const describeInterconnects: API.OperationMethod<
   DescribeInterconnectsRequest,
   Interconnects,
   DescribeInterconnectsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInterconnectsRequest,
   output: Interconnects,
@@ -4270,7 +4269,7 @@ export const describeLags: API.OperationMethod<
   DescribeLagsRequest,
   Lags,
   DescribeLagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLagsRequest,
   output: Lags,
@@ -4295,7 +4294,7 @@ export const describeLoa: API.OperationMethod<
   DescribeLoaRequest,
   Loa,
   DescribeLoaError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoaRequest,
   output: Loa,
@@ -4317,7 +4316,7 @@ export const describeLocations: API.OperationMethod<
   DescribeLocationsRequest,
   Locations,
   DescribeLocationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLocationsRequest,
   output: Locations,
@@ -4338,7 +4337,7 @@ export const describeRouterConfiguration: API.OperationMethod<
   DescribeRouterConfigurationRequest,
   DescribeRouterConfigurationResponse,
   DescribeRouterConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRouterConfigurationRequest,
   output: DescribeRouterConfigurationResponse,
@@ -4359,7 +4358,7 @@ export const describeTags: API.OperationMethod<
   DescribeTagsRequest,
   DescribeTagsResponse,
   DescribeTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagsRequest,
   output: DescribeTagsResponse,
@@ -4384,7 +4383,7 @@ export const describeVirtualGateways: API.OperationMethod<
   DescribeVirtualGatewaysRequest,
   VirtualGateways,
   DescribeVirtualGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualGatewaysRequest,
   output: VirtualGateways,
@@ -4414,7 +4413,7 @@ export const describeVirtualInterfaces: API.OperationMethod<
   DescribeVirtualInterfacesRequest,
   VirtualInterfaces,
   DescribeVirtualInterfacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualInterfacesRequest,
   output: VirtualInterfaces,
@@ -4445,7 +4444,7 @@ export const disassociateConnectionFromLag: API.OperationMethod<
   DisassociateConnectionFromLagRequest,
   Connection,
   DisassociateConnectionFromLagError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateConnectionFromLagRequest,
   output: Connection,
@@ -4466,7 +4465,7 @@ export const disassociateMacSecKey: API.OperationMethod<
   DisassociateMacSecKeyRequest,
   DisassociateMacSecKeyResponse,
   DisassociateMacSecKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMacSecKeyRequest,
   output: DisassociateMacSecKeyResponse,
@@ -4487,7 +4486,7 @@ export const listVirtualInterfaceTestHistory: API.OperationMethod<
   ListVirtualInterfaceTestHistoryRequest,
   ListVirtualInterfaceTestHistoryResponse,
   ListVirtualInterfaceTestHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVirtualInterfaceTestHistoryRequest,
   output: ListVirtualInterfaceTestHistoryResponse,
@@ -4514,7 +4513,7 @@ export const startBgpFailoverTest: API.OperationMethod<
   StartBgpFailoverTestRequest,
   StartBgpFailoverTestResponse,
   StartBgpFailoverTestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBgpFailoverTestRequest,
   output: StartBgpFailoverTestResponse,
@@ -4535,7 +4534,7 @@ export const stopBgpFailoverTest: API.OperationMethod<
   StopBgpFailoverTestRequest,
   StopBgpFailoverTestResponse,
   StopBgpFailoverTestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBgpFailoverTestRequest,
   output: StopBgpFailoverTestResponse,
@@ -4560,7 +4559,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4586,7 +4585,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4613,7 +4612,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   Connection,
   UpdateConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: Connection,
@@ -4634,7 +4633,7 @@ export const updateDirectConnectGateway: API.OperationMethod<
   UpdateDirectConnectGatewayRequest,
   UpdateDirectConnectGatewayResponse,
   UpdateDirectConnectGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectConnectGatewayRequest,
   output: UpdateDirectConnectGatewayResponse,
@@ -4657,7 +4656,7 @@ export const updateDirectConnectGatewayAssociation: API.OperationMethod<
   UpdateDirectConnectGatewayAssociationRequest,
   UpdateDirectConnectGatewayAssociationResult,
   UpdateDirectConnectGatewayAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectConnectGatewayAssociationRequest,
   output: UpdateDirectConnectGatewayAssociationResult,
@@ -4695,7 +4694,7 @@ export const updateLag: API.OperationMethod<
   UpdateLagRequest,
   Lag,
   UpdateLagError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLagRequest,
   output: Lag,
@@ -4723,7 +4722,7 @@ export const updateVirtualInterfaceAttributes: API.OperationMethod<
   UpdateVirtualInterfaceAttributesRequest,
   VirtualInterface,
   UpdateVirtualInterfaceAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVirtualInterfaceAttributesRequest,
   output: VirtualInterface,

--- a/packages/aws/src/services/directory-service-data.ts
+++ b/packages/aws/src/services/directory-service-data.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://directoryservicedata.amazonaws.com/doc/2023-05-31/",
@@ -1067,7 +1066,7 @@ export const addGroupMember: API.OperationMethod<
   AddGroupMemberRequest,
   AddGroupMemberResult,
   AddGroupMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddGroupMemberRequest,
   output: AddGroupMemberResult,
@@ -1100,7 +1099,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResult,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResult,
@@ -1132,7 +1131,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResult,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResult,
@@ -1165,7 +1164,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResult,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResult,
@@ -1199,7 +1198,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResult,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResult,
@@ -1232,7 +1231,7 @@ export const describeGroup: API.OperationMethod<
   DescribeGroupRequest,
   DescribeGroupResult,
   DescribeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupRequest,
   output: DescribeGroupResult,
@@ -1264,7 +1263,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResult,
   DescribeUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResult,
@@ -1299,7 +1298,7 @@ export const disableUser: API.OperationMethod<
   DisableUserRequest,
   DisableUserResult,
   DisableUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableUserRequest,
   output: DisableUserResult,
@@ -1340,7 +1339,7 @@ export const listGroupMembers: API.PaginatedOperationMethod<
   ListGroupMembersRequest,
   ListGroupMembersResult,
   ListGroupMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Member
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupMembersRequest,
@@ -1386,7 +1385,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResult,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -1432,7 +1431,7 @@ export const listGroupsForMember: API.PaginatedOperationMethod<
   ListGroupsForMemberRequest,
   ListGroupsForMemberResult,
   ListGroupsForMemberError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsForMemberRequest,
@@ -1478,7 +1477,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResult,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -1517,7 +1516,7 @@ export const removeGroupMember: API.OperationMethod<
   RemoveGroupMemberRequest,
   RemoveGroupMemberResult,
   RemoveGroupMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveGroupMemberRequest,
   output: RemoveGroupMemberResult,
@@ -1559,7 +1558,7 @@ export const searchGroups: API.PaginatedOperationMethod<
   SearchGroupsRequest,
   SearchGroupsResult,
   SearchGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchGroupsRequest,
@@ -1606,7 +1605,7 @@ export const searchUsers: API.PaginatedOperationMethod<
   SearchUsersRequest,
   SearchUsersResult,
   SearchUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchUsersRequest,
@@ -1645,7 +1644,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResult,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResult,
@@ -1679,7 +1678,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResult,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResult,

--- a/packages/aws/src/services/directory-service.ts
+++ b/packages/aws/src/services/directory-service.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://directoryservice.amazonaws.com/doc/2015-04-16/",
@@ -4230,7 +4229,7 @@ export const acceptSharedDirectory: API.OperationMethod<
   AcceptSharedDirectoryRequest,
   AcceptSharedDirectoryResult,
   AcceptSharedDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptSharedDirectoryRequest,
   output: AcceptSharedDirectoryResult,
@@ -4270,7 +4269,7 @@ export const addIpRoutes: API.OperationMethod<
   AddIpRoutesRequest,
   AddIpRoutesResult,
   AddIpRoutesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddIpRoutesRequest,
   output: AddIpRoutesResult,
@@ -4307,7 +4306,7 @@ export const addRegion: API.OperationMethod<
   AddRegionRequest,
   AddRegionResult,
   AddRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRegionRequest,
   output: AddRegionResult,
@@ -4344,7 +4343,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceRequest,
   AddTagsToResourceResult,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceRequest,
   output: AddTagsToResourceResult,
@@ -4376,7 +4375,7 @@ export const cancelSchemaExtension: API.OperationMethod<
   CancelSchemaExtensionRequest,
   CancelSchemaExtensionResult,
   CancelSchemaExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSchemaExtensionRequest,
   output: CancelSchemaExtensionResult,
@@ -4403,7 +4402,7 @@ export const connectDirectory: API.OperationMethod<
   ConnectDirectoryRequest,
   ConnectDirectoryResult,
   ConnectDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConnectDirectoryRequest,
   output: ConnectDirectoryResult,
@@ -4436,7 +4435,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasRequest,
   CreateAliasResult,
   CreateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasRequest,
   output: CreateAliasResult,
@@ -4469,7 +4468,7 @@ export const createComputer: API.OperationMethod<
   CreateComputerRequest,
   CreateComputerResult,
   CreateComputerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComputerRequest,
   output: CreateComputerResult,
@@ -4506,7 +4505,7 @@ export const createConditionalForwarder: API.OperationMethod<
   CreateConditionalForwarderRequest,
   CreateConditionalForwarderResult,
   CreateConditionalForwarderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConditionalForwarderRequest,
   output: CreateConditionalForwarderResult,
@@ -4541,7 +4540,7 @@ export const createDirectory: API.OperationMethod<
   CreateDirectoryRequest,
   CreateDirectoryResult,
   CreateDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectoryRequest,
   output: CreateDirectoryResult,
@@ -4579,7 +4578,7 @@ export const createHybridAD: API.OperationMethod<
   CreateHybridADRequest,
   CreateHybridADResult,
   CreateHybridADError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHybridADRequest,
   output: CreateHybridADResult,
@@ -4613,7 +4612,7 @@ export const createLogSubscription: API.OperationMethod<
   CreateLogSubscriptionRequest,
   CreateLogSubscriptionResult,
   CreateLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLogSubscriptionRequest,
   output: CreateLogSubscriptionResult,
@@ -4648,7 +4647,7 @@ export const createMicrosoftAD: API.OperationMethod<
   CreateMicrosoftADRequest,
   CreateMicrosoftADResult,
   CreateMicrosoftADError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMicrosoftADRequest,
   output: CreateMicrosoftADResult,
@@ -4680,7 +4679,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotRequest,
   CreateSnapshotResult,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotRequest,
   output: CreateSnapshotResult,
@@ -4718,7 +4717,7 @@ export const createTrust: API.OperationMethod<
   CreateTrustRequest,
   CreateTrustResult,
   CreateTrustError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustRequest,
   output: CreateTrustResult,
@@ -4754,7 +4753,7 @@ export const deleteADAssessment: API.OperationMethod<
   DeleteADAssessmentRequest,
   DeleteADAssessmentResult,
   DeleteADAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteADAssessmentRequest,
   output: DeleteADAssessmentResult,
@@ -4786,7 +4785,7 @@ export const deleteConditionalForwarder: API.OperationMethod<
   DeleteConditionalForwarderRequest,
   DeleteConditionalForwarderResult,
   DeleteConditionalForwarderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConditionalForwarderRequest,
   output: DeleteConditionalForwarderResult,
@@ -4819,7 +4818,7 @@ export const deleteDirectory: API.OperationMethod<
   DeleteDirectoryRequest,
   DeleteDirectoryResult,
   DeleteDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectoryRequest,
   output: DeleteDirectoryResult,
@@ -4842,7 +4841,7 @@ export const deleteLogSubscription: API.OperationMethod<
   DeleteLogSubscriptionRequest,
   DeleteLogSubscriptionResult,
   DeleteLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLogSubscriptionRequest,
   output: DeleteLogSubscriptionResult,
@@ -4870,7 +4869,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotRequest,
   DeleteSnapshotResult,
   DeleteSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotRequest,
   output: DeleteSnapshotResult,
@@ -4900,7 +4899,7 @@ export const deleteTrust: API.OperationMethod<
   DeleteTrustRequest,
   DeleteTrustResult,
   DeleteTrustError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustRequest,
   output: DeleteTrustResult,
@@ -4934,7 +4933,7 @@ export const deregisterCertificate: API.OperationMethod<
   DeregisterCertificateRequest,
   DeregisterCertificateResult,
   DeregisterCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterCertificateRequest,
   output: DeregisterCertificateResult,
@@ -4966,7 +4965,7 @@ export const deregisterEventTopic: API.OperationMethod<
   DeregisterEventTopicRequest,
   DeregisterEventTopicResult,
   DeregisterEventTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterEventTopicRequest,
   output: DeregisterEventTopicResult,
@@ -4997,7 +4996,7 @@ export const describeADAssessment: API.OperationMethod<
   DescribeADAssessmentRequest,
   DescribeADAssessmentResult,
   DescribeADAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeADAssessmentRequest,
   output: DescribeADAssessmentResult,
@@ -5028,7 +5027,7 @@ export const describeCAEnrollmentPolicy: API.OperationMethod<
   DescribeCAEnrollmentPolicyRequest,
   DescribeCAEnrollmentPolicyResult,
   DescribeCAEnrollmentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCAEnrollmentPolicyRequest,
   output: DescribeCAEnrollmentPolicyResult,
@@ -5059,7 +5058,7 @@ export const describeCertificate: API.OperationMethod<
   DescribeCertificateRequest,
   DescribeCertificateResult,
   DescribeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateRequest,
   output: DescribeCertificateResult,
@@ -5094,7 +5093,7 @@ export const describeClientAuthenticationSettings: API.PaginatedOperationMethod<
   DescribeClientAuthenticationSettingsRequest,
   DescribeClientAuthenticationSettingsResult,
   DescribeClientAuthenticationSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientAuthenticationSettingInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientAuthenticationSettingsRequest,
@@ -5136,7 +5135,7 @@ export const describeConditionalForwarders: API.OperationMethod<
   DescribeConditionalForwardersRequest,
   DescribeConditionalForwardersResult,
   DescribeConditionalForwardersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConditionalForwardersRequest,
   output: DescribeConditionalForwardersResult,
@@ -5180,7 +5179,7 @@ export const describeDirectories: API.PaginatedOperationMethod<
   DescribeDirectoriesRequest,
   DescribeDirectoriesResult,
   DescribeDirectoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DirectoryDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDirectoriesRequest,
@@ -5218,7 +5217,7 @@ export const describeDirectoryDataAccess: API.OperationMethod<
   DescribeDirectoryDataAccessRequest,
   DescribeDirectoryDataAccessResult,
   DescribeDirectoryDataAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDirectoryDataAccessRequest,
   output: DescribeDirectoryDataAccessResult,
@@ -5249,7 +5248,7 @@ export const describeDomainControllers: API.PaginatedOperationMethod<
   DescribeDomainControllersRequest,
   DescribeDomainControllersResult,
   DescribeDomainControllersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDomainControllersRequest,
@@ -5289,7 +5288,7 @@ export const describeEventTopics: API.OperationMethod<
   DescribeEventTopicsRequest,
   DescribeEventTopicsResult,
   DescribeEventTopicsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventTopicsRequest,
   output: DescribeEventTopicsResult,
@@ -5321,7 +5320,7 @@ export const describeHybridADUpdate: API.OperationMethod<
   DescribeHybridADUpdateRequest,
   DescribeHybridADUpdateResult,
   DescribeHybridADUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHybridADUpdateRequest,
   output: DescribeHybridADUpdateResult,
@@ -5353,7 +5352,7 @@ export const describeLDAPSSettings: API.PaginatedOperationMethod<
   DescribeLDAPSSettingsRequest,
   DescribeLDAPSSettingsResult,
   DescribeLDAPSSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LDAPSSettingInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLDAPSSettingsRequest,
@@ -5394,7 +5393,7 @@ export const describeRegions: API.PaginatedOperationMethod<
   DescribeRegionsRequest,
   DescribeRegionsResult,
   DescribeRegionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegionDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegionsRequest,
@@ -5433,7 +5432,7 @@ export const describeSettings: API.OperationMethod<
   DescribeSettingsRequest,
   DescribeSettingsResult,
   DescribeSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSettingsRequest,
   output: DescribeSettingsResult,
@@ -5465,7 +5464,7 @@ export const describeSharedDirectories: API.PaginatedOperationMethod<
   DescribeSharedDirectoriesRequest,
   DescribeSharedDirectoriesResult,
   DescribeSharedDirectoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SharedDirectory
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSharedDirectoriesRequest,
@@ -5511,7 +5510,7 @@ export const describeSnapshots: API.PaginatedOperationMethod<
   DescribeSnapshotsRequest,
   DescribeSnapshotsResult,
   DescribeSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotsRequest,
@@ -5552,7 +5551,7 @@ export const describeTrusts: API.PaginatedOperationMethod<
   DescribeTrustsRequest,
   DescribeTrustsResult,
   DescribeTrustsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Trust
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrustsRequest,
@@ -5591,7 +5590,7 @@ export const describeUpdateDirectory: API.PaginatedOperationMethod<
   DescribeUpdateDirectoryRequest,
   DescribeUpdateDirectoryResult,
   DescribeUpdateDirectoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UpdateInfoEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUpdateDirectoryRequest,
@@ -5636,7 +5635,7 @@ export const disableCAEnrollmentPolicy: API.OperationMethod<
   DisableCAEnrollmentPolicyRequest,
   DisableCAEnrollmentPolicyResult,
   DisableCAEnrollmentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableCAEnrollmentPolicyRequest,
   output: DisableCAEnrollmentPolicyResult,
@@ -5670,7 +5669,7 @@ export const disableClientAuthentication: API.OperationMethod<
   DisableClientAuthenticationRequest,
   DisableClientAuthenticationResult,
   DisableClientAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableClientAuthenticationRequest,
   output: DisableClientAuthenticationResult,
@@ -5704,7 +5703,7 @@ export const disableDirectoryDataAccess: API.OperationMethod<
   DisableDirectoryDataAccessRequest,
   DisableDirectoryDataAccessResult,
   DisableDirectoryDataAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDirectoryDataAccessRequest,
   output: DisableDirectoryDataAccessResult,
@@ -5738,7 +5737,7 @@ export const disableLDAPS: API.OperationMethod<
   DisableLDAPSRequest,
   DisableLDAPSResult,
   DisableLDAPSError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableLDAPSRequest,
   output: DisableLDAPSResult,
@@ -5769,7 +5768,7 @@ export const disableRadius: API.OperationMethod<
   DisableRadiusRequest,
   DisableRadiusResult,
   DisableRadiusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRadiusRequest,
   output: DisableRadiusResult,
@@ -5793,7 +5792,7 @@ export const disableSso: API.OperationMethod<
   DisableSsoRequest,
   DisableSsoResult,
   DisableSsoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSsoRequest,
   output: DisableSsoResult,
@@ -5833,7 +5832,7 @@ export const enableCAEnrollmentPolicy: API.OperationMethod<
   EnableCAEnrollmentPolicyRequest,
   EnableCAEnrollmentPolicyResult,
   EnableCAEnrollmentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableCAEnrollmentPolicyRequest,
   output: EnableCAEnrollmentPolicyResult,
@@ -5869,7 +5868,7 @@ export const enableClientAuthentication: API.OperationMethod<
   EnableClientAuthenticationRequest,
   EnableClientAuthenticationResult,
   EnableClientAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableClientAuthenticationRequest,
   output: EnableClientAuthenticationResult,
@@ -5904,7 +5903,7 @@ export const enableDirectoryDataAccess: API.OperationMethod<
   EnableDirectoryDataAccessRequest,
   EnableDirectoryDataAccessResult,
   EnableDirectoryDataAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDirectoryDataAccessRequest,
   output: EnableDirectoryDataAccessResult,
@@ -5939,7 +5938,7 @@ export const enableLDAPS: API.OperationMethod<
   EnableLDAPSRequest,
   EnableLDAPSResult,
   EnableLDAPSError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableLDAPSRequest,
   output: EnableLDAPSResult,
@@ -5973,7 +5972,7 @@ export const enableRadius: API.OperationMethod<
   EnableRadiusRequest,
   EnableRadiusResult,
   EnableRadiusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRadiusRequest,
   output: EnableRadiusResult,
@@ -6005,7 +6004,7 @@ export const enableSso: API.OperationMethod<
   EnableSsoRequest,
   EnableSsoResult,
   EnableSsoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSsoRequest,
   output: EnableSsoResult,
@@ -6033,7 +6032,7 @@ export const getDirectoryLimits: API.OperationMethod<
   GetDirectoryLimitsRequest,
   GetDirectoryLimitsResult,
   GetDirectoryLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDirectoryLimitsRequest,
   output: GetDirectoryLimitsResult,
@@ -6055,7 +6054,7 @@ export const getSnapshotLimits: API.OperationMethod<
   GetSnapshotLimitsRequest,
   GetSnapshotLimitsResult,
   GetSnapshotLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSnapshotLimitsRequest,
   output: GetSnapshotLimitsResult,
@@ -6081,7 +6080,7 @@ export const listADAssessments: API.PaginatedOperationMethod<
   ListADAssessmentsRequest,
   ListADAssessmentsResult,
   ListADAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssessmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListADAssessmentsRequest,
@@ -6120,7 +6119,7 @@ export const listCertificates: API.PaginatedOperationMethod<
   ListCertificatesRequest,
   ListCertificatesResult,
   ListCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CertificateInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificatesRequest,
@@ -6158,7 +6157,7 @@ export const listIpRoutes: API.PaginatedOperationMethod<
   ListIpRoutesRequest,
   ListIpRoutesResult,
   ListIpRoutesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpRouteInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIpRoutesRequest,
@@ -6194,7 +6193,7 @@ export const listLogSubscriptions: API.PaginatedOperationMethod<
   ListLogSubscriptionsRequest,
   ListLogSubscriptionsResult,
   ListLogSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogSubscriptionsRequest,
@@ -6229,7 +6228,7 @@ export const listSchemaExtensions: API.PaginatedOperationMethod<
   ListSchemaExtensionsRequest,
   ListSchemaExtensionsResult,
   ListSchemaExtensionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaExtensionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemaExtensionsRequest,
@@ -6265,7 +6264,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -6306,7 +6305,7 @@ export const registerCertificate: API.OperationMethod<
   RegisterCertificateRequest,
   RegisterCertificateResult,
   RegisterCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCertificateRequest,
   output: RegisterCertificateResult,
@@ -6343,7 +6342,7 @@ export const registerEventTopic: API.OperationMethod<
   RegisterEventTopicRequest,
   RegisterEventTopicResult,
   RegisterEventTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterEventTopicRequest,
   output: RegisterEventTopicResult,
@@ -6372,7 +6371,7 @@ export const rejectSharedDirectory: API.OperationMethod<
   RejectSharedDirectoryRequest,
   RejectSharedDirectoryResult,
   RejectSharedDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectSharedDirectoryRequest,
   output: RejectSharedDirectoryResult,
@@ -6402,7 +6401,7 @@ export const removeIpRoutes: API.OperationMethod<
   RemoveIpRoutesRequest,
   RemoveIpRoutesResult,
   RemoveIpRoutesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveIpRoutesRequest,
   output: RemoveIpRoutesResult,
@@ -6435,7 +6434,7 @@ export const removeRegion: API.OperationMethod<
   RemoveRegionRequest,
   RemoveRegionResult,
   RemoveRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRegionRequest,
   output: RemoveRegionResult,
@@ -6465,7 +6464,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceRequest,
   RemoveTagsFromResourceResult,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceRequest,
   output: RemoveTagsFromResourceResult,
@@ -6511,7 +6510,7 @@ export const resetUserPassword: API.OperationMethod<
   ResetUserPasswordRequest,
   ResetUserPasswordResult,
   ResetUserPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetUserPasswordRequest,
   output: ResetUserPasswordResult,
@@ -6549,7 +6548,7 @@ export const restoreFromSnapshot: API.OperationMethod<
   RestoreFromSnapshotRequest,
   RestoreFromSnapshotResult,
   RestoreFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreFromSnapshotRequest,
   output: RestoreFromSnapshotResult,
@@ -6598,7 +6597,7 @@ export const shareDirectory: API.OperationMethod<
   ShareDirectoryRequest,
   ShareDirectoryResult,
   ShareDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ShareDirectoryRequest,
   output: ShareDirectoryResult,
@@ -6654,7 +6653,7 @@ export const startADAssessment: API.OperationMethod<
   StartADAssessmentRequest,
   StartADAssessmentResult,
   StartADAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartADAssessmentRequest,
   output: StartADAssessmentResult,
@@ -6686,7 +6685,7 @@ export const startSchemaExtension: API.OperationMethod<
   StartSchemaExtensionRequest,
   StartSchemaExtensionResult,
   StartSchemaExtensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSchemaExtensionRequest,
   output: StartSchemaExtensionResult,
@@ -6717,7 +6716,7 @@ export const unshareDirectory: API.OperationMethod<
   UnshareDirectoryRequest,
   UnshareDirectoryResult,
   UnshareDirectoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnshareDirectoryRequest,
   output: UnshareDirectoryResult,
@@ -6749,7 +6748,7 @@ export const updateConditionalForwarder: API.OperationMethod<
   UpdateConditionalForwarderRequest,
   UpdateConditionalForwarderResult,
   UpdateConditionalForwarderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConditionalForwarderRequest,
   output: UpdateConditionalForwarderResult,
@@ -6784,7 +6783,7 @@ export const updateDirectorySetup: API.OperationMethod<
   UpdateDirectorySetupRequest,
   UpdateDirectorySetupResult,
   UpdateDirectorySetupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectorySetupRequest,
   output: UpdateDirectorySetupResult,
@@ -6832,7 +6831,7 @@ export const updateHybridAD: API.OperationMethod<
   UpdateHybridADRequest,
   UpdateHybridADResult,
   UpdateHybridADError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHybridADRequest,
   output: UpdateHybridADResult,
@@ -6869,7 +6868,7 @@ export const updateNumberOfDomainControllers: API.OperationMethod<
   UpdateNumberOfDomainControllersRequest,
   UpdateNumberOfDomainControllersResult,
   UpdateNumberOfDomainControllersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNumberOfDomainControllersRequest,
   output: UpdateNumberOfDomainControllersResult,
@@ -6901,7 +6900,7 @@ export const updateRadius: API.OperationMethod<
   UpdateRadiusRequest,
   UpdateRadiusResult,
   UpdateRadiusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRadiusRequest,
   output: UpdateRadiusResult,
@@ -6933,7 +6932,7 @@ export const updateSettings: API.OperationMethod<
   UpdateSettingsRequest,
   UpdateSettingsResult,
   UpdateSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSettingsRequest,
   output: UpdateSettingsResult,
@@ -6966,7 +6965,7 @@ export const updateTrust: API.OperationMethod<
   UpdateTrustRequest,
   UpdateTrustResult,
   UpdateTrustError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustRequest,
   output: UpdateTrustResult,
@@ -6999,7 +6998,7 @@ export const verifyTrust: API.OperationMethod<
   VerifyTrustRequest,
   VerifyTrustResult,
   VerifyTrustError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyTrustRequest,
   output: VerifyTrustResult,

--- a/packages/aws/src/services/dlm.ts
+++ b/packages/aws/src/services/dlm.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "DLM", serviceShapeName: "dlm_20180112" });
 const auth = T.AwsAuthSigv4({ name: "dlm" });
 const ver = T.ServiceVersion("2018-01-12");
@@ -1029,7 +1028,7 @@ export const createLifecyclePolicy: API.OperationMethod<
   CreateLifecyclePolicyRequest,
   CreateLifecyclePolicyResponse,
   CreateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLifecyclePolicyRequest,
   output: CreateLifecyclePolicyResponse,
@@ -1059,7 +1058,7 @@ export const deleteLifecyclePolicy: API.OperationMethod<
   DeleteLifecyclePolicyRequest,
   DeleteLifecyclePolicyResponse,
   DeleteLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecyclePolicyRequest,
   output: DeleteLifecyclePolicyResponse,
@@ -1088,7 +1087,7 @@ export const getLifecyclePolicies: API.OperationMethod<
   GetLifecyclePoliciesRequest,
   GetLifecyclePoliciesResponse,
   GetLifecyclePoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecyclePoliciesRequest,
   output: GetLifecyclePoliciesResponse,
@@ -1115,7 +1114,7 @@ export const getLifecyclePolicy: API.OperationMethod<
   GetLifecyclePolicyRequest,
   GetLifecyclePolicyResponse,
   GetLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecyclePolicyRequest,
   output: GetLifecyclePolicyResponse,
@@ -1141,7 +1140,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1167,7 +1166,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1193,7 +1192,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1223,7 +1222,7 @@ export const updateLifecyclePolicy: API.OperationMethod<
   UpdateLifecyclePolicyRequest,
   UpdateLifecyclePolicyResponse,
   UpdateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLifecyclePolicyRequest,
   output: UpdateLifecyclePolicyResponse,

--- a/packages/aws/src/services/docdb-elastic.ts
+++ b/packages/aws/src/services/docdb-elastic.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "DocDB Elastic",
@@ -957,7 +956,7 @@ export const applyPendingMaintenanceAction: API.OperationMethod<
   ApplyPendingMaintenanceActionInput,
   ApplyPendingMaintenanceActionOutput,
   ApplyPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyPendingMaintenanceActionInput,
   output: ApplyPendingMaintenanceActionOutput,
@@ -990,7 +989,7 @@ export const copyClusterSnapshot: API.OperationMethod<
   CopyClusterSnapshotInput,
   CopyClusterSnapshotOutput,
   CopyClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyClusterSnapshotInput,
   output: CopyClusterSnapshotOutput,
@@ -1023,7 +1022,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterInput,
   CreateClusterOutput,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterInput,
   output: CreateClusterOutput,
@@ -1056,7 +1055,7 @@ export const createClusterSnapshot: API.OperationMethod<
   CreateClusterSnapshotInput,
   CreateClusterSnapshotOutput,
   CreateClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterSnapshotInput,
   output: CreateClusterSnapshotOutput,
@@ -1089,7 +1088,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterInput,
   DeleteClusterOutput,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterInput,
   output: DeleteClusterOutput,
@@ -1121,7 +1120,7 @@ export const deleteClusterSnapshot: API.OperationMethod<
   DeleteClusterSnapshotInput,
   DeleteClusterSnapshotOutput,
   DeleteClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterSnapshotInput,
   output: DeleteClusterSnapshotOutput,
@@ -1152,7 +1151,7 @@ export const getCluster: API.OperationMethod<
   GetClusterInput,
   GetClusterOutput,
   GetClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterInput,
   output: GetClusterOutput,
@@ -1182,7 +1181,7 @@ export const getClusterSnapshot: API.OperationMethod<
   GetClusterSnapshotInput,
   GetClusterSnapshotOutput,
   GetClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterSnapshotInput,
   output: GetClusterSnapshotOutput,
@@ -1213,7 +1212,7 @@ export const getPendingMaintenanceAction: API.OperationMethod<
   GetPendingMaintenanceActionInput,
   GetPendingMaintenanceActionOutput,
   GetPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPendingMaintenanceActionInput,
   output: GetPendingMaintenanceActionOutput,
@@ -1243,7 +1242,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersInput,
   ListClustersOutput,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterInList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersInput,
@@ -1278,7 +1277,7 @@ export const listClusterSnapshots: API.PaginatedOperationMethod<
   ListClusterSnapshotsInput,
   ListClusterSnapshotsOutput,
   ListClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSnapshotInList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterSnapshotsInput,
@@ -1313,7 +1312,7 @@ export const listPendingMaintenanceActions: API.PaginatedOperationMethod<
   ListPendingMaintenanceActionsInput,
   ListPendingMaintenanceActionsOutput,
   ListPendingMaintenanceActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePendingMaintenanceAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPendingMaintenanceActionsInput,
@@ -1348,7 +1347,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1379,7 +1378,7 @@ export const restoreClusterFromSnapshot: API.OperationMethod<
   RestoreClusterFromSnapshotInput,
   RestoreClusterFromSnapshotOutput,
   RestoreClusterFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreClusterFromSnapshotInput,
   output: RestoreClusterFromSnapshotOutput,
@@ -1411,7 +1410,7 @@ export const startCluster: API.OperationMethod<
   StartClusterInput,
   StartClusterOutput,
   StartClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartClusterInput,
   output: StartClusterOutput,
@@ -1442,7 +1441,7 @@ export const stopCluster: API.OperationMethod<
   StopClusterInput,
   StopClusterOutput,
   StopClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopClusterInput,
   output: StopClusterOutput,
@@ -1471,7 +1470,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1499,7 +1498,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1530,7 +1529,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterInput,
   UpdateClusterOutput,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterInput,
   output: UpdateClusterOutput,

--- a/packages/aws/src/services/docdb.ts
+++ b/packages/aws/src/services/docdb.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://rds.amazonaws.com/doc/2014-10-31/");
 const svc = T.AwsApiService({
@@ -3774,7 +3773,7 @@ export const addSourceIdentifierToSubscription: API.OperationMethod<
   AddSourceIdentifierToSubscriptionMessage,
   AddSourceIdentifierToSubscriptionResult,
   AddSourceIdentifierToSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddSourceIdentifierToSubscriptionMessage,
   output: AddSourceIdentifierToSubscriptionResult,
@@ -3799,7 +3798,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceMessage,
   AddTagsToResourceResponse,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceMessage,
   output: AddTagsToResourceResponse,
@@ -3826,7 +3825,7 @@ export const applyPendingMaintenanceAction: API.OperationMethod<
   ApplyPendingMaintenanceActionMessage,
   ApplyPendingMaintenanceActionResult,
   ApplyPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyPendingMaintenanceActionMessage,
   output: ApplyPendingMaintenanceActionResult,
@@ -3852,7 +3851,7 @@ export const copyDBClusterParameterGroup: API.OperationMethod<
   CopyDBClusterParameterGroupMessage,
   CopyDBClusterParameterGroupResult,
   CopyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterParameterGroupMessage,
   output: CopyDBClusterParameterGroupResult,
@@ -3892,7 +3891,7 @@ export const copyDBClusterSnapshot: API.OperationMethod<
   CopyDBClusterSnapshotMessage,
   CopyDBClusterSnapshotResult,
   CopyDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterSnapshotMessage,
   output: CopyDBClusterSnapshotResult,
@@ -3936,7 +3935,7 @@ export const createDBCluster: API.OperationMethod<
   CreateDBClusterMessage,
   CreateDBClusterResult,
   CreateDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterMessage,
   output: CreateDBClusterResult,
@@ -3995,7 +3994,7 @@ export const createDBClusterParameterGroup: API.OperationMethod<
   CreateDBClusterParameterGroupMessage,
   CreateDBClusterParameterGroupResult,
   CreateDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterParameterGroupMessage,
   output: CreateDBClusterParameterGroupResult,
@@ -4022,7 +4021,7 @@ export const createDBClusterSnapshot: API.OperationMethod<
   CreateDBClusterSnapshotMessage,
   CreateDBClusterSnapshotResult,
   CreateDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterSnapshotMessage,
   output: CreateDBClusterSnapshotResult,
@@ -4062,7 +4061,7 @@ export const createDBInstance: API.OperationMethod<
   CreateDBInstanceMessage,
   CreateDBInstanceResult,
   CreateDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBInstanceMessage,
   output: CreateDBInstanceResult,
@@ -4103,7 +4102,7 @@ export const createDBSubnetGroup: API.OperationMethod<
   CreateDBSubnetGroupMessage,
   CreateDBSubnetGroupResult,
   CreateDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBSubnetGroupMessage,
   output: CreateDBSubnetGroupResult,
@@ -4139,7 +4138,7 @@ export const createEventSubscription: API.OperationMethod<
   CreateEventSubscriptionMessage,
   CreateEventSubscriptionResult,
   CreateEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSubscriptionMessage,
   output: CreateEventSubscriptionResult,
@@ -4176,7 +4175,7 @@ export const createGlobalCluster: API.OperationMethod<
   CreateGlobalClusterMessage,
   CreateGlobalClusterResult,
   CreateGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalClusterMessage,
   output: CreateGlobalClusterResult,
@@ -4205,7 +4204,7 @@ export const deleteDBCluster: API.OperationMethod<
   DeleteDBClusterMessage,
   DeleteDBClusterResult,
   DeleteDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterMessage,
   output: DeleteDBClusterResult,
@@ -4232,7 +4231,7 @@ export const deleteDBClusterParameterGroup: API.OperationMethod<
   DeleteDBClusterParameterGroupMessage,
   DeleteDBClusterParameterGroupResponse,
   DeleteDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterParameterGroupMessage,
   output: DeleteDBClusterParameterGroupResponse,
@@ -4255,7 +4254,7 @@ export const deleteDBClusterSnapshot: API.OperationMethod<
   DeleteDBClusterSnapshotMessage,
   DeleteDBClusterSnapshotResult,
   DeleteDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterSnapshotMessage,
   output: DeleteDBClusterSnapshotResult,
@@ -4279,7 +4278,7 @@ export const deleteDBInstance: API.OperationMethod<
   DeleteDBInstanceMessage,
   DeleteDBInstanceResult,
   DeleteDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBInstanceMessage,
   output: DeleteDBInstanceResult,
@@ -4310,7 +4309,7 @@ export const deleteDBSubnetGroup: API.OperationMethod<
   DeleteDBSubnetGroupMessage,
   DeleteDBSubnetGroupResponse,
   DeleteDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBSubnetGroupMessage,
   output: DeleteDBSubnetGroupResponse,
@@ -4335,7 +4334,7 @@ export const deleteEventSubscription: API.OperationMethod<
   DeleteEventSubscriptionMessage,
   DeleteEventSubscriptionResult,
   DeleteEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSubscriptionMessage,
   output: DeleteEventSubscriptionResult,
@@ -4358,7 +4357,7 @@ export const deleteGlobalCluster: API.OperationMethod<
   DeleteGlobalClusterMessage,
   DeleteGlobalClusterResult,
   DeleteGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalClusterMessage,
   output: DeleteGlobalClusterResult,
@@ -4376,7 +4375,7 @@ export const describeCertificates: API.PaginatedOperationMethod<
   DescribeCertificatesMessage,
   CertificateMessage,
   DescribeCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Certificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCertificatesMessage,
@@ -4403,7 +4402,7 @@ export const describeDBClusterParameterGroups: API.PaginatedOperationMethod<
   DescribeDBClusterParameterGroupsMessage,
   DBClusterParameterGroupsMessage,
   DescribeDBClusterParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParameterGroupsMessage,
@@ -4431,7 +4430,7 @@ export const describeDBClusterParameters: API.PaginatedOperationMethod<
   DescribeDBClusterParametersMessage,
   DBClusterParameterGroupDetails,
   DescribeDBClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParametersMessage,
@@ -4461,7 +4460,7 @@ export const describeDBClusters: API.PaginatedOperationMethod<
   DescribeDBClustersMessage,
   DBClusterMessage,
   DescribeDBClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClustersMessage,
@@ -4492,7 +4491,7 @@ export const describeDBClusterSnapshotAttributes: API.OperationMethod<
   DescribeDBClusterSnapshotAttributesMessage,
   DescribeDBClusterSnapshotAttributesResult,
   DescribeDBClusterSnapshotAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDBClusterSnapshotAttributesMessage,
   output: DescribeDBClusterSnapshotAttributesResult,
@@ -4512,7 +4511,7 @@ export const describeDBClusterSnapshots: API.PaginatedOperationMethod<
   DescribeDBClusterSnapshotsMessage,
   DBClusterSnapshotMessage,
   DescribeDBClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterSnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterSnapshotsMessage,
@@ -4537,7 +4536,7 @@ export const describeDBEngineVersions: API.PaginatedOperationMethod<
   DescribeDBEngineVersionsMessage,
   DBEngineVersionMessage,
   DescribeDBEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBEngineVersionsMessage,
@@ -4562,7 +4561,7 @@ export const describeDBInstances: API.PaginatedOperationMethod<
   DescribeDBInstancesMessage,
   DBInstanceMessage,
   DescribeDBInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBInstancesMessage,
@@ -4590,7 +4589,7 @@ export const describeDBSubnetGroups: API.PaginatedOperationMethod<
   DescribeDBSubnetGroupsMessage,
   DBSubnetGroupMessage,
   DescribeDBSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSubnetGroupsMessage,
@@ -4616,7 +4615,7 @@ export const describeEngineDefaultClusterParameters: API.OperationMethod<
   DescribeEngineDefaultClusterParametersMessage,
   DescribeEngineDefaultClusterParametersResult,
   DescribeEngineDefaultClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEngineDefaultClusterParametersMessage,
   output: DescribeEngineDefaultClusterParametersResult,
@@ -4635,7 +4634,7 @@ export const describeEventCategories: API.OperationMethod<
   DescribeEventCategoriesMessage,
   EventCategoriesMessage,
   DescribeEventCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventCategoriesMessage,
   output: EventCategoriesMessage,
@@ -4653,7 +4652,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -4682,7 +4681,7 @@ export const describeEventSubscriptions: API.PaginatedOperationMethod<
   DescribeEventSubscriptionsMessage,
   EventSubscriptionsMessage,
   DescribeEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventSubscriptionsMessage,
@@ -4711,7 +4710,7 @@ export const describeGlobalClusters: API.PaginatedOperationMethod<
   DescribeGlobalClustersMessage,
   GlobalClustersMessage,
   DescribeGlobalClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGlobalClustersMessage,
@@ -4736,7 +4735,7 @@ export const describeOrderableDBInstanceOptions: API.PaginatedOperationMethod<
   DescribeOrderableDBInstanceOptionsMessage,
   OrderableDBInstanceOptionsMessage,
   DescribeOrderableDBInstanceOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrderableDBInstanceOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrderableDBInstanceOptionsMessage,
@@ -4764,7 +4763,7 @@ export const describePendingMaintenanceActions: API.PaginatedOperationMethod<
   DescribePendingMaintenanceActionsMessage,
   PendingMaintenanceActionsMessage,
   DescribePendingMaintenanceActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePendingMaintenanceActions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePendingMaintenanceActionsMessage,
@@ -4797,7 +4796,7 @@ export const failoverDBCluster: API.OperationMethod<
   FailoverDBClusterMessage,
   FailoverDBClusterResult,
   FailoverDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverDBClusterMessage,
   output: FailoverDBClusterResult,
@@ -4828,7 +4827,7 @@ export const failoverGlobalCluster: API.OperationMethod<
   FailoverGlobalClusterMessage,
   FailoverGlobalClusterResult,
   FailoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverGlobalClusterMessage,
   output: FailoverGlobalClusterResult,
@@ -4855,7 +4854,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   TagListMessage,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: TagListMessage,
@@ -4892,7 +4891,7 @@ export const modifyDBCluster: API.OperationMethod<
   ModifyDBClusterMessage,
   ModifyDBClusterResult,
   ModifyDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterMessage,
   output: ModifyDBClusterResult,
@@ -4942,7 +4941,7 @@ export const modifyDBClusterParameterGroup: API.OperationMethod<
   ModifyDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ModifyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -4966,7 +4965,7 @@ export const modifyDBClusterSnapshotAttribute: API.OperationMethod<
   ModifyDBClusterSnapshotAttributeMessage,
   ModifyDBClusterSnapshotAttributeResult,
   ModifyDBClusterSnapshotAttributeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterSnapshotAttributeMessage,
   output: ModifyDBClusterSnapshotAttributeResult,
@@ -5002,7 +5001,7 @@ export const modifyDBInstance: API.OperationMethod<
   ModifyDBInstanceMessage,
   ModifyDBInstanceResult,
   ModifyDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBInstanceMessage,
   output: ModifyDBInstanceResult,
@@ -5040,7 +5039,7 @@ export const modifyDBSubnetGroup: API.OperationMethod<
   ModifyDBSubnetGroupMessage,
   ModifyDBSubnetGroupResult,
   ModifyDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBSubnetGroupMessage,
   output: ModifyDBSubnetGroupResult,
@@ -5071,7 +5070,7 @@ export const modifyEventSubscription: API.OperationMethod<
   ModifyEventSubscriptionMessage,
   ModifyEventSubscriptionResult,
   ModifyEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEventSubscriptionMessage,
   output: ModifyEventSubscriptionResult,
@@ -5101,7 +5100,7 @@ export const modifyGlobalCluster: API.OperationMethod<
   ModifyGlobalClusterMessage,
   ModifyGlobalClusterResult,
   ModifyGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyGlobalClusterMessage,
   output: ModifyGlobalClusterResult,
@@ -5129,7 +5128,7 @@ export const rebootDBInstance: API.OperationMethod<
   RebootDBInstanceMessage,
   RebootDBInstanceResult,
   RebootDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDBInstanceMessage,
   output: RebootDBInstanceResult,
@@ -5153,7 +5152,7 @@ export const removeFromGlobalCluster: API.OperationMethod<
   RemoveFromGlobalClusterMessage,
   RemoveFromGlobalClusterResult,
   RemoveFromGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFromGlobalClusterMessage,
   output: RemoveFromGlobalClusterResult,
@@ -5179,7 +5178,7 @@ export const removeSourceIdentifierFromSubscription: API.OperationMethod<
   RemoveSourceIdentifierFromSubscriptionMessage,
   RemoveSourceIdentifierFromSubscriptionResult,
   RemoveSourceIdentifierFromSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveSourceIdentifierFromSubscriptionMessage,
   output: RemoveSourceIdentifierFromSubscriptionResult,
@@ -5201,7 +5200,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceMessage,
   RemoveTagsFromResourceResponse,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceMessage,
   output: RemoveTagsFromResourceResponse,
@@ -5234,7 +5233,7 @@ export const resetDBClusterParameterGroup: API.OperationMethod<
   ResetDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ResetDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -5272,7 +5271,7 @@ export const restoreDBClusterFromSnapshot: API.OperationMethod<
   RestoreDBClusterFromSnapshotMessage,
   RestoreDBClusterFromSnapshotResult,
   RestoreDBClusterFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterFromSnapshotMessage,
   output: RestoreDBClusterFromSnapshotResult,
@@ -5327,7 +5326,7 @@ export const restoreDBClusterToPointInTime: API.OperationMethod<
   RestoreDBClusterToPointInTimeMessage,
   RestoreDBClusterToPointInTimeResult,
   RestoreDBClusterToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterToPointInTimeMessage,
   output: RestoreDBClusterToPointInTimeResult,
@@ -5368,7 +5367,7 @@ export const startDBCluster: API.OperationMethod<
   StartDBClusterMessage,
   StartDBClusterResult,
   StartDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDBClusterMessage,
   output: StartDBClusterResult,
@@ -5397,7 +5396,7 @@ export const stopDBCluster: API.OperationMethod<
   StopDBClusterMessage,
   StopDBClusterResult,
   StopDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDBClusterMessage,
   output: StopDBClusterResult,
@@ -5424,7 +5423,7 @@ export const switchoverGlobalCluster: API.OperationMethod<
   SwitchoverGlobalClusterMessage,
   SwitchoverGlobalClusterResult,
   SwitchoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverGlobalClusterMessage,
   output: SwitchoverGlobalClusterResult,

--- a/packages/aws/src/services/drs.ts
+++ b/packages/aws/src/services/drs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "drs",
@@ -3052,7 +3051,7 @@ export const associateSourceNetworkStack: API.OperationMethod<
   AssociateSourceNetworkStackRequest,
   AssociateSourceNetworkStackResponse,
   AssociateSourceNetworkStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceNetworkStackRequest,
   output: AssociateSourceNetworkStackResponse,
@@ -3086,7 +3085,7 @@ export const createExtendedSourceServer: API.OperationMethod<
   CreateExtendedSourceServerRequest,
   CreateExtendedSourceServerResponse,
   CreateExtendedSourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExtendedSourceServerRequest,
   output: CreateExtendedSourceServerResponse,
@@ -3119,7 +3118,7 @@ export const createLaunchConfigurationTemplate: API.OperationMethod<
   CreateLaunchConfigurationTemplateRequest,
   CreateLaunchConfigurationTemplateResponse,
   CreateLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLaunchConfigurationTemplateRequest,
   output: CreateLaunchConfigurationTemplateResponse,
@@ -3151,7 +3150,7 @@ export const createReplicationConfigurationTemplate: API.OperationMethod<
   CreateReplicationConfigurationTemplateRequest,
   ReplicationConfigurationTemplate,
   CreateReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationConfigurationTemplateRequest,
   output: ReplicationConfigurationTemplate,
@@ -3184,7 +3183,7 @@ export const createSourceNetwork: API.OperationMethod<
   CreateSourceNetworkRequest,
   CreateSourceNetworkResponse,
   CreateSourceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSourceNetworkRequest,
   output: CreateSourceNetworkResponse,
@@ -3216,7 +3215,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -3246,7 +3245,7 @@ export const deleteLaunchAction: API.OperationMethod<
   DeleteLaunchActionRequest,
   DeleteLaunchActionResponse,
   DeleteLaunchActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLaunchActionRequest,
   output: DeleteLaunchActionResponse,
@@ -3276,7 +3275,7 @@ export const deleteLaunchConfigurationTemplate: API.OperationMethod<
   DeleteLaunchConfigurationTemplateRequest,
   DeleteLaunchConfigurationTemplateResponse,
   DeleteLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLaunchConfigurationTemplateRequest,
   output: DeleteLaunchConfigurationTemplateResponse,
@@ -3306,7 +3305,7 @@ export const deleteRecoveryInstance: API.OperationMethod<
   DeleteRecoveryInstanceRequest,
   DeleteRecoveryInstanceResponse,
   DeleteRecoveryInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecoveryInstanceRequest,
   output: DeleteRecoveryInstanceResponse,
@@ -3336,7 +3335,7 @@ export const deleteReplicationConfigurationTemplate: API.OperationMethod<
   DeleteReplicationConfigurationTemplateRequest,
   DeleteReplicationConfigurationTemplateResponse,
   DeleteReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationConfigurationTemplateRequest,
   output: DeleteReplicationConfigurationTemplateResponse,
@@ -3366,7 +3365,7 @@ export const deleteSourceNetwork: API.OperationMethod<
   DeleteSourceNetworkRequest,
   DeleteSourceNetworkResponse,
   DeleteSourceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceNetworkRequest,
   output: DeleteSourceNetworkResponse,
@@ -3396,7 +3395,7 @@ export const deleteSourceServer: API.OperationMethod<
   DeleteSourceServerRequest,
   DeleteSourceServerResponse,
   DeleteSourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceServerRequest,
   output: DeleteSourceServerResponse,
@@ -3425,7 +3424,7 @@ export const describeJobLogItems: API.PaginatedOperationMethod<
   DescribeJobLogItemsRequest,
   DescribeJobLogItemsResponse,
   DescribeJobLogItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobLog
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobLogItemsRequest,
@@ -3460,7 +3459,7 @@ export const describeJobs: API.PaginatedOperationMethod<
   DescribeJobsRequest,
   DescribeJobsResponse,
   DescribeJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobsRequest,
@@ -3496,7 +3495,7 @@ export const describeLaunchConfigurationTemplates: API.PaginatedOperationMethod<
   DescribeLaunchConfigurationTemplatesRequest,
   DescribeLaunchConfigurationTemplatesResponse,
   DescribeLaunchConfigurationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchConfigurationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLaunchConfigurationTemplatesRequest,
@@ -3532,7 +3531,7 @@ export const describeRecoveryInstances: API.PaginatedOperationMethod<
   DescribeRecoveryInstancesRequest,
   DescribeRecoveryInstancesResponse,
   DescribeRecoveryInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRecoveryInstancesRequest,
@@ -3568,7 +3567,7 @@ export const describeRecoverySnapshots: API.PaginatedOperationMethod<
   DescribeRecoverySnapshotsRequest,
   DescribeRecoverySnapshotsResponse,
   DescribeRecoverySnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoverySnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRecoverySnapshotsRequest,
@@ -3605,7 +3604,7 @@ export const describeReplicationConfigurationTemplates: API.PaginatedOperationMe
   DescribeReplicationConfigurationTemplatesRequest,
   DescribeReplicationConfigurationTemplatesResponse,
   DescribeReplicationConfigurationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplicationConfigurationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationConfigurationTemplatesRequest,
@@ -3641,7 +3640,7 @@ export const describeSourceNetworks: API.PaginatedOperationMethod<
   DescribeSourceNetworksRequest,
   DescribeSourceNetworksResponse,
   DescribeSourceNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceNetwork
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSourceNetworksRequest,
@@ -3676,7 +3675,7 @@ export const describeSourceServers: API.PaginatedOperationMethod<
   DescribeSourceServersRequest,
   DescribeSourceServersResponse,
   DescribeSourceServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSourceServersRequest,
@@ -3713,7 +3712,7 @@ export const disconnectRecoveryInstance: API.OperationMethod<
   DisconnectRecoveryInstanceRequest,
   DisconnectRecoveryInstanceResponse,
   DisconnectRecoveryInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectRecoveryInstanceRequest,
   output: DisconnectRecoveryInstanceResponse,
@@ -3744,7 +3743,7 @@ export const disconnectSourceServer: API.OperationMethod<
   DisconnectSourceServerRequest,
   SourceServer,
   DisconnectSourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectSourceServerRequest,
   output: SourceServer,
@@ -3775,7 +3774,7 @@ export const exportSourceNetworkCfnTemplate: API.OperationMethod<
   ExportSourceNetworkCfnTemplateRequest,
   ExportSourceNetworkCfnTemplateResponse,
   ExportSourceNetworkCfnTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportSourceNetworkCfnTemplateRequest,
   output: ExportSourceNetworkCfnTemplateResponse,
@@ -3805,7 +3804,7 @@ export const getFailbackReplicationConfiguration: API.OperationMethod<
   GetFailbackReplicationConfigurationRequest,
   GetFailbackReplicationConfigurationResponse,
   GetFailbackReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFailbackReplicationConfigurationRequest,
   output: GetFailbackReplicationConfigurationResponse,
@@ -3833,7 +3832,7 @@ export const getLaunchConfiguration: API.OperationMethod<
   GetLaunchConfigurationRequest,
   LaunchConfiguration,
   GetLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLaunchConfigurationRequest,
   output: LaunchConfiguration,
@@ -3862,7 +3861,7 @@ export const getReplicationConfiguration: API.OperationMethod<
   GetReplicationConfigurationRequest,
   ReplicationConfiguration,
   GetReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReplicationConfigurationRequest,
   output: ReplicationConfiguration,
@@ -3891,7 +3890,7 @@ export const initializeService: API.OperationMethod<
   InitializeServiceRequest,
   InitializeServiceResponse,
   InitializeServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitializeServiceRequest,
   output: InitializeServiceResponse,
@@ -3920,7 +3919,7 @@ export const listExtensibleSourceServers: API.PaginatedOperationMethod<
   ListExtensibleSourceServersRequest,
   ListExtensibleSourceServersResponse,
   ListExtensibleSourceServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StagingSourceServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExtensibleSourceServersRequest,
@@ -3957,7 +3956,7 @@ export const listLaunchActions: API.PaginatedOperationMethod<
   ListLaunchActionsRequest,
   ListLaunchActionsResponse,
   ListLaunchActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLaunchActionsRequest,
@@ -3994,7 +3993,7 @@ export const listStagingAccounts: API.PaginatedOperationMethod<
   ListStagingAccountsRequest,
   ListStagingAccountsResponse,
   ListStagingAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Account
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStagingAccountsRequest,
@@ -4031,7 +4030,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4062,7 +4061,7 @@ export const putLaunchAction: API.OperationMethod<
   PutLaunchActionRequest,
   PutLaunchActionResponse,
   PutLaunchActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLaunchActionRequest,
   output: PutLaunchActionResponse,
@@ -4093,7 +4092,7 @@ export const retryDataReplication: API.OperationMethod<
   RetryDataReplicationRequest,
   SourceServer,
   RetryDataReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryDataReplicationRequest,
   output: SourceServer,
@@ -4125,7 +4124,7 @@ export const reverseReplication: API.OperationMethod<
   ReverseReplicationRequest,
   ReverseReplicationResponse,
   ReverseReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReverseReplicationRequest,
   output: ReverseReplicationResponse,
@@ -4158,7 +4157,7 @@ export const startFailbackLaunch: API.OperationMethod<
   StartFailbackLaunchRequest,
   StartFailbackLaunchResponse,
   StartFailbackLaunchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFailbackLaunchRequest,
   output: StartFailbackLaunchResponse,
@@ -4189,7 +4188,7 @@ export const startRecovery: API.OperationMethod<
   StartRecoveryRequest,
   StartRecoveryResponse,
   StartRecoveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecoveryRequest,
   output: StartRecoveryResponse,
@@ -4219,7 +4218,7 @@ export const startReplication: API.OperationMethod<
   StartReplicationRequest,
   StartReplicationResponse,
   StartReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationRequest,
   output: StartReplicationResponse,
@@ -4250,7 +4249,7 @@ export const startSourceNetworkRecovery: API.OperationMethod<
   StartSourceNetworkRecoveryRequest,
   StartSourceNetworkRecoveryResponse,
   StartSourceNetworkRecoveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSourceNetworkRecoveryRequest,
   output: StartSourceNetworkRecoveryResponse,
@@ -4281,7 +4280,7 @@ export const startSourceNetworkReplication: API.OperationMethod<
   StartSourceNetworkReplicationRequest,
   StartSourceNetworkReplicationResponse,
   StartSourceNetworkReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSourceNetworkReplicationRequest,
   output: StartSourceNetworkReplicationResponse,
@@ -4310,7 +4309,7 @@ export const stopFailback: API.OperationMethod<
   StopFailbackRequest,
   StopFailbackResponse,
   StopFailbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFailbackRequest,
   output: StopFailbackResponse,
@@ -4339,7 +4338,7 @@ export const stopReplication: API.OperationMethod<
   StopReplicationRequest,
   StopReplicationResponse,
   StopReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopReplicationRequest,
   output: StopReplicationResponse,
@@ -4370,7 +4369,7 @@ export const stopSourceNetworkReplication: API.OperationMethod<
   StopSourceNetworkReplicationRequest,
   StopSourceNetworkReplicationResponse,
   StopSourceNetworkReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSourceNetworkReplicationRequest,
   output: StopSourceNetworkReplicationResponse,
@@ -4401,7 +4400,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4431,7 +4430,7 @@ export const terminateRecoveryInstances: API.OperationMethod<
   TerminateRecoveryInstancesRequest,
   TerminateRecoveryInstancesResponse,
   TerminateRecoveryInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateRecoveryInstancesRequest,
   output: TerminateRecoveryInstancesResponse,
@@ -4461,7 +4460,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4491,7 +4490,7 @@ export const updateFailbackReplicationConfiguration: API.OperationMethod<
   UpdateFailbackReplicationConfigurationRequest,
   UpdateFailbackReplicationConfigurationResponse,
   UpdateFailbackReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFailbackReplicationConfigurationRequest,
   output: UpdateFailbackReplicationConfigurationResponse,
@@ -4522,7 +4521,7 @@ export const updateLaunchConfiguration: API.OperationMethod<
   UpdateLaunchConfigurationRequest,
   LaunchConfiguration,
   UpdateLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLaunchConfigurationRequest,
   output: LaunchConfiguration,
@@ -4554,7 +4553,7 @@ export const updateLaunchConfigurationTemplate: API.OperationMethod<
   UpdateLaunchConfigurationTemplateRequest,
   UpdateLaunchConfigurationTemplateResponse,
   UpdateLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLaunchConfigurationTemplateRequest,
   output: UpdateLaunchConfigurationTemplateResponse,
@@ -4587,7 +4586,7 @@ export const updateReplicationConfiguration: API.OperationMethod<
   UpdateReplicationConfigurationRequest,
   ReplicationConfiguration,
   UpdateReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationConfigurationRequest,
   output: ReplicationConfiguration,
@@ -4620,7 +4619,7 @@ export const updateReplicationConfigurationTemplate: API.OperationMethod<
   UpdateReplicationConfigurationTemplateRequest,
   ReplicationConfigurationTemplate,
   UpdateReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationConfigurationTemplateRequest,
   output: ReplicationConfigurationTemplate,

--- a/packages/aws/src/services/dsql.ts
+++ b/packages/aws/src/services/dsql.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "DSQL", serviceShapeName: "DSQL" });
 const auth = T.AwsAuthSigv4({ name: "dsql" });
 const ver = T.ServiceVersion("2018-05-10");
@@ -953,7 +952,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterInput,
   CreateClusterOutput,
   CreateClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterInput,
   output: CreateClusterOutput,
@@ -1000,7 +999,7 @@ export const createStream: API.OperationMethod<
   CreateStreamInput,
   CreateStreamOutput,
   CreateStreamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamInput,
   output: CreateStreamOutput,
@@ -1026,7 +1025,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterInput,
   DeleteClusterOutput,
   DeleteClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterInput,
   output: DeleteClusterOutput,
@@ -1048,7 +1047,7 @@ export const deleteClusterPolicy: API.OperationMethod<
   DeleteClusterPolicyInput,
   DeleteClusterPolicyOutput,
   DeleteClusterPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterPolicyInput,
   output: DeleteClusterPolicyOutput,
@@ -1069,7 +1068,7 @@ export const deleteStream: API.OperationMethod<
   DeleteStreamInput,
   DeleteStreamOutput,
   DeleteStreamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamInput,
   output: DeleteStreamOutput,
@@ -1087,7 +1086,7 @@ export const getCluster: API.OperationMethod<
   GetClusterInput,
   GetClusterOutput,
   GetClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterInput,
   output: GetClusterOutput,
@@ -1108,7 +1107,7 @@ export const getClusterPolicy: API.OperationMethod<
   GetClusterPolicyInput,
   GetClusterPolicyOutput,
   GetClusterPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterPolicyInput,
   output: GetClusterPolicyOutput,
@@ -1126,7 +1125,7 @@ export const getStream: API.OperationMethod<
   GetStreamInput,
   GetStreamOutput,
   GetStreamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamInput,
   output: GetStreamOutput,
@@ -1149,7 +1148,7 @@ export const getVpcEndpointServiceName: API.OperationMethod<
   GetVpcEndpointServiceNameInput,
   GetVpcEndpointServiceNameOutput,
   GetVpcEndpointServiceNameError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcEndpointServiceNameInput,
   output: GetVpcEndpointServiceNameOutput,
@@ -1172,7 +1171,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersInput,
   ListClustersOutput,
   ListClustersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersInput,
@@ -1197,7 +1196,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsInput,
   ListStreamsOutput,
   ListStreamsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsInput,
@@ -1222,7 +1221,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1244,7 +1243,7 @@ export const putClusterPolicy: API.OperationMethod<
   PutClusterPolicyInput,
   PutClusterPolicyOutput,
   PutClusterPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutClusterPolicyInput,
   output: PutClusterPolicyOutput,
@@ -1265,7 +1264,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -1283,7 +1282,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -1359,7 +1358,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterInput,
   UpdateClusterOutput,
   UpdateClusterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterInput,
   output: UpdateClusterOutput,

--- a/packages/aws/src/services/dynamodb-streams.ts
+++ b/packages/aws/src/services/dynamodb-streams.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://dynamodb.amazonaws.com/doc/2012-08-10/");
 const svc = T.AwsApiService({
   sdkId: "DynamoDB Streams",
@@ -679,7 +678,7 @@ export const describeStream: API.OperationMethod<
   DescribeStreamInput,
   DescribeStreamOutput,
   DescribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamInput,
   output: DescribeStreamOutput,
@@ -712,7 +711,7 @@ export const getRecords: API.OperationMethod<
   GetRecordsInput,
   GetRecordsOutput,
   GetRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecordsInput,
   output: GetRecordsOutput,
@@ -746,7 +745,7 @@ export const getShardIterator: API.OperationMethod<
   GetShardIteratorInput,
   GetShardIteratorOutput,
   GetShardIteratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetShardIteratorInput,
   output: GetShardIteratorOutput,
@@ -775,7 +774,7 @@ export const listStreams: API.OperationMethod<
   ListStreamsInput,
   ListStreamsOutput,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStreamsInput,
   output: ListStreamsOutput,

--- a/packages/aws/src/services/dynamodb.ts
+++ b/packages/aws/src/services/dynamodb.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://dynamodb.amazonaws.com/doc/2012-08-10/");
 const svc = T.AwsApiService({
   sdkId: "DynamoDB",
@@ -5326,7 +5325,7 @@ export const batchExecuteStatement: API.OperationMethod<
   BatchExecuteStatementInput,
   BatchExecuteStatementOutput,
   BatchExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchExecuteStatementInput,
   output: BatchExecuteStatementOutput,
@@ -5406,7 +5405,7 @@ export const batchGetItem: API.OperationMethod<
   BatchGetItemInput,
   BatchGetItemOutput,
   BatchGetItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetItemInput,
   output: BatchGetItemOutput,
@@ -5523,7 +5522,7 @@ export const batchWriteItem: API.OperationMethod<
   BatchWriteItemInput,
   BatchWriteItemOutput,
   BatchWriteItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchWriteItemInput,
   output: BatchWriteItemOutput,
@@ -5587,7 +5586,7 @@ export const createBackup: API.OperationMethod<
   CreateBackupInput,
   CreateBackupOutput,
   CreateBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackupInput,
   output: CreateBackupOutput,
@@ -5662,7 +5661,7 @@ export const createGlobalTable: API.OperationMethod<
   CreateGlobalTableInput,
   CreateGlobalTableOutput,
   CreateGlobalTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalTableInput,
   output: CreateGlobalTableOutput,
@@ -5705,7 +5704,7 @@ export const createTable: API.OperationMethod<
   CreateTableInput,
   CreateTableOutput,
   CreateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableInput,
   output: CreateTableOutput,
@@ -5737,7 +5736,7 @@ export const deleteBackup: API.OperationMethod<
   DeleteBackupInput,
   DeleteBackupOutput,
   DeleteBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupInput,
   output: DeleteBackupOutput,
@@ -5785,7 +5784,7 @@ export const deleteItem: API.OperationMethod<
   DeleteItemInput,
   DeleteItemOutput,
   DeleteItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteItemInput,
   output: DeleteItemOutput,
@@ -5839,7 +5838,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyInput,
   DeleteResourcePolicyOutput,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyInput,
   output: DeleteResourcePolicyOutput,
@@ -5890,7 +5889,7 @@ export const deleteTable: API.OperationMethod<
   DeleteTableInput,
   DeleteTableOutput,
   DeleteTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableInput,
   output: DeleteTableOutput,
@@ -5921,7 +5920,7 @@ export const describeBackup: API.OperationMethod<
   DescribeBackupInput,
   DescribeBackupOutput,
   DescribeBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBackupInput,
   output: DescribeBackupOutput,
@@ -5961,7 +5960,7 @@ export const describeContinuousBackups: API.OperationMethod<
   DescribeContinuousBackupsInput,
   DescribeContinuousBackupsOutput,
   DescribeContinuousBackupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContinuousBackupsInput,
   output: DescribeContinuousBackupsOutput,
@@ -5987,7 +5986,7 @@ export const describeContributorInsights: API.OperationMethod<
   DescribeContributorInsightsInput,
   DescribeContributorInsightsOutput,
   DescribeContributorInsightsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContributorInsightsInput,
   output: DescribeContributorInsightsOutput,
@@ -6006,7 +6005,7 @@ export const describeEndpoints: API.OperationMethod<
   DescribeEndpointsRequest,
   DescribeEndpointsResponse,
   DescribeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointsRequest,
   output: DescribeEndpointsResponse,
@@ -6028,7 +6027,7 @@ export const describeExport: API.OperationMethod<
   DescribeExportInput,
   DescribeExportOutput,
   DescribeExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExportInput,
   output: DescribeExportOutput,
@@ -6058,7 +6057,7 @@ export const describeGlobalTable: API.OperationMethod<
   DescribeGlobalTableInput,
   DescribeGlobalTableOutput,
   DescribeGlobalTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGlobalTableInput,
   output: DescribeGlobalTableOutput,
@@ -6088,7 +6087,7 @@ export const describeGlobalTableSettings: API.OperationMethod<
   DescribeGlobalTableSettingsInput,
   DescribeGlobalTableSettingsOutput,
   DescribeGlobalTableSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGlobalTableSettingsInput,
   output: DescribeGlobalTableSettingsOutput,
@@ -6110,7 +6109,7 @@ export const describeImport: API.OperationMethod<
   DescribeImportInput,
   DescribeImportOutput,
   DescribeImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImportInput,
   output: DescribeImportOutput,
@@ -6132,7 +6131,7 @@ export const describeKinesisStreamingDestination: API.OperationMethod<
   DescribeKinesisStreamingDestinationInput,
   DescribeKinesisStreamingDestinationOutput,
   DescribeKinesisStreamingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKinesisStreamingDestinationInput,
   output: DescribeKinesisStreamingDestinationOutput,
@@ -6219,7 +6218,7 @@ export const describeLimits: API.OperationMethod<
   DescribeLimitsInput,
   DescribeLimitsOutput,
   DescribeLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLimitsInput,
   output: DescribeLimitsOutput,
@@ -6249,7 +6248,7 @@ export const describeTable: API.OperationMethod<
   DescribeTableInput,
   DescribeTableOutput,
   DescribeTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTableInput,
   output: DescribeTableOutput,
@@ -6274,7 +6273,7 @@ export const describeTableReplicaAutoScaling: API.OperationMethod<
   DescribeTableReplicaAutoScalingInput,
   DescribeTableReplicaAutoScalingOutput,
   DescribeTableReplicaAutoScalingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTableReplicaAutoScalingInput,
   output: DescribeTableReplicaAutoScalingOutput,
@@ -6296,7 +6295,7 @@ export const describeTimeToLive: API.OperationMethod<
   DescribeTimeToLiveInput,
   DescribeTimeToLiveOutput,
   DescribeTimeToLiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTimeToLiveInput,
   output: DescribeTimeToLiveOutput,
@@ -6325,7 +6324,7 @@ export const disableKinesisStreamingDestination: API.OperationMethod<
   KinesisStreamingDestinationInput,
   KinesisStreamingDestinationOutput,
   DisableKinesisStreamingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: KinesisStreamingDestinationInput,
   output: KinesisStreamingDestinationOutput,
@@ -6358,7 +6357,7 @@ export const enableKinesisStreamingDestination: API.OperationMethod<
   KinesisStreamingDestinationInput,
   KinesisStreamingDestinationOutput,
   EnableKinesisStreamingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: KinesisStreamingDestinationInput,
   output: KinesisStreamingDestinationOutput,
@@ -6406,7 +6405,7 @@ export const executeStatement: API.OperationMethod<
   ExecuteStatementInput,
   ExecuteStatementOutput,
   ExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteStatementInput,
   output: ExecuteStatementOutput,
@@ -6449,7 +6448,7 @@ export const executeTransaction: API.OperationMethod<
   ExecuteTransactionInput,
   ExecuteTransactionOutput,
   ExecuteTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteTransactionInput,
   output: ExecuteTransactionOutput,
@@ -6485,7 +6484,7 @@ export const exportTableToPointInTime: API.OperationMethod<
   ExportTableToPointInTimeInput,
   ExportTableToPointInTimeOutput,
   ExportTableToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportTableToPointInTimeInput,
   output: ExportTableToPointInTimeOutput,
@@ -6524,7 +6523,7 @@ export const getItem: API.OperationMethod<
   GetItemInput,
   GetItemOutput,
   GetItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetItemInput,
   output: GetItemOutput,
@@ -6586,7 +6585,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -6613,7 +6612,7 @@ export const importTable: API.OperationMethod<
   ImportTableInput,
   ImportTableOutput,
   ImportTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportTableInput,
   output: ImportTableOutput,
@@ -6651,7 +6650,7 @@ export const listBackups: API.OperationMethod<
   ListBackupsInput,
   ListBackupsOutput,
   ListBackupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBackupsInput,
   output: ListBackupsOutput,
@@ -6673,7 +6672,7 @@ export const listContributorInsights: API.PaginatedOperationMethod<
   ListContributorInsightsInput,
   ListContributorInsightsOutput,
   ListContributorInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContributorInsightsInput,
@@ -6700,7 +6699,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsInput,
   ListExportsOutput,
   ListExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsInput,
@@ -6731,7 +6730,7 @@ export const listGlobalTables: API.OperationMethod<
   ListGlobalTablesInput,
   ListGlobalTablesOutput,
   ListGlobalTablesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGlobalTablesInput,
   output: ListGlobalTablesOutput,
@@ -6749,7 +6748,7 @@ export const listImports: API.PaginatedOperationMethod<
   ListImportsInput,
   ListImportsOutput,
   ListImportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportsInput,
@@ -6778,7 +6777,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesInput,
   ListTablesOutput,
   ListTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesInput,
@@ -6811,7 +6810,7 @@ export const listTagsOfResource: API.OperationMethod<
   ListTagsOfResourceInput,
   ListTagsOfResourceOutput,
   ListTagsOfResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsOfResourceInput,
   output: ListTagsOfResourceOutput,
@@ -6871,7 +6870,7 @@ export const putItem: API.OperationMethod<
   PutItemInput,
   PutItemOutput,
   PutItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutItemInput,
   output: PutItemOutput,
@@ -6926,7 +6925,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyInput,
   PutResourcePolicyOutput,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyInput,
   output: PutResourcePolicyOutput,
@@ -7009,7 +7008,7 @@ export const query: API.PaginatedOperationMethod<
   QueryInput,
   QueryOutput,
   QueryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   { [key: string]: AttributeValue | undefined }
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryInput,
@@ -7067,7 +7066,7 @@ export const restoreTableFromBackup: API.OperationMethod<
   RestoreTableFromBackupInput,
   RestoreTableFromBackupOutput,
   RestoreTableFromBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableFromBackupInput,
   output: RestoreTableFromBackupOutput,
@@ -7139,7 +7138,7 @@ export const restoreTableToPointInTime: API.OperationMethod<
   RestoreTableToPointInTimeInput,
   RestoreTableToPointInTimeOutput,
   RestoreTableToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableToPointInTimeInput,
   output: RestoreTableToPointInTimeOutput,
@@ -7215,7 +7214,7 @@ export const scan: API.PaginatedOperationMethod<
   ScanInput,
   ScanOutput,
   ScanError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   { [key: string]: AttributeValue | undefined }
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ScanInput,
@@ -7272,7 +7271,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -7324,7 +7323,7 @@ export const transactGetItems: API.OperationMethod<
   TransactGetItemsInput,
   TransactGetItemsOutput,
   TransactGetItemsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransactGetItemsInput,
   output: TransactGetItemsOutput,
@@ -7415,7 +7414,7 @@ export const transactWriteItems: API.OperationMethod<
   TransactWriteItemsInput,
   TransactWriteItemsOutput,
   TransactWriteItemsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransactWriteItemsInput,
   output: TransactWriteItemsOutput,
@@ -7466,7 +7465,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -7507,7 +7506,7 @@ export const updateContinuousBackups: API.OperationMethod<
   UpdateContinuousBackupsInput,
   UpdateContinuousBackupsOutput,
   UpdateContinuousBackupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContinuousBackupsInput,
   output: UpdateContinuousBackupsOutput,
@@ -7539,7 +7538,7 @@ export const updateContributorInsights: API.OperationMethod<
   UpdateContributorInsightsInput,
   UpdateContributorInsightsOutput,
   UpdateContributorInsightsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContributorInsightsInput,
   output: UpdateContributorInsightsOutput,
@@ -7589,7 +7588,7 @@ export const updateGlobalTable: API.OperationMethod<
   UpdateGlobalTableInput,
   UpdateGlobalTableOutput,
   UpdateGlobalTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalTableInput,
   output: UpdateGlobalTableOutput,
@@ -7626,7 +7625,7 @@ export const updateGlobalTableSettings: API.OperationMethod<
   UpdateGlobalTableSettingsInput,
   UpdateGlobalTableSettingsOutput,
   UpdateGlobalTableSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalTableSettingsInput,
   output: UpdateGlobalTableSettingsOutput,
@@ -7670,7 +7669,7 @@ export const updateItem: API.OperationMethod<
   UpdateItemInput,
   UpdateItemOutput,
   UpdateItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateItemInput,
   output: UpdateItemOutput,
@@ -7705,7 +7704,7 @@ export const updateKinesisStreamingDestination: API.OperationMethod<
   UpdateKinesisStreamingDestinationInput,
   UpdateKinesisStreamingDestinationOutput,
   UpdateKinesisStreamingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKinesisStreamingDestinationInput,
   output: UpdateKinesisStreamingDestinationOutput,
@@ -7752,7 +7751,7 @@ export const updateTable: API.OperationMethod<
   UpdateTableInput,
   UpdateTableOutput,
   UpdateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableInput,
   output: UpdateTableOutput,
@@ -7781,7 +7780,7 @@ export const updateTableReplicaAutoScaling: API.OperationMethod<
   UpdateTableReplicaAutoScalingInput,
   UpdateTableReplicaAutoScalingOutput,
   UpdateTableReplicaAutoScalingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableReplicaAutoScalingInput,
   output: UpdateTableReplicaAutoScalingOutput,
@@ -7836,7 +7835,7 @@ export const updateTimeToLive: API.OperationMethod<
   UpdateTimeToLiveInput,
   UpdateTimeToLiveOutput,
   UpdateTimeToLiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTimeToLiveInput,
   output: UpdateTimeToLiveOutput,

--- a/packages/aws/src/services/ebs.ts
+++ b/packages/aws/src/services/ebs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "EBS", serviceShapeName: "Ebs" });
 const auth = T.AwsAuthSigv4({ name: "ebs" });
@@ -594,7 +593,7 @@ export const completeSnapshot: API.OperationMethod<
   CompleteSnapshotRequest,
   CompleteSnapshotResponse,
   CompleteSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteSnapshotRequest,
   output: CompleteSnapshotResponse,
@@ -632,7 +631,7 @@ export const getSnapshotBlock: API.OperationMethod<
   GetSnapshotBlockRequest,
   GetSnapshotBlockResponse,
   GetSnapshotBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSnapshotBlockRequest,
   output: GetSnapshotBlockResponse,
@@ -670,7 +669,7 @@ export const listChangedBlocks: API.PaginatedOperationMethod<
   ListChangedBlocksRequest,
   ListChangedBlocksResponse,
   ListChangedBlocksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChangedBlocksRequest,
@@ -713,7 +712,7 @@ export const listSnapshotBlocks: API.PaginatedOperationMethod<
   ListSnapshotBlocksRequest,
   ListSnapshotBlocksResponse,
   ListSnapshotBlocksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSnapshotBlocksRequest,
@@ -761,7 +760,7 @@ export const putSnapshotBlock: API.OperationMethod<
   PutSnapshotBlockRequest,
   PutSnapshotBlockResponse,
   PutSnapshotBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSnapshotBlockRequest,
   output: PutSnapshotBlockResponse,
@@ -805,7 +804,7 @@ export const startSnapshot: API.OperationMethod<
   StartSnapshotRequest,
   StartSnapshotResponse,
   StartSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSnapshotRequest,
   output: StartSnapshotResponse,

--- a/packages/aws/src/services/ec2-instance-connect.ts
+++ b/packages/aws/src/services/ec2-instance-connect.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "EC2 Instance Connect",
   serviceShapeName: "AWSEC2InstanceConnectService",
@@ -301,7 +300,7 @@ export const sendSerialConsoleSSHPublicKey: API.OperationMethod<
   SendSerialConsoleSSHPublicKeyRequest,
   SendSerialConsoleSSHPublicKeyResponse,
   SendSerialConsoleSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendSerialConsoleSSHPublicKeyRequest,
   output: SendSerialConsoleSSHPublicKeyResponse,
@@ -343,7 +342,7 @@ export const sendSSHPublicKey: API.OperationMethod<
   SendSSHPublicKeyRequest,
   SendSSHPublicKeyResponse,
   SendSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendSSHPublicKeyRequest,
   output: SendSSHPublicKeyResponse,

--- a/packages/aws/src/services/ec2.ts
+++ b/packages/aws/src/services/ec2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://ec2.amazonaws.com/doc/2016-11-15");
 const svc = T.AwsApiService({ sdkId: "EC2", serviceShapeName: "AmazonEC2" });
@@ -74447,7 +74446,7 @@ export const acceptAddressTransfer: API.OperationMethod<
   AcceptAddressTransferRequest,
   AcceptAddressTransferResult,
   AcceptAddressTransferError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAddressTransferRequest,
   output: AcceptAddressTransferResult,
@@ -74476,7 +74475,7 @@ export const acceptCapacityReservationBillingOwnership: API.OperationMethod<
   AcceptCapacityReservationBillingOwnershipRequest,
   AcceptCapacityReservationBillingOwnershipResult,
   AcceptCapacityReservationBillingOwnershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptCapacityReservationBillingOwnershipRequest,
   output: AcceptCapacityReservationBillingOwnershipResult,
@@ -74502,7 +74501,7 @@ export const acceptReservedInstancesExchangeQuote: API.OperationMethod<
   AcceptReservedInstancesExchangeQuoteRequest,
   AcceptReservedInstancesExchangeQuoteResult,
   AcceptReservedInstancesExchangeQuoteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptReservedInstancesExchangeQuoteRequest,
   output: AcceptReservedInstancesExchangeQuoteResult,
@@ -74524,7 +74523,7 @@ export const acceptTransitGatewayClientVpnAttachment: API.OperationMethod<
   AcceptTransitGatewayClientVpnAttachmentRequest,
   AcceptTransitGatewayClientVpnAttachmentResult,
   AcceptTransitGatewayClientVpnAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptTransitGatewayClientVpnAttachmentRequest,
   output: AcceptTransitGatewayClientVpnAttachmentResult,
@@ -74546,7 +74545,7 @@ export const acceptTransitGatewayMulticastDomainAssociations: API.OperationMetho
   AcceptTransitGatewayMulticastDomainAssociationsRequest,
   AcceptTransitGatewayMulticastDomainAssociationsResult,
   AcceptTransitGatewayMulticastDomainAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptTransitGatewayMulticastDomainAssociationsRequest,
   output: AcceptTransitGatewayMulticastDomainAssociationsResult,
@@ -74569,7 +74568,7 @@ export const acceptTransitGatewayPeeringAttachment: API.OperationMethod<
   AcceptTransitGatewayPeeringAttachmentRequest,
   AcceptTransitGatewayPeeringAttachmentResult,
   AcceptTransitGatewayPeeringAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptTransitGatewayPeeringAttachmentRequest,
   output: AcceptTransitGatewayPeeringAttachmentResult,
@@ -74599,7 +74598,7 @@ export const acceptTransitGatewayVpcAttachment: API.OperationMethod<
   AcceptTransitGatewayVpcAttachmentRequest,
   AcceptTransitGatewayVpcAttachmentResult,
   AcceptTransitGatewayVpcAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptTransitGatewayVpcAttachmentRequest,
   output: AcceptTransitGatewayVpcAttachmentResult,
@@ -74626,7 +74625,7 @@ export const acceptVpcEndpointConnections: API.OperationMethod<
   AcceptVpcEndpointConnectionsRequest,
   AcceptVpcEndpointConnectionsResult,
   AcceptVpcEndpointConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptVpcEndpointConnectionsRequest,
   output: AcceptVpcEndpointConnectionsResult,
@@ -74660,7 +74659,7 @@ export const acceptVpcPeeringConnection: API.OperationMethod<
   AcceptVpcPeeringConnectionRequest,
   AcceptVpcPeeringConnectionResult,
   AcceptVpcPeeringConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptVpcPeeringConnectionRequest,
   output: AcceptVpcPeeringConnectionResult,
@@ -74698,7 +74697,7 @@ export const advertiseByoipCidr: API.OperationMethod<
   AdvertiseByoipCidrRequest,
   AdvertiseByoipCidrResult,
   AdvertiseByoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdvertiseByoipCidrRequest,
   output: AdvertiseByoipCidrResult,
@@ -74744,7 +74743,7 @@ export const allocateAddress: API.OperationMethod<
   AllocateAddressRequest,
   AllocateAddressResult,
   AllocateAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateAddressRequest,
   output: AllocateAddressResult,
@@ -74769,7 +74768,7 @@ export const allocateHosts: API.OperationMethod<
   AllocateHostsRequest,
   AllocateHostsResult,
   AllocateHostsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateHostsRequest,
   output: AllocateHostsResult,
@@ -74800,7 +74799,7 @@ export const allocateIpamPoolCidr: API.OperationMethod<
   AllocateIpamPoolCidrRequest,
   AllocateIpamPoolCidrResult,
   AllocateIpamPoolCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateIpamPoolCidrRequest,
   output: AllocateIpamPoolCidrResult,
@@ -74827,7 +74826,7 @@ export const applySecurityGroupsToClientVpnTargetNetwork: API.OperationMethod<
   ApplySecurityGroupsToClientVpnTargetNetworkRequest,
   ApplySecurityGroupsToClientVpnTargetNetworkResult,
   ApplySecurityGroupsToClientVpnTargetNetworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplySecurityGroupsToClientVpnTargetNetworkRequest,
   output: ApplySecurityGroupsToClientVpnTargetNetworkResult,
@@ -74861,7 +74860,7 @@ export const assignIpv6Addresses: API.OperationMethod<
   AssignIpv6AddressesRequest,
   AssignIpv6AddressesResult,
   AssignIpv6AddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssignIpv6AddressesRequest,
   output: AssignIpv6AddressesResult,
@@ -74913,7 +74912,7 @@ export const assignPrivateIpAddresses: API.OperationMethod<
   AssignPrivateIpAddressesRequest,
   AssignPrivateIpAddressesResult,
   AssignPrivateIpAddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssignPrivateIpAddressesRequest,
   output: AssignPrivateIpAddressesResult,
@@ -74942,7 +74941,7 @@ export const assignPrivateNatGatewayAddress: API.OperationMethod<
   AssignPrivateNatGatewayAddressRequest,
   AssignPrivateNatGatewayAddressResult,
   AssignPrivateNatGatewayAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssignPrivateNatGatewayAddressRequest,
   output: AssignPrivateNatGatewayAddressResult,
@@ -74986,7 +74985,7 @@ export const associateAddress: API.OperationMethod<
   AssociateAddressRequest,
   AssociateAddressResult,
   AssociateAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAddressRequest,
   output: AssociateAddressResult,
@@ -75019,7 +75018,7 @@ export const associateCapacityReservationBillingOwner: API.OperationMethod<
   AssociateCapacityReservationBillingOwnerRequest,
   AssociateCapacityReservationBillingOwnerResult,
   AssociateCapacityReservationBillingOwnerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCapacityReservationBillingOwnerRequest,
   output: AssociateCapacityReservationBillingOwnerResult,
@@ -75049,7 +75048,7 @@ export const associateClientVpnTargetNetwork: API.OperationMethod<
   AssociateClientVpnTargetNetworkRequest,
   AssociateClientVpnTargetNetworkResult,
   AssociateClientVpnTargetNetworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateClientVpnTargetNetworkRequest,
   output: AssociateClientVpnTargetNetworkResult,
@@ -75083,7 +75082,7 @@ export const associateDhcpOptions: API.OperationMethod<
   AssociateDhcpOptionsRequest,
   AssociateDhcpOptionsResponse,
   AssociateDhcpOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDhcpOptionsRequest,
   output: AssociateDhcpOptionsResponse,
@@ -75126,7 +75125,7 @@ export const associateEnclaveCertificateIamRole: API.OperationMethod<
   AssociateEnclaveCertificateIamRoleRequest,
   AssociateEnclaveCertificateIamRoleResult,
   AssociateEnclaveCertificateIamRoleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEnclaveCertificateIamRoleRequest,
   output: AssociateEnclaveCertificateIamRoleResult,
@@ -75154,7 +75153,7 @@ export const associateIamInstanceProfile: API.OperationMethod<
   AssociateIamInstanceProfileRequest,
   AssociateIamInstanceProfileResult,
   AssociateIamInstanceProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIamInstanceProfileRequest,
   output: AssociateIamInstanceProfileResult,
@@ -75180,7 +75179,7 @@ export const associateInstanceEventWindow: API.OperationMethod<
   AssociateInstanceEventWindowRequest,
   AssociateInstanceEventWindowResult,
   AssociateInstanceEventWindowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateInstanceEventWindowRequest,
   output: AssociateInstanceEventWindowResult,
@@ -75206,7 +75205,7 @@ export const associateIpamByoasn: API.OperationMethod<
   AssociateIpamByoasnRequest,
   AssociateIpamByoasnResult,
   AssociateIpamByoasnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIpamByoasnRequest,
   output: AssociateIpamByoasnResult,
@@ -75229,7 +75228,7 @@ export const associateIpamResourceDiscovery: API.OperationMethod<
   AssociateIpamResourceDiscoveryRequest,
   AssociateIpamResourceDiscoveryResult,
   AssociateIpamResourceDiscoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIpamResourceDiscoveryRequest,
   output: AssociateIpamResourceDiscoveryResult,
@@ -75268,7 +75267,7 @@ export const associateNatGatewayAddress: API.OperationMethod<
   AssociateNatGatewayAddressRequest,
   AssociateNatGatewayAddressResult,
   AssociateNatGatewayAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateNatGatewayAddressRequest,
   output: AssociateNatGatewayAddressResult,
@@ -75300,7 +75299,7 @@ export const associateRouteServer: API.OperationMethod<
   AssociateRouteServerRequest,
   AssociateRouteServerResult,
   AssociateRouteServerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateRouteServerRequest,
   output: AssociateRouteServerResult,
@@ -75340,7 +75339,7 @@ export const associateRouteTable: API.OperationMethod<
   AssociateRouteTableRequest,
   AssociateRouteTableResult,
   AssociateRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateRouteTableRequest,
   output: AssociateRouteTableResult,
@@ -75384,7 +75383,7 @@ export const associateSecurityGroupVpc: API.OperationMethod<
   AssociateSecurityGroupVpcRequest,
   AssociateSecurityGroupVpcResult,
   AssociateSecurityGroupVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSecurityGroupVpcRequest,
   output: AssociateSecurityGroupVpcResult,
@@ -75413,7 +75412,7 @@ export const associateSubnetCidrBlock: API.OperationMethod<
   AssociateSubnetCidrBlockRequest,
   AssociateSubnetCidrBlockResult,
   AssociateSubnetCidrBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSubnetCidrBlockRequest,
   output: AssociateSubnetCidrBlockResult,
@@ -75443,7 +75442,7 @@ export const associateTransitGatewayMulticastDomain: API.OperationMethod<
   AssociateTransitGatewayMulticastDomainRequest,
   AssociateTransitGatewayMulticastDomainResult,
   AssociateTransitGatewayMulticastDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTransitGatewayMulticastDomainRequest,
   output: AssociateTransitGatewayMulticastDomainResult,
@@ -75470,7 +75469,7 @@ export const associateTransitGatewayPolicyTable: API.OperationMethod<
   AssociateTransitGatewayPolicyTableRequest,
   AssociateTransitGatewayPolicyTableResult,
   AssociateTransitGatewayPolicyTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTransitGatewayPolicyTableRequest,
   output: AssociateTransitGatewayPolicyTableResult,
@@ -75498,7 +75497,7 @@ export const associateTransitGatewayRouteTable: API.OperationMethod<
   AssociateTransitGatewayRouteTableRequest,
   AssociateTransitGatewayRouteTableResult,
   AssociateTransitGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTransitGatewayRouteTableRequest,
   output: AssociateTransitGatewayRouteTableResult,
@@ -75529,7 +75528,7 @@ export const associateTrunkInterface: API.OperationMethod<
   AssociateTrunkInterfaceRequest,
   AssociateTrunkInterfaceResult,
   AssociateTrunkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTrunkInterfaceRequest,
   output: AssociateTrunkInterfaceResult,
@@ -75564,7 +75563,7 @@ export const associateVpcCidrBlock: API.OperationMethod<
   AssociateVpcCidrBlockRequest,
   AssociateVpcCidrBlockResult,
   AssociateVpcCidrBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateVpcCidrBlockRequest,
   output: AssociateVpcCidrBlockResult,
@@ -75605,7 +75604,7 @@ export const attachClassicLinkVpc: API.OperationMethod<
   AttachClassicLinkVpcRequest,
   AttachClassicLinkVpcResult,
   AttachClassicLinkVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachClassicLinkVpcRequest,
   output: AttachClassicLinkVpcResult,
@@ -75634,7 +75633,7 @@ export const attachImageWatermark: API.OperationMethod<
   AttachImageWatermarkRequest,
   AttachImageWatermarkResult,
   AttachImageWatermarkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachImageWatermarkRequest,
   output: AttachImageWatermarkResult,
@@ -75661,7 +75660,7 @@ export const attachInternetGateway: API.OperationMethod<
   AttachInternetGatewayRequest,
   AttachInternetGatewayResponse,
   AttachInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachInternetGatewayRequest,
   output: AttachInternetGatewayResponse,
@@ -75692,7 +75691,7 @@ export const attachNetworkInterface: API.OperationMethod<
   AttachNetworkInterfaceRequest,
   AttachNetworkInterfaceResult,
   AttachNetworkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachNetworkInterfaceRequest,
   output: AttachNetworkInterfaceResult,
@@ -75720,7 +75719,7 @@ export const attachVerifiedAccessTrustProvider: API.OperationMethod<
   AttachVerifiedAccessTrustProviderRequest,
   AttachVerifiedAccessTrustProviderResult,
   AttachVerifiedAccessTrustProviderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachVerifiedAccessTrustProviderRequest,
   output: AttachVerifiedAccessTrustProviderResult,
@@ -75775,7 +75774,7 @@ export const attachVolume: API.OperationMethod<
   AttachVolumeRequest,
   VolumeAttachment,
   AttachVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachVolumeRequest,
   output: VolumeAttachment,
@@ -75809,7 +75808,7 @@ export const attachVpnGateway: API.OperationMethod<
   AttachVpnGatewayRequest,
   AttachVpnGatewayResult,
   AttachVpnGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachVpnGatewayRequest,
   output: AttachVpnGatewayResult,
@@ -75838,7 +75837,7 @@ export const authorizeClientVpnIngress: API.OperationMethod<
   AuthorizeClientVpnIngressRequest,
   AuthorizeClientVpnIngressResult,
   AuthorizeClientVpnIngressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeClientVpnIngressRequest,
   output: AuthorizeClientVpnIngressResult,
@@ -75880,7 +75879,7 @@ export const authorizeSecurityGroupEgress: API.OperationMethod<
   AuthorizeSecurityGroupEgressRequest,
   AuthorizeSecurityGroupEgressResult,
   AuthorizeSecurityGroupEgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeSecurityGroupEgressRequest,
   output: AuthorizeSecurityGroupEgressResult,
@@ -75929,7 +75928,7 @@ export const authorizeSecurityGroupIngress: API.OperationMethod<
   AuthorizeSecurityGroupIngressRequest,
   AuthorizeSecurityGroupIngressResult,
   AuthorizeSecurityGroupIngressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeSecurityGroupIngressRequest,
   output: AuthorizeSecurityGroupIngressResult,
@@ -75966,7 +75965,7 @@ export const bundleInstance: API.OperationMethod<
   BundleInstanceRequest,
   BundleInstanceResult,
   BundleInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BundleInstanceRequest,
   output: BundleInstanceResult,
@@ -75989,7 +75988,7 @@ export const cancelBundleTask: API.OperationMethod<
   CancelBundleTaskRequest,
   CancelBundleTaskResult,
   CancelBundleTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelBundleTaskRequest,
   output: CancelBundleTaskResult,
@@ -76045,7 +76044,7 @@ export const cancelCapacityReservation: API.OperationMethod<
   CancelCapacityReservationRequest,
   CancelCapacityReservationResult,
   CancelCapacityReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCapacityReservationRequest,
   output: CancelCapacityReservationResult,
@@ -76082,7 +76081,7 @@ export const cancelCapacityReservationFleets: API.OperationMethod<
   CancelCapacityReservationFleetsRequest,
   CancelCapacityReservationFleetsResult,
   CancelCapacityReservationFleetsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCapacityReservationFleetsRequest,
   output: CancelCapacityReservationFleetsResult,
@@ -76110,7 +76109,7 @@ export const cancelConversionTask: API.OperationMethod<
   CancelConversionRequest,
   CancelConversionTaskResponse,
   CancelConversionTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelConversionRequest,
   output: CancelConversionTaskResponse,
@@ -76139,7 +76138,7 @@ export const cancelDeclarativePoliciesReport: API.OperationMethod<
   CancelDeclarativePoliciesReportRequest,
   CancelDeclarativePoliciesReportResult,
   CancelDeclarativePoliciesReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDeclarativePoliciesReportRequest,
   output: CancelDeclarativePoliciesReportResult,
@@ -76167,7 +76166,7 @@ export const cancelExportTask: API.OperationMethod<
   CancelExportTaskRequest,
   CancelExportTaskResponse,
   CancelExportTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelExportTaskRequest,
   output: CancelExportTaskResponse,
@@ -76191,7 +76190,7 @@ export const cancelImageLaunchPermission: API.OperationMethod<
   CancelImageLaunchPermissionRequest,
   CancelImageLaunchPermissionResult,
   CancelImageLaunchPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelImageLaunchPermissionRequest,
   output: CancelImageLaunchPermissionResult,
@@ -76213,7 +76212,7 @@ export const cancelImportTask: API.OperationMethod<
   CancelImportTaskRequest,
   CancelImportTaskResult,
   CancelImportTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelImportTaskRequest,
   output: CancelImportTaskResult,
@@ -76243,7 +76242,7 @@ export const cancelReservedInstancesListing: API.OperationMethod<
   CancelReservedInstancesListingRequest,
   CancelReservedInstancesListingResult,
   CancelReservedInstancesListingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelReservedInstancesListingRequest,
   output: CancelReservedInstancesListingResult,
@@ -76290,7 +76289,7 @@ export const cancelSpotFleetRequests: API.OperationMethod<
   CancelSpotFleetRequestsRequest,
   CancelSpotFleetRequestsResponse,
   CancelSpotFleetRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSpotFleetRequestsRequest,
   output: CancelSpotFleetRequestsResponse,
@@ -76321,7 +76320,7 @@ export const cancelSpotInstanceRequests: API.OperationMethod<
   CancelSpotInstanceRequestsRequest,
   CancelSpotInstanceRequestsResult,
   CancelSpotInstanceRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSpotInstanceRequestsRequest,
   output: CancelSpotInstanceRequestsResult,
@@ -76350,7 +76349,7 @@ export const confirmProductInstance: API.OperationMethod<
   ConfirmProductInstanceRequest,
   ConfirmProductInstanceResult,
   ConfirmProductInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmProductInstanceRequest,
   output: ConfirmProductInstanceResult,
@@ -76372,7 +76371,7 @@ export const copyFpgaImage: API.OperationMethod<
   CopyFpgaImageRequest,
   CopyFpgaImageResult,
   CopyFpgaImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyFpgaImageRequest,
   output: CopyFpgaImageResult,
@@ -76462,7 +76461,7 @@ export const copyImage: API.OperationMethod<
   CopyImageRequest,
   CopyImageResult,
   CopyImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyImageRequest,
   output: CopyImageResult,
@@ -76521,7 +76520,7 @@ export const copySnapshot: API.OperationMethod<
   CopySnapshotRequest,
   CopySnapshotResult,
   CopySnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopySnapshotRequest,
   output: CopySnapshotResult,
@@ -76551,7 +76550,7 @@ export const copyVolumes: API.OperationMethod<
   CopyVolumesRequest,
   CopyVolumesResult,
   CopyVolumesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyVolumesRequest,
   output: CopyVolumesResult,
@@ -76578,7 +76577,7 @@ export const createCapacityManagerDataExport: API.OperationMethod<
   CreateCapacityManagerDataExportRequest,
   CreateCapacityManagerDataExportResult,
   CreateCapacityManagerDataExportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityManagerDataExportRequest,
   output: CreateCapacityManagerDataExportResult,
@@ -76623,7 +76622,7 @@ export const createCapacityReservation: API.OperationMethod<
   CreateCapacityReservationRequest,
   CreateCapacityReservationResult,
   CreateCapacityReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityReservationRequest,
   output: CreateCapacityReservationResult,
@@ -76649,7 +76648,7 @@ export const createCapacityReservationBySplitting: API.OperationMethod<
   CreateCapacityReservationBySplittingRequest,
   CreateCapacityReservationBySplittingResult,
   CreateCapacityReservationBySplittingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityReservationBySplittingRequest,
   output: CreateCapacityReservationBySplittingResult,
@@ -76675,7 +76674,7 @@ export const createCapacityReservationCancellationQuote: API.OperationMethod<
   CreateCapacityReservationCancellationQuoteRequest,
   CreateCapacityReservationCancellationQuoteResult,
   CreateCapacityReservationCancellationQuoteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityReservationCancellationQuoteRequest,
   output: CreateCapacityReservationCancellationQuoteResult,
@@ -76699,7 +76698,7 @@ export const createCapacityReservationFleet: API.OperationMethod<
   CreateCapacityReservationFleetRequest,
   CreateCapacityReservationFleetResult,
   CreateCapacityReservationFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityReservationFleetRequest,
   output: CreateCapacityReservationFleetResult,
@@ -76724,7 +76723,7 @@ export const createCarrierGateway: API.OperationMethod<
   CreateCarrierGatewayRequest,
   CreateCarrierGatewayResult,
   CreateCarrierGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCarrierGatewayRequest,
   output: CreateCarrierGatewayResult,
@@ -76755,7 +76754,7 @@ export const createClientVpnEndpoint: API.OperationMethod<
   CreateClientVpnEndpointRequest,
   CreateClientVpnEndpointResult,
   CreateClientVpnEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClientVpnEndpointRequest,
   output: CreateClientVpnEndpointResult,
@@ -76778,7 +76777,7 @@ export const createClientVpnRoute: API.OperationMethod<
   CreateClientVpnRouteRequest,
   CreateClientVpnRouteResult,
   CreateClientVpnRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClientVpnRouteRequest,
   output: CreateClientVpnRouteResult,
@@ -76806,7 +76805,7 @@ export const createCoipCidr: API.OperationMethod<
   CreateCoipCidrRequest,
   CreateCoipCidrResult,
   CreateCoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoipCidrRequest,
   output: CreateCoipCidrResult,
@@ -76836,7 +76835,7 @@ export const createCoipPool: API.OperationMethod<
   CreateCoipPoolRequest,
   CreateCoipPoolResult,
   CreateCoipPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoipPoolRequest,
   output: CreateCoipPoolResult,
@@ -76880,7 +76879,7 @@ export const createCustomerGateway: API.OperationMethod<
   CreateCustomerGatewayRequest,
   CreateCustomerGatewayResult,
   CreateCustomerGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomerGatewayRequest,
   output: CreateCustomerGatewayResult,
@@ -76911,7 +76910,7 @@ export const createDefaultSubnet: API.OperationMethod<
   CreateDefaultSubnetRequest,
   CreateDefaultSubnetResult,
   CreateDefaultSubnetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDefaultSubnetRequest,
   output: CreateDefaultSubnetResult,
@@ -76945,7 +76944,7 @@ export const createDefaultVpc: API.OperationMethod<
   CreateDefaultVpcRequest,
   CreateDefaultVpcResult,
   CreateDefaultVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDefaultVpcRequest,
   output: CreateDefaultVpcResult,
@@ -76972,7 +76971,7 @@ export const createDelegateMacVolumeOwnershipTask: API.OperationMethod<
   CreateDelegateMacVolumeOwnershipTaskRequest,
   CreateDelegateMacVolumeOwnershipTaskResult,
   CreateDelegateMacVolumeOwnershipTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDelegateMacVolumeOwnershipTaskRequest,
   output: CreateDelegateMacVolumeOwnershipTaskResult,
@@ -77032,7 +77031,7 @@ export const createDhcpOptions: API.OperationMethod<
   CreateDhcpOptionsRequest,
   CreateDhcpOptionsResult,
   CreateDhcpOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDhcpOptionsRequest,
   output: CreateDhcpOptionsResult,
@@ -77065,7 +77064,7 @@ export const createEgressOnlyInternetGateway: API.OperationMethod<
   CreateEgressOnlyInternetGatewayRequest,
   CreateEgressOnlyInternetGatewayResult,
   CreateEgressOnlyInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEgressOnlyInternetGatewayRequest,
   output: CreateEgressOnlyInternetGatewayResult,
@@ -77100,7 +77099,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetRequest,
   CreateFleetResult,
   CreateFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetRequest,
   output: CreateFleetResult,
@@ -77138,7 +77137,7 @@ export const createFlowLogs: API.OperationMethod<
   CreateFlowLogsRequest,
   CreateFlowLogsResult,
   CreateFlowLogsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowLogsRequest,
   output: CreateFlowLogsResult,
@@ -77173,7 +77172,7 @@ export const createFpgaImage: API.OperationMethod<
   CreateFpgaImageRequest,
   CreateFpgaImageResult,
   CreateFpgaImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFpgaImageRequest,
   output: CreateFpgaImageResult,
@@ -77214,7 +77213,7 @@ export const createImage: API.OperationMethod<
   CreateImageRequest,
   CreateImageResult,
   CreateImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageRequest,
   output: CreateImageResult,
@@ -77246,7 +77245,7 @@ export const createImageUsageReport: API.OperationMethod<
   CreateImageUsageReportRequest,
   CreateImageUsageReportResult,
   CreateImageUsageReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageUsageReportRequest,
   output: CreateImageUsageReportResult,
@@ -77275,7 +77274,7 @@ export const createInstanceConnectEndpoint: API.OperationMethod<
   CreateInstanceConnectEndpointRequest,
   CreateInstanceConnectEndpointResult,
   CreateInstanceConnectEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceConnectEndpointRequest,
   output: CreateInstanceConnectEndpointResult,
@@ -77325,7 +77324,7 @@ export const createInstanceEventWindow: API.OperationMethod<
   CreateInstanceEventWindowRequest,
   CreateInstanceEventWindowResult,
   CreateInstanceEventWindowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceEventWindowRequest,
   output: CreateInstanceEventWindowResult,
@@ -77351,7 +77350,7 @@ export const createInstanceExportTask: API.OperationMethod<
   CreateInstanceExportTaskRequest,
   CreateInstanceExportTaskResult,
   CreateInstanceExportTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceExportTaskRequest,
   output: CreateInstanceExportTaskResult,
@@ -77378,7 +77377,7 @@ export const createInternetGateway: API.OperationMethod<
   CreateInternetGatewayRequest,
   CreateInternetGatewayResult,
   CreateInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInternetGatewayRequest,
   output: CreateInternetGatewayResult,
@@ -77405,7 +77404,7 @@ export const createInterruptibleCapacityReservationAllocation: API.OperationMeth
   CreateInterruptibleCapacityReservationAllocationRequest,
   CreateInterruptibleCapacityReservationAllocationResult,
   CreateInterruptibleCapacityReservationAllocationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInterruptibleCapacityReservationAllocationRequest,
   output: CreateInterruptibleCapacityReservationAllocationResult,
@@ -77438,7 +77437,7 @@ export const createIpam: API.OperationMethod<
   CreateIpamRequest,
   CreateIpamResult,
   CreateIpamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamRequest,
   output: CreateIpamResult,
@@ -77469,7 +77468,7 @@ export const createIpamExternalResourceVerificationToken: API.OperationMethod<
   CreateIpamExternalResourceVerificationTokenRequest,
   CreateIpamExternalResourceVerificationTokenResult,
   CreateIpamExternalResourceVerificationTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamExternalResourceVerificationTokenRequest,
   output: CreateIpamExternalResourceVerificationTokenResult,
@@ -77501,7 +77500,7 @@ export const createIpamPolicy: API.OperationMethod<
   CreateIpamPolicyRequest,
   CreateIpamPolicyResult,
   CreateIpamPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamPolicyRequest,
   output: CreateIpamPolicyResult,
@@ -77531,7 +77530,7 @@ export const createIpamPool: API.OperationMethod<
   CreateIpamPoolRequest,
   CreateIpamPoolResult,
   CreateIpamPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamPoolRequest,
   output: CreateIpamPoolResult,
@@ -77562,7 +77561,7 @@ export const createIpamPrefixListResolver: API.OperationMethod<
   CreateIpamPrefixListResolverRequest,
   CreateIpamPrefixListResolverResult,
   CreateIpamPrefixListResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamPrefixListResolverRequest,
   output: CreateIpamPrefixListResolverResult,
@@ -77590,7 +77589,7 @@ export const createIpamPrefixListResolverTarget: API.OperationMethod<
   CreateIpamPrefixListResolverTargetRequest,
   CreateIpamPrefixListResolverTargetResult,
   CreateIpamPrefixListResolverTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamPrefixListResolverTargetRequest,
   output: CreateIpamPrefixListResolverTargetResult,
@@ -77618,7 +77617,7 @@ export const createIpamResourceDiscovery: API.OperationMethod<
   CreateIpamResourceDiscoveryRequest,
   CreateIpamResourceDiscoveryResult,
   CreateIpamResourceDiscoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamResourceDiscoveryRequest,
   output: CreateIpamResourceDiscoveryResult,
@@ -77643,7 +77642,7 @@ export const createIpamScope: API.OperationMethod<
   CreateIpamScopeRequest,
   CreateIpamScopeResult,
   CreateIpamScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpamScopeRequest,
   output: CreateIpamScopeResult,
@@ -77683,7 +77682,7 @@ export const createKeyPair: API.OperationMethod<
   CreateKeyPairRequest,
   KeyPair,
   CreateKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyPairRequest,
   output: KeyPair,
@@ -77720,7 +77719,7 @@ export const createLaunchTemplate: API.OperationMethod<
   CreateLaunchTemplateRequest,
   CreateLaunchTemplateResult,
   CreateLaunchTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLaunchTemplateRequest,
   output: CreateLaunchTemplateResult,
@@ -77751,7 +77750,7 @@ export const createLaunchTemplateVersion: API.OperationMethod<
   CreateLaunchTemplateVersionRequest,
   CreateLaunchTemplateVersionResult,
   CreateLaunchTemplateVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLaunchTemplateVersionRequest,
   output: CreateLaunchTemplateVersionResult,
@@ -77779,7 +77778,7 @@ export const createLocalGatewayRoute: API.OperationMethod<
   CreateLocalGatewayRouteRequest,
   CreateLocalGatewayRouteResult,
   CreateLocalGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayRouteRequest,
   output: CreateLocalGatewayRouteResult,
@@ -77808,7 +77807,7 @@ export const createLocalGatewayRouteTable: API.OperationMethod<
   CreateLocalGatewayRouteTableRequest,
   CreateLocalGatewayRouteTableResult,
   CreateLocalGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayRouteTableRequest,
   output: CreateLocalGatewayRouteTableResult,
@@ -77838,7 +77837,7 @@ export const createLocalGatewayRouteTableVirtualInterfaceGroupAssociation: API.O
   CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
   CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
   CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
   output: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
@@ -77869,7 +77868,7 @@ export const createLocalGatewayRouteTableVpcAssociation: API.OperationMethod<
   CreateLocalGatewayRouteTableVpcAssociationRequest,
   CreateLocalGatewayRouteTableVpcAssociationResult,
   CreateLocalGatewayRouteTableVpcAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayRouteTableVpcAssociationRequest,
   output: CreateLocalGatewayRouteTableVpcAssociationResult,
@@ -77900,7 +77899,7 @@ export const createLocalGatewayVirtualInterface: API.OperationMethod<
   CreateLocalGatewayVirtualInterfaceRequest,
   CreateLocalGatewayVirtualInterfaceResult,
   CreateLocalGatewayVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayVirtualInterfaceRequest,
   output: CreateLocalGatewayVirtualInterfaceResult,
@@ -77929,7 +77928,7 @@ export const createLocalGatewayVirtualInterfaceGroup: API.OperationMethod<
   CreateLocalGatewayVirtualInterfaceGroupRequest,
   CreateLocalGatewayVirtualInterfaceGroupResult,
   CreateLocalGatewayVirtualInterfaceGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocalGatewayVirtualInterfaceGroupRequest,
   output: CreateLocalGatewayVirtualInterfaceGroupResult,
@@ -77986,7 +77985,7 @@ export const createMacSystemIntegrityProtectionModificationTask: API.OperationMe
   CreateMacSystemIntegrityProtectionModificationTaskRequest,
   CreateMacSystemIntegrityProtectionModificationTaskResult,
   CreateMacSystemIntegrityProtectionModificationTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMacSystemIntegrityProtectionModificationTaskRequest,
   output: CreateMacSystemIntegrityProtectionModificationTaskResult,
@@ -78010,7 +78009,7 @@ export const createManagedPrefixList: API.OperationMethod<
   CreateManagedPrefixListRequest,
   CreateManagedPrefixListResult,
   CreateManagedPrefixListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateManagedPrefixListRequest,
   output: CreateManagedPrefixListResult,
@@ -78061,7 +78060,7 @@ export const createNatGateway: API.OperationMethod<
   CreateNatGatewayRequest,
   CreateNatGatewayResult,
   CreateNatGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNatGatewayRequest,
   output: CreateNatGatewayResult,
@@ -78096,7 +78095,7 @@ export const createNetworkAcl: API.OperationMethod<
   CreateNetworkAclRequest,
   CreateNetworkAclResult,
   CreateNetworkAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkAclRequest,
   output: CreateNetworkAclResult,
@@ -78136,7 +78135,7 @@ export const createNetworkAclEntry: API.OperationMethod<
   CreateNetworkAclEntryRequest,
   CreateNetworkAclEntryResponse,
   CreateNetworkAclEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkAclEntryRequest,
   output: CreateNetworkAclEntryResponse,
@@ -78163,7 +78162,7 @@ export const createNetworkInsightsAccessScope: API.OperationMethod<
   CreateNetworkInsightsAccessScopeRequest,
   CreateNetworkInsightsAccessScopeResult,
   CreateNetworkInsightsAccessScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkInsightsAccessScopeRequest,
   output: CreateNetworkInsightsAccessScopeResult,
@@ -78190,7 +78189,7 @@ export const createNetworkInsightsPath: API.OperationMethod<
   CreateNetworkInsightsPathRequest,
   CreateNetworkInsightsPathResult,
   CreateNetworkInsightsPathError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkInsightsPathRequest,
   output: CreateNetworkInsightsPathResult,
@@ -78225,7 +78224,7 @@ export const createNetworkInterface: API.OperationMethod<
   CreateNetworkInterfaceRequest,
   CreateNetworkInterfaceResult,
   CreateNetworkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkInterfaceRequest,
   output: CreateNetworkInterfaceResult,
@@ -78257,7 +78256,7 @@ export const createNetworkInterfacePermission: API.OperationMethod<
   CreateNetworkInterfacePermissionRequest,
   CreateNetworkInterfacePermissionResult,
   CreateNetworkInterfacePermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkInterfacePermissionRequest,
   output: CreateNetworkInterfacePermissionResult,
@@ -78293,7 +78292,7 @@ export const createPlacementGroup: API.OperationMethod<
   CreatePlacementGroupRequest,
   CreatePlacementGroupResult,
   CreatePlacementGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlacementGroupRequest,
   output: CreatePlacementGroupResult,
@@ -78316,7 +78315,7 @@ export const createPublicIpv4Pool: API.OperationMethod<
   CreatePublicIpv4PoolRequest,
   CreatePublicIpv4PoolResult,
   CreatePublicIpv4PoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePublicIpv4PoolRequest,
   output: CreatePublicIpv4PoolResult,
@@ -78343,7 +78342,7 @@ export const createReplaceRootVolumeTask: API.OperationMethod<
   CreateReplaceRootVolumeTaskRequest,
   CreateReplaceRootVolumeTaskResult,
   CreateReplaceRootVolumeTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplaceRootVolumeTaskRequest,
   output: CreateReplaceRootVolumeTaskResult,
@@ -78389,7 +78388,7 @@ export const createReservedInstancesListing: API.OperationMethod<
   CreateReservedInstancesListingRequest,
   CreateReservedInstancesListingResult,
   CreateReservedInstancesListingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReservedInstancesListingRequest,
   output: CreateReservedInstancesListingResult,
@@ -78418,7 +78417,7 @@ export const createRestoreImageTask: API.OperationMethod<
   CreateRestoreImageTaskRequest,
   CreateRestoreImageTaskResult,
   CreateRestoreImageTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRestoreImageTaskRequest,
   output: CreateRestoreImageTaskResult,
@@ -78466,7 +78465,7 @@ export const createRoute: API.OperationMethod<
   CreateRouteRequest,
   CreateRouteResult,
   CreateRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteRequest,
   output: CreateRouteResult,
@@ -78515,7 +78514,7 @@ export const createRouteServer: API.OperationMethod<
   CreateRouteServerRequest,
   CreateRouteServerResult,
   CreateRouteServerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteServerRequest,
   output: CreateRouteServerResult,
@@ -78544,7 +78543,7 @@ export const createRouteServerEndpoint: API.OperationMethod<
   CreateRouteServerEndpointRequest,
   CreateRouteServerEndpointResult,
   CreateRouteServerEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteServerEndpointRequest,
   output: CreateRouteServerEndpointResult,
@@ -78583,7 +78582,7 @@ export const createRouteServerPeer: API.OperationMethod<
   CreateRouteServerPeerRequest,
   CreateRouteServerPeerResult,
   CreateRouteServerPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteServerPeerRequest,
   output: CreateRouteServerPeerResult,
@@ -78610,7 +78609,7 @@ export const createRouteTable: API.OperationMethod<
   CreateRouteTableRequest,
   CreateRouteTableResult,
   CreateRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteTableRequest,
   output: CreateRouteTableResult,
@@ -78636,7 +78635,7 @@ export const createSecondaryNetwork: API.OperationMethod<
   CreateSecondaryNetworkRequest,
   CreateSecondaryNetworkResult,
   CreateSecondaryNetworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecondaryNetworkRequest,
   output: CreateSecondaryNetworkResult,
@@ -78658,7 +78657,7 @@ export const createSecondarySubnet: API.OperationMethod<
   CreateSecondarySubnetRequest,
   CreateSecondarySubnetResult,
   CreateSecondarySubnetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecondarySubnetRequest,
   output: CreateSecondarySubnetResult,
@@ -78708,7 +78707,7 @@ export const createSecurityGroup: API.OperationMethod<
   CreateSecurityGroupRequest,
   CreateSecurityGroupResult,
   CreateSecurityGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityGroupRequest,
   output: CreateSecurityGroupResult,
@@ -78774,7 +78773,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotRequest,
   Snapshot,
   CreateSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotRequest,
   output: Snapshot,
@@ -78817,7 +78816,7 @@ export const createSnapshots: API.OperationMethod<
   CreateSnapshotsRequest,
   CreateSnapshotsResult,
   CreateSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotsRequest,
   output: CreateSnapshotsResult,
@@ -78842,7 +78841,7 @@ export const createSpotDatafeedSubscription: API.OperationMethod<
   CreateSpotDatafeedSubscriptionRequest,
   CreateSpotDatafeedSubscriptionResult,
   CreateSpotDatafeedSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSpotDatafeedSubscriptionRequest,
   output: CreateSpotDatafeedSubscriptionResult,
@@ -78874,7 +78873,7 @@ export const createStoreImageTask: API.OperationMethod<
   CreateStoreImageTaskRequest,
   CreateStoreImageTaskResult,
   CreateStoreImageTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStoreImageTaskRequest,
   output: CreateStoreImageTaskResult,
@@ -78922,7 +78921,7 @@ export const createSubnet: API.OperationMethod<
   CreateSubnetRequest,
   CreateSubnetResult,
   CreateSubnetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubnetRequest,
   output: CreateSubnetResult,
@@ -78956,7 +78955,7 @@ export const createSubnetCidrReservation: API.OperationMethod<
   CreateSubnetCidrReservationRequest,
   CreateSubnetCidrReservationResult,
   CreateSubnetCidrReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubnetCidrReservationRequest,
   output: CreateSubnetCidrReservationResult,
@@ -78994,7 +78993,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResponse,
@@ -79027,7 +79026,7 @@ export const createTrafficMirrorFilter: API.OperationMethod<
   CreateTrafficMirrorFilterRequest,
   CreateTrafficMirrorFilterResult,
   CreateTrafficMirrorFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficMirrorFilterRequest,
   output: CreateTrafficMirrorFilterResult,
@@ -79053,7 +79052,7 @@ export const createTrafficMirrorFilterRule: API.OperationMethod<
   CreateTrafficMirrorFilterRuleRequest,
   CreateTrafficMirrorFilterRuleResult,
   CreateTrafficMirrorFilterRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficMirrorFilterRuleRequest,
   output: CreateTrafficMirrorFilterRuleResult,
@@ -79086,7 +79085,7 @@ export const createTrafficMirrorSession: API.OperationMethod<
   CreateTrafficMirrorSessionRequest,
   CreateTrafficMirrorSessionResult,
   CreateTrafficMirrorSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficMirrorSessionRequest,
   output: CreateTrafficMirrorSessionResult,
@@ -79122,7 +79121,7 @@ export const createTrafficMirrorTarget: API.OperationMethod<
   CreateTrafficMirrorTargetRequest,
   CreateTrafficMirrorTargetResult,
   CreateTrafficMirrorTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficMirrorTargetRequest,
   output: CreateTrafficMirrorTargetResult,
@@ -79165,7 +79164,7 @@ export const createTransitGateway: API.OperationMethod<
   CreateTransitGatewayRequest,
   CreateTransitGatewayResult,
   CreateTransitGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayRequest,
   output: CreateTransitGatewayResult,
@@ -79194,7 +79193,7 @@ export const createTransitGatewayConnect: API.OperationMethod<
   CreateTransitGatewayConnectRequest,
   CreateTransitGatewayConnectResult,
   CreateTransitGatewayConnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayConnectRequest,
   output: CreateTransitGatewayConnectResult,
@@ -79222,7 +79221,7 @@ export const createTransitGatewayConnectPeer: API.OperationMethod<
   CreateTransitGatewayConnectPeerRequest,
   CreateTransitGatewayConnectPeerResult,
   CreateTransitGatewayConnectPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayConnectPeerRequest,
   output: CreateTransitGatewayConnectPeerResult,
@@ -79246,7 +79245,7 @@ export const createTransitGatewayMeteringPolicy: API.OperationMethod<
   CreateTransitGatewayMeteringPolicyRequest,
   CreateTransitGatewayMeteringPolicyResult,
   CreateTransitGatewayMeteringPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayMeteringPolicyRequest,
   output: CreateTransitGatewayMeteringPolicyResult,
@@ -79274,7 +79273,7 @@ export const createTransitGatewayMeteringPolicyEntry: API.OperationMethod<
   CreateTransitGatewayMeteringPolicyEntryRequest,
   CreateTransitGatewayMeteringPolicyEntryResult,
   CreateTransitGatewayMeteringPolicyEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayMeteringPolicyEntryRequest,
   output: CreateTransitGatewayMeteringPolicyEntryResult,
@@ -79301,7 +79300,7 @@ export const createTransitGatewayMulticastDomain: API.OperationMethod<
   CreateTransitGatewayMulticastDomainRequest,
   CreateTransitGatewayMulticastDomainResult,
   CreateTransitGatewayMulticastDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayMulticastDomainRequest,
   output: CreateTransitGatewayMulticastDomainResult,
@@ -79337,7 +79336,7 @@ export const createTransitGatewayPeeringAttachment: API.OperationMethod<
   CreateTransitGatewayPeeringAttachmentRequest,
   CreateTransitGatewayPeeringAttachmentResult,
   CreateTransitGatewayPeeringAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayPeeringAttachmentRequest,
   output: CreateTransitGatewayPeeringAttachmentResult,
@@ -79367,7 +79366,7 @@ export const createTransitGatewayPolicyTable: API.OperationMethod<
   CreateTransitGatewayPolicyTableRequest,
   CreateTransitGatewayPolicyTableResult,
   CreateTransitGatewayPolicyTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayPolicyTableRequest,
   output: CreateTransitGatewayPolicyTableResult,
@@ -79395,7 +79394,7 @@ export const createTransitGatewayPrefixListReference: API.OperationMethod<
   CreateTransitGatewayPrefixListReferenceRequest,
   CreateTransitGatewayPrefixListReferenceResult,
   CreateTransitGatewayPrefixListReferenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayPrefixListReferenceRequest,
   output: CreateTransitGatewayPrefixListReferenceResult,
@@ -79418,7 +79417,7 @@ export const createTransitGatewayRoute: API.OperationMethod<
   CreateTransitGatewayRouteRequest,
   CreateTransitGatewayRouteResult,
   CreateTransitGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayRouteRequest,
   output: CreateTransitGatewayRouteResult,
@@ -79448,7 +79447,7 @@ export const createTransitGatewayRouteTable: API.OperationMethod<
   CreateTransitGatewayRouteTableRequest,
   CreateTransitGatewayRouteTableResult,
   CreateTransitGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayRouteTableRequest,
   output: CreateTransitGatewayRouteTableResult,
@@ -79479,7 +79478,7 @@ export const createTransitGatewayRouteTableAnnouncement: API.OperationMethod<
   CreateTransitGatewayRouteTableAnnouncementRequest,
   CreateTransitGatewayRouteTableAnnouncementResult,
   CreateTransitGatewayRouteTableAnnouncementError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayRouteTableAnnouncementRequest,
   output: CreateTransitGatewayRouteTableAnnouncementResult,
@@ -79514,7 +79513,7 @@ export const createTransitGatewayVpcAttachment: API.OperationMethod<
   CreateTransitGatewayVpcAttachmentRequest,
   CreateTransitGatewayVpcAttachmentResult,
   CreateTransitGatewayVpcAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayVpcAttachmentRequest,
   output: CreateTransitGatewayVpcAttachmentResult,
@@ -79542,7 +79541,7 @@ export const createVerifiedAccessEndpoint: API.OperationMethod<
   CreateVerifiedAccessEndpointRequest,
   CreateVerifiedAccessEndpointResult,
   CreateVerifiedAccessEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVerifiedAccessEndpointRequest,
   output: CreateVerifiedAccessEndpointResult,
@@ -79569,7 +79568,7 @@ export const createVerifiedAccessGroup: API.OperationMethod<
   CreateVerifiedAccessGroupRequest,
   CreateVerifiedAccessGroupResult,
   CreateVerifiedAccessGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVerifiedAccessGroupRequest,
   output: CreateVerifiedAccessGroupResult,
@@ -79599,7 +79598,7 @@ export const createVerifiedAccessInstance: API.OperationMethod<
   CreateVerifiedAccessInstanceRequest,
   CreateVerifiedAccessInstanceResult,
   CreateVerifiedAccessInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVerifiedAccessInstanceRequest,
   output: CreateVerifiedAccessInstanceResult,
@@ -79629,7 +79628,7 @@ export const createVerifiedAccessTrustProvider: API.OperationMethod<
   CreateVerifiedAccessTrustProviderRequest,
   CreateVerifiedAccessTrustProviderResult,
   CreateVerifiedAccessTrustProviderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVerifiedAccessTrustProviderRequest,
   output: CreateVerifiedAccessTrustProviderResult,
@@ -79666,7 +79665,7 @@ export const createVolume: API.OperationMethod<
   CreateVolumeRequest,
   Volume,
   CreateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVolumeRequest,
   output: Volume,
@@ -79711,7 +79710,7 @@ export const createVpc: API.OperationMethod<
   CreateVpcRequest,
   CreateVpcResult,
   CreateVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcRequest,
   output: CreateVpcResult,
@@ -79741,7 +79740,7 @@ export const createVpcBlockPublicAccessExclusion: API.OperationMethod<
   CreateVpcBlockPublicAccessExclusionRequest,
   CreateVpcBlockPublicAccessExclusionResult,
   CreateVpcBlockPublicAccessExclusionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcBlockPublicAccessExclusionRequest,
   output: CreateVpcBlockPublicAccessExclusionResult,
@@ -79771,7 +79770,7 @@ export const createVpcEncryptionControl: API.OperationMethod<
   CreateVpcEncryptionControlRequest,
   CreateVpcEncryptionControlResult,
   CreateVpcEncryptionControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEncryptionControlRequest,
   output: CreateVpcEncryptionControlResult,
@@ -79805,7 +79804,7 @@ export const createVpcEndpoint: API.OperationMethod<
   CreateVpcEndpointRequest,
   CreateVpcEndpointResult,
   CreateVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointRequest,
   output: CreateVpcEndpointResult,
@@ -79840,7 +79839,7 @@ export const createVpcEndpointConnectionNotification: API.OperationMethod<
   CreateVpcEndpointConnectionNotificationRequest,
   CreateVpcEndpointConnectionNotificationResult,
   CreateVpcEndpointConnectionNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointConnectionNotificationRequest,
   output: CreateVpcEndpointConnectionNotificationResult,
@@ -79877,7 +79876,7 @@ export const createVpcEndpointServiceConfiguration: API.OperationMethod<
   CreateVpcEndpointServiceConfigurationRequest,
   CreateVpcEndpointServiceConfigurationResult,
   CreateVpcEndpointServiceConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointServiceConfigurationRequest,
   output: CreateVpcEndpointServiceConfigurationResult,
@@ -79915,7 +79914,7 @@ export const createVpcPeeringConnection: API.OperationMethod<
   CreateVpcPeeringConnectionRequest,
   CreateVpcPeeringConnectionResult,
   CreateVpcPeeringConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcPeeringConnectionRequest,
   output: CreateVpcPeeringConnectionResult,
@@ -79944,7 +79943,7 @@ export const createVpnConcentrator: API.OperationMethod<
   CreateVpnConcentratorRequest,
   CreateVpnConcentratorResult,
   CreateVpnConcentratorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpnConcentratorRequest,
   output: CreateVpnConcentratorResult,
@@ -79988,7 +79987,7 @@ export const createVpnConnection: API.OperationMethod<
   CreateVpnConnectionRequest,
   CreateVpnConnectionResult,
   CreateVpnConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpnConnectionRequest,
   output: CreateVpnConnectionResult,
@@ -80023,7 +80022,7 @@ export const createVpnConnectionRoute: API.OperationMethod<
   CreateVpnConnectionRouteRequest,
   CreateVpnConnectionRouteResponse,
   CreateVpnConnectionRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpnConnectionRouteRequest,
   output: CreateVpnConnectionRouteResponse,
@@ -80056,7 +80055,7 @@ export const createVpnGateway: API.OperationMethod<
   CreateVpnGatewayRequest,
   CreateVpnGatewayResult,
   CreateVpnGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpnGatewayRequest,
   output: CreateVpnGatewayResult,
@@ -80084,7 +80083,7 @@ export const deleteCapacityManagerDataExport: API.OperationMethod<
   DeleteCapacityManagerDataExportRequest,
   DeleteCapacityManagerDataExportResult,
   DeleteCapacityManagerDataExportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapacityManagerDataExportRequest,
   output: DeleteCapacityManagerDataExportResult,
@@ -80117,7 +80116,7 @@ export const deleteCarrierGateway: API.OperationMethod<
   DeleteCarrierGatewayRequest,
   DeleteCarrierGatewayResult,
   DeleteCarrierGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCarrierGatewayRequest,
   output: DeleteCarrierGatewayResult,
@@ -80146,7 +80145,7 @@ export const deleteClientVpnEndpoint: API.OperationMethod<
   DeleteClientVpnEndpointRequest,
   DeleteClientVpnEndpointResult,
   DeleteClientVpnEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClientVpnEndpointRequest,
   output: DeleteClientVpnEndpointResult,
@@ -80175,7 +80174,7 @@ export const deleteClientVpnRoute: API.OperationMethod<
   DeleteClientVpnRouteRequest,
   DeleteClientVpnRouteResult,
   DeleteClientVpnRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClientVpnRouteRequest,
   output: DeleteClientVpnRouteResult,
@@ -80203,7 +80202,7 @@ export const deleteCoipCidr: API.OperationMethod<
   DeleteCoipCidrRequest,
   DeleteCoipCidrResult,
   DeleteCoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoipCidrRequest,
   output: DeleteCoipCidrResult,
@@ -80233,7 +80232,7 @@ export const deleteCoipPool: API.OperationMethod<
   DeleteCoipPoolRequest,
   DeleteCoipPoolResult,
   DeleteCoipPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoipPoolRequest,
   output: DeleteCoipPoolResult,
@@ -80264,7 +80263,7 @@ export const deleteCustomerGateway: API.OperationMethod<
   DeleteCustomerGatewayRequest,
   DeleteCustomerGatewayResponse,
   DeleteCustomerGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomerGatewayRequest,
   output: DeleteCustomerGatewayResponse,
@@ -80295,7 +80294,7 @@ export const deleteDhcpOptions: API.OperationMethod<
   DeleteDhcpOptionsRequest,
   DeleteDhcpOptionsResponse,
   DeleteDhcpOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDhcpOptionsRequest,
   output: DeleteDhcpOptionsResponse,
@@ -80329,7 +80328,7 @@ export const deleteEgressOnlyInternetGateway: API.OperationMethod<
   DeleteEgressOnlyInternetGatewayRequest,
   DeleteEgressOnlyInternetGatewayResult,
   DeleteEgressOnlyInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEgressOnlyInternetGatewayRequest,
   output: DeleteEgressOnlyInternetGatewayResult,
@@ -80402,7 +80401,7 @@ export const deleteFleets: API.OperationMethod<
   DeleteFleetsRequest,
   DeleteFleetsResult,
   DeleteFleetsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetsRequest,
   output: DeleteFleetsResult,
@@ -80428,7 +80427,7 @@ export const deleteFlowLogs: API.OperationMethod<
   DeleteFlowLogsRequest,
   DeleteFlowLogsResult,
   DeleteFlowLogsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowLogsRequest,
   output: DeleteFlowLogsResult,
@@ -80454,7 +80453,7 @@ export const deleteFpgaImage: API.OperationMethod<
   DeleteFpgaImageRequest,
   DeleteFpgaImageResult,
   DeleteFpgaImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFpgaImageRequest,
   output: DeleteFpgaImageResult,
@@ -80484,7 +80483,7 @@ export const deleteImageUsageReport: API.OperationMethod<
   DeleteImageUsageReportRequest,
   DeleteImageUsageReportResult,
   DeleteImageUsageReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageUsageReportRequest,
   output: DeleteImageUsageReportResult,
@@ -80514,7 +80513,7 @@ export const deleteInstanceConnectEndpoint: API.OperationMethod<
   DeleteInstanceConnectEndpointRequest,
   DeleteInstanceConnectEndpointResult,
   DeleteInstanceConnectEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceConnectEndpointRequest,
   output: DeleteInstanceConnectEndpointResult,
@@ -80547,7 +80546,7 @@ export const deleteInstanceEventWindow: API.OperationMethod<
   DeleteInstanceEventWindowRequest,
   DeleteInstanceEventWindowResult,
   DeleteInstanceEventWindowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceEventWindowRequest,
   output: DeleteInstanceEventWindowResult,
@@ -80577,7 +80576,7 @@ export const deleteInternetGateway: API.OperationMethod<
   DeleteInternetGatewayRequest,
   DeleteInternetGatewayResponse,
   DeleteInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInternetGatewayRequest,
   output: DeleteInternetGatewayResponse,
@@ -80609,7 +80608,7 @@ export const deleteIpam: API.OperationMethod<
   DeleteIpamRequest,
   DeleteIpamResult,
   DeleteIpamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamRequest,
   output: DeleteIpamResult,
@@ -80641,7 +80640,7 @@ export const deleteIpamExternalResourceVerificationToken: API.OperationMethod<
   DeleteIpamExternalResourceVerificationTokenRequest,
   DeleteIpamExternalResourceVerificationTokenResult,
   DeleteIpamExternalResourceVerificationTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamExternalResourceVerificationTokenRequest,
   output: DeleteIpamExternalResourceVerificationTokenResult,
@@ -80673,7 +80672,7 @@ export const deleteIpamPolicy: API.OperationMethod<
   DeleteIpamPolicyRequest,
   DeleteIpamPolicyResult,
   DeleteIpamPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamPolicyRequest,
   output: DeleteIpamPolicyResult,
@@ -80709,7 +80708,7 @@ export const deleteIpamPool: API.OperationMethod<
   DeleteIpamPoolRequest,
   DeleteIpamPoolResult,
   DeleteIpamPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamPoolRequest,
   output: DeleteIpamPoolResult,
@@ -80739,7 +80738,7 @@ export const deleteIpamPrefixListResolver: API.OperationMethod<
   DeleteIpamPrefixListResolverRequest,
   DeleteIpamPrefixListResolverResult,
   DeleteIpamPrefixListResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamPrefixListResolverRequest,
   output: DeleteIpamPrefixListResolverResult,
@@ -80770,7 +80769,7 @@ export const deleteIpamPrefixListResolverTarget: API.OperationMethod<
   DeleteIpamPrefixListResolverTargetRequest,
   DeleteIpamPrefixListResolverTargetResult,
   DeleteIpamPrefixListResolverTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamPrefixListResolverTargetRequest,
   output: DeleteIpamPrefixListResolverTargetResult,
@@ -80798,7 +80797,7 @@ export const deleteIpamResourceDiscovery: API.OperationMethod<
   DeleteIpamResourceDiscoveryRequest,
   DeleteIpamResourceDiscoveryResult,
   DeleteIpamResourceDiscoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamResourceDiscoveryRequest,
   output: DeleteIpamResourceDiscoveryResult,
@@ -80830,7 +80829,7 @@ export const deleteIpamScope: API.OperationMethod<
   DeleteIpamScopeRequest,
   DeleteIpamScopeResult,
   DeleteIpamScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpamScopeRequest,
   output: DeleteIpamScopeResult,
@@ -80859,7 +80858,7 @@ export const deleteKeyPair: API.OperationMethod<
   DeleteKeyPairRequest,
   DeleteKeyPairResult,
   DeleteKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyPairRequest,
   output: DeleteKeyPairResult,
@@ -80883,7 +80882,7 @@ export const deleteLaunchTemplate: API.OperationMethod<
   DeleteLaunchTemplateRequest,
   DeleteLaunchTemplateResult,
   DeleteLaunchTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLaunchTemplateRequest,
   output: DeleteLaunchTemplateResult,
@@ -80921,7 +80920,7 @@ export const deleteLaunchTemplateVersions: API.OperationMethod<
   DeleteLaunchTemplateVersionsRequest,
   DeleteLaunchTemplateVersionsResult,
   DeleteLaunchTemplateVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLaunchTemplateVersionsRequest,
   output: DeleteLaunchTemplateVersionsResult,
@@ -80943,7 +80942,7 @@ export const deleteLocalGatewayRoute: API.OperationMethod<
   DeleteLocalGatewayRouteRequest,
   DeleteLocalGatewayRouteResult,
   DeleteLocalGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayRouteRequest,
   output: DeleteLocalGatewayRouteResult,
@@ -80966,7 +80965,7 @@ export const deleteLocalGatewayRouteTable: API.OperationMethod<
   DeleteLocalGatewayRouteTableRequest,
   DeleteLocalGatewayRouteTableResult,
   DeleteLocalGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayRouteTableRequest,
   output: DeleteLocalGatewayRouteTableResult,
@@ -80995,7 +80994,7 @@ export const deleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation: API.O
   DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
   DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
   DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
   output: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
@@ -81025,7 +81024,7 @@ export const deleteLocalGatewayRouteTableVpcAssociation: API.OperationMethod<
   DeleteLocalGatewayRouteTableVpcAssociationRequest,
   DeleteLocalGatewayRouteTableVpcAssociationResult,
   DeleteLocalGatewayRouteTableVpcAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayRouteTableVpcAssociationRequest,
   output: DeleteLocalGatewayRouteTableVpcAssociationResult,
@@ -81055,7 +81054,7 @@ export const deleteLocalGatewayVirtualInterface: API.OperationMethod<
   DeleteLocalGatewayVirtualInterfaceRequest,
   DeleteLocalGatewayVirtualInterfaceResult,
   DeleteLocalGatewayVirtualInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayVirtualInterfaceRequest,
   output: DeleteLocalGatewayVirtualInterfaceResult,
@@ -81085,7 +81084,7 @@ export const deleteLocalGatewayVirtualInterfaceGroup: API.OperationMethod<
   DeleteLocalGatewayVirtualInterfaceGroupRequest,
   DeleteLocalGatewayVirtualInterfaceGroupResult,
   DeleteLocalGatewayVirtualInterfaceGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocalGatewayVirtualInterfaceGroupRequest,
   output: DeleteLocalGatewayVirtualInterfaceGroupResult,
@@ -81115,7 +81114,7 @@ export const deleteManagedPrefixList: API.OperationMethod<
   DeleteManagedPrefixListRequest,
   DeleteManagedPrefixListResult,
   DeleteManagedPrefixListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteManagedPrefixListRequest,
   output: DeleteManagedPrefixListResult,
@@ -81150,7 +81149,7 @@ export const deleteNatGateway: API.OperationMethod<
   DeleteNatGatewayRequest,
   DeleteNatGatewayResult,
   DeleteNatGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNatGatewayRequest,
   output: DeleteNatGatewayResult,
@@ -81186,7 +81185,7 @@ export const deleteNetworkAcl: API.OperationMethod<
   DeleteNetworkAclRequest,
   DeleteNetworkAclResponse,
   DeleteNetworkAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkAclRequest,
   output: DeleteNetworkAclResponse,
@@ -81220,7 +81219,7 @@ export const deleteNetworkAclEntry: API.OperationMethod<
   DeleteNetworkAclEntryRequest,
   DeleteNetworkAclEntryResponse,
   DeleteNetworkAclEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkAclEntryRequest,
   output: DeleteNetworkAclEntryResponse,
@@ -81250,7 +81249,7 @@ export const deleteNetworkInsightsAccessScope: API.OperationMethod<
   DeleteNetworkInsightsAccessScopeRequest,
   DeleteNetworkInsightsAccessScopeResult,
   DeleteNetworkInsightsAccessScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInsightsAccessScopeRequest,
   output: DeleteNetworkInsightsAccessScopeResult,
@@ -81278,7 +81277,7 @@ export const deleteNetworkInsightsAccessScopeAnalysis: API.OperationMethod<
   DeleteNetworkInsightsAccessScopeAnalysisRequest,
   DeleteNetworkInsightsAccessScopeAnalysisResult,
   DeleteNetworkInsightsAccessScopeAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInsightsAccessScopeAnalysisRequest,
   output: DeleteNetworkInsightsAccessScopeAnalysisResult,
@@ -81306,7 +81305,7 @@ export const deleteNetworkInsightsAnalysis: API.OperationMethod<
   DeleteNetworkInsightsAnalysisRequest,
   DeleteNetworkInsightsAnalysisResult,
   DeleteNetworkInsightsAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInsightsAnalysisRequest,
   output: DeleteNetworkInsightsAnalysisResult,
@@ -81334,7 +81333,7 @@ export const deleteNetworkInsightsPath: API.OperationMethod<
   DeleteNetworkInsightsPathRequest,
   DeleteNetworkInsightsPathResult,
   DeleteNetworkInsightsPathError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInsightsPathRequest,
   output: DeleteNetworkInsightsPathResult,
@@ -81366,7 +81365,7 @@ export const deleteNetworkInterface: API.OperationMethod<
   DeleteNetworkInterfaceRequest,
   DeleteNetworkInterfaceResponse,
   DeleteNetworkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInterfaceRequest,
   output: DeleteNetworkInterfaceResponse,
@@ -81401,7 +81400,7 @@ export const deleteNetworkInterfacePermission: API.OperationMethod<
   DeleteNetworkInterfacePermissionRequest,
   DeleteNetworkInterfacePermissionResult,
   DeleteNetworkInterfacePermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkInterfacePermissionRequest,
   output: DeleteNetworkInterfacePermissionResult,
@@ -81433,7 +81432,7 @@ export const deletePlacementGroup: API.OperationMethod<
   DeletePlacementGroupRequest,
   DeletePlacementGroupResponse,
   DeletePlacementGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlacementGroupRequest,
   output: DeletePlacementGroupResponse,
@@ -81460,7 +81459,7 @@ export const deletePublicIpv4Pool: API.OperationMethod<
   DeletePublicIpv4PoolRequest,
   DeletePublicIpv4PoolResult,
   DeletePublicIpv4PoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublicIpv4PoolRequest,
   output: DeletePublicIpv4PoolResult,
@@ -81487,7 +81486,7 @@ export const deleteQueuedReservedInstances: API.OperationMethod<
   DeleteQueuedReservedInstancesRequest,
   DeleteQueuedReservedInstancesResult,
   DeleteQueuedReservedInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueuedReservedInstancesRequest,
   output: DeleteQueuedReservedInstancesResult,
@@ -81518,7 +81517,7 @@ export const deleteRoute: API.OperationMethod<
   DeleteRouteRequest,
   DeleteRouteResponse,
   DeleteRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteRequest,
   output: DeleteRouteResponse,
@@ -81565,7 +81564,7 @@ export const deleteRouteServer: API.OperationMethod<
   DeleteRouteServerRequest,
   DeleteRouteServerResult,
   DeleteRouteServerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteServerRequest,
   output: DeleteRouteServerResult,
@@ -81595,7 +81594,7 @@ export const deleteRouteServerEndpoint: API.OperationMethod<
   DeleteRouteServerEndpointRequest,
   DeleteRouteServerEndpointResult,
   DeleteRouteServerEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteServerEndpointRequest,
   output: DeleteRouteServerEndpointResult,
@@ -81632,7 +81631,7 @@ export const deleteRouteServerPeer: API.OperationMethod<
   DeleteRouteServerPeerRequest,
   DeleteRouteServerPeerResult,
   DeleteRouteServerPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteServerPeerRequest,
   output: DeleteRouteServerPeerResult,
@@ -81662,7 +81661,7 @@ export const deleteRouteTable: API.OperationMethod<
   DeleteRouteTableRequest,
   DeleteRouteTableResponse,
   DeleteRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteTableRequest,
   output: DeleteRouteTableResponse,
@@ -81686,7 +81685,7 @@ export const deleteSecondaryNetwork: API.OperationMethod<
   DeleteSecondaryNetworkRequest,
   DeleteSecondaryNetworkResult,
   DeleteSecondaryNetworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecondaryNetworkRequest,
   output: DeleteSecondaryNetworkResult,
@@ -81704,7 +81703,7 @@ export const deleteSecondarySubnet: API.OperationMethod<
   DeleteSecondarySubnetRequest,
   DeleteSecondarySubnetResult,
   DeleteSecondarySubnetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecondarySubnetRequest,
   output: DeleteSecondarySubnetResult,
@@ -81735,7 +81734,7 @@ export const deleteSecurityGroup: API.OperationMethod<
   DeleteSecurityGroupRequest,
   DeleteSecurityGroupResult,
   DeleteSecurityGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityGroupRequest,
   output: DeleteSecurityGroupResult,
@@ -81780,7 +81779,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
   DeleteSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotRequest,
   output: DeleteSnapshotResponse,
@@ -81804,7 +81803,7 @@ export const deleteSpotDatafeedSubscription: API.OperationMethod<
   DeleteSpotDatafeedSubscriptionRequest,
   DeleteSpotDatafeedSubscriptionResponse,
   DeleteSpotDatafeedSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpotDatafeedSubscriptionRequest,
   output: DeleteSpotDatafeedSubscriptionResponse,
@@ -81829,7 +81828,7 @@ export const deleteSubnet: API.OperationMethod<
   DeleteSubnetRequest,
   DeleteSubnetResponse,
   DeleteSubnetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubnetRequest,
   output: DeleteSubnetResponse,
@@ -81860,7 +81859,7 @@ export const deleteSubnetCidrReservation: API.OperationMethod<
   DeleteSubnetCidrReservationRequest,
   DeleteSubnetCidrReservationResult,
   DeleteSubnetCidrReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubnetCidrReservationRequest,
   output: DeleteSubnetCidrReservationResult,
@@ -81894,7 +81893,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResponse,
@@ -81924,7 +81923,7 @@ export const deleteTrafficMirrorFilter: API.OperationMethod<
   DeleteTrafficMirrorFilterRequest,
   DeleteTrafficMirrorFilterResult,
   DeleteTrafficMirrorFilterError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficMirrorFilterRequest,
   output: DeleteTrafficMirrorFilterResult,
@@ -81953,7 +81952,7 @@ export const deleteTrafficMirrorFilterRule: API.OperationMethod<
   DeleteTrafficMirrorFilterRuleRequest,
   DeleteTrafficMirrorFilterRuleResult,
   DeleteTrafficMirrorFilterRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficMirrorFilterRuleRequest,
   output: DeleteTrafficMirrorFilterRuleResult,
@@ -81983,7 +81982,7 @@ export const deleteTrafficMirrorSession: API.OperationMethod<
   DeleteTrafficMirrorSessionRequest,
   DeleteTrafficMirrorSessionResult,
   DeleteTrafficMirrorSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficMirrorSessionRequest,
   output: DeleteTrafficMirrorSessionResult,
@@ -82015,7 +82014,7 @@ export const deleteTrafficMirrorTarget: API.OperationMethod<
   DeleteTrafficMirrorTargetRequest,
   DeleteTrafficMirrorTargetResult,
   DeleteTrafficMirrorTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficMirrorTargetRequest,
   output: DeleteTrafficMirrorTargetResult,
@@ -82047,7 +82046,7 @@ export const deleteTransitGateway: API.OperationMethod<
   DeleteTransitGatewayRequest,
   DeleteTransitGatewayResult,
   DeleteTransitGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayRequest,
   output: DeleteTransitGatewayResult,
@@ -82073,7 +82072,7 @@ export const deleteTransitGatewayClientVpnAttachment: API.OperationMethod<
   DeleteTransitGatewayClientVpnAttachmentRequest,
   DeleteTransitGatewayClientVpnAttachmentResult,
   DeleteTransitGatewayClientVpnAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayClientVpnAttachmentRequest,
   output: DeleteTransitGatewayClientVpnAttachmentResult,
@@ -82096,7 +82095,7 @@ export const deleteTransitGatewayConnect: API.OperationMethod<
   DeleteTransitGatewayConnectRequest,
   DeleteTransitGatewayConnectResult,
   DeleteTransitGatewayConnectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayConnectRequest,
   output: DeleteTransitGatewayConnectResult,
@@ -82123,7 +82122,7 @@ export const deleteTransitGatewayConnectPeer: API.OperationMethod<
   DeleteTransitGatewayConnectPeerRequest,
   DeleteTransitGatewayConnectPeerResult,
   DeleteTransitGatewayConnectPeerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayConnectPeerRequest,
   output: DeleteTransitGatewayConnectPeerResult,
@@ -82152,7 +82151,7 @@ export const deleteTransitGatewayMeteringPolicy: API.OperationMethod<
   DeleteTransitGatewayMeteringPolicyRequest,
   DeleteTransitGatewayMeteringPolicyResult,
   DeleteTransitGatewayMeteringPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayMeteringPolicyRequest,
   output: DeleteTransitGatewayMeteringPolicyResult,
@@ -82182,7 +82181,7 @@ export const deleteTransitGatewayMeteringPolicyEntry: API.OperationMethod<
   DeleteTransitGatewayMeteringPolicyEntryRequest,
   DeleteTransitGatewayMeteringPolicyEntryResult,
   DeleteTransitGatewayMeteringPolicyEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayMeteringPolicyEntryRequest,
   output: DeleteTransitGatewayMeteringPolicyEntryResult,
@@ -82211,7 +82210,7 @@ export const deleteTransitGatewayMulticastDomain: API.OperationMethod<
   DeleteTransitGatewayMulticastDomainRequest,
   DeleteTransitGatewayMulticastDomainResult,
   DeleteTransitGatewayMulticastDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayMulticastDomainRequest,
   output: DeleteTransitGatewayMulticastDomainResult,
@@ -82238,7 +82237,7 @@ export const deleteTransitGatewayPeeringAttachment: API.OperationMethod<
   DeleteTransitGatewayPeeringAttachmentRequest,
   DeleteTransitGatewayPeeringAttachmentResult,
   DeleteTransitGatewayPeeringAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayPeeringAttachmentRequest,
   output: DeleteTransitGatewayPeeringAttachmentResult,
@@ -82266,7 +82265,7 @@ export const deleteTransitGatewayPolicyTable: API.OperationMethod<
   DeleteTransitGatewayPolicyTableRequest,
   DeleteTransitGatewayPolicyTableResult,
   DeleteTransitGatewayPolicyTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayPolicyTableRequest,
   output: DeleteTransitGatewayPolicyTableResult,
@@ -82295,7 +82294,7 @@ export const deleteTransitGatewayPrefixListReference: API.OperationMethod<
   DeleteTransitGatewayPrefixListReferenceRequest,
   DeleteTransitGatewayPrefixListReferenceResult,
   DeleteTransitGatewayPrefixListReferenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayPrefixListReferenceRequest,
   output: DeleteTransitGatewayPrefixListReferenceResult,
@@ -82323,7 +82322,7 @@ export const deleteTransitGatewayRoute: API.OperationMethod<
   DeleteTransitGatewayRouteRequest,
   DeleteTransitGatewayRouteResult,
   DeleteTransitGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayRouteRequest,
   output: DeleteTransitGatewayRouteResult,
@@ -82355,7 +82354,7 @@ export const deleteTransitGatewayRouteTable: API.OperationMethod<
   DeleteTransitGatewayRouteTableRequest,
   DeleteTransitGatewayRouteTableResult,
   DeleteTransitGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayRouteTableRequest,
   output: DeleteTransitGatewayRouteTableResult,
@@ -82386,7 +82385,7 @@ export const deleteTransitGatewayRouteTableAnnouncement: API.OperationMethod<
   DeleteTransitGatewayRouteTableAnnouncementRequest,
   DeleteTransitGatewayRouteTableAnnouncementResult,
   DeleteTransitGatewayRouteTableAnnouncementError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayRouteTableAnnouncementRequest,
   output: DeleteTransitGatewayRouteTableAnnouncementResult,
@@ -82414,7 +82413,7 @@ export const deleteTransitGatewayVpcAttachment: API.OperationMethod<
   DeleteTransitGatewayVpcAttachmentRequest,
   DeleteTransitGatewayVpcAttachmentResult,
   DeleteTransitGatewayVpcAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTransitGatewayVpcAttachmentRequest,
   output: DeleteTransitGatewayVpcAttachmentResult,
@@ -82443,7 +82442,7 @@ export const deleteVerifiedAccessEndpoint: API.OperationMethod<
   DeleteVerifiedAccessEndpointRequest,
   DeleteVerifiedAccessEndpointResult,
   DeleteVerifiedAccessEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedAccessEndpointRequest,
   output: DeleteVerifiedAccessEndpointResult,
@@ -82472,7 +82471,7 @@ export const deleteVerifiedAccessGroup: API.OperationMethod<
   DeleteVerifiedAccessGroupRequest,
   DeleteVerifiedAccessGroupResult,
   DeleteVerifiedAccessGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedAccessGroupRequest,
   output: DeleteVerifiedAccessGroupResult,
@@ -82499,7 +82498,7 @@ export const deleteVerifiedAccessInstance: API.OperationMethod<
   DeleteVerifiedAccessInstanceRequest,
   DeleteVerifiedAccessInstanceResult,
   DeleteVerifiedAccessInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedAccessInstanceRequest,
   output: DeleteVerifiedAccessInstanceResult,
@@ -82525,7 +82524,7 @@ export const deleteVerifiedAccessTrustProvider: API.OperationMethod<
   DeleteVerifiedAccessTrustProviderRequest,
   DeleteVerifiedAccessTrustProviderResult,
   DeleteVerifiedAccessTrustProviderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedAccessTrustProviderRequest,
   output: DeleteVerifiedAccessTrustProviderResult,
@@ -82559,7 +82558,7 @@ export const deleteVolume: API.OperationMethod<
   DeleteVolumeRequest,
   DeleteVolumeResponse,
   DeleteVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVolumeRequest,
   output: DeleteVolumeResponse,
@@ -82598,7 +82597,7 @@ export const deleteVpc: API.OperationMethod<
   DeleteVpcRequest,
   DeleteVpcResponse,
   DeleteVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcRequest,
   output: DeleteVpcResponse,
@@ -82629,7 +82628,7 @@ export const deleteVpcBlockPublicAccessExclusion: API.OperationMethod<
   DeleteVpcBlockPublicAccessExclusionRequest,
   DeleteVpcBlockPublicAccessExclusionResult,
   DeleteVpcBlockPublicAccessExclusionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcBlockPublicAccessExclusionRequest,
   output: DeleteVpcBlockPublicAccessExclusionResult,
@@ -82660,7 +82659,7 @@ export const deleteVpcEncryptionControl: API.OperationMethod<
   DeleteVpcEncryptionControlRequest,
   DeleteVpcEncryptionControlResult,
   DeleteVpcEncryptionControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEncryptionControlRequest,
   output: DeleteVpcEncryptionControlResult,
@@ -82684,7 +82683,7 @@ export const deleteVpcEndpointConnectionNotifications: API.OperationMethod<
   DeleteVpcEndpointConnectionNotificationsRequest,
   DeleteVpcEndpointConnectionNotificationsResult,
   DeleteVpcEndpointConnectionNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointConnectionNotificationsRequest,
   output: DeleteVpcEndpointConnectionNotificationsResult,
@@ -82714,7 +82713,7 @@ export const deleteVpcEndpoints: API.OperationMethod<
   DeleteVpcEndpointsRequest,
   DeleteVpcEndpointsResult,
   DeleteVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointsRequest,
   output: DeleteVpcEndpointsResult,
@@ -82740,7 +82739,7 @@ export const deleteVpcEndpointServiceConfigurations: API.OperationMethod<
   DeleteVpcEndpointServiceConfigurationsRequest,
   DeleteVpcEndpointServiceConfigurationsResult,
   DeleteVpcEndpointServiceConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointServiceConfigurationsRequest,
   output: DeleteVpcEndpointServiceConfigurationsResult,
@@ -82768,7 +82767,7 @@ export const deleteVpcPeeringConnection: API.OperationMethod<
   DeleteVpcPeeringConnectionRequest,
   DeleteVpcPeeringConnectionResult,
   DeleteVpcPeeringConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcPeeringConnectionRequest,
   output: DeleteVpcPeeringConnectionResult,
@@ -82796,7 +82795,7 @@ export const deleteVpnConcentrator: API.OperationMethod<
   DeleteVpnConcentratorRequest,
   DeleteVpnConcentratorResult,
   DeleteVpnConcentratorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpnConcentratorRequest,
   output: DeleteVpnConcentratorResult,
@@ -82835,7 +82834,7 @@ export const deleteVpnConnection: API.OperationMethod<
   DeleteVpnConnectionRequest,
   DeleteVpnConnectionResponse,
   DeleteVpnConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpnConnectionRequest,
   output: DeleteVpnConnectionResponse,
@@ -82866,7 +82865,7 @@ export const deleteVpnConnectionRoute: API.OperationMethod<
   DeleteVpnConnectionRouteRequest,
   DeleteVpnConnectionRouteResponse,
   DeleteVpnConnectionRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpnConnectionRouteRequest,
   output: DeleteVpnConnectionRouteResponse,
@@ -82897,7 +82896,7 @@ export const deleteVpnGateway: API.OperationMethod<
   DeleteVpnGatewayRequest,
   DeleteVpnGatewayResponse,
   DeleteVpnGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpnGatewayRequest,
   output: DeleteVpnGatewayResponse,
@@ -82927,7 +82926,7 @@ export const deprovisionByoipCidr: API.OperationMethod<
   DeprovisionByoipCidrRequest,
   DeprovisionByoipCidrResult,
   DeprovisionByoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprovisionByoipCidrRequest,
   output: DeprovisionByoipCidrResult,
@@ -82951,7 +82950,7 @@ export const deprovisionIpamByoasn: API.OperationMethod<
   DeprovisionIpamByoasnRequest,
   DeprovisionIpamByoasnResult,
   DeprovisionIpamByoasnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprovisionIpamByoasnRequest,
   output: DeprovisionIpamByoasnResult,
@@ -82979,7 +82978,7 @@ export const deprovisionIpamPoolCidr: API.OperationMethod<
   DeprovisionIpamPoolCidrRequest,
   DeprovisionIpamPoolCidrResult,
   DeprovisionIpamPoolCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprovisionIpamPoolCidrRequest,
   output: DeprovisionIpamPoolCidrResult,
@@ -83008,7 +83007,7 @@ export const deprovisionPublicIpv4PoolCidr: API.OperationMethod<
   DeprovisionPublicIpv4PoolCidrRequest,
   DeprovisionPublicIpv4PoolCidrResult,
   DeprovisionPublicIpv4PoolCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprovisionPublicIpv4PoolCidrRequest,
   output: DeprovisionPublicIpv4PoolCidrResult,
@@ -83064,7 +83063,7 @@ export const deregisterImage: API.OperationMethod<
   DeregisterImageRequest,
   DeregisterImageResult,
   DeregisterImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterImageRequest,
   output: DeregisterImageResult,
@@ -83093,7 +83092,7 @@ export const deregisterInstanceEventNotificationAttributes: API.OperationMethod<
   DeregisterInstanceEventNotificationAttributesRequest,
   DeregisterInstanceEventNotificationAttributesResult,
   DeregisterInstanceEventNotificationAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterInstanceEventNotificationAttributesRequest,
   output: DeregisterInstanceEventNotificationAttributesResult,
@@ -83115,7 +83114,7 @@ export const deregisterTransitGatewayMulticastGroupMembers: API.OperationMethod<
   DeregisterTransitGatewayMulticastGroupMembersRequest,
   DeregisterTransitGatewayMulticastGroupMembersResult,
   DeregisterTransitGatewayMulticastGroupMembersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTransitGatewayMulticastGroupMembersRequest,
   output: DeregisterTransitGatewayMulticastGroupMembersResult,
@@ -83137,7 +83136,7 @@ export const deregisterTransitGatewayMulticastGroupSources: API.OperationMethod<
   DeregisterTransitGatewayMulticastGroupSourcesRequest,
   DeregisterTransitGatewayMulticastGroupSourcesResult,
   DeregisterTransitGatewayMulticastGroupSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTransitGatewayMulticastGroupSourcesRequest,
   output: DeregisterTransitGatewayMulticastGroupSourcesResult,
@@ -83175,7 +83174,7 @@ export const describeAccountAttributes: API.OperationMethod<
   DescribeAccountAttributesRequest,
   DescribeAccountAttributesResult,
   DescribeAccountAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAttributesRequest,
   output: DescribeAccountAttributesResult,
@@ -83197,7 +83196,7 @@ export const describeAddresses: API.OperationMethod<
   DescribeAddressesRequest,
   DescribeAddressesResult,
   DescribeAddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAddressesRequest,
   output: DescribeAddressesResult,
@@ -83223,7 +83222,7 @@ export const describeAddressesAttribute: API.PaginatedOperationMethod<
   DescribeAddressesAttributeRequest,
   DescribeAddressesAttributeResult,
   DescribeAddressesAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddressAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAddressesAttributeRequest,
@@ -83262,7 +83261,7 @@ export const describeAddressTransfers: API.PaginatedOperationMethod<
   DescribeAddressTransfersRequest,
   DescribeAddressTransfersResult,
   DescribeAddressTransfersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddressTransfer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAddressTransfersRequest,
@@ -83305,7 +83304,7 @@ export const describeAggregateIdFormat: API.OperationMethod<
   DescribeAggregateIdFormatRequest,
   DescribeAggregateIdFormatResult,
   DescribeAggregateIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAggregateIdFormatRequest,
   output: DescribeAggregateIdFormatResult,
@@ -83337,7 +83336,7 @@ export const describeAvailabilityZones: API.OperationMethod<
   DescribeAvailabilityZonesRequest,
   DescribeAvailabilityZonesResult,
   DescribeAvailabilityZonesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAvailabilityZonesRequest,
   output: DescribeAvailabilityZonesResult,
@@ -83361,7 +83360,7 @@ export const describeAwsNetworkPerformanceMetricSubscriptions: API.PaginatedOper
   DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
   DescribeAwsNetworkPerformanceMetricSubscriptionsResult,
   DescribeAwsNetworkPerformanceMetricSubscriptionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
@@ -83399,7 +83398,7 @@ export const describeBundleTasks: API.OperationMethod<
   DescribeBundleTasksRequest,
   DescribeBundleTasksResult,
   DescribeBundleTasksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBundleTasksRequest,
   output: DescribeBundleTasksResult,
@@ -83427,7 +83426,7 @@ export const describeByoipCidrs: API.PaginatedOperationMethod<
   DescribeByoipCidrsRequest,
   DescribeByoipCidrsResult,
   DescribeByoipCidrsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ByoipCidr
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeByoipCidrsRequest,
@@ -83457,7 +83456,7 @@ export const describeCapacityBlockExtensionHistory: API.PaginatedOperationMethod
   DescribeCapacityBlockExtensionHistoryRequest,
   DescribeCapacityBlockExtensionHistoryResult,
   DescribeCapacityBlockExtensionHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityBlockExtension
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityBlockExtensionHistoryRequest,
@@ -83491,7 +83490,7 @@ export const describeCapacityBlockExtensionOfferings: API.PaginatedOperationMeth
   DescribeCapacityBlockExtensionOfferingsRequest,
   DescribeCapacityBlockExtensionOfferingsResult,
   DescribeCapacityBlockExtensionOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityBlockExtensionOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityBlockExtensionOfferingsRequest,
@@ -83528,7 +83527,7 @@ export const describeCapacityBlockOfferings: API.PaginatedOperationMethod<
   DescribeCapacityBlockOfferingsRequest,
   DescribeCapacityBlockOfferingsResult,
   DescribeCapacityBlockOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityBlockOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityBlockOfferingsRequest,
@@ -83557,7 +83556,7 @@ export const describeCapacityBlocks: API.PaginatedOperationMethod<
   DescribeCapacityBlocksRequest,
   DescribeCapacityBlocksResult,
   DescribeCapacityBlocksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityBlock
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityBlocksRequest,
@@ -83590,7 +83589,7 @@ export const describeCapacityBlockStatus: API.PaginatedOperationMethod<
   DescribeCapacityBlockStatusRequest,
   DescribeCapacityBlockStatusResult,
   DescribeCapacityBlockStatusError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityBlockStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityBlockStatusRequest,
@@ -83623,7 +83622,7 @@ export const describeCapacityManagerDataExports: API.PaginatedOperationMethod<
   DescribeCapacityManagerDataExportsRequest,
   DescribeCapacityManagerDataExportsResult,
   DescribeCapacityManagerDataExportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityManagerDataExportResponse
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityManagerDataExportsRequest,
@@ -83658,7 +83657,7 @@ export const describeCapacityReservationBillingRequests: API.PaginatedOperationM
   DescribeCapacityReservationBillingRequestsRequest,
   DescribeCapacityReservationBillingRequestsResult,
   DescribeCapacityReservationBillingRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityReservationBillingRequest
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityReservationBillingRequestsRequest,
@@ -83685,7 +83684,7 @@ export const describeCapacityReservationCancellationQuotes: API.OperationMethod<
   DescribeCapacityReservationCancellationQuotesRequest,
   DescribeCapacityReservationCancellationQuotesResult,
   DescribeCapacityReservationCancellationQuotesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCapacityReservationCancellationQuotesRequest,
   output: DescribeCapacityReservationCancellationQuotesResult,
@@ -83707,7 +83706,7 @@ export const describeCapacityReservationFleets: API.PaginatedOperationMethod<
   DescribeCapacityReservationFleetsRequest,
   DescribeCapacityReservationFleetsResult,
   DescribeCapacityReservationFleetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityReservationFleet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityReservationFleetsRequest,
@@ -83742,7 +83741,7 @@ export const describeCapacityReservations: API.PaginatedOperationMethod<
   DescribeCapacityReservationsRequest,
   DescribeCapacityReservationsResult,
   DescribeCapacityReservationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityReservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCapacityReservationsRequest,
@@ -83792,7 +83791,7 @@ export const describeCapacityReservationTopology: API.OperationMethod<
   DescribeCapacityReservationTopologyRequest,
   DescribeCapacityReservationTopologyResult,
   DescribeCapacityReservationTopologyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCapacityReservationTopologyRequest,
   output: DescribeCapacityReservationTopologyResult,
@@ -83816,7 +83815,7 @@ export const describeCarrierGateways: API.PaginatedOperationMethod<
   DescribeCarrierGatewaysRequest,
   DescribeCarrierGatewaysResult,
   DescribeCarrierGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CarrierGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCarrierGatewaysRequest,
@@ -83855,7 +83854,7 @@ export const describeClassicLinkInstances: API.PaginatedOperationMethod<
   DescribeClassicLinkInstancesRequest,
   DescribeClassicLinkInstancesResult,
   DescribeClassicLinkInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClassicLinkInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClassicLinkInstancesRequest,
@@ -83888,7 +83887,7 @@ export const describeClientVpnAuthorizationRules: API.PaginatedOperationMethod<
   DescribeClientVpnAuthorizationRulesRequest,
   DescribeClientVpnAuthorizationRulesResult,
   DescribeClientVpnAuthorizationRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuthorizationRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientVpnAuthorizationRulesRequest,
@@ -83923,7 +83922,7 @@ export const describeClientVpnConnections: API.PaginatedOperationMethod<
   DescribeClientVpnConnectionsRequest,
   DescribeClientVpnConnectionsResult,
   DescribeClientVpnConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientVpnConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientVpnConnectionsRequest,
@@ -83957,7 +83956,7 @@ export const describeClientVpnEndpoints: API.PaginatedOperationMethod<
   DescribeClientVpnEndpointsRequest,
   DescribeClientVpnEndpointsResult,
   DescribeClientVpnEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientVpnEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientVpnEndpointsRequest,
@@ -83991,7 +83990,7 @@ export const describeClientVpnRoutes: API.PaginatedOperationMethod<
   DescribeClientVpnRoutesRequest,
   DescribeClientVpnRoutesResult,
   DescribeClientVpnRoutesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientVpnRoute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientVpnRoutesRequest,
@@ -84026,7 +84025,7 @@ export const describeClientVpnTargetNetworks: API.PaginatedOperationMethod<
   DescribeClientVpnTargetNetworksRequest,
   DescribeClientVpnTargetNetworksResult,
   DescribeClientVpnTargetNetworksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetNetwork
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClientVpnTargetNetworksRequest,
@@ -84060,7 +84059,7 @@ export const describeCoipPools: API.PaginatedOperationMethod<
   DescribeCoipPoolsRequest,
   DescribeCoipPoolsResult,
   DescribeCoipPoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoipPool
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCoipPoolsRequest,
@@ -84088,7 +84087,7 @@ export const describeConversionTasks: API.OperationMethod<
   DescribeConversionTasksRequest,
   DescribeConversionTasksResult,
   DescribeConversionTasksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConversionTasksRequest,
   output: DescribeConversionTasksResult,
@@ -84114,7 +84113,7 @@ export const describeCustomerGateways: API.OperationMethod<
   DescribeCustomerGatewaysRequest,
   DescribeCustomerGatewaysResult,
   DescribeCustomerGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomerGatewaysRequest,
   output: DescribeCustomerGatewaysResult,
@@ -84152,7 +84151,7 @@ export const describeDeclarativePoliciesReports: API.OperationMethod<
   DescribeDeclarativePoliciesReportsRequest,
   DescribeDeclarativePoliciesReportsResult,
   DescribeDeclarativePoliciesReportsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeclarativePoliciesReportsRequest,
   output: DescribeDeclarativePoliciesReportsResult,
@@ -84182,7 +84181,7 @@ export const describeDhcpOptions: API.PaginatedOperationMethod<
   DescribeDhcpOptionsRequest,
   DescribeDhcpOptionsResult,
   DescribeDhcpOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DhcpOptions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDhcpOptionsRequest,
@@ -84222,7 +84221,7 @@ export const describeEgressOnlyInternetGateways: API.PaginatedOperationMethod<
   DescribeEgressOnlyInternetGatewaysRequest,
   DescribeEgressOnlyInternetGatewaysResult,
   DescribeEgressOnlyInternetGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EgressOnlyInternetGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEgressOnlyInternetGatewaysRequest,
@@ -84259,7 +84258,7 @@ export const describeElasticGpus: API.OperationMethod<
   DescribeElasticGpusRequest,
   DescribeElasticGpusResult,
   DescribeElasticGpusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeElasticGpusRequest,
   output: DescribeElasticGpusResult,
@@ -84281,7 +84280,7 @@ export const describeExportImageTasks: API.PaginatedOperationMethod<
   DescribeExportImageTasksRequest,
   DescribeExportImageTasksResult,
   DescribeExportImageTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportImageTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeExportImageTasksRequest,
@@ -84314,7 +84313,7 @@ export const describeExportTasks: API.OperationMethod<
   DescribeExportTasksRequest,
   DescribeExportTasksResult,
   DescribeExportTasksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExportTasksRequest,
   output: DescribeExportTasksResult,
@@ -84340,7 +84339,7 @@ export const describeFastLaunchImages: API.PaginatedOperationMethod<
   DescribeFastLaunchImagesRequest,
   DescribeFastLaunchImagesResult,
   DescribeFastLaunchImagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeFastLaunchImagesSuccessItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFastLaunchImagesRequest,
@@ -84365,7 +84364,7 @@ export const describeFastSnapshotRestores: API.PaginatedOperationMethod<
   DescribeFastSnapshotRestoresRequest,
   DescribeFastSnapshotRestoresResult,
   DescribeFastSnapshotRestoresError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeFastSnapshotRestoreSuccessItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFastSnapshotRestoresRequest,
@@ -84401,7 +84400,7 @@ export const describeFleetHistory: API.OperationMethod<
   DescribeFleetHistoryRequest,
   DescribeFleetHistoryResult,
   DescribeFleetHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetHistoryRequest,
   output: DescribeFleetHistoryResult,
@@ -84434,7 +84433,7 @@ export const describeFleetInstances: API.OperationMethod<
   DescribeFleetInstancesRequest,
   DescribeFleetInstancesResult,
   DescribeFleetInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetInstancesRequest,
   output: DescribeFleetInstancesResult,
@@ -84466,7 +84465,7 @@ export const describeFleets: API.PaginatedOperationMethod<
   DescribeFleetsRequest,
   DescribeFleetsResult,
   DescribeFleetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetsRequest,
@@ -84503,7 +84502,7 @@ export const describeFlowLogs: API.PaginatedOperationMethod<
   DescribeFlowLogsRequest,
   DescribeFlowLogsResult,
   DescribeFlowLogsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowLog
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFlowLogsRequest,
@@ -84538,7 +84537,7 @@ export const describeFpgaImageAttribute: API.OperationMethod<
   DescribeFpgaImageAttributeRequest,
   DescribeFpgaImageAttributeResult,
   DescribeFpgaImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFpgaImageAttributeRequest,
   output: DescribeFpgaImageAttributeResult,
@@ -84567,7 +84566,7 @@ export const describeFpgaImages: API.PaginatedOperationMethod<
   DescribeFpgaImagesRequest,
   DescribeFpgaImagesResult,
   DescribeFpgaImagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FpgaImage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFpgaImagesRequest,
@@ -84607,7 +84606,7 @@ export const describeHostReservationOfferings: API.PaginatedOperationMethod<
   DescribeHostReservationOfferingsRequest,
   DescribeHostReservationOfferingsResult,
   DescribeHostReservationOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HostOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHostReservationOfferingsRequest,
@@ -84637,7 +84636,7 @@ export const describeHostReservations: API.PaginatedOperationMethod<
   DescribeHostReservationsRequest,
   DescribeHostReservationsResult,
   DescribeHostReservationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HostReservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHostReservationsRequest,
@@ -84670,7 +84669,7 @@ export const describeHosts: API.PaginatedOperationMethod<
   DescribeHostsRequest,
   DescribeHostsResult,
   DescribeHostsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Host
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHostsRequest,
@@ -84699,7 +84698,7 @@ export const describeIamInstanceProfileAssociations: API.PaginatedOperationMetho
   DescribeIamInstanceProfileAssociationsRequest,
   DescribeIamInstanceProfileAssociationsResult,
   DescribeIamInstanceProfileAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IamInstanceProfileAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIamInstanceProfileAssociationsRequest,
@@ -84748,7 +84747,7 @@ export const describeIdentityIdFormat: API.OperationMethod<
   DescribeIdentityIdFormatRequest,
   DescribeIdentityIdFormatResult,
   DescribeIdentityIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityIdFormatRequest,
   output: DescribeIdentityIdFormatResult,
@@ -84791,7 +84790,7 @@ export const describeIdFormat: API.OperationMethod<
   DescribeIdFormatRequest,
   DescribeIdFormatResult,
   DescribeIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdFormatRequest,
   output: DescribeIdFormatResult,
@@ -84818,7 +84817,7 @@ export const describeImageAttribute: API.OperationMethod<
   DescribeImageAttributeRequest,
   ImageAttribute,
   DescribeImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageAttributeRequest,
   output: ImageAttribute,
@@ -84848,7 +84847,7 @@ export const describeImageReferences: API.PaginatedOperationMethod<
   DescribeImageReferencesRequest,
   DescribeImageReferencesResult,
   DescribeImageReferencesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImageReferencesRequest,
@@ -84906,7 +84905,7 @@ export const describeImages: API.PaginatedOperationMethod<
   DescribeImagesRequest,
   DescribeImagesResult,
   DescribeImagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Image
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImagesRequest,
@@ -84944,7 +84943,7 @@ export const describeImageUsageReportEntries: API.PaginatedOperationMethod<
   DescribeImageUsageReportEntriesRequest,
   DescribeImageUsageReportEntriesResult,
   DescribeImageUsageReportEntriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageUsageReportEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImageUsageReportEntriesRequest,
@@ -84977,7 +84976,7 @@ export const describeImageUsageReports: API.PaginatedOperationMethod<
   DescribeImageUsageReportsRequest,
   DescribeImageUsageReportsResult,
   DescribeImageUsageReportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageUsageReport
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImageUsageReportsRequest,
@@ -85006,7 +85005,7 @@ export const describeImportImageTasks: API.PaginatedOperationMethod<
   DescribeImportImageTasksRequest,
   DescribeImportImageTasksResult,
   DescribeImportImageTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportImageTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImportImageTasksRequest,
@@ -85035,7 +85034,7 @@ export const describeImportSnapshotTasks: API.PaginatedOperationMethod<
   DescribeImportSnapshotTasksRequest,
   DescribeImportSnapshotTasksResult,
   DescribeImportSnapshotTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportSnapshotTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImportSnapshotTasksRequest,
@@ -85067,7 +85066,7 @@ export const describeInstanceAttribute: API.OperationMethod<
   DescribeInstanceAttributeRequest,
   InstanceAttribute,
   DescribeInstanceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceAttributeRequest,
   output: InstanceAttribute,
@@ -85094,7 +85093,7 @@ export const describeInstanceConnectEndpoints: API.PaginatedOperationMethod<
   DescribeInstanceConnectEndpointsRequest,
   DescribeInstanceConnectEndpointsResult,
   DescribeInstanceConnectEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Ec2InstanceConnectEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceConnectEndpointsRequest,
@@ -85151,7 +85150,7 @@ export const describeInstanceCreditSpecifications: API.PaginatedOperationMethod<
   DescribeInstanceCreditSpecificationsRequest,
   DescribeInstanceCreditSpecificationsResult,
   DescribeInstanceCreditSpecificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceCreditSpecification
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceCreditSpecificationsRequest,
@@ -85181,7 +85180,7 @@ export const describeInstanceEventNotificationAttributes: API.OperationMethod<
   DescribeInstanceEventNotificationAttributesRequest,
   DescribeInstanceEventNotificationAttributesResult,
   DescribeInstanceEventNotificationAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceEventNotificationAttributesRequest,
   output: DescribeInstanceEventNotificationAttributesResult,
@@ -85213,7 +85212,7 @@ export const describeInstanceEventWindows: API.PaginatedOperationMethod<
   DescribeInstanceEventWindowsRequest,
   DescribeInstanceEventWindowsResult,
   DescribeInstanceEventWindowsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceEventWindow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceEventWindowsRequest,
@@ -85268,7 +85267,7 @@ export const describeInstanceImageMetadata: API.PaginatedOperationMethod<
   DescribeInstanceImageMetadataRequest,
   DescribeInstanceImageMetadataResult,
   DescribeInstanceImageMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceImageMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceImageMetadataRequest,
@@ -85339,7 +85338,7 @@ export const describeInstances: API.PaginatedOperationMethod<
   DescribeInstancesRequest,
   DescribeInstancesResult,
   DescribeInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Reservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancesRequest,
@@ -85375,7 +85374,7 @@ export const describeInstanceSqlHaHistoryStates: API.OperationMethod<
   DescribeInstanceSqlHaHistoryStatesRequest,
   DescribeInstanceSqlHaHistoryStatesResult,
   DescribeInstanceSqlHaHistoryStatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceSqlHaHistoryStatesRequest,
   output: DescribeInstanceSqlHaHistoryStatesResult,
@@ -85402,7 +85401,7 @@ export const describeInstanceSqlHaStates: API.OperationMethod<
   DescribeInstanceSqlHaStatesRequest,
   DescribeInstanceSqlHaStatesResult,
   DescribeInstanceSqlHaStatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceSqlHaStatesRequest,
   output: DescribeInstanceSqlHaStatesResult,
@@ -85461,7 +85460,7 @@ export const describeInstanceStatus: API.PaginatedOperationMethod<
   DescribeInstanceStatusRequest,
   DescribeInstanceStatusResult,
   DescribeInstanceStatusError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceStatusRequest,
@@ -85511,7 +85510,7 @@ export const describeInstanceTopology: API.PaginatedOperationMethod<
   DescribeInstanceTopologyRequest,
   DescribeInstanceTopologyResult,
   DescribeInstanceTopologyError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTopology
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceTopologyRequest,
@@ -85538,7 +85537,7 @@ export const describeInstanceTypeOfferings: API.PaginatedOperationMethod<
   DescribeInstanceTypeOfferingsRequest,
   DescribeInstanceTypeOfferingsResult,
   DescribeInstanceTypeOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceTypeOfferingsRequest,
@@ -85566,7 +85565,7 @@ export const describeInstanceTypes: API.PaginatedOperationMethod<
   DescribeInstanceTypesRequest,
   DescribeInstanceTypesResult,
   DescribeInstanceTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceTypesRequest,
@@ -85598,7 +85597,7 @@ export const describeInternetGateways: API.PaginatedOperationMethod<
   DescribeInternetGatewaysRequest,
   DescribeInternetGatewaysResult,
   DescribeInternetGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InternetGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInternetGatewaysRequest,
@@ -85628,7 +85627,7 @@ export const describeIpamByoasn: API.OperationMethod<
   DescribeIpamByoasnRequest,
   DescribeIpamByoasnResult,
   DescribeIpamByoasnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIpamByoasnRequest,
   output: DescribeIpamByoasnResult,
@@ -85652,7 +85651,7 @@ export const describeIpamExternalResourceVerificationTokens: API.OperationMethod
   DescribeIpamExternalResourceVerificationTokensRequest,
   DescribeIpamExternalResourceVerificationTokensResult,
   DescribeIpamExternalResourceVerificationTokensError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIpamExternalResourceVerificationTokensRequest,
   output: DescribeIpamExternalResourceVerificationTokensResult,
@@ -85680,7 +85679,7 @@ export const describeIpamPolicies: API.OperationMethod<
   DescribeIpamPoliciesRequest,
   DescribeIpamPoliciesResult,
   DescribeIpamPoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIpamPoliciesRequest,
   output: DescribeIpamPoliciesResult,
@@ -85706,7 +85705,7 @@ export const describeIpamPoolAllocations: API.PaginatedOperationMethod<
   DescribeIpamPoolAllocationsRequest,
   DescribeIpamPoolAllocationsResult,
   DescribeIpamPoolAllocationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPoolAllocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamPoolAllocationsRequest,
@@ -85735,7 +85734,7 @@ export const describeIpamPools: API.PaginatedOperationMethod<
   DescribeIpamPoolsRequest,
   DescribeIpamPoolsResult,
   DescribeIpamPoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPool
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamPoolsRequest,
@@ -85768,7 +85767,7 @@ export const describeIpamPrefixListResolvers: API.PaginatedOperationMethod<
   DescribeIpamPrefixListResolversRequest,
   DescribeIpamPrefixListResolversResult,
   DescribeIpamPrefixListResolversError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPrefixListResolver
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamPrefixListResolversRequest,
@@ -85801,7 +85800,7 @@ export const describeIpamPrefixListResolverTargets: API.PaginatedOperationMethod
   DescribeIpamPrefixListResolverTargetsRequest,
   DescribeIpamPrefixListResolverTargetsResult,
   DescribeIpamPrefixListResolverTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPrefixListResolverTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamPrefixListResolverTargetsRequest,
@@ -85834,7 +85833,7 @@ export const describeIpamResourceDiscoveries: API.PaginatedOperationMethod<
   DescribeIpamResourceDiscoveriesRequest,
   DescribeIpamResourceDiscoveriesResult,
   DescribeIpamResourceDiscoveriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamResourceDiscovery
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamResourceDiscoveriesRequest,
@@ -85867,7 +85866,7 @@ export const describeIpamResourceDiscoveryAssociations: API.PaginatedOperationMe
   DescribeIpamResourceDiscoveryAssociationsRequest,
   DescribeIpamResourceDiscoveryAssociationsResult,
   DescribeIpamResourceDiscoveryAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamResourceDiscoveryAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamResourceDiscoveryAssociationsRequest,
@@ -85902,7 +85901,7 @@ export const describeIpams: API.PaginatedOperationMethod<
   DescribeIpamsRequest,
   DescribeIpamsResult,
   DescribeIpamsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Ipam
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamsRequest,
@@ -85931,7 +85930,7 @@ export const describeIpamScopes: API.PaginatedOperationMethod<
   DescribeIpamScopesRequest,
   DescribeIpamScopesResult,
   DescribeIpamScopesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamScope
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpamScopesRequest,
@@ -85964,7 +85963,7 @@ export const describeIpv6Pools: API.PaginatedOperationMethod<
   DescribeIpv6PoolsRequest,
   DescribeIpv6PoolsResult,
   DescribeIpv6PoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Ipv6Pool
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIpv6PoolsRequest,
@@ -86001,7 +86000,7 @@ export const describeKeyPairs: API.OperationMethod<
   DescribeKeyPairsRequest,
   DescribeKeyPairsResult,
   DescribeKeyPairsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyPairsRequest,
   output: DescribeKeyPairsResult,
@@ -86031,7 +86030,7 @@ export const describeLaunchTemplates: API.PaginatedOperationMethod<
   DescribeLaunchTemplatesRequest,
   DescribeLaunchTemplatesResult,
   DescribeLaunchTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLaunchTemplatesRequest,
@@ -86071,7 +86070,7 @@ export const describeLaunchTemplateVersions: API.PaginatedOperationMethod<
   DescribeLaunchTemplateVersionsRequest,
   DescribeLaunchTemplateVersionsResult,
   DescribeLaunchTemplateVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchTemplateVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLaunchTemplateVersionsRequest,
@@ -86102,7 +86101,7 @@ export const describeLocalGatewayRouteTables: API.PaginatedOperationMethod<
   DescribeLocalGatewayRouteTablesRequest,
   DescribeLocalGatewayRouteTablesResult,
   DescribeLocalGatewayRouteTablesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayRouteTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewayRouteTablesRequest,
@@ -86128,7 +86127,7 @@ export const describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations: AP
   DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest,
   DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult,
   DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayRouteTableVirtualInterfaceGroupAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest,
@@ -86154,7 +86153,7 @@ export const describeLocalGatewayRouteTableVpcAssociations: API.PaginatedOperati
   DescribeLocalGatewayRouteTableVpcAssociationsRequest,
   DescribeLocalGatewayRouteTableVpcAssociationsResult,
   DescribeLocalGatewayRouteTableVpcAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayRouteTableVpcAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewayRouteTableVpcAssociationsRequest,
@@ -86180,7 +86179,7 @@ export const describeLocalGateways: API.PaginatedOperationMethod<
   DescribeLocalGatewaysRequest,
   DescribeLocalGatewaysResult,
   DescribeLocalGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewaysRequest,
@@ -86205,7 +86204,7 @@ export const describeLocalGatewayVirtualInterfaceGroups: API.PaginatedOperationM
   DescribeLocalGatewayVirtualInterfaceGroupsRequest,
   DescribeLocalGatewayVirtualInterfaceGroupsResult,
   DescribeLocalGatewayVirtualInterfaceGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayVirtualInterfaceGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewayVirtualInterfaceGroupsRequest,
@@ -86230,7 +86229,7 @@ export const describeLocalGatewayVirtualInterfaces: API.PaginatedOperationMethod
   DescribeLocalGatewayVirtualInterfacesRequest,
   DescribeLocalGatewayVirtualInterfacesResult,
   DescribeLocalGatewayVirtualInterfacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayVirtualInterface
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLocalGatewayVirtualInterfacesRequest,
@@ -86259,7 +86258,7 @@ export const describeLockedSnapshots: API.OperationMethod<
   DescribeLockedSnapshotsRequest,
   DescribeLockedSnapshotsResult,
   DescribeLockedSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLockedSnapshotsRequest,
   output: DescribeLockedSnapshotsResult,
@@ -86281,7 +86280,7 @@ export const describeMacHosts: API.PaginatedOperationMethod<
   DescribeMacHostsRequest,
   DescribeMacHostsResult,
   DescribeMacHostsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MacHost
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMacHostsRequest,
@@ -86312,7 +86311,7 @@ export const describeMacModificationTasks: API.PaginatedOperationMethod<
   DescribeMacModificationTasksRequest,
   DescribeMacModificationTasksResult,
   DescribeMacModificationTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MacModificationTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMacModificationTasksRequest,
@@ -86342,7 +86341,7 @@ export const describeManagedPrefixLists: API.PaginatedOperationMethod<
   DescribeManagedPrefixListsRequest,
   DescribeManagedPrefixListsResult,
   DescribeManagedPrefixListsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedPrefixList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeManagedPrefixListsRequest,
@@ -86379,7 +86378,7 @@ export const describeMovingAddresses: API.PaginatedOperationMethod<
   DescribeMovingAddressesRequest,
   DescribeMovingAddressesResult,
   DescribeMovingAddressesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MovingAddressStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMovingAddressesRequest,
@@ -86415,7 +86414,7 @@ export const describeNatGateways: API.PaginatedOperationMethod<
   DescribeNatGatewaysRequest,
   DescribeNatGatewaysResult,
   DescribeNatGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NatGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNatGatewaysRequest,
@@ -86460,7 +86459,7 @@ export const describeNetworkAcls: API.PaginatedOperationMethod<
   DescribeNetworkAclsRequest,
   DescribeNetworkAclsResult,
   DescribeNetworkAclsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkAcl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkAclsRequest,
@@ -86495,7 +86494,7 @@ export const describeNetworkInsightsAccessScopeAnalyses: API.PaginatedOperationM
   DescribeNetworkInsightsAccessScopeAnalysesRequest,
   DescribeNetworkInsightsAccessScopeAnalysesResult,
   DescribeNetworkInsightsAccessScopeAnalysesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInsightsAccessScopeAnalysis
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInsightsAccessScopeAnalysesRequest,
@@ -86524,7 +86523,7 @@ export const describeNetworkInsightsAccessScopes: API.PaginatedOperationMethod<
   DescribeNetworkInsightsAccessScopesRequest,
   DescribeNetworkInsightsAccessScopesResult,
   DescribeNetworkInsightsAccessScopesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInsightsAccessScope
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInsightsAccessScopesRequest,
@@ -86553,7 +86552,7 @@ export const describeNetworkInsightsAnalyses: API.PaginatedOperationMethod<
   DescribeNetworkInsightsAnalysesRequest,
   DescribeNetworkInsightsAnalysesResult,
   DescribeNetworkInsightsAnalysesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInsightsAnalysis
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInsightsAnalysesRequest,
@@ -86582,7 +86581,7 @@ export const describeNetworkInsightsPaths: API.PaginatedOperationMethod<
   DescribeNetworkInsightsPathsRequest,
   DescribeNetworkInsightsPathsResult,
   DescribeNetworkInsightsPathsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInsightsPath
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInsightsPathsRequest,
@@ -86614,7 +86613,7 @@ export const describeNetworkInterfaceAttribute: API.OperationMethod<
   DescribeNetworkInterfaceAttributeRequest,
   DescribeNetworkInterfaceAttributeResult,
   DescribeNetworkInterfaceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNetworkInterfaceAttributeRequest,
   output: DescribeNetworkInterfaceAttributeResult,
@@ -86642,7 +86641,7 @@ export const describeNetworkInterfacePermissions: API.PaginatedOperationMethod<
   DescribeNetworkInterfacePermissionsRequest,
   DescribeNetworkInterfacePermissionsResult,
   DescribeNetworkInterfacePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInterfacePermission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInterfacePermissionsRequest,
@@ -86686,7 +86685,7 @@ export const describeNetworkInterfaces: API.PaginatedOperationMethod<
   DescribeNetworkInterfacesRequest,
   DescribeNetworkInterfacesResult,
   DescribeNetworkInterfacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInterface
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNetworkInterfacesRequest,
@@ -86723,7 +86722,7 @@ export const describeOutpostLags: API.OperationMethod<
   DescribeOutpostLagsRequest,
   DescribeOutpostLagsResult,
   DescribeOutpostLagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOutpostLagsRequest,
   output: DescribeOutpostLagsResult,
@@ -86759,7 +86758,7 @@ export const describePlacementGroups: API.OperationMethod<
   DescribePlacementGroupsRequest,
   DescribePlacementGroupsResult,
   DescribePlacementGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePlacementGroupsRequest,
   output: DescribePlacementGroupsResult,
@@ -86787,7 +86786,7 @@ export const describePrefixLists: API.PaginatedOperationMethod<
   DescribePrefixListsRequest,
   DescribePrefixListsResult,
   DescribePrefixListsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrefixList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePrefixListsRequest,
@@ -86835,7 +86834,7 @@ export const describePrincipalIdFormat: API.PaginatedOperationMethod<
   DescribePrincipalIdFormatRequest,
   DescribePrincipalIdFormatResult,
   DescribePrincipalIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrincipalIdFormat
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePrincipalIdFormatRequest,
@@ -86864,7 +86863,7 @@ export const describePublicIpv4Pools: API.PaginatedOperationMethod<
   DescribePublicIpv4PoolsRequest,
   DescribePublicIpv4PoolsResult,
   DescribePublicIpv4PoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PublicIpv4Pool
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePublicIpv4PoolsRequest,
@@ -86905,7 +86904,7 @@ export const describeRegions: API.OperationMethod<
   DescribeRegionsRequest,
   DescribeRegionsResult,
   DescribeRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRegionsRequest,
   output: DescribeRegionsResult,
@@ -86928,7 +86927,7 @@ export const describeReplaceRootVolumeTasks: API.PaginatedOperationMethod<
   DescribeReplaceRootVolumeTasksRequest,
   DescribeReplaceRootVolumeTasksResult,
   DescribeReplaceRootVolumeTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplaceRootVolumeTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplaceRootVolumeTasksRequest,
@@ -86963,7 +86962,7 @@ export const describeReservedInstances: API.OperationMethod<
   DescribeReservedInstancesRequest,
   DescribeReservedInstancesResult,
   DescribeReservedInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReservedInstancesRequest,
   output: DescribeReservedInstancesResult,
@@ -87003,7 +87002,7 @@ export const describeReservedInstancesListings: API.OperationMethod<
   DescribeReservedInstancesListingsRequest,
   DescribeReservedInstancesListingsResult,
   DescribeReservedInstancesListingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReservedInstancesListingsRequest,
   output: DescribeReservedInstancesListingsResult,
@@ -87034,7 +87033,7 @@ export const describeReservedInstancesModifications: API.PaginatedOperationMetho
   DescribeReservedInstancesModificationsRequest,
   DescribeReservedInstancesModificationsResult,
   DescribeReservedInstancesModificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedInstancesModification
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedInstancesModificationsRequest,
@@ -87075,7 +87074,7 @@ export const describeReservedInstancesOfferings: API.PaginatedOperationMethod<
   DescribeReservedInstancesOfferingsRequest,
   DescribeReservedInstancesOfferingsResult,
   DescribeReservedInstancesOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedInstancesOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedInstancesOfferingsRequest,
@@ -87108,7 +87107,7 @@ export const describeRouteServerEndpoints: API.PaginatedOperationMethod<
   DescribeRouteServerEndpointsRequest,
   DescribeRouteServerEndpointsResult,
   DescribeRouteServerEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteServerEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRouteServerEndpointsRequest,
@@ -87151,7 +87150,7 @@ export const describeRouteServerPeers: API.PaginatedOperationMethod<
   DescribeRouteServerPeersRequest,
   DescribeRouteServerPeersResult,
   DescribeRouteServerPeersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteServerPeer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRouteServerPeersRequest,
@@ -87199,7 +87198,7 @@ export const describeRouteServers: API.PaginatedOperationMethod<
   DescribeRouteServersRequest,
   DescribeRouteServersResult,
   DescribeRouteServersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRouteServersRequest,
@@ -87240,7 +87239,7 @@ export const describeRouteTables: API.PaginatedOperationMethod<
   DescribeRouteTablesRequest,
   DescribeRouteTablesResult,
   DescribeRouteTablesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRouteTablesRequest,
@@ -87275,7 +87274,7 @@ export const describeScheduledInstanceAvailability: API.PaginatedOperationMethod
   DescribeScheduledInstanceAvailabilityRequest,
   DescribeScheduledInstanceAvailabilityResult,
   DescribeScheduledInstanceAvailabilityError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledInstanceAvailability
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduledInstanceAvailabilityRequest,
@@ -87300,7 +87299,7 @@ export const describeScheduledInstances: API.PaginatedOperationMethod<
   DescribeScheduledInstancesRequest,
   DescribeScheduledInstancesResult,
   DescribeScheduledInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduledInstancesRequest,
@@ -87325,7 +87324,7 @@ export const describeSecondaryInterfaces: API.PaginatedOperationMethod<
   DescribeSecondaryInterfacesRequest,
   DescribeSecondaryInterfacesResult,
   DescribeSecondaryInterfacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecondaryInterface
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecondaryInterfacesRequest,
@@ -87350,7 +87349,7 @@ export const describeSecondaryNetworks: API.PaginatedOperationMethod<
   DescribeSecondaryNetworksRequest,
   DescribeSecondaryNetworksResult,
   DescribeSecondaryNetworksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecondaryNetwork
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecondaryNetworksRequest,
@@ -87375,7 +87374,7 @@ export const describeSecondarySubnets: API.PaginatedOperationMethod<
   DescribeSecondarySubnetsRequest,
   DescribeSecondarySubnetsResult,
   DescribeSecondarySubnetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecondarySubnet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecondarySubnetsRequest,
@@ -87400,7 +87399,7 @@ export const describeSecurityGroupReferences: API.OperationMethod<
   DescribeSecurityGroupReferencesRequest,
   DescribeSecurityGroupReferencesResult,
   DescribeSecurityGroupReferencesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityGroupReferencesRequest,
   output: DescribeSecurityGroupReferencesResult,
@@ -87422,7 +87421,7 @@ export const describeSecurityGroupRules: API.PaginatedOperationMethod<
   DescribeSecurityGroupRulesRequest,
   DescribeSecurityGroupRulesResult,
   DescribeSecurityGroupRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityGroupRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecurityGroupRulesRequest,
@@ -87458,7 +87457,7 @@ export const describeSecurityGroups: API.PaginatedOperationMethod<
   DescribeSecurityGroupsRequest,
   DescribeSecurityGroupsResult,
   DescribeSecurityGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecurityGroupsRequest,
@@ -87490,7 +87489,7 @@ export const describeSecurityGroupVpcAssociations: API.PaginatedOperationMethod<
   DescribeSecurityGroupVpcAssociationsRequest,
   DescribeSecurityGroupVpcAssociationsResult,
   DescribeSecurityGroupVpcAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityGroupVpcAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSecurityGroupVpcAssociationsRequest,
@@ -87519,7 +87518,7 @@ export const describeServiceLinkVirtualInterfaces: API.OperationMethod<
   DescribeServiceLinkVirtualInterfacesRequest,
   DescribeServiceLinkVirtualInterfacesResult,
   DescribeServiceLinkVirtualInterfacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceLinkVirtualInterfacesRequest,
   output: DescribeServiceLinkVirtualInterfacesResult,
@@ -87550,7 +87549,7 @@ export const describeSnapshotAttribute: API.OperationMethod<
   DescribeSnapshotAttributeRequest,
   DescribeSnapshotAttributeResult,
   DescribeSnapshotAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSnapshotAttributeRequest,
   output: DescribeSnapshotAttributeResult,
@@ -87623,7 +87622,7 @@ export const describeSnapshots: API.PaginatedOperationMethod<
   DescribeSnapshotsRequest,
   DescribeSnapshotsResult,
   DescribeSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotsRequest,
@@ -87653,7 +87652,7 @@ export const describeSnapshotTierStatus: API.PaginatedOperationMethod<
   DescribeSnapshotTierStatusRequest,
   DescribeSnapshotTierStatusResult,
   DescribeSnapshotTierStatusError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotTierStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotTierStatusRequest,
@@ -87683,7 +87682,7 @@ export const describeSpotDatafeedSubscription: API.OperationMethod<
   DescribeSpotDatafeedSubscriptionRequest,
   DescribeSpotDatafeedSubscriptionResult,
   DescribeSpotDatafeedSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpotDatafeedSubscriptionRequest,
   output: DescribeSpotDatafeedSubscriptionResult,
@@ -87709,7 +87708,7 @@ export const describeSpotFleetInstances: API.OperationMethod<
   DescribeSpotFleetInstancesRequest,
   DescribeSpotFleetInstancesResponse,
   DescribeSpotFleetInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpotFleetInstancesRequest,
   output: DescribeSpotFleetInstancesResponse,
@@ -87739,7 +87738,7 @@ export const describeSpotFleetRequestHistory: API.OperationMethod<
   DescribeSpotFleetRequestHistoryRequest,
   DescribeSpotFleetRequestHistoryResponse,
   DescribeSpotFleetRequestHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpotFleetRequestHistoryRequest,
   output: DescribeSpotFleetRequestHistoryResponse,
@@ -87765,7 +87764,7 @@ export const describeSpotFleetRequests: API.PaginatedOperationMethod<
   DescribeSpotFleetRequestsRequest,
   DescribeSpotFleetRequestsResponse,
   DescribeSpotFleetRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpotFleetRequestConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSpotFleetRequestsRequest,
@@ -87818,7 +87817,7 @@ export const describeSpotInstanceRequests: API.PaginatedOperationMethod<
   DescribeSpotInstanceRequestsRequest,
   DescribeSpotInstanceRequestsResult,
   DescribeSpotInstanceRequestsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpotInstanceRequest
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSpotInstanceRequestsRequest,
@@ -87853,7 +87852,7 @@ export const describeSpotPriceHistory: API.PaginatedOperationMethod<
   DescribeSpotPriceHistoryRequest,
   DescribeSpotPriceHistoryResult,
   DescribeSpotPriceHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpotPrice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSpotPriceHistoryRequest,
@@ -87889,7 +87888,7 @@ export const describeStaleSecurityGroups: API.PaginatedOperationMethod<
   DescribeStaleSecurityGroupsRequest,
   DescribeStaleSecurityGroupsResult,
   DescribeStaleSecurityGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StaleSecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStaleSecurityGroupsRequest,
@@ -87929,7 +87928,7 @@ export const describeStoreImageTasks: API.PaginatedOperationMethod<
   DescribeStoreImageTasksRequest,
   DescribeStoreImageTasksResult,
   DescribeStoreImageTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StoreImageTaskResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStoreImageTasksRequest,
@@ -87964,7 +87963,7 @@ export const describeSubnets: API.PaginatedOperationMethod<
   DescribeSubnetsRequest,
   DescribeSubnetsResult,
   DescribeSubnetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subnet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSubnetsRequest,
@@ -88008,7 +88007,7 @@ export const describeTags: API.PaginatedOperationMethod<
   DescribeTagsRequest,
   DescribeTagsResult,
   DescribeTagsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTagsRequest,
@@ -88033,7 +88032,7 @@ export const describeTrafficMirrorFilterRules: API.OperationMethod<
   DescribeTrafficMirrorFilterRulesRequest,
   DescribeTrafficMirrorFilterRulesResult,
   DescribeTrafficMirrorFilterRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrafficMirrorFilterRulesRequest,
   output: DescribeTrafficMirrorFilterRulesResult,
@@ -88055,7 +88054,7 @@ export const describeTrafficMirrorFilters: API.PaginatedOperationMethod<
   DescribeTrafficMirrorFiltersRequest,
   DescribeTrafficMirrorFiltersResult,
   DescribeTrafficMirrorFiltersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrafficMirrorFilter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrafficMirrorFiltersRequest,
@@ -88088,7 +88087,7 @@ export const describeTrafficMirrorSessions: API.PaginatedOperationMethod<
   DescribeTrafficMirrorSessionsRequest,
   DescribeTrafficMirrorSessionsResult,
   DescribeTrafficMirrorSessionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrafficMirrorSession
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrafficMirrorSessionsRequest,
@@ -88121,7 +88120,7 @@ export const describeTrafficMirrorTargets: API.PaginatedOperationMethod<
   DescribeTrafficMirrorTargetsRequest,
   DescribeTrafficMirrorTargetsResult,
   DescribeTrafficMirrorTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrafficMirrorTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrafficMirrorTargetsRequest,
@@ -88156,7 +88155,7 @@ export const describeTransitGatewayAttachments: API.PaginatedOperationMethod<
   DescribeTransitGatewayAttachmentsRequest,
   DescribeTransitGatewayAttachmentsResult,
   DescribeTransitGatewayAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayAttachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayAttachmentsRequest,
@@ -88190,7 +88189,7 @@ export const describeTransitGatewayConnectPeers: API.PaginatedOperationMethod<
   DescribeTransitGatewayConnectPeersRequest,
   DescribeTransitGatewayConnectPeersResult,
   DescribeTransitGatewayConnectPeersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayConnectPeer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayConnectPeersRequest,
@@ -88223,7 +88222,7 @@ export const describeTransitGatewayConnects: API.PaginatedOperationMethod<
   DescribeTransitGatewayConnectsRequest,
   DescribeTransitGatewayConnectsResult,
   DescribeTransitGatewayConnectsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayConnect
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayConnectsRequest,
@@ -88256,7 +88255,7 @@ export const describeTransitGatewayMeteringPolicies: API.OperationMethod<
   DescribeTransitGatewayMeteringPoliciesRequest,
   DescribeTransitGatewayMeteringPoliciesResult,
   DescribeTransitGatewayMeteringPoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTransitGatewayMeteringPoliciesRequest,
   output: DescribeTransitGatewayMeteringPoliciesResult,
@@ -88282,7 +88281,7 @@ export const describeTransitGatewayMulticastDomains: API.PaginatedOperationMetho
   DescribeTransitGatewayMulticastDomainsRequest,
   DescribeTransitGatewayMulticastDomainsResult,
   DescribeTransitGatewayMulticastDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayMulticastDomain
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayMulticastDomainsRequest,
@@ -88315,7 +88314,7 @@ export const describeTransitGatewayPeeringAttachments: API.PaginatedOperationMet
   DescribeTransitGatewayPeeringAttachmentsRequest,
   DescribeTransitGatewayPeeringAttachmentsResult,
   DescribeTransitGatewayPeeringAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayPeeringAttachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayPeeringAttachmentsRequest,
@@ -88348,7 +88347,7 @@ export const describeTransitGatewayPolicyTables: API.PaginatedOperationMethod<
   DescribeTransitGatewayPolicyTablesRequest,
   DescribeTransitGatewayPolicyTablesResult,
   DescribeTransitGatewayPolicyTablesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayPolicyTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayPolicyTablesRequest,
@@ -88381,7 +88380,7 @@ export const describeTransitGatewayRouteTableAnnouncements: API.PaginatedOperati
   DescribeTransitGatewayRouteTableAnnouncementsRequest,
   DescribeTransitGatewayRouteTableAnnouncementsResult,
   DescribeTransitGatewayRouteTableAnnouncementsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRouteTableAnnouncement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayRouteTableAnnouncementsRequest,
@@ -88416,7 +88415,7 @@ export const describeTransitGatewayRouteTables: API.PaginatedOperationMethod<
   DescribeTransitGatewayRouteTablesRequest,
   DescribeTransitGatewayRouteTablesResult,
   DescribeTransitGatewayRouteTablesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRouteTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayRouteTablesRequest,
@@ -88452,7 +88451,7 @@ export const describeTransitGateways: API.PaginatedOperationMethod<
   DescribeTransitGatewaysRequest,
   DescribeTransitGatewaysResult,
   DescribeTransitGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewaysRequest,
@@ -88487,7 +88486,7 @@ export const describeTransitGatewayVpcAttachments: API.PaginatedOperationMethod<
   DescribeTransitGatewayVpcAttachmentsRequest,
   DescribeTransitGatewayVpcAttachmentsResult,
   DescribeTransitGatewayVpcAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayVpcAttachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTransitGatewayVpcAttachmentsRequest,
@@ -88520,7 +88519,7 @@ export const describeTrunkInterfaceAssociations: API.PaginatedOperationMethod<
   DescribeTrunkInterfaceAssociationsRequest,
   DescribeTrunkInterfaceAssociationsResult,
   DescribeTrunkInterfaceAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrunkInterfaceAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrunkInterfaceAssociationsRequest,
@@ -88549,7 +88548,7 @@ export const describeVerifiedAccessEndpoints: API.PaginatedOperationMethod<
   DescribeVerifiedAccessEndpointsRequest,
   DescribeVerifiedAccessEndpointsResult,
   DescribeVerifiedAccessEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedAccessEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedAccessEndpointsRequest,
@@ -88582,7 +88581,7 @@ export const describeVerifiedAccessGroups: API.PaginatedOperationMethod<
   DescribeVerifiedAccessGroupsRequest,
   DescribeVerifiedAccessGroupsResult,
   DescribeVerifiedAccessGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedAccessGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedAccessGroupsRequest,
@@ -88615,7 +88614,7 @@ export const describeVerifiedAccessInstanceLoggingConfigurations: API.PaginatedO
   DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
   DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
   DescribeVerifiedAccessInstanceLoggingConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedAccessInstanceLoggingConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
@@ -88648,7 +88647,7 @@ export const describeVerifiedAccessInstances: API.PaginatedOperationMethod<
   DescribeVerifiedAccessInstancesRequest,
   DescribeVerifiedAccessInstancesResult,
   DescribeVerifiedAccessInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedAccessInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedAccessInstancesRequest,
@@ -88681,7 +88680,7 @@ export const describeVerifiedAccessTrustProviders: API.PaginatedOperationMethod<
   DescribeVerifiedAccessTrustProvidersRequest,
   DescribeVerifiedAccessTrustProvidersResult,
   DescribeVerifiedAccessTrustProvidersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedAccessTrustProvider
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedAccessTrustProvidersRequest,
@@ -88719,7 +88718,7 @@ export const describeVolumeAttribute: API.OperationMethod<
   DescribeVolumeAttributeRequest,
   DescribeVolumeAttributeResult,
   DescribeVolumeAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVolumeAttributeRequest,
   output: DescribeVolumeAttributeResult,
@@ -88761,7 +88760,7 @@ export const describeVolumes: API.PaginatedOperationMethod<
   DescribeVolumesRequest,
   DescribeVolumesResult,
   DescribeVolumesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Volume
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVolumesRequest,
@@ -88799,7 +88798,7 @@ export const describeVolumesModifications: API.PaginatedOperationMethod<
   DescribeVolumesModificationsRequest,
   DescribeVolumesModificationsResult,
   DescribeVolumesModificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VolumeModification
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVolumesModificationsRequest,
@@ -88871,7 +88870,7 @@ export const describeVolumeStatus: API.PaginatedOperationMethod<
   DescribeVolumeStatusRequest,
   DescribeVolumeStatusResult,
   DescribeVolumeStatusError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VolumeStatusItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVolumeStatusRequest,
@@ -88905,7 +88904,7 @@ export const describeVpcAttribute: API.OperationMethod<
   DescribeVpcAttributeRequest,
   DescribeVpcAttributeResult,
   DescribeVpcAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcAttributeRequest,
   output: DescribeVpcAttributeResult,
@@ -88933,7 +88932,7 @@ export const describeVpcBlockPublicAccessExclusions: API.OperationMethod<
   DescribeVpcBlockPublicAccessExclusionsRequest,
   DescribeVpcBlockPublicAccessExclusionsResult,
   DescribeVpcBlockPublicAccessExclusionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcBlockPublicAccessExclusionsRequest,
   output: DescribeVpcBlockPublicAccessExclusionsResult,
@@ -88956,7 +88955,7 @@ export const describeVpcBlockPublicAccessOptions: API.OperationMethod<
   DescribeVpcBlockPublicAccessOptionsRequest,
   DescribeVpcBlockPublicAccessOptionsResult,
   DescribeVpcBlockPublicAccessOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcBlockPublicAccessOptionsRequest,
   output: DescribeVpcBlockPublicAccessOptionsResult,
@@ -88981,7 +88980,7 @@ export const describeVpcClassicLink: API.OperationMethod<
   DescribeVpcClassicLinkRequest,
   DescribeVpcClassicLinkResult,
   DescribeVpcClassicLinkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcClassicLinkRequest,
   output: DescribeVpcClassicLinkResult,
@@ -89014,7 +89013,7 @@ export const describeVpcClassicLinkDnsSupport: API.PaginatedOperationMethod<
   DescribeVpcClassicLinkDnsSupportRequest,
   DescribeVpcClassicLinkDnsSupportResult,
   DescribeVpcClassicLinkDnsSupportError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClassicLinkDnsSupport
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcClassicLinkDnsSupportRequest,
@@ -89045,7 +89044,7 @@ export const describeVpcEncryptionControls: API.OperationMethod<
   DescribeVpcEncryptionControlsRequest,
   DescribeVpcEncryptionControlsResult,
   DescribeVpcEncryptionControlsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEncryptionControlsRequest,
   output: DescribeVpcEncryptionControlsResult,
@@ -89068,7 +89067,7 @@ export const describeVpcEndpointAssociations: API.OperationMethod<
   DescribeVpcEndpointAssociationsRequest,
   DescribeVpcEndpointAssociationsResult,
   DescribeVpcEndpointAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEndpointAssociationsRequest,
   output: DescribeVpcEndpointAssociationsResult,
@@ -89091,7 +89090,7 @@ export const describeVpcEndpointConnectionNotifications: API.PaginatedOperationM
   DescribeVpcEndpointConnectionNotificationsRequest,
   DescribeVpcEndpointConnectionNotificationsResult,
   DescribeVpcEndpointConnectionNotificationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionNotification
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcEndpointConnectionNotificationsRequest,
@@ -89121,7 +89120,7 @@ export const describeVpcEndpointConnections: API.PaginatedOperationMethod<
   DescribeVpcEndpointConnectionsRequest,
   DescribeVpcEndpointConnectionsResult,
   DescribeVpcEndpointConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcEndpointConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcEndpointConnectionsRequest,
@@ -89153,7 +89152,7 @@ export const describeVpcEndpoints: API.PaginatedOperationMethod<
   DescribeVpcEndpointsRequest,
   DescribeVpcEndpointsResult,
   DescribeVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcEndpointsRequest,
@@ -89187,7 +89186,7 @@ export const describeVpcEndpointServiceConfigurations: API.PaginatedOperationMet
   DescribeVpcEndpointServiceConfigurationsRequest,
   DescribeVpcEndpointServiceConfigurationsResult,
   DescribeVpcEndpointServiceConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcEndpointServiceConfigurationsRequest,
@@ -89222,7 +89221,7 @@ export const describeVpcEndpointServicePermissions: API.PaginatedOperationMethod
   DescribeVpcEndpointServicePermissionsRequest,
   DescribeVpcEndpointServicePermissionsResult,
   DescribeVpcEndpointServicePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AllowedPrincipal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcEndpointServicePermissionsRequest,
@@ -89264,7 +89263,7 @@ export const describeVpcEndpointServices: API.OperationMethod<
   DescribeVpcEndpointServicesRequest,
   DescribeVpcEndpointServicesResult,
   DescribeVpcEndpointServicesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEndpointServicesRequest,
   output: DescribeVpcEndpointServicesResult,
@@ -89290,7 +89289,7 @@ export const describeVpcPeeringConnections: API.PaginatedOperationMethod<
   DescribeVpcPeeringConnectionsRequest,
   DescribeVpcPeeringConnectionsResult,
   DescribeVpcPeeringConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcPeeringConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcPeeringConnectionsRequest,
@@ -89329,7 +89328,7 @@ export const describeVpcs: API.PaginatedOperationMethod<
   DescribeVpcsRequest,
   DescribeVpcsResult,
   DescribeVpcsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Vpc
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpcsRequest,
@@ -89364,7 +89363,7 @@ export const describeVpnConcentrators: API.PaginatedOperationMethod<
   DescribeVpnConcentratorsRequest,
   DescribeVpnConcentratorsResult,
   DescribeVpnConcentratorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpnConcentrator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVpnConcentratorsRequest,
@@ -89400,7 +89399,7 @@ export const describeVpnConnections: API.OperationMethod<
   DescribeVpnConnectionsRequest,
   DescribeVpnConnectionsResult,
   DescribeVpnConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpnConnectionsRequest,
   output: DescribeVpnConnectionsResult,
@@ -89430,7 +89429,7 @@ export const describeVpnGateways: API.OperationMethod<
   DescribeVpnGatewaysRequest,
   DescribeVpnGatewaysResult,
   DescribeVpnGatewaysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpnGatewaysRequest,
   output: DescribeVpnGatewaysResult,
@@ -89464,7 +89463,7 @@ export const detachClassicLinkVpc: API.OperationMethod<
   DetachClassicLinkVpcRequest,
   DetachClassicLinkVpcResult,
   DetachClassicLinkVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachClassicLinkVpcRequest,
   output: DetachClassicLinkVpcResult,
@@ -89495,7 +89494,7 @@ export const detachImageWatermark: API.OperationMethod<
   DetachImageWatermarkRequest,
   DetachImageWatermarkResult,
   DetachImageWatermarkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachImageWatermarkRequest,
   output: DetachImageWatermarkResult,
@@ -89523,7 +89522,7 @@ export const detachInternetGateway: API.OperationMethod<
   DetachInternetGatewayRequest,
   DetachInternetGatewayResponse,
   DetachInternetGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachInternetGatewayRequest,
   output: DetachInternetGatewayResponse,
@@ -89555,7 +89554,7 @@ export const detachNetworkInterface: API.OperationMethod<
   DetachNetworkInterfaceRequest,
   DetachNetworkInterfaceResponse,
   DetachNetworkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachNetworkInterfaceRequest,
   output: DetachNetworkInterfaceResponse,
@@ -89584,7 +89583,7 @@ export const detachVerifiedAccessTrustProvider: API.OperationMethod<
   DetachVerifiedAccessTrustProviderRequest,
   DetachVerifiedAccessTrustProviderResult,
   DetachVerifiedAccessTrustProviderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachVerifiedAccessTrustProviderRequest,
   output: DetachVerifiedAccessTrustProviderResult,
@@ -89630,7 +89629,7 @@ export const detachVolume: API.OperationMethod<
   DetachVolumeRequest,
   VolumeAttachment,
   DetachVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachVolumeRequest,
   output: VolumeAttachment,
@@ -89668,7 +89667,7 @@ export const detachVpnGateway: API.OperationMethod<
   DetachVpnGatewayRequest,
   DetachVpnGatewayResponse,
   DetachVpnGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachVpnGatewayRequest,
   output: DetachVpnGatewayResponse,
@@ -89697,7 +89696,7 @@ export const disableAddressTransfer: API.OperationMethod<
   DisableAddressTransferRequest,
   DisableAddressTransferResult,
   DisableAddressTransferError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAddressTransferRequest,
   output: DisableAddressTransferResult,
@@ -89730,7 +89729,7 @@ export const disableAllowedImagesSettings: API.OperationMethod<
   DisableAllowedImagesSettingsRequest,
   DisableAllowedImagesSettingsResult,
   DisableAllowedImagesSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAllowedImagesSettingsRequest,
   output: DisableAllowedImagesSettingsResult,
@@ -89752,7 +89751,7 @@ export const disableAwsNetworkPerformanceMetricSubscription: API.OperationMethod
   DisableAwsNetworkPerformanceMetricSubscriptionRequest,
   DisableAwsNetworkPerformanceMetricSubscriptionResult,
   DisableAwsNetworkPerformanceMetricSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAwsNetworkPerformanceMetricSubscriptionRequest,
   output: DisableAwsNetworkPerformanceMetricSubscriptionResult,
@@ -89775,7 +89774,7 @@ export const disableCapacityManager: API.OperationMethod<
   DisableCapacityManagerRequest,
   DisableCapacityManagerResult,
   DisableCapacityManagerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableCapacityManagerRequest,
   output: DisableCapacityManagerResult,
@@ -89806,7 +89805,7 @@ export const disableEbsEncryptionByDefault: API.OperationMethod<
   DisableEbsEncryptionByDefaultRequest,
   DisableEbsEncryptionByDefaultResult,
   DisableEbsEncryptionByDefaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableEbsEncryptionByDefaultRequest,
   output: DisableEbsEncryptionByDefaultResult,
@@ -89834,7 +89833,7 @@ export const disableFastLaunch: API.OperationMethod<
   DisableFastLaunchRequest,
   DisableFastLaunchResult,
   DisableFastLaunchError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableFastLaunchRequest,
   output: DisableFastLaunchResult,
@@ -89856,7 +89855,7 @@ export const disableFastSnapshotRestores: API.OperationMethod<
   DisableFastSnapshotRestoresRequest,
   DisableFastSnapshotRestoresResult,
   DisableFastSnapshotRestoresError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableFastSnapshotRestoresRequest,
   output: DisableFastSnapshotRestoresResult,
@@ -89893,7 +89892,7 @@ export const disableImage: API.OperationMethod<
   DisableImageRequest,
   DisableImageResult,
   DisableImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableImageRequest,
   output: DisableImageResult,
@@ -89917,7 +89916,7 @@ export const disableImageBlockPublicAccess: API.OperationMethod<
   DisableImageBlockPublicAccessRequest,
   DisableImageBlockPublicAccessResult,
   DisableImageBlockPublicAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableImageBlockPublicAccessRequest,
   output: DisableImageBlockPublicAccessResult,
@@ -89942,7 +89941,7 @@ export const disableImageDeprecation: API.OperationMethod<
   DisableImageDeprecationRequest,
   DisableImageDeprecationResult,
   DisableImageDeprecationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableImageDeprecationRequest,
   output: DisableImageDeprecationResult,
@@ -89972,7 +89971,7 @@ export const disableImageDeregistrationProtection: API.OperationMethod<
   DisableImageDeregistrationProtectionRequest,
   DisableImageDeregistrationProtectionResult,
   DisableImageDeregistrationProtectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableImageDeregistrationProtectionRequest,
   output: DisableImageDeregistrationProtectionResult,
@@ -89997,7 +89996,7 @@ export const disableInstanceSqlHaStandbyDetections: API.OperationMethod<
   DisableInstanceSqlHaStandbyDetectionsRequest,
   DisableInstanceSqlHaStandbyDetectionsResult,
   DisableInstanceSqlHaStandbyDetectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableInstanceSqlHaStandbyDetectionsRequest,
   output: DisableInstanceSqlHaStandbyDetectionsResult,
@@ -90023,7 +90022,7 @@ export const disableIpamOrganizationAdminAccount: API.OperationMethod<
   DisableIpamOrganizationAdminAccountRequest,
   DisableIpamOrganizationAdminAccountResult,
   DisableIpamOrganizationAdminAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableIpamOrganizationAdminAccountRequest,
   output: DisableIpamOrganizationAdminAccountResult,
@@ -90048,7 +90047,7 @@ export const disableIpamPolicy: API.OperationMethod<
   DisableIpamPolicyRequest,
   DisableIpamPolicyResult,
   DisableIpamPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableIpamPolicyRequest,
   output: DisableIpamPolicyResult,
@@ -90092,7 +90091,7 @@ export const disableRouteServerPropagation: API.OperationMethod<
   DisableRouteServerPropagationRequest,
   DisableRouteServerPropagationResult,
   DisableRouteServerPropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRouteServerPropagationRequest,
   output: DisableRouteServerPropagationResult,
@@ -90117,7 +90116,7 @@ export const disableSerialConsoleAccess: API.OperationMethod<
   DisableSerialConsoleAccessRequest,
   DisableSerialConsoleAccessResult,
   DisableSerialConsoleAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSerialConsoleAccessRequest,
   output: DisableSerialConsoleAccessResult,
@@ -90149,7 +90148,7 @@ export const disableSnapshotBlockPublicAccess: API.OperationMethod<
   DisableSnapshotBlockPublicAccessRequest,
   DisableSnapshotBlockPublicAccessResult,
   DisableSnapshotBlockPublicAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSnapshotBlockPublicAccessRequest,
   output: DisableSnapshotBlockPublicAccessResult,
@@ -90172,7 +90171,7 @@ export const disableTransitGatewayRouteTablePropagation: API.OperationMethod<
   DisableTransitGatewayRouteTablePropagationRequest,
   DisableTransitGatewayRouteTablePropagationResult,
   DisableTransitGatewayRouteTablePropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableTransitGatewayRouteTablePropagationRequest,
   output: DisableTransitGatewayRouteTablePropagationResult,
@@ -90195,7 +90194,7 @@ export const disableVgwRoutePropagation: API.OperationMethod<
   DisableVgwRoutePropagationRequest,
   DisableVgwRoutePropagationResponse,
   DisableVgwRoutePropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableVgwRoutePropagationRequest,
   output: DisableVgwRoutePropagationResponse,
@@ -90225,7 +90224,7 @@ export const disableVpcClassicLink: API.OperationMethod<
   DisableVpcClassicLinkRequest,
   DisableVpcClassicLinkResult,
   DisableVpcClassicLinkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableVpcClassicLinkRequest,
   output: DisableVpcClassicLinkResult,
@@ -90259,7 +90258,7 @@ export const disableVpcClassicLinkDnsSupport: API.OperationMethod<
   DisableVpcClassicLinkDnsSupportRequest,
   DisableVpcClassicLinkDnsSupportResult,
   DisableVpcClassicLinkDnsSupportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableVpcClassicLinkDnsSupportRequest,
   output: DisableVpcClassicLinkDnsSupportResult,
@@ -90297,7 +90296,7 @@ export const disassociateAddress: API.OperationMethod<
   DisassociateAddressRequest,
   DisassociateAddressResponse,
   DisassociateAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAddressRequest,
   output: DisassociateAddressResponse,
@@ -90328,7 +90327,7 @@ export const disassociateCapacityReservationBillingOwner: API.OperationMethod<
   DisassociateCapacityReservationBillingOwnerRequest,
   DisassociateCapacityReservationBillingOwnerResult,
   DisassociateCapacityReservationBillingOwnerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCapacityReservationBillingOwnerRequest,
   output: DisassociateCapacityReservationBillingOwnerResult,
@@ -90365,7 +90364,7 @@ export const disassociateClientVpnTargetNetwork: API.OperationMethod<
   DisassociateClientVpnTargetNetworkRequest,
   DisassociateClientVpnTargetNetworkResult,
   DisassociateClientVpnTargetNetworkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateClientVpnTargetNetworkRequest,
   output: DisassociateClientVpnTargetNetworkResult,
@@ -90397,7 +90396,7 @@ export const disassociateEnclaveCertificateIamRole: API.OperationMethod<
   DisassociateEnclaveCertificateIamRoleRequest,
   DisassociateEnclaveCertificateIamRoleResult,
   DisassociateEnclaveCertificateIamRoleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEnclaveCertificateIamRoleRequest,
   output: DisassociateEnclaveCertificateIamRoleResult,
@@ -90427,7 +90426,7 @@ export const disassociateIamInstanceProfile: API.OperationMethod<
   DisassociateIamInstanceProfileRequest,
   DisassociateIamInstanceProfileResult,
   DisassociateIamInstanceProfileError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIamInstanceProfileRequest,
   output: DisassociateIamInstanceProfileResult,
@@ -90453,7 +90452,7 @@ export const disassociateInstanceEventWindow: API.OperationMethod<
   DisassociateInstanceEventWindowRequest,
   DisassociateInstanceEventWindowResult,
   DisassociateInstanceEventWindowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateInstanceEventWindowRequest,
   output: DisassociateInstanceEventWindowResult,
@@ -90481,7 +90480,7 @@ export const disassociateIpamByoasn: API.OperationMethod<
   DisassociateIpamByoasnRequest,
   DisassociateIpamByoasnResult,
   DisassociateIpamByoasnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIpamByoasnRequest,
   output: DisassociateIpamByoasnResult,
@@ -90504,7 +90503,7 @@ export const disassociateIpamResourceDiscovery: API.OperationMethod<
   DisassociateIpamResourceDiscoveryRequest,
   DisassociateIpamResourceDiscoveryResult,
   DisassociateIpamResourceDiscoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIpamResourceDiscoveryRequest,
   output: DisassociateIpamResourceDiscoveryResult,
@@ -90542,7 +90541,7 @@ export const disassociateNatGatewayAddress: API.OperationMethod<
   DisassociateNatGatewayAddressRequest,
   DisassociateNatGatewayAddressResult,
   DisassociateNatGatewayAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateNatGatewayAddressRequest,
   output: DisassociateNatGatewayAddressResult,
@@ -90576,7 +90575,7 @@ export const disassociateRouteServer: API.OperationMethod<
   DisassociateRouteServerRequest,
   DisassociateRouteServerResult,
   DisassociateRouteServerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRouteServerRequest,
   output: DisassociateRouteServerResult,
@@ -90611,7 +90610,7 @@ export const disassociateRouteTable: API.OperationMethod<
   DisassociateRouteTableRequest,
   DisassociateRouteTableResponse,
   DisassociateRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRouteTableRequest,
   output: DisassociateRouteTableResponse,
@@ -90642,7 +90641,7 @@ export const disassociateSecurityGroupVpc: API.OperationMethod<
   DisassociateSecurityGroupVpcRequest,
   DisassociateSecurityGroupVpcResult,
   DisassociateSecurityGroupVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSecurityGroupVpcRequest,
   output: DisassociateSecurityGroupVpcResult,
@@ -90670,7 +90669,7 @@ export const disassociateSubnetCidrBlock: API.OperationMethod<
   DisassociateSubnetCidrBlockRequest,
   DisassociateSubnetCidrBlockResult,
   DisassociateSubnetCidrBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSubnetCidrBlockRequest,
   output: DisassociateSubnetCidrBlockResult,
@@ -90698,7 +90697,7 @@ export const disassociateTransitGatewayMulticastDomain: API.OperationMethod<
   DisassociateTransitGatewayMulticastDomainRequest,
   DisassociateTransitGatewayMulticastDomainResult,
   DisassociateTransitGatewayMulticastDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTransitGatewayMulticastDomainRequest,
   output: DisassociateTransitGatewayMulticastDomainResult,
@@ -90727,7 +90726,7 @@ export const disassociateTransitGatewayPolicyTable: API.OperationMethod<
   DisassociateTransitGatewayPolicyTableRequest,
   DisassociateTransitGatewayPolicyTableResult,
   DisassociateTransitGatewayPolicyTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTransitGatewayPolicyTableRequest,
   output: DisassociateTransitGatewayPolicyTableResult,
@@ -90756,7 +90755,7 @@ export const disassociateTransitGatewayRouteTable: API.OperationMethod<
   DisassociateTransitGatewayRouteTableRequest,
   DisassociateTransitGatewayRouteTableResult,
   DisassociateTransitGatewayRouteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTransitGatewayRouteTableRequest,
   output: DisassociateTransitGatewayRouteTableResult,
@@ -90783,7 +90782,7 @@ export const disassociateTrunkInterface: API.OperationMethod<
   DisassociateTrunkInterfaceRequest,
   DisassociateTrunkInterfaceResult,
   DisassociateTrunkInterfaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTrunkInterfaceRequest,
   output: DisassociateTrunkInterfaceResult,
@@ -90814,7 +90813,7 @@ export const disassociateVpcCidrBlock: API.OperationMethod<
   DisassociateVpcCidrBlockRequest,
   DisassociateVpcCidrBlockResult,
   DisassociateVpcCidrBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateVpcCidrBlockRequest,
   output: DisassociateVpcCidrBlockResult,
@@ -90843,7 +90842,7 @@ export const enableAddressTransfer: API.OperationMethod<
   EnableAddressTransferRequest,
   EnableAddressTransferResult,
   EnableAddressTransferError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAddressTransferRequest,
   output: EnableAddressTransferResult,
@@ -90884,7 +90883,7 @@ export const enableAllowedImagesSettings: API.OperationMethod<
   EnableAllowedImagesSettingsRequest,
   EnableAllowedImagesSettingsResult,
   EnableAllowedImagesSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAllowedImagesSettingsRequest,
   output: EnableAllowedImagesSettingsResult,
@@ -90906,7 +90905,7 @@ export const enableAwsNetworkPerformanceMetricSubscription: API.OperationMethod<
   EnableAwsNetworkPerformanceMetricSubscriptionRequest,
   EnableAwsNetworkPerformanceMetricSubscriptionResult,
   EnableAwsNetworkPerformanceMetricSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAwsNetworkPerformanceMetricSubscriptionRequest,
   output: EnableAwsNetworkPerformanceMetricSubscriptionResult,
@@ -90925,7 +90924,7 @@ export const enableCapacityManager: API.OperationMethod<
   EnableCapacityManagerRequest,
   EnableCapacityManagerResult,
   EnableCapacityManagerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableCapacityManagerRequest,
   output: EnableCapacityManagerResult,
@@ -90955,7 +90954,7 @@ export const enableEbsEncryptionByDefault: API.OperationMethod<
   EnableEbsEncryptionByDefaultRequest,
   EnableEbsEncryptionByDefaultResult,
   EnableEbsEncryptionByDefaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableEbsEncryptionByDefaultRequest,
   output: EnableEbsEncryptionByDefaultResult,
@@ -90985,7 +90984,7 @@ export const enableFastLaunch: API.OperationMethod<
   EnableFastLaunchRequest,
   EnableFastLaunchResult,
   EnableFastLaunchError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableFastLaunchRequest,
   output: EnableFastLaunchResult,
@@ -91012,7 +91011,7 @@ export const enableFastSnapshotRestores: API.OperationMethod<
   EnableFastSnapshotRestoresRequest,
   EnableFastSnapshotRestoresResult,
   EnableFastSnapshotRestoresError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableFastSnapshotRestoresRequest,
   output: EnableFastSnapshotRestoresResult,
@@ -91043,7 +91042,7 @@ export const enableImage: API.OperationMethod<
   EnableImageRequest,
   EnableImageResult,
   EnableImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableImageRequest,
   output: EnableImageResult,
@@ -91075,7 +91074,7 @@ export const enableImageBlockPublicAccess: API.OperationMethod<
   EnableImageBlockPublicAccessRequest,
   EnableImageBlockPublicAccessResult,
   EnableImageBlockPublicAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableImageBlockPublicAccessRequest,
   output: EnableImageBlockPublicAccessResult,
@@ -91100,7 +91099,7 @@ export const enableImageDeprecation: API.OperationMethod<
   EnableImageDeprecationRequest,
   EnableImageDeprecationResult,
   EnableImageDeprecationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableImageDeprecationRequest,
   output: EnableImageDeprecationResult,
@@ -91128,7 +91127,7 @@ export const enableImageDeregistrationProtection: API.OperationMethod<
   EnableImageDeregistrationProtectionRequest,
   EnableImageDeregistrationProtectionResult,
   EnableImageDeregistrationProtectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableImageDeregistrationProtectionRequest,
   output: EnableImageDeregistrationProtectionResult,
@@ -91160,7 +91159,7 @@ export const enableInstanceSqlHaStandbyDetections: API.OperationMethod<
   EnableInstanceSqlHaStandbyDetectionsRequest,
   EnableInstanceSqlHaStandbyDetectionsResult,
   EnableInstanceSqlHaStandbyDetectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableInstanceSqlHaStandbyDetectionsRequest,
   output: EnableInstanceSqlHaStandbyDetectionsResult,
@@ -91186,7 +91185,7 @@ export const enableIpamOrganizationAdminAccount: API.OperationMethod<
   EnableIpamOrganizationAdminAccountRequest,
   EnableIpamOrganizationAdminAccountResult,
   EnableIpamOrganizationAdminAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableIpamOrganizationAdminAccountRequest,
   output: EnableIpamOrganizationAdminAccountResult,
@@ -91213,7 +91212,7 @@ export const enableIpamPolicy: API.OperationMethod<
   EnableIpamPolicyRequest,
   EnableIpamPolicyResult,
   EnableIpamPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableIpamPolicyRequest,
   output: EnableIpamPolicyResult,
@@ -91241,7 +91240,7 @@ export const enableReachabilityAnalyzerOrganizationSharing: API.OperationMethod<
   EnableReachabilityAnalyzerOrganizationSharingRequest,
   EnableReachabilityAnalyzerOrganizationSharingResult,
   EnableReachabilityAnalyzerOrganizationSharingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableReachabilityAnalyzerOrganizationSharingRequest,
   output: EnableReachabilityAnalyzerOrganizationSharingResult,
@@ -91267,7 +91266,7 @@ export const enableRouteServerPropagation: API.OperationMethod<
   EnableRouteServerPropagationRequest,
   EnableRouteServerPropagationResult,
   EnableRouteServerPropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRouteServerPropagationRequest,
   output: EnableRouteServerPropagationResult,
@@ -91291,7 +91290,7 @@ export const enableSerialConsoleAccess: API.OperationMethod<
   EnableSerialConsoleAccessRequest,
   EnableSerialConsoleAccessResult,
   EnableSerialConsoleAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSerialConsoleAccessRequest,
   output: EnableSerialConsoleAccessResult,
@@ -91330,7 +91329,7 @@ export const enableSnapshotBlockPublicAccess: API.OperationMethod<
   EnableSnapshotBlockPublicAccessRequest,
   EnableSnapshotBlockPublicAccessResult,
   EnableSnapshotBlockPublicAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSnapshotBlockPublicAccessRequest,
   output: EnableSnapshotBlockPublicAccessResult,
@@ -91353,7 +91352,7 @@ export const enableTransitGatewayRouteTablePropagation: API.OperationMethod<
   EnableTransitGatewayRouteTablePropagationRequest,
   EnableTransitGatewayRouteTablePropagationResult,
   EnableTransitGatewayRouteTablePropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableTransitGatewayRouteTablePropagationRequest,
   output: EnableTransitGatewayRouteTablePropagationResult,
@@ -91376,7 +91375,7 @@ export const enableVgwRoutePropagation: API.OperationMethod<
   EnableVgwRoutePropagationRequest,
   EnableVgwRoutePropagationResponse,
   EnableVgwRoutePropagationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableVgwRoutePropagationRequest,
   output: EnableVgwRoutePropagationResponse,
@@ -91399,7 +91398,7 @@ export const enableVolumeIO: API.OperationMethod<
   EnableVolumeIORequest,
   EnableVolumeIOResponse,
   EnableVolumeIOError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableVolumeIORequest,
   output: EnableVolumeIOResponse,
@@ -91429,7 +91428,7 @@ export const enableVpcClassicLink: API.OperationMethod<
   EnableVpcClassicLinkRequest,
   EnableVpcClassicLinkResult,
   EnableVpcClassicLinkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableVpcClassicLinkRequest,
   output: EnableVpcClassicLinkResult,
@@ -91465,7 +91464,7 @@ export const enableVpcClassicLinkDnsSupport: API.OperationMethod<
   EnableVpcClassicLinkDnsSupportRequest,
   EnableVpcClassicLinkDnsSupportResult,
   EnableVpcClassicLinkDnsSupportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableVpcClassicLinkDnsSupportRequest,
   output: EnableVpcClassicLinkDnsSupportResult,
@@ -91492,7 +91491,7 @@ export const exportClientVpnClientCertificateRevocationList: API.OperationMethod
   ExportClientVpnClientCertificateRevocationListRequest,
   ExportClientVpnClientCertificateRevocationListResult,
   ExportClientVpnClientCertificateRevocationListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportClientVpnClientCertificateRevocationListRequest,
   output: ExportClientVpnClientCertificateRevocationListResult,
@@ -91520,7 +91519,7 @@ export const exportClientVpnClientConfiguration: API.OperationMethod<
   ExportClientVpnClientConfigurationRequest,
   ExportClientVpnClientConfigurationResult,
   ExportClientVpnClientConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportClientVpnClientConfigurationRequest,
   output: ExportClientVpnClientConfigurationResult,
@@ -91548,7 +91547,7 @@ export const exportImage: API.OperationMethod<
   ExportImageRequest,
   ExportImageResult,
   ExportImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportImageRequest,
   output: ExportImageResult,
@@ -91575,7 +91574,7 @@ export const exportTransitGatewayRoutes: API.OperationMethod<
   ExportTransitGatewayRoutesRequest,
   ExportTransitGatewayRoutesResult,
   ExportTransitGatewayRoutesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportTransitGatewayRoutesRequest,
   output: ExportTransitGatewayRoutesResult,
@@ -91601,7 +91600,7 @@ export const exportVerifiedAccessInstanceClientConfiguration: API.OperationMetho
   ExportVerifiedAccessInstanceClientConfigurationRequest,
   ExportVerifiedAccessInstanceClientConfigurationResult,
   ExportVerifiedAccessInstanceClientConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportVerifiedAccessInstanceClientConfigurationRequest,
   output: ExportVerifiedAccessInstanceClientConfigurationResult,
@@ -91627,7 +91626,7 @@ export const getActiveVpnTunnelStatus: API.OperationMethod<
   GetActiveVpnTunnelStatusRequest,
   GetActiveVpnTunnelStatusResult,
   GetActiveVpnTunnelStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActiveVpnTunnelStatusRequest,
   output: GetActiveVpnTunnelStatusResult,
@@ -91658,7 +91657,7 @@ export const getAllowedImagesSettings: API.OperationMethod<
   GetAllowedImagesSettingsRequest,
   GetAllowedImagesSettingsResult,
   GetAllowedImagesSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAllowedImagesSettingsRequest,
   output: GetAllowedImagesSettingsResult,
@@ -91683,7 +91682,7 @@ export const getAssociatedEnclaveCertificateIamRoles: API.OperationMethod<
   GetAssociatedEnclaveCertificateIamRolesRequest,
   GetAssociatedEnclaveCertificateIamRolesResult,
   GetAssociatedEnclaveCertificateIamRolesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociatedEnclaveCertificateIamRolesRequest,
   output: GetAssociatedEnclaveCertificateIamRolesResult,
@@ -91709,7 +91708,7 @@ export const getAssociatedIpv6PoolCidrs: API.PaginatedOperationMethod<
   GetAssociatedIpv6PoolCidrsRequest,
   GetAssociatedIpv6PoolCidrsResult,
   GetAssociatedIpv6PoolCidrsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Ipv6CidrAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAssociatedIpv6PoolCidrsRequest,
@@ -91742,7 +91741,7 @@ export const getAwsNetworkPerformanceData: API.PaginatedOperationMethod<
   GetAwsNetworkPerformanceDataRequest,
   GetAwsNetworkPerformanceDataResult,
   GetAwsNetworkPerformanceDataError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataResponse
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAwsNetworkPerformanceDataRequest,
@@ -91767,7 +91766,7 @@ export const getCapacityManagerAttributes: API.OperationMethod<
   GetCapacityManagerAttributesRequest,
   GetCapacityManagerAttributesResult,
   GetCapacityManagerAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityManagerAttributesRequest,
   output: GetCapacityManagerAttributesResult,
@@ -91790,7 +91789,7 @@ export const getCapacityManagerMetricData: API.PaginatedOperationMethod<
   GetCapacityManagerMetricDataRequest,
   GetCapacityManagerMetricDataResult,
   GetCapacityManagerMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricDataResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCapacityManagerMetricDataRequest,
@@ -91820,7 +91819,7 @@ export const getCapacityManagerMetricDimensions: API.PaginatedOperationMethod<
   GetCapacityManagerMetricDimensionsRequest,
   GetCapacityManagerMetricDimensionsResult,
   GetCapacityManagerMetricDimensionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityManagerDimension
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCapacityManagerMetricDimensionsRequest,
@@ -91845,7 +91844,7 @@ export const getCapacityManagerMonitoredTagKeys: API.PaginatedOperationMethod<
   GetCapacityManagerMonitoredTagKeysRequest,
   GetCapacityManagerMonitoredTagKeysResult,
   GetCapacityManagerMonitoredTagKeysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityManagerMonitoredTagKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCapacityManagerMonitoredTagKeysRequest,
@@ -91876,7 +91875,7 @@ export const getCapacityReservationUsage: API.OperationMethod<
   GetCapacityReservationUsageRequest,
   GetCapacityReservationUsageResult,
   GetCapacityReservationUsageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityReservationUsageRequest,
   output: GetCapacityReservationUsageResult,
@@ -91902,7 +91901,7 @@ export const getCoipPoolUsage: API.OperationMethod<
   GetCoipPoolUsageRequest,
   GetCoipPoolUsageResult,
   GetCoipPoolUsageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoipPoolUsageRequest,
   output: GetCoipPoolUsageResult,
@@ -91931,7 +91930,7 @@ export const getConsoleOutput: API.OperationMethod<
   GetConsoleOutputRequest,
   GetConsoleOutputResult,
   GetConsoleOutputError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConsoleOutputRequest,
   output: GetConsoleOutputResult,
@@ -91964,7 +91963,7 @@ export const getConsoleScreenshot: API.OperationMethod<
   GetConsoleScreenshotRequest,
   GetConsoleScreenshotResult,
   GetConsoleScreenshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConsoleScreenshotRequest,
   output: GetConsoleScreenshotResult,
@@ -92001,7 +92000,7 @@ export const getDeclarativePoliciesReportSummary: API.OperationMethod<
   GetDeclarativePoliciesReportSummaryRequest,
   GetDeclarativePoliciesReportSummaryResult,
   GetDeclarativePoliciesReportSummaryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeclarativePoliciesReportSummaryRequest,
   output: GetDeclarativePoliciesReportSummaryResult,
@@ -92031,7 +92030,7 @@ export const getDefaultCreditSpecification: API.OperationMethod<
   GetDefaultCreditSpecificationRequest,
   GetDefaultCreditSpecificationResult,
   GetDefaultCreditSpecificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultCreditSpecificationRequest,
   output: GetDefaultCreditSpecificationResult,
@@ -92052,7 +92051,7 @@ export const getEbsDefaultKmsKeyId: API.OperationMethod<
   GetEbsDefaultKmsKeyIdRequest,
   GetEbsDefaultKmsKeyIdResult,
   GetEbsDefaultKmsKeyIdError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEbsDefaultKmsKeyIdRequest,
   output: GetEbsDefaultKmsKeyIdResult,
@@ -92074,7 +92073,7 @@ export const getEbsEncryptionByDefault: API.OperationMethod<
   GetEbsEncryptionByDefaultRequest,
   GetEbsEncryptionByDefaultResult,
   GetEbsEncryptionByDefaultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEbsEncryptionByDefaultRequest,
   output: GetEbsEncryptionByDefaultResult,
@@ -92094,7 +92093,7 @@ export const getEnabledIpamPolicy: API.OperationMethod<
   GetEnabledIpamPolicyRequest,
   GetEnabledIpamPolicyResult,
   GetEnabledIpamPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnabledIpamPolicyRequest,
   output: GetEnabledIpamPolicyResult,
@@ -92126,7 +92125,7 @@ export const getFlowLogsIntegrationTemplate: API.OperationMethod<
   GetFlowLogsIntegrationTemplateRequest,
   GetFlowLogsIntegrationTemplateResult,
   GetFlowLogsIntegrationTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowLogsIntegrationTemplateRequest,
   output: GetFlowLogsIntegrationTemplateResult,
@@ -92148,7 +92147,7 @@ export const getGroupsForCapacityReservation: API.PaginatedOperationMethod<
   GetGroupsForCapacityReservationRequest,
   GetGroupsForCapacityReservationResult,
   GetGroupsForCapacityReservationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityReservationGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetGroupsForCapacityReservationRequest,
@@ -92182,7 +92181,7 @@ export const getHostReservationPurchasePreview: API.OperationMethod<
   GetHostReservationPurchasePreviewRequest,
   GetHostReservationPurchasePreviewResult,
   GetHostReservationPurchasePreviewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostReservationPurchasePreviewRequest,
   output: GetHostReservationPurchasePreviewResult,
@@ -92206,7 +92205,7 @@ export const getImageAncestry: API.OperationMethod<
   GetImageAncestryRequest,
   GetImageAncestryResult,
   GetImageAncestryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageAncestryRequest,
   output: GetImageAncestryResult,
@@ -92228,7 +92227,7 @@ export const getImageBlockPublicAccessState: API.OperationMethod<
   GetImageBlockPublicAccessStateRequest,
   GetImageBlockPublicAccessStateResult,
   GetImageBlockPublicAccessStateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageBlockPublicAccessStateRequest,
   output: GetImageBlockPublicAccessStateResult,
@@ -92251,7 +92250,7 @@ export const getInstanceMetadataDefaults: API.OperationMethod<
   GetInstanceMetadataDefaultsRequest,
   GetInstanceMetadataDefaultsResult,
   GetInstanceMetadataDefaultsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceMetadataDefaultsRequest,
   output: GetInstanceMetadataDefaultsResult,
@@ -92274,7 +92273,7 @@ export const getInstanceTpmEkPub: API.OperationMethod<
   GetInstanceTpmEkPubRequest,
   GetInstanceTpmEkPubResult,
   GetInstanceTpmEkPubError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceTpmEkPubRequest,
   output: GetInstanceTpmEkPubResult,
@@ -92307,7 +92306,7 @@ export const getInstanceTypesFromInstanceRequirements: API.PaginatedOperationMet
   GetInstanceTypesFromInstanceRequirementsRequest,
   GetInstanceTypesFromInstanceRequirementsResult,
   GetInstanceTypesFromInstanceRequirementsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeInfoFromInstanceRequirements
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInstanceTypesFromInstanceRequirementsRequest,
@@ -92348,7 +92347,7 @@ export const getInstanceUefiData: API.OperationMethod<
   GetInstanceUefiDataRequest,
   GetInstanceUefiDataResult,
   GetInstanceUefiDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceUefiDataRequest,
   output: GetInstanceUefiDataResult,
@@ -92374,7 +92373,7 @@ export const getIpamAddressHistory: API.PaginatedOperationMethod<
   GetIpamAddressHistoryRequest,
   GetIpamAddressHistoryResult,
   GetIpamAddressHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamAddressHistoryRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamAddressHistoryRequest,
@@ -92408,7 +92407,7 @@ export const getIpamDiscoveredAccounts: API.PaginatedOperationMethod<
   GetIpamDiscoveredAccountsRequest,
   GetIpamDiscoveredAccountsResult,
   GetIpamDiscoveredAccountsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamDiscoveredAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamDiscoveredAccountsRequest,
@@ -92443,7 +92442,7 @@ export const getIpamDiscoveredPublicAddresses: API.OperationMethod<
   GetIpamDiscoveredPublicAddressesRequest,
   GetIpamDiscoveredPublicAddressesResult,
   GetIpamDiscoveredPublicAddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIpamDiscoveredPublicAddressesRequest,
   output: GetIpamDiscoveredPublicAddressesResult,
@@ -92471,7 +92470,7 @@ export const getIpamDiscoveredResourceCidrs: API.PaginatedOperationMethod<
   GetIpamDiscoveredResourceCidrsRequest,
   GetIpamDiscoveredResourceCidrsResult,
   GetIpamDiscoveredResourceCidrsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamDiscoveredResourceCidr
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamDiscoveredResourceCidrsRequest,
@@ -92510,7 +92509,7 @@ export const getIpamPolicyAllocationRules: API.OperationMethod<
   GetIpamPolicyAllocationRulesRequest,
   GetIpamPolicyAllocationRulesResult,
   GetIpamPolicyAllocationRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIpamPolicyAllocationRulesRequest,
   output: GetIpamPolicyAllocationRulesResult,
@@ -92542,7 +92541,7 @@ export const getIpamPolicyOrganizationTargets: API.OperationMethod<
   GetIpamPolicyOrganizationTargetsRequest,
   GetIpamPolicyOrganizationTargetsResult,
   GetIpamPolicyOrganizationTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIpamPolicyOrganizationTargetsRequest,
   output: GetIpamPolicyOrganizationTargetsResult,
@@ -92572,7 +92571,7 @@ export const getIpamPoolAllocations: API.PaginatedOperationMethod<
   GetIpamPoolAllocationsRequest,
   GetIpamPoolAllocationsResult,
   GetIpamPoolAllocationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPoolAllocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamPoolAllocationsRequest,
@@ -92607,7 +92606,7 @@ export const getIpamPoolCidrs: API.PaginatedOperationMethod<
   GetIpamPoolCidrsRequest,
   GetIpamPoolCidrsResult,
   GetIpamPoolCidrsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPoolCidr
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamPoolCidrsRequest,
@@ -92642,7 +92641,7 @@ export const getIpamPrefixListResolverRules: API.PaginatedOperationMethod<
   GetIpamPrefixListResolverRulesRequest,
   GetIpamPrefixListResolverRulesResult,
   GetIpamPrefixListResolverRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPrefixListResolverRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamPrefixListResolverRulesRequest,
@@ -92676,7 +92675,7 @@ export const getIpamPrefixListResolverVersionEntries: API.PaginatedOperationMeth
   GetIpamPrefixListResolverVersionEntriesRequest,
   GetIpamPrefixListResolverVersionEntriesResult,
   GetIpamPrefixListResolverVersionEntriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPrefixListResolverVersionEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamPrefixListResolverVersionEntriesRequest,
@@ -92733,7 +92732,7 @@ export const getIpamPrefixListResolverVersions: API.PaginatedOperationMethod<
   GetIpamPrefixListResolverVersionsRequest,
   GetIpamPrefixListResolverVersionsResult,
   GetIpamPrefixListResolverVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamPrefixListResolverVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamPrefixListResolverVersionsRequest,
@@ -92768,7 +92767,7 @@ export const getIpamResourceCidrs: API.PaginatedOperationMethod<
   GetIpamResourceCidrsRequest,
   GetIpamResourceCidrsResult,
   GetIpamResourceCidrsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpamResourceCidr
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIpamResourceCidrsRequest,
@@ -92810,7 +92809,7 @@ export const getLaunchTemplateData: API.OperationMethod<
   GetLaunchTemplateDataRequest,
   GetLaunchTemplateDataResult,
   GetLaunchTemplateDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLaunchTemplateDataRequest,
   output: GetLaunchTemplateDataResult,
@@ -92837,7 +92836,7 @@ export const getManagedPrefixListAssociations: API.PaginatedOperationMethod<
   GetManagedPrefixListAssociationsRequest,
   GetManagedPrefixListAssociationsResult,
   GetManagedPrefixListAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrefixListAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetManagedPrefixListAssociationsRequest,
@@ -92873,7 +92872,7 @@ export const getManagedPrefixListEntries: API.PaginatedOperationMethod<
   GetManagedPrefixListEntriesRequest,
   GetManagedPrefixListEntriesResult,
   GetManagedPrefixListEntriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrefixListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetManagedPrefixListEntriesRequest,
@@ -92905,7 +92904,7 @@ export const getManagedResourceVisibility: API.OperationMethod<
   GetManagedResourceVisibilityRequest,
   GetManagedResourceVisibilityResult,
   GetManagedResourceVisibilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedResourceVisibilityRequest,
   output: GetManagedResourceVisibilityResult,
@@ -92927,7 +92926,7 @@ export const getNetworkInsightsAccessScopeAnalysisFindings: API.PaginatedOperati
   GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
   GetNetworkInsightsAccessScopeAnalysisFindingsResult,
   GetNetworkInsightsAccessScopeAnalysisFindingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessScopeAnalysisFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
@@ -92956,7 +92955,7 @@ export const getNetworkInsightsAccessScopeContent: API.OperationMethod<
   GetNetworkInsightsAccessScopeContentRequest,
   GetNetworkInsightsAccessScopeContentResult,
   GetNetworkInsightsAccessScopeContentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkInsightsAccessScopeContentRequest,
   output: GetNetworkInsightsAccessScopeContentResult,
@@ -92995,7 +92994,7 @@ export const getPasswordData: API.OperationMethod<
   GetPasswordDataRequest,
   GetPasswordDataResult,
   GetPasswordDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPasswordDataRequest,
   output: GetPasswordDataResult,
@@ -93024,7 +93023,7 @@ export const getReservedInstancesExchangeQuote: API.OperationMethod<
   GetReservedInstancesExchangeQuoteRequest,
   GetReservedInstancesExchangeQuoteResult,
   GetReservedInstancesExchangeQuoteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReservedInstancesExchangeQuoteRequest,
   output: GetReservedInstancesExchangeQuoteResult,
@@ -93054,7 +93053,7 @@ export const getRouteServerAssociations: API.OperationMethod<
   GetRouteServerAssociationsRequest,
   GetRouteServerAssociationsResult,
   GetRouteServerAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteServerAssociationsRequest,
   output: GetRouteServerAssociationsResult,
@@ -93095,7 +93094,7 @@ export const getRouteServerPropagations: API.OperationMethod<
   GetRouteServerPropagationsRequest,
   GetRouteServerPropagationsResult,
   GetRouteServerPropagationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteServerPropagationsRequest,
   output: GetRouteServerPropagationsResult,
@@ -93134,7 +93133,7 @@ export const getRouteServerRoutingDatabase: API.OperationMethod<
   GetRouteServerRoutingDatabaseRequest,
   GetRouteServerRoutingDatabaseResult,
   GetRouteServerRoutingDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteServerRoutingDatabaseRequest,
   output: GetRouteServerRoutingDatabaseResult,
@@ -93161,7 +93160,7 @@ export const getSecurityGroupsForVpc: API.PaginatedOperationMethod<
   GetSecurityGroupsForVpcRequest,
   GetSecurityGroupsForVpcResult,
   GetSecurityGroupsForVpcError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityGroupForVpc
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSecurityGroupsForVpcRequest,
@@ -93194,7 +93193,7 @@ export const getSerialConsoleAccessStatus: API.OperationMethod<
   GetSerialConsoleAccessStatusRequest,
   GetSerialConsoleAccessStatusResult,
   GetSerialConsoleAccessStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSerialConsoleAccessStatusRequest,
   output: GetSerialConsoleAccessStatusResult,
@@ -93216,7 +93215,7 @@ export const getSnapshotBlockPublicAccessState: API.OperationMethod<
   GetSnapshotBlockPublicAccessStateRequest,
   GetSnapshotBlockPublicAccessStateResult,
   GetSnapshotBlockPublicAccessStateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSnapshotBlockPublicAccessStateRequest,
   output: GetSnapshotBlockPublicAccessStateResult,
@@ -93243,7 +93242,7 @@ export const getSpotPlacementScores: API.PaginatedOperationMethod<
   GetSpotPlacementScoresRequest,
   GetSpotPlacementScoresResult,
   GetSpotPlacementScoresError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpotPlacementScore
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSpotPlacementScoresRequest,
@@ -93273,7 +93272,7 @@ export const getSubnetCidrReservations: API.OperationMethod<
   GetSubnetCidrReservationsRequest,
   GetSubnetCidrReservationsResult,
   GetSubnetCidrReservationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubnetCidrReservationsRequest,
   output: GetSubnetCidrReservationsResult,
@@ -93300,7 +93299,7 @@ export const getTransitGatewayAttachmentPropagations: API.PaginatedOperationMeth
   GetTransitGatewayAttachmentPropagationsRequest,
   GetTransitGatewayAttachmentPropagationsResult,
   GetTransitGatewayAttachmentPropagationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayAttachmentPropagation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayAttachmentPropagationsRequest,
@@ -93334,7 +93333,7 @@ export const getTransitGatewayMeteringPolicyEntries: API.OperationMethod<
   GetTransitGatewayMeteringPolicyEntriesRequest,
   GetTransitGatewayMeteringPolicyEntriesResult,
   GetTransitGatewayMeteringPolicyEntriesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransitGatewayMeteringPolicyEntriesRequest,
   output: GetTransitGatewayMeteringPolicyEntriesResult,
@@ -93363,7 +93362,7 @@ export const getTransitGatewayMulticastDomainAssociations: API.PaginatedOperatio
   GetTransitGatewayMulticastDomainAssociationsRequest,
   GetTransitGatewayMulticastDomainAssociationsResult,
   GetTransitGatewayMulticastDomainAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayMulticastDomainAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayMulticastDomainAssociationsRequest,
@@ -93399,7 +93398,7 @@ export const getTransitGatewayPolicyTableAssociations: API.PaginatedOperationMet
   GetTransitGatewayPolicyTableAssociationsRequest,
   GetTransitGatewayPolicyTableAssociationsResult,
   GetTransitGatewayPolicyTableAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayPolicyTableAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayPolicyTableAssociationsRequest,
@@ -93434,7 +93433,7 @@ export const getTransitGatewayPolicyTableEntries: API.OperationMethod<
   GetTransitGatewayPolicyTableEntriesRequest,
   GetTransitGatewayPolicyTableEntriesResult,
   GetTransitGatewayPolicyTableEntriesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransitGatewayPolicyTableEntriesRequest,
   output: GetTransitGatewayPolicyTableEntriesResult,
@@ -93462,7 +93461,7 @@ export const getTransitGatewayPrefixListReferences: API.PaginatedOperationMethod
   GetTransitGatewayPrefixListReferencesRequest,
   GetTransitGatewayPrefixListReferencesResult,
   GetTransitGatewayPrefixListReferencesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayPrefixListReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayPrefixListReferencesRequest,
@@ -93496,7 +93495,7 @@ export const getTransitGatewayRouteTableAssociations: API.PaginatedOperationMeth
   GetTransitGatewayRouteTableAssociationsRequest,
   GetTransitGatewayRouteTableAssociationsResult,
   GetTransitGatewayRouteTableAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRouteTableAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayRouteTableAssociationsRequest,
@@ -93529,7 +93528,7 @@ export const getTransitGatewayRouteTablePropagations: API.PaginatedOperationMeth
   GetTransitGatewayRouteTablePropagationsRequest,
   GetTransitGatewayRouteTablePropagationsResult,
   GetTransitGatewayRouteTablePropagationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRouteTablePropagation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayRouteTablePropagationsRequest,
@@ -93563,7 +93562,7 @@ export const getVerifiedAccessEndpointPolicy: API.OperationMethod<
   GetVerifiedAccessEndpointPolicyRequest,
   GetVerifiedAccessEndpointPolicyResult,
   GetVerifiedAccessEndpointPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVerifiedAccessEndpointPolicyRequest,
   output: GetVerifiedAccessEndpointPolicyResult,
@@ -93590,7 +93589,7 @@ export const getVerifiedAccessEndpointTargets: API.OperationMethod<
   GetVerifiedAccessEndpointTargetsRequest,
   GetVerifiedAccessEndpointTargetsResult,
   GetVerifiedAccessEndpointTargetsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVerifiedAccessEndpointTargetsRequest,
   output: GetVerifiedAccessEndpointTargetsResult,
@@ -93616,7 +93615,7 @@ export const getVerifiedAccessGroupPolicy: API.OperationMethod<
   GetVerifiedAccessGroupPolicyRequest,
   GetVerifiedAccessGroupPolicyResult,
   GetVerifiedAccessGroupPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVerifiedAccessGroupPolicyRequest,
   output: GetVerifiedAccessGroupPolicyResult,
@@ -93644,7 +93643,7 @@ export const getVpcResourcesBlockingEncryptionEnforcement: API.OperationMethod<
   GetVpcResourcesBlockingEncryptionEnforcementRequest,
   GetVpcResourcesBlockingEncryptionEnforcementResult,
   GetVpcResourcesBlockingEncryptionEnforcementError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcResourcesBlockingEncryptionEnforcementRequest,
   output: GetVpcResourcesBlockingEncryptionEnforcementResult,
@@ -93667,7 +93666,7 @@ export const getVpnConnectionDeviceSampleConfiguration: API.OperationMethod<
   GetVpnConnectionDeviceSampleConfigurationRequest,
   GetVpnConnectionDeviceSampleConfigurationResult,
   GetVpnConnectionDeviceSampleConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpnConnectionDeviceSampleConfigurationRequest,
   output: GetVpnConnectionDeviceSampleConfigurationResult,
@@ -93692,7 +93691,7 @@ export const getVpnConnectionDeviceTypes: API.PaginatedOperationMethod<
   GetVpnConnectionDeviceTypesRequest,
   GetVpnConnectionDeviceTypesResult,
   GetVpnConnectionDeviceTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpnConnectionDeviceType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetVpnConnectionDeviceTypesRequest,
@@ -93721,7 +93720,7 @@ export const getVpnTunnelReplacementStatus: API.OperationMethod<
   GetVpnTunnelReplacementStatusRequest,
   GetVpnTunnelReplacementStatusResult,
   GetVpnTunnelReplacementStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpnTunnelReplacementStatusRequest,
   output: GetVpnTunnelReplacementStatusResult,
@@ -93745,7 +93744,7 @@ export const importClientVpnClientCertificateRevocationList: API.OperationMethod
   ImportClientVpnClientCertificateRevocationListRequest,
   ImportClientVpnClientCertificateRevocationListResult,
   ImportClientVpnClientCertificateRevocationListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportClientVpnClientCertificateRevocationListRequest,
   output: ImportClientVpnClientCertificateRevocationListResult,
@@ -93785,7 +93784,7 @@ export const importImage: API.OperationMethod<
   ImportImageRequest,
   ImportImageResult,
   ImportImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportImageRequest,
   output: ImportImageResult,
@@ -93824,7 +93823,7 @@ export const importInstance: API.OperationMethod<
   ImportInstanceRequest,
   ImportInstanceResult,
   ImportInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportInstanceRequest,
   output: ImportInstanceResult,
@@ -93849,7 +93848,7 @@ export const importKeyPair: API.OperationMethod<
   ImportKeyPairRequest,
   ImportKeyPairResult,
   ImportKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportKeyPairRequest,
   output: ImportKeyPairResult,
@@ -93878,7 +93877,7 @@ export const importSnapshot: API.OperationMethod<
   ImportSnapshotRequest,
   ImportSnapshotResult,
   ImportSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportSnapshotRequest,
   output: ImportSnapshotResult,
@@ -93904,7 +93903,7 @@ export const importVolume: API.OperationMethod<
   ImportVolumeRequest,
   ImportVolumeResult,
   ImportVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportVolumeRequest,
   output: ImportVolumeResult,
@@ -93928,7 +93927,7 @@ export const listImagesInRecycleBin: API.PaginatedOperationMethod<
   ListImagesInRecycleBinRequest,
   ListImagesInRecycleBinResult,
   ListImagesInRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageRecycleBinInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagesInRecycleBinRequest,
@@ -93957,7 +93956,7 @@ export const listSnapshotsInRecycleBin: API.PaginatedOperationMethod<
   ListSnapshotsInRecycleBinRequest,
   ListSnapshotsInRecycleBinResult,
   ListSnapshotsInRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotRecycleBinInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSnapshotsInRecycleBinRequest,
@@ -93990,7 +93989,7 @@ export const listVolumesInRecycleBin: API.OperationMethod<
   ListVolumesInRecycleBinRequest,
   ListVolumesInRecycleBinResult,
   ListVolumesInRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVolumesInRecycleBinRequest,
   output: ListVolumesInRecycleBinResult,
@@ -94030,7 +94029,7 @@ export const lockSnapshot: API.OperationMethod<
   LockSnapshotRequest,
   LockSnapshotResult,
   LockSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LockSnapshotRequest,
   output: LockSnapshotResult,
@@ -94053,7 +94052,7 @@ export const modifyAddressAttribute: API.OperationMethod<
   ModifyAddressAttributeRequest,
   ModifyAddressAttributeResult,
   ModifyAddressAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyAddressAttributeRequest,
   output: ModifyAddressAttributeResult,
@@ -94080,7 +94079,7 @@ export const modifyAvailabilityZoneGroup: API.OperationMethod<
   ModifyAvailabilityZoneGroupRequest,
   ModifyAvailabilityZoneGroupResult,
   ModifyAvailabilityZoneGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyAvailabilityZoneGroupRequest,
   output: ModifyAvailabilityZoneGroupResult,
@@ -94127,7 +94126,7 @@ export const modifyCapacityReservation: API.OperationMethod<
   ModifyCapacityReservationRequest,
   ModifyCapacityReservationResult,
   ModifyCapacityReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCapacityReservationRequest,
   output: ModifyCapacityReservationResult,
@@ -94159,7 +94158,7 @@ export const modifyCapacityReservationFleet: API.OperationMethod<
   ModifyCapacityReservationFleetRequest,
   ModifyCapacityReservationFleetResult,
   ModifyCapacityReservationFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCapacityReservationFleetRequest,
   output: ModifyCapacityReservationFleetResult,
@@ -94185,7 +94184,7 @@ export const modifyClientVpnEndpoint: API.OperationMethod<
   ModifyClientVpnEndpointRequest,
   ModifyClientVpnEndpointResult,
   ModifyClientVpnEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClientVpnEndpointRequest,
   output: ModifyClientVpnEndpointResult,
@@ -94225,7 +94224,7 @@ export const modifyDefaultCreditSpecification: API.OperationMethod<
   ModifyDefaultCreditSpecificationRequest,
   ModifyDefaultCreditSpecificationResult,
   ModifyDefaultCreditSpecificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDefaultCreditSpecificationRequest,
   output: ModifyDefaultCreditSpecificationResult,
@@ -94257,7 +94256,7 @@ export const modifyEbsDefaultKmsKeyId: API.OperationMethod<
   ModifyEbsDefaultKmsKeyIdRequest,
   ModifyEbsDefaultKmsKeyIdResult,
   ModifyEbsDefaultKmsKeyIdError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEbsDefaultKmsKeyIdRequest,
   output: ModifyEbsDefaultKmsKeyIdResult,
@@ -94305,7 +94304,7 @@ export const modifyFleet: API.OperationMethod<
   ModifyFleetRequest,
   ModifyFleetResult,
   ModifyFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyFleetRequest,
   output: ModifyFleetResult,
@@ -94332,7 +94331,7 @@ export const modifyFpgaImageAttribute: API.OperationMethod<
   ModifyFpgaImageAttributeRequest,
   ModifyFpgaImageAttributeResult,
   ModifyFpgaImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyFpgaImageAttributeRequest,
   output: ModifyFpgaImageAttributeResult,
@@ -94364,7 +94363,7 @@ export const modifyHosts: API.OperationMethod<
   ModifyHostsRequest,
   ModifyHostsResult,
   ModifyHostsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyHostsRequest,
   output: ModifyHostsResult,
@@ -94407,7 +94406,7 @@ export const modifyIdentityIdFormat: API.OperationMethod<
   ModifyIdentityIdFormatRequest,
   ModifyIdentityIdFormatResponse,
   ModifyIdentityIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIdentityIdFormatRequest,
   output: ModifyIdentityIdFormatResponse,
@@ -94451,7 +94450,7 @@ export const modifyIdFormat: API.OperationMethod<
   ModifyIdFormatRequest,
   ModifyIdFormatResponse,
   ModifyIdFormatError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIdFormatRequest,
   output: ModifyIdFormatResponse,
@@ -94485,7 +94484,7 @@ export const modifyImageAttribute: API.OperationMethod<
   ModifyImageAttributeRequest,
   ModifyImageAttributeResponse,
   ModifyImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyImageAttributeRequest,
   output: ModifyImageAttributeResponse,
@@ -94525,7 +94524,7 @@ export const modifyInstanceAttribute: API.OperationMethod<
   ModifyInstanceAttributeRequest,
   ModifyInstanceAttributeResponse,
   ModifyInstanceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceAttributeRequest,
   output: ModifyInstanceAttributeResponse,
@@ -94555,7 +94554,7 @@ export const modifyInstanceCapacityReservationAttributes: API.OperationMethod<
   ModifyInstanceCapacityReservationAttributesRequest,
   ModifyInstanceCapacityReservationAttributesResult,
   ModifyInstanceCapacityReservationAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceCapacityReservationAttributesRequest,
   output: ModifyInstanceCapacityReservationAttributesResult,
@@ -94582,7 +94581,7 @@ export const modifyInstanceConnectEndpoint: API.OperationMethod<
   ModifyInstanceConnectEndpointRequest,
   ModifyInstanceConnectEndpointResult,
   ModifyInstanceConnectEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceConnectEndpointRequest,
   output: ModifyInstanceConnectEndpointResult,
@@ -94618,7 +94617,7 @@ export const modifyInstanceCpuOptions: API.OperationMethod<
   ModifyInstanceCpuOptionsRequest,
   ModifyInstanceCpuOptionsResult,
   ModifyInstanceCpuOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceCpuOptionsRequest,
   output: ModifyInstanceCpuOptionsResult,
@@ -94645,7 +94644,7 @@ export const modifyInstanceCreditSpecification: API.OperationMethod<
   ModifyInstanceCreditSpecificationRequest,
   ModifyInstanceCreditSpecificationResult,
   ModifyInstanceCreditSpecificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceCreditSpecificationRequest,
   output: ModifyInstanceCreditSpecificationResult,
@@ -94667,7 +94666,7 @@ export const modifyInstanceEventStartTime: API.OperationMethod<
   ModifyInstanceEventStartTimeRequest,
   ModifyInstanceEventStartTimeResult,
   ModifyInstanceEventStartTimeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceEventStartTimeRequest,
   output: ModifyInstanceEventStartTimeResult,
@@ -94701,7 +94700,7 @@ export const modifyInstanceEventWindow: API.OperationMethod<
   ModifyInstanceEventWindowRequest,
   ModifyInstanceEventWindowResult,
   ModifyInstanceEventWindowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceEventWindowRequest,
   output: ModifyInstanceEventWindowResult,
@@ -94734,7 +94733,7 @@ export const modifyInstanceMaintenanceOptions: API.OperationMethod<
   ModifyInstanceMaintenanceOptionsRequest,
   ModifyInstanceMaintenanceOptionsResult,
   ModifyInstanceMaintenanceOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceMaintenanceOptionsRequest,
   output: ModifyInstanceMaintenanceOptionsResult,
@@ -94768,7 +94767,7 @@ export const modifyInstanceMetadataDefaults: API.OperationMethod<
   ModifyInstanceMetadataDefaultsRequest,
   ModifyInstanceMetadataDefaultsResult,
   ModifyInstanceMetadataDefaultsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceMetadataDefaultsRequest,
   output: ModifyInstanceMetadataDefaultsResult,
@@ -94796,7 +94795,7 @@ export const modifyInstanceMetadataOptions: API.OperationMethod<
   ModifyInstanceMetadataOptionsRequest,
   ModifyInstanceMetadataOptionsResult,
   ModifyInstanceMetadataOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceMetadataOptionsRequest,
   output: ModifyInstanceMetadataOptionsResult,
@@ -94823,7 +94822,7 @@ export const modifyInstanceNetworkPerformanceOptions: API.OperationMethod<
   ModifyInstanceNetworkPerformanceRequest,
   ModifyInstanceNetworkPerformanceResult,
   ModifyInstanceNetworkPerformanceOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceNetworkPerformanceRequest,
   output: ModifyInstanceNetworkPerformanceResult,
@@ -94866,7 +94865,7 @@ export const modifyInstancePlacement: API.OperationMethod<
   ModifyInstancePlacementRequest,
   ModifyInstancePlacementResult,
   ModifyInstancePlacementError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstancePlacementRequest,
   output: ModifyInstancePlacementResult,
@@ -94892,7 +94891,7 @@ export const modifyIpam: API.OperationMethod<
   ModifyIpamRequest,
   ModifyIpamResult,
   ModifyIpamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamRequest,
   output: ModifyIpamResult,
@@ -94922,7 +94921,7 @@ export const modifyIpamPolicyAllocationRules: API.OperationMethod<
   ModifyIpamPolicyAllocationRulesRequest,
   ModifyIpamPolicyAllocationRulesResult,
   ModifyIpamPolicyAllocationRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamPolicyAllocationRulesRequest,
   output: ModifyIpamPolicyAllocationRulesResult,
@@ -94946,7 +94945,7 @@ export const modifyIpamPool: API.OperationMethod<
   ModifyIpamPoolRequest,
   ModifyIpamPoolResult,
   ModifyIpamPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamPoolRequest,
   output: ModifyIpamPoolResult,
@@ -94968,7 +94967,7 @@ export const modifyIpamPoolAllocation: API.OperationMethod<
   ModifyIpamPoolAllocationRequest,
   ModifyIpamPoolAllocationResult,
   ModifyIpamPoolAllocationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamPoolAllocationRequest,
   output: ModifyIpamPoolAllocationResult,
@@ -94991,7 +94990,7 @@ export const modifyIpamPrefixListResolver: API.OperationMethod<
   ModifyIpamPrefixListResolverRequest,
   ModifyIpamPrefixListResolverResult,
   ModifyIpamPrefixListResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamPrefixListResolverRequest,
   output: ModifyIpamPrefixListResolverResult,
@@ -95018,7 +95017,7 @@ export const modifyIpamPrefixListResolverTarget: API.OperationMethod<
   ModifyIpamPrefixListResolverTargetRequest,
   ModifyIpamPrefixListResolverTargetResult,
   ModifyIpamPrefixListResolverTargetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamPrefixListResolverTargetRequest,
   output: ModifyIpamPrefixListResolverTargetResult,
@@ -95047,7 +95046,7 @@ export const modifyIpamResourceCidr: API.OperationMethod<
   ModifyIpamResourceCidrRequest,
   ModifyIpamResourceCidrResult,
   ModifyIpamResourceCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamResourceCidrRequest,
   output: ModifyIpamResourceCidrResult,
@@ -95075,7 +95074,7 @@ export const modifyIpamResourceDiscovery: API.OperationMethod<
   ModifyIpamResourceDiscoveryRequest,
   ModifyIpamResourceDiscoveryResult,
   ModifyIpamResourceDiscoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamResourceDiscoveryRequest,
   output: ModifyIpamResourceDiscoveryResult,
@@ -95102,7 +95101,7 @@ export const modifyIpamScope: API.OperationMethod<
   ModifyIpamScopeRequest,
   ModifyIpamScopeResult,
   ModifyIpamScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpamScopeRequest,
   output: ModifyIpamScopeResult,
@@ -95130,7 +95129,7 @@ export const modifyLaunchTemplate: API.OperationMethod<
   ModifyLaunchTemplateRequest,
   ModifyLaunchTemplateResult,
   ModifyLaunchTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLaunchTemplateRequest,
   output: ModifyLaunchTemplateResult,
@@ -95152,7 +95151,7 @@ export const modifyLocalGatewayRoute: API.OperationMethod<
   ModifyLocalGatewayRouteRequest,
   ModifyLocalGatewayRouteResult,
   ModifyLocalGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLocalGatewayRouteRequest,
   output: ModifyLocalGatewayRouteResult,
@@ -95182,7 +95181,7 @@ export const modifyManagedPrefixList: API.OperationMethod<
   ModifyManagedPrefixListRequest,
   ModifyManagedPrefixListResult,
   ModifyManagedPrefixListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyManagedPrefixListRequest,
   output: ModifyManagedPrefixListResult,
@@ -95209,7 +95208,7 @@ export const modifyManagedResourceVisibility: API.OperationMethod<
   ModifyManagedResourceVisibilityRequest,
   ModifyManagedResourceVisibilityResult,
   ModifyManagedResourceVisibilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyManagedResourceVisibilityRequest,
   output: ModifyManagedResourceVisibilityResult,
@@ -95235,7 +95234,7 @@ export const modifyNetworkInterfaceAttribute: API.OperationMethod<
   ModifyNetworkInterfaceAttributeRequest,
   ModifyNetworkInterfaceAttributeResponse,
   ModifyNetworkInterfaceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyNetworkInterfaceAttributeRequest,
   output: ModifyNetworkInterfaceAttributeResponse,
@@ -95263,7 +95262,7 @@ export const modifyPrivateDnsNameOptions: API.OperationMethod<
   ModifyPrivateDnsNameOptionsRequest,
   ModifyPrivateDnsNameOptionsResult,
   ModifyPrivateDnsNameOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyPrivateDnsNameOptionsRequest,
   output: ModifyPrivateDnsNameOptionsResult,
@@ -95285,7 +95284,7 @@ export const modifyPublicIpDnsNameOptions: API.OperationMethod<
   ModifyPublicIpDnsNameOptionsRequest,
   ModifyPublicIpDnsNameOptionsResult,
   ModifyPublicIpDnsNameOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyPublicIpDnsNameOptionsRequest,
   output: ModifyPublicIpDnsNameOptionsResult,
@@ -95312,7 +95311,7 @@ export const modifyReservedInstances: API.OperationMethod<
   ModifyReservedInstancesRequest,
   ModifyReservedInstancesResult,
   ModifyReservedInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReservedInstancesRequest,
   output: ModifyReservedInstancesResult,
@@ -95349,7 +95348,7 @@ export const modifyRouteServer: API.OperationMethod<
   ModifyRouteServerRequest,
   ModifyRouteServerResult,
   ModifyRouteServerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyRouteServerRequest,
   output: ModifyRouteServerResult,
@@ -95375,7 +95374,7 @@ export const modifySecurityGroupRules: API.OperationMethod<
   ModifySecurityGroupRulesRequest,
   ModifySecurityGroupRulesResult,
   ModifySecurityGroupRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySecurityGroupRulesRequest,
   output: ModifySecurityGroupRulesResult,
@@ -95407,7 +95406,7 @@ export const modifySnapshotAttribute: API.OperationMethod<
   ModifySnapshotAttributeRequest,
   ModifySnapshotAttributeResponse,
   ModifySnapshotAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySnapshotAttributeRequest,
   output: ModifySnapshotAttributeResponse,
@@ -95438,7 +95437,7 @@ export const modifySnapshotTier: API.OperationMethod<
   ModifySnapshotTierRequest,
   ModifySnapshotTierResult,
   ModifySnapshotTierError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySnapshotTierRequest,
   output: ModifySnapshotTierResult,
@@ -95489,7 +95488,7 @@ export const modifySpotFleetRequest: API.OperationMethod<
   ModifySpotFleetRequestRequest,
   ModifySpotFleetRequestResponse,
   ModifySpotFleetRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySpotFleetRequestRequest,
   output: ModifySpotFleetRequestResponse,
@@ -95529,7 +95528,7 @@ export const modifySubnetAttribute: API.OperationMethod<
   ModifySubnetAttributeRequest,
   ModifySubnetAttributeResponse,
   ModifySubnetAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySubnetAttributeRequest,
   output: ModifySubnetAttributeResponse,
@@ -95559,7 +95558,7 @@ export const modifyTrafficMirrorFilterNetworkServices: API.OperationMethod<
   ModifyTrafficMirrorFilterNetworkServicesRequest,
   ModifyTrafficMirrorFilterNetworkServicesResult,
   ModifyTrafficMirrorFilterNetworkServicesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTrafficMirrorFilterNetworkServicesRequest,
   output: ModifyTrafficMirrorFilterNetworkServicesResult,
@@ -95585,7 +95584,7 @@ export const modifyTrafficMirrorFilterRule: API.OperationMethod<
   ModifyTrafficMirrorFilterRuleRequest,
   ModifyTrafficMirrorFilterRuleResult,
   ModifyTrafficMirrorFilterRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTrafficMirrorFilterRuleRequest,
   output: ModifyTrafficMirrorFilterRuleResult,
@@ -95612,7 +95611,7 @@ export const modifyTrafficMirrorSession: API.OperationMethod<
   ModifyTrafficMirrorSessionRequest,
   ModifyTrafficMirrorSessionResult,
   ModifyTrafficMirrorSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTrafficMirrorSessionRequest,
   output: ModifyTrafficMirrorSessionResult,
@@ -95634,7 +95633,7 @@ export const modifyTransitGateway: API.OperationMethod<
   ModifyTransitGatewayRequest,
   ModifyTransitGatewayResult,
   ModifyTransitGatewayError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTransitGatewayRequest,
   output: ModifyTransitGatewayResult,
@@ -95657,7 +95656,7 @@ export const modifyTransitGatewayMeteringPolicy: API.OperationMethod<
   ModifyTransitGatewayMeteringPolicyRequest,
   ModifyTransitGatewayMeteringPolicyResult,
   ModifyTransitGatewayMeteringPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTransitGatewayMeteringPolicyRequest,
   output: ModifyTransitGatewayMeteringPolicyResult,
@@ -95684,7 +95683,7 @@ export const modifyTransitGatewayPrefixListReference: API.OperationMethod<
   ModifyTransitGatewayPrefixListReferenceRequest,
   ModifyTransitGatewayPrefixListReferenceResult,
   ModifyTransitGatewayPrefixListReferenceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTransitGatewayPrefixListReferenceRequest,
   output: ModifyTransitGatewayPrefixListReferenceResult,
@@ -95706,7 +95705,7 @@ export const modifyTransitGatewayVpcAttachment: API.OperationMethod<
   ModifyTransitGatewayVpcAttachmentRequest,
   ModifyTransitGatewayVpcAttachmentResult,
   ModifyTransitGatewayVpcAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTransitGatewayVpcAttachmentRequest,
   output: ModifyTransitGatewayVpcAttachmentResult,
@@ -95733,7 +95732,7 @@ export const modifyVerifiedAccessEndpoint: API.OperationMethod<
   ModifyVerifiedAccessEndpointRequest,
   ModifyVerifiedAccessEndpointResult,
   ModifyVerifiedAccessEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessEndpointRequest,
   output: ModifyVerifiedAccessEndpointResult,
@@ -95761,7 +95760,7 @@ export const modifyVerifiedAccessEndpointPolicy: API.OperationMethod<
   ModifyVerifiedAccessEndpointPolicyRequest,
   ModifyVerifiedAccessEndpointPolicyResult,
   ModifyVerifiedAccessEndpointPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessEndpointPolicyRequest,
   output: ModifyVerifiedAccessEndpointPolicyResult,
@@ -95788,7 +95787,7 @@ export const modifyVerifiedAccessGroup: API.OperationMethod<
   ModifyVerifiedAccessGroupRequest,
   ModifyVerifiedAccessGroupResult,
   ModifyVerifiedAccessGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessGroupRequest,
   output: ModifyVerifiedAccessGroupResult,
@@ -95814,7 +95813,7 @@ export const modifyVerifiedAccessGroupPolicy: API.OperationMethod<
   ModifyVerifiedAccessGroupPolicyRequest,
   ModifyVerifiedAccessGroupPolicyResult,
   ModifyVerifiedAccessGroupPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessGroupPolicyRequest,
   output: ModifyVerifiedAccessGroupPolicyResult,
@@ -95840,7 +95839,7 @@ export const modifyVerifiedAccessInstance: API.OperationMethod<
   ModifyVerifiedAccessInstanceRequest,
   ModifyVerifiedAccessInstanceResult,
   ModifyVerifiedAccessInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessInstanceRequest,
   output: ModifyVerifiedAccessInstanceResult,
@@ -95866,7 +95865,7 @@ export const modifyVerifiedAccessInstanceLoggingConfiguration: API.OperationMeth
   ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
   ModifyVerifiedAccessInstanceLoggingConfigurationResult,
   ModifyVerifiedAccessInstanceLoggingConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
   output: ModifyVerifiedAccessInstanceLoggingConfigurationResult,
@@ -95888,7 +95887,7 @@ export const modifyVerifiedAccessTrustProvider: API.OperationMethod<
   ModifyVerifiedAccessTrustProviderRequest,
   ModifyVerifiedAccessTrustProviderResult,
   ModifyVerifiedAccessTrustProviderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVerifiedAccessTrustProviderRequest,
   output: ModifyVerifiedAccessTrustProviderResult,
@@ -95935,7 +95934,7 @@ export const modifyVolume: API.OperationMethod<
   ModifyVolumeRequest,
   ModifyVolumeResult,
   ModifyVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVolumeRequest,
   output: ModifyVolumeResult,
@@ -95972,7 +95971,7 @@ export const modifyVolumeAttribute: API.OperationMethod<
   ModifyVolumeAttributeRequest,
   ModifyVolumeAttributeResponse,
   ModifyVolumeAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVolumeAttributeRequest,
   output: ModifyVolumeAttributeResponse,
@@ -96000,7 +95999,7 @@ export const modifyVpcAttribute: API.OperationMethod<
   ModifyVpcAttributeRequest,
   ModifyVpcAttributeResponse,
   ModifyVpcAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcAttributeRequest,
   output: ModifyVpcAttributeResponse,
@@ -96023,7 +96022,7 @@ export const modifyVpcBlockPublicAccessExclusion: API.OperationMethod<
   ModifyVpcBlockPublicAccessExclusionRequest,
   ModifyVpcBlockPublicAccessExclusionResult,
   ModifyVpcBlockPublicAccessExclusionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcBlockPublicAccessExclusionRequest,
   output: ModifyVpcBlockPublicAccessExclusionResult,
@@ -96041,7 +96040,7 @@ export const modifyVpcBlockPublicAccessOptions: API.OperationMethod<
   ModifyVpcBlockPublicAccessOptionsRequest,
   ModifyVpcBlockPublicAccessOptionsResult,
   ModifyVpcBlockPublicAccessOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcBlockPublicAccessOptionsRequest,
   output: ModifyVpcBlockPublicAccessOptionsResult,
@@ -96066,7 +96065,7 @@ export const modifyVpcEncryptionControl: API.OperationMethod<
   ModifyVpcEncryptionControlRequest,
   ModifyVpcEncryptionControlResult,
   ModifyVpcEncryptionControlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEncryptionControlRequest,
   output: ModifyVpcEncryptionControlResult,
@@ -96096,7 +96095,7 @@ export const modifyVpcEndpoint: API.OperationMethod<
   ModifyVpcEndpointRequest,
   ModifyVpcEndpointResult,
   ModifyVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEndpointRequest,
   output: ModifyVpcEndpointResult,
@@ -96124,7 +96123,7 @@ export const modifyVpcEndpointConnectionNotification: API.OperationMethod<
   ModifyVpcEndpointConnectionNotificationRequest,
   ModifyVpcEndpointConnectionNotificationResult,
   ModifyVpcEndpointConnectionNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEndpointConnectionNotificationRequest,
   output: ModifyVpcEndpointConnectionNotificationResult,
@@ -96155,7 +96154,7 @@ export const modifyVpcEndpointServiceConfiguration: API.OperationMethod<
   ModifyVpcEndpointServiceConfigurationRequest,
   ModifyVpcEndpointServiceConfigurationResult,
   ModifyVpcEndpointServiceConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEndpointServiceConfigurationRequest,
   output: ModifyVpcEndpointServiceConfigurationResult,
@@ -96182,7 +96181,7 @@ export const modifyVpcEndpointServicePayerResponsibility: API.OperationMethod<
   ModifyVpcEndpointServicePayerResponsibilityRequest,
   ModifyVpcEndpointServicePayerResponsibilityResult,
   ModifyVpcEndpointServicePayerResponsibilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEndpointServicePayerResponsibilityRequest,
   output: ModifyVpcEndpointServicePayerResponsibilityResult,
@@ -96211,7 +96210,7 @@ export const modifyVpcEndpointServicePermissions: API.OperationMethod<
   ModifyVpcEndpointServicePermissionsRequest,
   ModifyVpcEndpointServicePermissionsResult,
   ModifyVpcEndpointServicePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcEndpointServicePermissionsRequest,
   output: ModifyVpcEndpointServicePermissionsResult,
@@ -96250,7 +96249,7 @@ export const modifyVpcPeeringConnectionOptions: API.OperationMethod<
   ModifyVpcPeeringConnectionOptionsRequest,
   ModifyVpcPeeringConnectionOptionsResult,
   ModifyVpcPeeringConnectionOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcPeeringConnectionOptionsRequest,
   output: ModifyVpcPeeringConnectionOptionsResult,
@@ -96287,7 +96286,7 @@ export const modifyVpcTenancy: API.OperationMethod<
   ModifyVpcTenancyRequest,
   ModifyVpcTenancyResult,
   ModifyVpcTenancyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpcTenancyRequest,
   output: ModifyVpcTenancyResult,
@@ -96351,7 +96350,7 @@ export const modifyVpnConnection: API.OperationMethod<
   ModifyVpnConnectionRequest,
   ModifyVpnConnectionResult,
   ModifyVpnConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpnConnectionRequest,
   output: ModifyVpnConnectionResult,
@@ -96378,7 +96377,7 @@ export const modifyVpnConnectionOptions: API.OperationMethod<
   ModifyVpnConnectionOptionsRequest,
   ModifyVpnConnectionOptionsResult,
   ModifyVpnConnectionOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpnConnectionOptionsRequest,
   output: ModifyVpnConnectionOptionsResult,
@@ -96404,7 +96403,7 @@ export const modifyVpnTunnelCertificate: API.OperationMethod<
   ModifyVpnTunnelCertificateRequest,
   ModifyVpnTunnelCertificateResult,
   ModifyVpnTunnelCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpnTunnelCertificateRequest,
   output: ModifyVpnTunnelCertificateResult,
@@ -96429,7 +96428,7 @@ export const modifyVpnTunnelOptions: API.OperationMethod<
   ModifyVpnTunnelOptionsRequest,
   ModifyVpnTunnelOptionsResult,
   ModifyVpnTunnelOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyVpnTunnelOptionsRequest,
   output: ModifyVpnTunnelOptionsResult,
@@ -96456,7 +96455,7 @@ export const monitorInstances: API.OperationMethod<
   MonitorInstancesRequest,
   MonitorInstancesResult,
   MonitorInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MonitorInstancesRequest,
   output: MonitorInstancesResult,
@@ -96489,7 +96488,7 @@ export const moveAddressToVpc: API.OperationMethod<
   MoveAddressToVpcRequest,
   MoveAddressToVpcResult,
   MoveAddressToVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MoveAddressToVpcRequest,
   output: MoveAddressToVpcResult,
@@ -96513,7 +96512,7 @@ export const moveByoipCidrToIpam: API.OperationMethod<
   MoveByoipCidrToIpamRequest,
   MoveByoipCidrToIpamResult,
   MoveByoipCidrToIpamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MoveByoipCidrToIpamRequest,
   output: MoveByoipCidrToIpamResult,
@@ -96554,7 +96553,7 @@ export const moveCapacityReservationInstances: API.OperationMethod<
   MoveCapacityReservationInstancesRequest,
   MoveCapacityReservationInstancesResult,
   MoveCapacityReservationInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MoveCapacityReservationInstancesRequest,
   output: MoveCapacityReservationInstancesResult,
@@ -96591,7 +96590,7 @@ export const provisionByoipCidr: API.OperationMethod<
   ProvisionByoipCidrRequest,
   ProvisionByoipCidrResult,
   ProvisionByoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionByoipCidrRequest,
   output: ProvisionByoipCidrResult,
@@ -96613,7 +96612,7 @@ export const provisionIpamByoasn: API.OperationMethod<
   ProvisionIpamByoasnRequest,
   ProvisionIpamByoasnResult,
   ProvisionIpamByoasnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionIpamByoasnRequest,
   output: ProvisionIpamByoasnResult,
@@ -96638,7 +96637,7 @@ export const provisionIpamPoolCidr: API.OperationMethod<
   ProvisionIpamPoolCidrRequest,
   ProvisionIpamPoolCidrResult,
   ProvisionIpamPoolCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionIpamPoolCidrRequest,
   output: ProvisionIpamPoolCidrResult,
@@ -96668,7 +96667,7 @@ export const provisionPublicIpv4PoolCidr: API.OperationMethod<
   ProvisionPublicIpv4PoolCidrRequest,
   ProvisionPublicIpv4PoolCidrResult,
   ProvisionPublicIpv4PoolCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionPublicIpv4PoolCidrRequest,
   output: ProvisionPublicIpv4PoolCidrResult,
@@ -96697,7 +96696,7 @@ export const purchaseCapacityBlock: API.OperationMethod<
   PurchaseCapacityBlockRequest,
   PurchaseCapacityBlockResult,
   PurchaseCapacityBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseCapacityBlockRequest,
   output: PurchaseCapacityBlockResult,
@@ -96720,7 +96719,7 @@ export const purchaseCapacityBlockExtension: API.OperationMethod<
   PurchaseCapacityBlockExtensionRequest,
   PurchaseCapacityBlockExtensionResult,
   PurchaseCapacityBlockExtensionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseCapacityBlockExtensionRequest,
   output: PurchaseCapacityBlockExtensionResult,
@@ -96745,7 +96744,7 @@ export const purchaseHostReservation: API.OperationMethod<
   PurchaseHostReservationRequest,
   PurchaseHostReservationResult,
   PurchaseHostReservationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseHostReservationRequest,
   output: PurchaseHostReservationResult,
@@ -96779,7 +96778,7 @@ export const purchaseReservedInstancesOffering: API.OperationMethod<
   PurchaseReservedInstancesOfferingRequest,
   PurchaseReservedInstancesOfferingResult,
   PurchaseReservedInstancesOfferingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedInstancesOfferingRequest,
   output: PurchaseReservedInstancesOfferingResult,
@@ -96810,7 +96809,7 @@ export const purchaseScheduledInstances: API.OperationMethod<
   PurchaseScheduledInstancesRequest,
   PurchaseScheduledInstancesResult,
   PurchaseScheduledInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseScheduledInstancesRequest,
   output: PurchaseScheduledInstancesResult,
@@ -96847,7 +96846,7 @@ export const rebootInstances: API.OperationMethod<
   RebootInstancesRequest,
   RebootInstancesResponse,
   RebootInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootInstancesRequest,
   output: RebootInstancesResponse,
@@ -96916,7 +96915,7 @@ export const registerImage: API.OperationMethod<
   RegisterImageRequest,
   RegisterImageResult,
   RegisterImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterImageRequest,
   output: RegisterImageResult,
@@ -96945,7 +96944,7 @@ export const registerInstanceEventNotificationAttributes: API.OperationMethod<
   RegisterInstanceEventNotificationAttributesRequest,
   RegisterInstanceEventNotificationAttributesResult,
   RegisterInstanceEventNotificationAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterInstanceEventNotificationAttributesRequest,
   output: RegisterInstanceEventNotificationAttributesResult,
@@ -96974,7 +96973,7 @@ export const registerTransitGatewayMulticastGroupMembers: API.OperationMethod<
   RegisterTransitGatewayMulticastGroupMembersRequest,
   RegisterTransitGatewayMulticastGroupMembersResult,
   RegisterTransitGatewayMulticastGroupMembersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTransitGatewayMulticastGroupMembersRequest,
   output: RegisterTransitGatewayMulticastGroupMembersResult,
@@ -97009,7 +97008,7 @@ export const registerTransitGatewayMulticastGroupSources: API.OperationMethod<
   RegisterTransitGatewayMulticastGroupSourcesRequest,
   RegisterTransitGatewayMulticastGroupSourcesResult,
   RegisterTransitGatewayMulticastGroupSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTransitGatewayMulticastGroupSourcesRequest,
   output: RegisterTransitGatewayMulticastGroupSourcesResult,
@@ -97038,7 +97037,7 @@ export const rejectCapacityReservationBillingOwnership: API.OperationMethod<
   RejectCapacityReservationBillingOwnershipRequest,
   RejectCapacityReservationBillingOwnershipResult,
   RejectCapacityReservationBillingOwnershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectCapacityReservationBillingOwnershipRequest,
   output: RejectCapacityReservationBillingOwnershipResult,
@@ -97060,7 +97059,7 @@ export const rejectTransitGatewayClientVpnAttachment: API.OperationMethod<
   RejectTransitGatewayClientVpnAttachmentRequest,
   RejectTransitGatewayClientVpnAttachmentResult,
   RejectTransitGatewayClientVpnAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectTransitGatewayClientVpnAttachmentRequest,
   output: RejectTransitGatewayClientVpnAttachmentResult,
@@ -97082,7 +97081,7 @@ export const rejectTransitGatewayMulticastDomainAssociations: API.OperationMetho
   RejectTransitGatewayMulticastDomainAssociationsRequest,
   RejectTransitGatewayMulticastDomainAssociationsResult,
   RejectTransitGatewayMulticastDomainAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectTransitGatewayMulticastDomainAssociationsRequest,
   output: RejectTransitGatewayMulticastDomainAssociationsResult,
@@ -97105,7 +97104,7 @@ export const rejectTransitGatewayPeeringAttachment: API.OperationMethod<
   RejectTransitGatewayPeeringAttachmentRequest,
   RejectTransitGatewayPeeringAttachmentResult,
   RejectTransitGatewayPeeringAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectTransitGatewayPeeringAttachmentRequest,
   output: RejectTransitGatewayPeeringAttachmentResult,
@@ -97137,7 +97136,7 @@ export const rejectTransitGatewayVpcAttachment: API.OperationMethod<
   RejectTransitGatewayVpcAttachmentRequest,
   RejectTransitGatewayVpcAttachmentResult,
   RejectTransitGatewayVpcAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectTransitGatewayVpcAttachmentRequest,
   output: RejectTransitGatewayVpcAttachmentResult,
@@ -97165,7 +97164,7 @@ export const rejectVpcEndpointConnections: API.OperationMethod<
   RejectVpcEndpointConnectionsRequest,
   RejectVpcEndpointConnectionsResult,
   RejectVpcEndpointConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectVpcEndpointConnectionsRequest,
   output: RejectVpcEndpointConnectionsResult,
@@ -97197,7 +97196,7 @@ export const rejectVpcPeeringConnection: API.OperationMethod<
   RejectVpcPeeringConnectionRequest,
   RejectVpcPeeringConnectionResult,
   RejectVpcPeeringConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectVpcPeeringConnectionRequest,
   output: RejectVpcPeeringConnectionResult,
@@ -97248,7 +97247,7 @@ export const releaseAddress: API.OperationMethod<
   ReleaseAddressRequest,
   ReleaseAddressResponse,
   ReleaseAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseAddressRequest,
   output: ReleaseAddressResponse,
@@ -97292,7 +97291,7 @@ export const releaseHosts: API.OperationMethod<
   ReleaseHostsRequest,
   ReleaseHostsResult,
   ReleaseHostsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseHostsRequest,
   output: ReleaseHostsResult,
@@ -97316,7 +97315,7 @@ export const releaseIpamPoolAllocation: API.OperationMethod<
   ReleaseIpamPoolAllocationRequest,
   ReleaseIpamPoolAllocationResult,
   ReleaseIpamPoolAllocationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseIpamPoolAllocationRequest,
   output: ReleaseIpamPoolAllocationResult,
@@ -97343,7 +97342,7 @@ export const replaceIamInstanceProfileAssociation: API.OperationMethod<
   ReplaceIamInstanceProfileAssociationRequest,
   ReplaceIamInstanceProfileAssociationResult,
   ReplaceIamInstanceProfileAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceIamInstanceProfileAssociationRequest,
   output: ReplaceIamInstanceProfileAssociationResult,
@@ -97373,7 +97372,7 @@ export const replaceImageCriteriaInAllowedImagesSettings: API.OperationMethod<
   ReplaceImageCriteriaInAllowedImagesSettingsRequest,
   ReplaceImageCriteriaInAllowedImagesSettingsResult,
   ReplaceImageCriteriaInAllowedImagesSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceImageCriteriaInAllowedImagesSettingsRequest,
   output: ReplaceImageCriteriaInAllowedImagesSettingsResult,
@@ -97401,7 +97400,7 @@ export const replaceNetworkAclAssociation: API.OperationMethod<
   ReplaceNetworkAclAssociationRequest,
   ReplaceNetworkAclAssociationResult,
   ReplaceNetworkAclAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceNetworkAclAssociationRequest,
   output: ReplaceNetworkAclAssociationResult,
@@ -97431,7 +97430,7 @@ export const replaceNetworkAclEntry: API.OperationMethod<
   ReplaceNetworkAclEntryRequest,
   ReplaceNetworkAclEntryResponse,
   ReplaceNetworkAclEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceNetworkAclEntryRequest,
   output: ReplaceNetworkAclEntryResponse,
@@ -97466,7 +97465,7 @@ export const replaceRoute: API.OperationMethod<
   ReplaceRouteRequest,
   ReplaceRouteResponse,
   ReplaceRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceRouteRequest,
   output: ReplaceRouteResponse,
@@ -97499,7 +97498,7 @@ export const replaceRouteTableAssociation: API.OperationMethod<
   ReplaceRouteTableAssociationRequest,
   ReplaceRouteTableAssociationResult,
   ReplaceRouteTableAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceRouteTableAssociationRequest,
   output: ReplaceRouteTableAssociationResult,
@@ -97526,7 +97525,7 @@ export const replaceTransitGatewayRoute: API.OperationMethod<
   ReplaceTransitGatewayRouteRequest,
   ReplaceTransitGatewayRouteResult,
   ReplaceTransitGatewayRouteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceTransitGatewayRouteRequest,
   output: ReplaceTransitGatewayRouteResult,
@@ -97552,7 +97551,7 @@ export const replaceVpnTunnel: API.OperationMethod<
   ReplaceVpnTunnelRequest,
   ReplaceVpnTunnelResult,
   ReplaceVpnTunnelError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceVpnTunnelRequest,
   output: ReplaceVpnTunnelResult,
@@ -97579,7 +97578,7 @@ export const reportInstanceStatus: API.OperationMethod<
   ReportInstanceStatusRequest,
   ReportInstanceStatusResponse,
   ReportInstanceStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReportInstanceStatusRequest,
   output: ReportInstanceStatusResponse,
@@ -97632,7 +97631,7 @@ export const requestSpotFleet: API.OperationMethod<
   RequestSpotFleetRequest,
   RequestSpotFleetResponse,
   RequestSpotFleetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestSpotFleetRequest,
   output: RequestSpotFleetResponse,
@@ -97663,7 +97662,7 @@ export const requestSpotInstances: API.OperationMethod<
   RequestSpotInstancesRequest,
   RequestSpotInstancesResult,
   RequestSpotInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestSpotInstancesRequest,
   output: RequestSpotInstancesResult,
@@ -97685,7 +97684,7 @@ export const resetAddressAttribute: API.OperationMethod<
   ResetAddressAttributeRequest,
   ResetAddressAttributeResult,
   ResetAddressAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetAddressAttributeRequest,
   output: ResetAddressAttributeResult,
@@ -97709,7 +97708,7 @@ export const resetEbsDefaultKmsKeyId: API.OperationMethod<
   ResetEbsDefaultKmsKeyIdRequest,
   ResetEbsDefaultKmsKeyIdResult,
   ResetEbsDefaultKmsKeyIdError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetEbsDefaultKmsKeyIdRequest,
   output: ResetEbsDefaultKmsKeyIdResult,
@@ -97732,7 +97731,7 @@ export const resetFpgaImageAttribute: API.OperationMethod<
   ResetFpgaImageAttributeRequest,
   ResetFpgaImageAttributeResult,
   ResetFpgaImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetFpgaImageAttributeRequest,
   output: ResetFpgaImageAttributeResult,
@@ -97760,7 +97759,7 @@ export const resetImageAttribute: API.OperationMethod<
   ResetImageAttributeRequest,
   ResetImageAttributeResponse,
   ResetImageAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetImageAttributeRequest,
   output: ResetImageAttributeResponse,
@@ -97797,7 +97796,7 @@ export const resetInstanceAttribute: API.OperationMethod<
   ResetInstanceAttributeRequest,
   ResetInstanceAttributeResponse,
   ResetInstanceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetInstanceAttributeRequest,
   output: ResetInstanceAttributeResponse,
@@ -97820,7 +97819,7 @@ export const resetNetworkInterfaceAttribute: API.OperationMethod<
   ResetNetworkInterfaceAttributeRequest,
   ResetNetworkInterfaceAttributeResponse,
   ResetNetworkInterfaceAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetNetworkInterfaceAttributeRequest,
   output: ResetNetworkInterfaceAttributeResponse,
@@ -97851,7 +97850,7 @@ export const resetSnapshotAttribute: API.OperationMethod<
   ResetSnapshotAttributeRequest,
   ResetSnapshotAttributeResponse,
   ResetSnapshotAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetSnapshotAttributeRequest,
   output: ResetSnapshotAttributeResponse,
@@ -97881,7 +97880,7 @@ export const restoreAddressToClassic: API.OperationMethod<
   RestoreAddressToClassicRequest,
   RestoreAddressToClassicResult,
   RestoreAddressToClassicError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreAddressToClassicRequest,
   output: RestoreAddressToClassicResult,
@@ -97905,7 +97904,7 @@ export const restoreImageFromRecycleBin: API.OperationMethod<
   RestoreImageFromRecycleBinRequest,
   RestoreImageFromRecycleBinResult,
   RestoreImageFromRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreImageFromRecycleBinRequest,
   output: RestoreImageFromRecycleBinResult,
@@ -97927,7 +97926,7 @@ export const restoreManagedPrefixListVersion: API.OperationMethod<
   RestoreManagedPrefixListVersionRequest,
   RestoreManagedPrefixListVersionResult,
   RestoreManagedPrefixListVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreManagedPrefixListVersionRequest,
   output: RestoreManagedPrefixListVersionResult,
@@ -97950,7 +97949,7 @@ export const restoreSnapshotFromRecycleBin: API.OperationMethod<
   RestoreSnapshotFromRecycleBinRequest,
   RestoreSnapshotFromRecycleBinResult,
   RestoreSnapshotFromRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreSnapshotFromRecycleBinRequest,
   output: RestoreSnapshotFromRecycleBinResult,
@@ -97981,7 +97980,7 @@ export const restoreSnapshotTier: API.OperationMethod<
   RestoreSnapshotTierRequest,
   RestoreSnapshotTierResult,
   RestoreSnapshotTierError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreSnapshotTierRequest,
   output: RestoreSnapshotTierResult,
@@ -98008,7 +98007,7 @@ export const restoreVolumeFromRecycleBin: API.OperationMethod<
   RestoreVolumeFromRecycleBinRequest,
   RestoreVolumeFromRecycleBinResult,
   RestoreVolumeFromRecycleBinError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreVolumeFromRecycleBinRequest,
   output: RestoreVolumeFromRecycleBinResult,
@@ -98034,7 +98033,7 @@ export const revokeClientVpnIngress: API.OperationMethod<
   RevokeClientVpnIngressRequest,
   RevokeClientVpnIngressResult,
   RevokeClientVpnIngressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeClientVpnIngressRequest,
   output: RevokeClientVpnIngressResult,
@@ -98079,7 +98078,7 @@ export const revokeSecurityGroupEgress: API.OperationMethod<
   RevokeSecurityGroupEgressRequest,
   RevokeSecurityGroupEgressResult,
   RevokeSecurityGroupEgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSecurityGroupEgressRequest,
   output: RevokeSecurityGroupEgressResult,
@@ -98137,7 +98136,7 @@ export const revokeSecurityGroupIngress: API.OperationMethod<
   RevokeSecurityGroupIngressRequest,
   RevokeSecurityGroupIngressResult,
   RevokeSecurityGroupIngressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSecurityGroupIngressRequest,
   output: RevokeSecurityGroupIngressResult,
@@ -98220,7 +98219,7 @@ export const runInstances: API.OperationMethod<
   RunInstancesRequest,
   Reservation,
   RunInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunInstancesRequest,
   output: Reservation,
@@ -98257,7 +98256,7 @@ export const runScheduledInstances: API.OperationMethod<
   RunScheduledInstancesRequest,
   RunScheduledInstancesResult,
   RunScheduledInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunScheduledInstancesRequest,
   output: RunScheduledInstancesResult,
@@ -98284,7 +98283,7 @@ export const searchLocalGatewayRoutes: API.PaginatedOperationMethod<
   SearchLocalGatewayRoutesRequest,
   SearchLocalGatewayRoutesResult,
   SearchLocalGatewayRoutesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocalGatewayRoute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchLocalGatewayRoutesRequest,
@@ -98319,7 +98318,7 @@ export const searchTransitGatewayMulticastGroups: API.PaginatedOperationMethod<
   SearchTransitGatewayMulticastGroupsRequest,
   SearchTransitGatewayMulticastGroupsResult,
   SearchTransitGatewayMulticastGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayMulticastGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTransitGatewayMulticastGroupsRequest,
@@ -98354,7 +98353,7 @@ export const searchTransitGatewayRoutes: API.PaginatedOperationMethod<
   SearchTransitGatewayRoutesRequest,
   SearchTransitGatewayRoutesResult,
   SearchTransitGatewayRoutesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRoute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTransitGatewayRoutesRequest,
@@ -98404,7 +98403,7 @@ export const sendDiagnosticInterrupt: API.OperationMethod<
   SendDiagnosticInterruptRequest,
   SendDiagnosticInterruptResponse,
   SendDiagnosticInterruptError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDiagnosticInterruptRequest,
   output: SendDiagnosticInterruptResponse,
@@ -98468,7 +98467,7 @@ export const startDeclarativePoliciesReport: API.OperationMethod<
   StartDeclarativePoliciesReportRequest,
   StartDeclarativePoliciesReportResult,
   StartDeclarativePoliciesReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeclarativePoliciesReportRequest,
   output: StartDeclarativePoliciesReportResult,
@@ -98519,7 +98518,7 @@ export const startInstances: API.OperationMethod<
   StartInstancesRequest,
   StartInstancesResult,
   StartInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInstancesRequest,
   output: StartInstancesResult,
@@ -98548,7 +98547,7 @@ export const startNetworkInsightsAccessScopeAnalysis: API.OperationMethod<
   StartNetworkInsightsAccessScopeAnalysisRequest,
   StartNetworkInsightsAccessScopeAnalysisResult,
   StartNetworkInsightsAccessScopeAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkInsightsAccessScopeAnalysisRequest,
   output: StartNetworkInsightsAccessScopeAnalysisResult,
@@ -98577,7 +98576,7 @@ export const startNetworkInsightsAnalysis: API.OperationMethod<
   StartNetworkInsightsAnalysisRequest,
   StartNetworkInsightsAnalysisResult,
   StartNetworkInsightsAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkInsightsAnalysisRequest,
   output: StartNetworkInsightsAnalysisResult,
@@ -98610,7 +98609,7 @@ export const startVpcEndpointServicePrivateDnsVerification: API.OperationMethod<
   StartVpcEndpointServicePrivateDnsVerificationRequest,
   StartVpcEndpointServicePrivateDnsVerificationResult,
   StartVpcEndpointServicePrivateDnsVerificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVpcEndpointServicePrivateDnsVerificationRequest,
   output: StartVpcEndpointServicePrivateDnsVerificationResult,
@@ -98675,7 +98674,7 @@ export const stopInstances: API.OperationMethod<
   StopInstancesRequest,
   StopInstancesResult,
   StopInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInstancesRequest,
   output: StopInstancesResult,
@@ -98703,7 +98702,7 @@ export const terminateClientVpnConnections: API.OperationMethod<
   TerminateClientVpnConnectionsRequest,
   TerminateClientVpnConnectionsResult,
   TerminateClientVpnConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateClientVpnConnectionsRequest,
   output: TerminateClientVpnConnectionsResult,
@@ -98799,7 +98798,7 @@ export const terminateInstances: API.OperationMethod<
   TerminateInstancesRequest,
   TerminateInstancesResult,
   TerminateInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateInstancesRequest,
   output: TerminateInstancesResult,
@@ -98829,7 +98828,7 @@ export const unassignIpv6Addresses: API.OperationMethod<
   UnassignIpv6AddressesRequest,
   UnassignIpv6AddressesResult,
   UnassignIpv6AddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnassignIpv6AddressesRequest,
   output: UnassignIpv6AddressesResult,
@@ -98859,7 +98858,7 @@ export const unassignPrivateIpAddresses: API.OperationMethod<
   UnassignPrivateIpAddressesRequest,
   UnassignPrivateIpAddressesResponse,
   UnassignPrivateIpAddressesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnassignPrivateIpAddressesRequest,
   output: UnassignPrivateIpAddressesResponse,
@@ -98893,7 +98892,7 @@ export const unassignPrivateNatGatewayAddress: API.OperationMethod<
   UnassignPrivateNatGatewayAddressRequest,
   UnassignPrivateNatGatewayAddressResult,
   UnassignPrivateNatGatewayAddressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnassignPrivateNatGatewayAddressRequest,
   output: UnassignPrivateNatGatewayAddressResult,
@@ -98917,7 +98916,7 @@ export const unlockSnapshot: API.OperationMethod<
   UnlockSnapshotRequest,
   UnlockSnapshotResult,
   UnlockSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnlockSnapshotRequest,
   output: UnlockSnapshotResult,
@@ -98946,7 +98945,7 @@ export const unmonitorInstances: API.OperationMethod<
   UnmonitorInstancesRequest,
   UnmonitorInstancesResult,
   UnmonitorInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnmonitorInstancesRequest,
   output: UnmonitorInstancesResult,
@@ -98969,7 +98968,7 @@ export const updateCapacityManagerMonitoredTagKeys: API.OperationMethod<
   UpdateCapacityManagerMonitoredTagKeysRequest,
   UpdateCapacityManagerMonitoredTagKeysResult,
   UpdateCapacityManagerMonitoredTagKeysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapacityManagerMonitoredTagKeysRequest,
   output: UpdateCapacityManagerMonitoredTagKeysResult,
@@ -98992,7 +98991,7 @@ export const updateCapacityManagerOrganizationsAccess: API.OperationMethod<
   UpdateCapacityManagerOrganizationsAccessRequest,
   UpdateCapacityManagerOrganizationsAccessResult,
   UpdateCapacityManagerOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapacityManagerOrganizationsAccessRequest,
   output: UpdateCapacityManagerOrganizationsAccessResult,
@@ -99014,7 +99013,7 @@ export const updateInterruptibleCapacityReservationAllocation: API.OperationMeth
   UpdateInterruptibleCapacityReservationAllocationRequest,
   UpdateInterruptibleCapacityReservationAllocationResult,
   UpdateInterruptibleCapacityReservationAllocationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInterruptibleCapacityReservationAllocationRequest,
   output: UpdateInterruptibleCapacityReservationAllocationResult,
@@ -99043,7 +99042,7 @@ export const updateSecurityGroupRuleDescriptionsEgress: API.OperationMethod<
   UpdateSecurityGroupRuleDescriptionsEgressRequest,
   UpdateSecurityGroupRuleDescriptionsEgressResult,
   UpdateSecurityGroupRuleDescriptionsEgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityGroupRuleDescriptionsEgressRequest,
   output: UpdateSecurityGroupRuleDescriptionsEgressResult,
@@ -99068,7 +99067,7 @@ export const updateSecurityGroupRuleDescriptionsIngress: API.OperationMethod<
   UpdateSecurityGroupRuleDescriptionsIngressRequest,
   UpdateSecurityGroupRuleDescriptionsIngressResult,
   UpdateSecurityGroupRuleDescriptionsIngressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityGroupRuleDescriptionsIngressRequest,
   output: UpdateSecurityGroupRuleDescriptionsIngressResult,
@@ -99095,7 +99094,7 @@ export const withdrawByoipCidr: API.OperationMethod<
   WithdrawByoipCidrRequest,
   WithdrawByoipCidrResult,
   WithdrawByoipCidrError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: WithdrawByoipCidrRequest,
   output: WithdrawByoipCidrResult,

--- a/packages/aws/src/services/ecr-public.ts
+++ b/packages/aws/src/services/ecr-public.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://ecr-public.amazonaws.com/doc/2020-12-02/");
 const svc = T.AwsApiService({
@@ -1332,7 +1331,7 @@ export const batchCheckLayerAvailability: API.OperationMethod<
   BatchCheckLayerAvailabilityRequest,
   BatchCheckLayerAvailabilityResponse,
   BatchCheckLayerAvailabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCheckLayerAvailabilityRequest,
   output: BatchCheckLayerAvailabilityResponse,
@@ -1369,7 +1368,7 @@ export const batchDeleteImage: API.OperationMethod<
   BatchDeleteImageRequest,
   BatchDeleteImageResponse,
   BatchDeleteImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteImageRequest,
   output: BatchDeleteImageResponse,
@@ -1410,7 +1409,7 @@ export const completeLayerUpload: API.OperationMethod<
   CompleteLayerUploadRequest,
   CompleteLayerUploadResponse,
   CompleteLayerUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteLayerUploadRequest,
   output: CompleteLayerUploadResponse,
@@ -1448,7 +1447,7 @@ export const createRepository: API.OperationMethod<
   CreateRepositoryRequest,
   CreateRepositoryResponse,
   CreateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryRequest,
   output: CreateRepositoryResponse,
@@ -1482,7 +1481,7 @@ export const deleteRepository: API.OperationMethod<
   DeleteRepositoryRequest,
   DeleteRepositoryResponse,
   DeleteRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryRequest,
   output: DeleteRepositoryResponse,
@@ -1512,7 +1511,7 @@ export const deleteRepositoryPolicy: API.OperationMethod<
   DeleteRepositoryPolicyRequest,
   DeleteRepositoryPolicyResponse,
   DeleteRepositoryPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryPolicyRequest,
   output: DeleteRepositoryPolicyResponse,
@@ -1548,7 +1547,7 @@ export const describeImages: API.PaginatedOperationMethod<
   DescribeImagesRequest,
   DescribeImagesResponse,
   DescribeImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImagesRequest,
@@ -1584,7 +1583,7 @@ export const describeImageTags: API.PaginatedOperationMethod<
   DescribeImageTagsRequest,
   DescribeImageTagsResponse,
   DescribeImageTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageTagDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImageTagsRequest,
@@ -1618,7 +1617,7 @@ export const describeRegistries: API.PaginatedOperationMethod<
   DescribeRegistriesRequest,
   DescribeRegistriesResponse,
   DescribeRegistriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Registry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistriesRequest,
@@ -1652,7 +1651,7 @@ export const describeRepositories: API.PaginatedOperationMethod<
   DescribeRepositoriesRequest,
   DescribeRepositoriesResponse,
   DescribeRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Repository
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRepositoriesRequest,
@@ -1690,7 +1689,7 @@ export const getAuthorizationToken: API.OperationMethod<
   GetAuthorizationTokenRequest,
   GetAuthorizationTokenResponse,
   GetAuthorizationTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizationTokenRequest,
   output: GetAuthorizationTokenResponse,
@@ -1715,7 +1714,7 @@ export const getRegistryCatalogData: API.OperationMethod<
   GetRegistryCatalogDataRequest,
   GetRegistryCatalogDataResponse,
   GetRegistryCatalogDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryCatalogDataRequest,
   output: GetRegistryCatalogDataResponse,
@@ -1740,7 +1739,7 @@ export const getRepositoryCatalogData: API.OperationMethod<
   GetRepositoryCatalogDataRequest,
   GetRepositoryCatalogDataResponse,
   GetRepositoryCatalogDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryCatalogDataRequest,
   output: GetRepositoryCatalogDataResponse,
@@ -1770,7 +1769,7 @@ export const getRepositoryPolicy: API.OperationMethod<
   GetRepositoryPolicyRequest,
   GetRepositoryPolicyResponse,
   GetRepositoryPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryPolicyRequest,
   output: GetRepositoryPolicyResponse,
@@ -1806,7 +1805,7 @@ export const initiateLayerUpload: API.OperationMethod<
   InitiateLayerUploadRequest,
   InitiateLayerUploadResponse,
   InitiateLayerUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateLayerUploadRequest,
   output: InitiateLayerUploadResponse,
@@ -1835,7 +1834,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1876,7 +1875,7 @@ export const putImage: API.OperationMethod<
   PutImageRequest,
   PutImageResponse,
   PutImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImageRequest,
   output: PutImageResponse,
@@ -1910,7 +1909,7 @@ export const putRegistryCatalogData: API.OperationMethod<
   PutRegistryCatalogDataRequest,
   PutRegistryCatalogDataResponse,
   PutRegistryCatalogDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRegistryCatalogDataRequest,
   output: PutRegistryCatalogDataResponse,
@@ -1937,7 +1936,7 @@ export const putRepositoryCatalogData: API.OperationMethod<
   PutRepositoryCatalogDataRequest,
   PutRepositoryCatalogDataResponse,
   PutRepositoryCatalogDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRepositoryCatalogDataRequest,
   output: PutRepositoryCatalogDataResponse,
@@ -1967,7 +1966,7 @@ export const setRepositoryPolicy: API.OperationMethod<
   SetRepositoryPolicyRequest,
   SetRepositoryPolicyResponse,
   SetRepositoryPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetRepositoryPolicyRequest,
   output: SetRepositoryPolicyResponse,
@@ -2000,7 +1999,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2032,7 +2031,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2072,7 +2071,7 @@ export const uploadLayerPart: API.OperationMethod<
   UploadLayerPartRequest,
   UploadLayerPartResponse,
   UploadLayerPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadLayerPartRequest,
   output: UploadLayerPartResponse,

--- a/packages/aws/src/services/ecr.ts
+++ b/packages/aws/src/services/ecr.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://ecr.amazonaws.com/doc/2015-09-21/");
 const svc = T.AwsApiService({
@@ -4033,7 +4032,7 @@ export const batchCheckLayerAvailability: API.OperationMethod<
   BatchCheckLayerAvailabilityRequest,
   BatchCheckLayerAvailabilityResponse,
   BatchCheckLayerAvailabilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCheckLayerAvailabilityRequest,
   output: BatchCheckLayerAvailabilityResponse,
@@ -4066,7 +4065,7 @@ export const batchDeleteImage: API.OperationMethod<
   BatchDeleteImageRequest,
   BatchDeleteImageResponse,
   BatchDeleteImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteImageRequest,
   output: BatchDeleteImageResponse,
@@ -4098,7 +4097,7 @@ export const batchGetImage: API.OperationMethod<
   BatchGetImageRequest,
   BatchGetImageResponse,
   BatchGetImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetImageRequest,
   output: BatchGetImageResponse,
@@ -4127,7 +4126,7 @@ export const batchGetRepositoryScanningConfiguration: API.OperationMethod<
   BatchGetRepositoryScanningConfigurationRequest,
   BatchGetRepositoryScanningConfigurationResponse,
   BatchGetRepositoryScanningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRepositoryScanningConfigurationRequest,
   output: BatchGetRepositoryScanningConfigurationResponse,
@@ -4168,7 +4167,7 @@ export const completeLayerUpload: API.OperationMethod<
   CompleteLayerUploadRequest,
   CompleteLayerUploadResponse,
   CompleteLayerUploadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteLayerUploadRequest,
   output: CompleteLayerUploadResponse,
@@ -4209,7 +4208,7 @@ export const createPullThroughCacheRule: API.OperationMethod<
   CreatePullThroughCacheRuleRequest,
   CreatePullThroughCacheRuleResponse,
   CreatePullThroughCacheRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePullThroughCacheRuleRequest,
   output: CreatePullThroughCacheRuleResponse,
@@ -4246,7 +4245,7 @@ export const createRepository: API.OperationMethod<
   CreateRepositoryRequest,
   CreateRepositoryResponse,
   CreateRepositoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryRequest,
   output: CreateRepositoryResponse,
@@ -4282,7 +4281,7 @@ export const createRepositoryCreationTemplate: API.OperationMethod<
   CreateRepositoryCreationTemplateRequest,
   CreateRepositoryCreationTemplateResponse,
   CreateRepositoryCreationTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryCreationTemplateRequest,
   output: CreateRepositoryCreationTemplateResponse,
@@ -4312,7 +4311,7 @@ export const deleteLifecyclePolicy: API.OperationMethod<
   DeleteLifecyclePolicyRequest,
   DeleteLifecyclePolicyResponse,
   DeleteLifecyclePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecyclePolicyRequest,
   output: DeleteLifecyclePolicyResponse,
@@ -4341,7 +4340,7 @@ export const deletePullThroughCacheRule: API.OperationMethod<
   DeletePullThroughCacheRuleRequest,
   DeletePullThroughCacheRuleResponse,
   DeletePullThroughCacheRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePullThroughCacheRuleRequest,
   output: DeletePullThroughCacheRuleResponse,
@@ -4369,7 +4368,7 @@ export const deleteRegistryPolicy: API.OperationMethod<
   DeleteRegistryPolicyRequest,
   DeleteRegistryPolicyResponse,
   DeleteRegistryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistryPolicyRequest,
   output: DeleteRegistryPolicyResponse,
@@ -4400,7 +4399,7 @@ export const deleteRepository: API.OperationMethod<
   DeleteRepositoryRequest,
   DeleteRepositoryResponse,
   DeleteRepositoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryRequest,
   output: DeleteRepositoryResponse,
@@ -4429,7 +4428,7 @@ export const deleteRepositoryCreationTemplate: API.OperationMethod<
   DeleteRepositoryCreationTemplateRequest,
   DeleteRepositoryCreationTemplateResponse,
   DeleteRepositoryCreationTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryCreationTemplateRequest,
   output: DeleteRepositoryCreationTemplateResponse,
@@ -4457,7 +4456,7 @@ export const deleteRepositoryPolicy: API.OperationMethod<
   DeleteRepositoryPolicyRequest,
   DeleteRepositoryPolicyResponse,
   DeleteRepositoryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryPolicyRequest,
   output: DeleteRepositoryPolicyResponse,
@@ -4490,7 +4489,7 @@ export const deleteSigningConfiguration: API.OperationMethod<
   DeleteSigningConfigurationRequest,
   DeleteSigningConfigurationResponse,
   DeleteSigningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSigningConfigurationRequest,
   output: DeleteSigningConfigurationResponse,
@@ -4518,7 +4517,7 @@ export const deregisterPullTimeUpdateExclusion: API.OperationMethod<
   DeregisterPullTimeUpdateExclusionRequest,
   DeregisterPullTimeUpdateExclusionResponse,
   DeregisterPullTimeUpdateExclusionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterPullTimeUpdateExclusionRequest,
   output: DeregisterPullTimeUpdateExclusionResponse,
@@ -4548,7 +4547,7 @@ export const describeImageReplicationStatus: API.OperationMethod<
   DescribeImageReplicationStatusRequest,
   DescribeImageReplicationStatusResponse,
   DescribeImageReplicationStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageReplicationStatusRequest,
   output: DescribeImageReplicationStatusResponse,
@@ -4588,7 +4587,7 @@ export const describeImages: API.PaginatedOperationMethod<
   DescribeImagesRequest,
   DescribeImagesResponse,
   DescribeImagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImagesRequest,
@@ -4625,7 +4624,7 @@ export const describeImageScanFindings: API.PaginatedOperationMethod<
   DescribeImageScanFindingsRequest,
   DescribeImageScanFindingsResponse,
   DescribeImageScanFindingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeImageScanFindingsRequest,
@@ -4667,7 +4666,7 @@ export const describeImageSigningStatus: API.OperationMethod<
   DescribeImageSigningStatusRequest,
   DescribeImageSigningStatusResponse,
   DescribeImageSigningStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageSigningStatusRequest,
   output: DescribeImageSigningStatusResponse,
@@ -4696,7 +4695,7 @@ export const describePullThroughCacheRules: API.PaginatedOperationMethod<
   DescribePullThroughCacheRulesRequest,
   DescribePullThroughCacheRulesResponse,
   DescribePullThroughCacheRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PullThroughCacheRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePullThroughCacheRulesRequest,
@@ -4732,7 +4731,7 @@ export const describeRegistry: API.OperationMethod<
   DescribeRegistryRequest,
   DescribeRegistryResponse,
   DescribeRegistryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRegistryRequest,
   output: DescribeRegistryResponse,
@@ -4754,7 +4753,7 @@ export const describeRepositories: API.PaginatedOperationMethod<
   DescribeRepositoriesRequest,
   DescribeRepositoriesResponse,
   DescribeRepositoriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Repository
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRepositoriesRequest,
@@ -4789,7 +4788,7 @@ export const describeRepositoryCreationTemplates: API.PaginatedOperationMethod<
   DescribeRepositoryCreationTemplatesRequest,
   DescribeRepositoryCreationTemplatesResponse,
   DescribeRepositoryCreationTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositoryCreationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRepositoryCreationTemplatesRequest,
@@ -4818,7 +4817,7 @@ export const getAccountSetting: API.OperationMethod<
   GetAccountSettingRequest,
   GetAccountSettingResponse,
   GetAccountSettingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingRequest,
   output: GetAccountSettingResponse,
@@ -4847,7 +4846,7 @@ export const getAuthorizationToken: API.OperationMethod<
   GetAuthorizationTokenRequest,
   GetAuthorizationTokenResponse,
   GetAuthorizationTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthorizationTokenRequest,
   output: GetAuthorizationTokenResponse,
@@ -4879,7 +4878,7 @@ export const getDownloadUrlForLayer: API.OperationMethod<
   GetDownloadUrlForLayerRequest,
   GetDownloadUrlForLayerResponse,
   GetDownloadUrlForLayerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDownloadUrlForLayerRequest,
   output: GetDownloadUrlForLayerResponse,
@@ -4910,7 +4909,7 @@ export const getLifecyclePolicy: API.OperationMethod<
   GetLifecyclePolicyRequest,
   GetLifecyclePolicyResponse,
   GetLifecyclePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecyclePolicyRequest,
   output: GetLifecyclePolicyResponse,
@@ -4941,7 +4940,7 @@ export const getLifecyclePolicyPreview: API.PaginatedOperationMethod<
   GetLifecyclePolicyPreviewRequest,
   GetLifecyclePolicyPreviewResponse,
   GetLifecyclePolicyPreviewError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LifecyclePolicyPreviewResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLifecyclePolicyPreviewRequest,
@@ -4977,7 +4976,7 @@ export const getRegistryPolicy: API.OperationMethod<
   GetRegistryPolicyRequest,
   GetRegistryPolicyResponse,
   GetRegistryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryPolicyRequest,
   output: GetRegistryPolicyResponse,
@@ -5004,7 +5003,7 @@ export const getRegistryScanningConfiguration: API.OperationMethod<
   GetRegistryScanningConfigurationRequest,
   GetRegistryScanningConfigurationResponse,
   GetRegistryScanningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryScanningConfigurationRequest,
   output: GetRegistryScanningConfigurationResponse,
@@ -5027,7 +5026,7 @@ export const getRepositoryPolicy: API.OperationMethod<
   GetRepositoryPolicyRequest,
   GetRepositoryPolicyResponse,
   GetRepositoryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryPolicyRequest,
   output: GetRepositoryPolicyResponse,
@@ -5059,7 +5058,7 @@ export const getSigningConfiguration: API.OperationMethod<
   GetSigningConfigurationRequest,
   GetSigningConfigurationResponse,
   GetSigningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSigningConfigurationRequest,
   output: GetSigningConfigurationResponse,
@@ -5094,7 +5093,7 @@ export const initiateLayerUpload: API.OperationMethod<
   InitiateLayerUploadRequest,
   InitiateLayerUploadResponse,
   InitiateLayerUploadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateLayerUploadRequest,
   output: InitiateLayerUploadResponse,
@@ -5125,7 +5124,7 @@ export const listImageReferrers: API.OperationMethod<
   ListImageReferrersRequest,
   ListImageReferrersResponse,
   ListImageReferrersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListImageReferrersRequest,
   output: ListImageReferrersResponse,
@@ -5160,7 +5159,7 @@ export const listImages: API.PaginatedOperationMethod<
   ListImagesRequest,
   ListImagesResponse,
   ListImagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagesRequest,
@@ -5194,7 +5193,7 @@ export const listPullTimeUpdateExclusions: API.OperationMethod<
   ListPullTimeUpdateExclusionsRequest,
   ListPullTimeUpdateExclusionsResponse,
   ListPullTimeUpdateExclusionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPullTimeUpdateExclusionsRequest,
   output: ListPullTimeUpdateExclusionsResponse,
@@ -5221,7 +5220,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5248,7 +5247,7 @@ export const putAccountSetting: API.OperationMethod<
   PutAccountSettingRequest,
   PutAccountSettingResponse,
   PutAccountSettingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSettingRequest,
   output: PutAccountSettingResponse,
@@ -5289,7 +5288,7 @@ export const putImage: API.OperationMethod<
   PutImageRequest,
   PutImageResponse,
   PutImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImageRequest,
   output: PutImageResponse,
@@ -5327,7 +5326,7 @@ export const putImageScanningConfiguration: API.OperationMethod<
   PutImageScanningConfigurationRequest,
   PutImageScanningConfigurationResponse,
   PutImageScanningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImageScanningConfigurationRequest,
   output: PutImageScanningConfigurationResponse,
@@ -5356,7 +5355,7 @@ export const putImageTagMutability: API.OperationMethod<
   PutImageTagMutabilityRequest,
   PutImageTagMutabilityResponse,
   PutImageTagMutabilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImageTagMutabilityRequest,
   output: PutImageTagMutabilityResponse,
@@ -5385,7 +5384,7 @@ export const putLifecyclePolicy: API.OperationMethod<
   PutLifecyclePolicyRequest,
   PutLifecyclePolicyResponse,
   PutLifecyclePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLifecyclePolicyRequest,
   output: PutLifecyclePolicyResponse,
@@ -5415,7 +5414,7 @@ export const putRegistryPolicy: API.OperationMethod<
   PutRegistryPolicyRequest,
   PutRegistryPolicyResponse,
   PutRegistryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRegistryPolicyRequest,
   output: PutRegistryPolicyResponse,
@@ -5438,7 +5437,7 @@ export const putRegistryScanningConfiguration: API.OperationMethod<
   PutRegistryScanningConfigurationRequest,
   PutRegistryScanningConfigurationResponse,
   PutRegistryScanningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRegistryScanningConfigurationRequest,
   output: PutRegistryScanningConfigurationResponse,
@@ -5474,7 +5473,7 @@ export const putReplicationConfiguration: API.OperationMethod<
   PutReplicationConfigurationRequest,
   PutReplicationConfigurationResponse,
   PutReplicationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutReplicationConfigurationRequest,
   output: PutReplicationConfigurationResponse,
@@ -5504,7 +5503,7 @@ export const putSigningConfiguration: API.OperationMethod<
   PutSigningConfigurationRequest,
   PutSigningConfigurationResponse,
   PutSigningConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSigningConfigurationRequest,
   output: PutSigningConfigurationResponse,
@@ -5528,7 +5527,7 @@ export const registerPullTimeUpdateExclusion: API.OperationMethod<
   RegisterPullTimeUpdateExclusionRequest,
   RegisterPullTimeUpdateExclusionResponse,
   RegisterPullTimeUpdateExclusionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterPullTimeUpdateExclusionRequest,
   output: RegisterPullTimeUpdateExclusionResponse,
@@ -5558,7 +5557,7 @@ export const setRepositoryPolicy: API.OperationMethod<
   SetRepositoryPolicyRequest,
   SetRepositoryPolicyResponse,
   SetRepositoryPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetRepositoryPolicyRequest,
   output: SetRepositoryPolicyResponse,
@@ -5594,7 +5593,7 @@ export const startImageScan: API.OperationMethod<
   StartImageScanRequest,
   StartImageScanResponse,
   StartImageScanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImageScanRequest,
   output: StartImageScanResponse,
@@ -5629,7 +5628,7 @@ export const startLifecyclePolicyPreview: API.OperationMethod<
   StartLifecyclePolicyPreviewRequest,
   StartLifecyclePolicyPreviewResponse,
   StartLifecyclePolicyPreviewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLifecyclePolicyPreviewRequest,
   output: StartLifecyclePolicyPreviewResponse,
@@ -5661,7 +5660,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5691,7 +5690,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5722,7 +5721,7 @@ export const updateImageStorageClass: API.OperationMethod<
   UpdateImageStorageClassRequest,
   UpdateImageStorageClassResponse,
   UpdateImageStorageClassError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImageStorageClassRequest,
   output: UpdateImageStorageClassResponse,
@@ -5755,7 +5754,7 @@ export const updatePullThroughCacheRule: API.OperationMethod<
   UpdatePullThroughCacheRuleRequest,
   UpdatePullThroughCacheRuleResponse,
   UpdatePullThroughCacheRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePullThroughCacheRuleRequest,
   output: UpdatePullThroughCacheRuleResponse,
@@ -5786,7 +5785,7 @@ export const updateRepositoryCreationTemplate: API.OperationMethod<
   UpdateRepositoryCreationTemplateRequest,
   UpdateRepositoryCreationTemplateResponse,
   UpdateRepositoryCreationTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRepositoryCreationTemplateRequest,
   output: UpdateRepositoryCreationTemplateResponse,
@@ -5824,7 +5823,7 @@ export const uploadLayerPart: API.OperationMethod<
   UploadLayerPartRequest,
   UploadLayerPartResponse,
   UploadLayerPartError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadLayerPartRequest,
   output: UploadLayerPartResponse,
@@ -5858,7 +5857,7 @@ export const validatePullThroughCacheRule: API.OperationMethod<
   ValidatePullThroughCacheRuleRequest,
   ValidatePullThroughCacheRuleResponse,
   ValidatePullThroughCacheRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidatePullThroughCacheRuleRequest,
   output: ValidatePullThroughCacheRuleResponse,

--- a/packages/aws/src/services/ecs.ts
+++ b/packages/aws/src/services/ecs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://ecs.amazonaws.com/doc/2014-11-13/");
 const svc = T.AwsApiService({
@@ -7499,7 +7498,7 @@ export const continueServiceDeployment: API.OperationMethod<
   ContinueServiceDeploymentRequest,
   ContinueServiceDeploymentResponse,
   ContinueServiceDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ContinueServiceDeploymentRequest,
   output: ContinueServiceDeploymentResponse,
@@ -7533,7 +7532,7 @@ export const createCapacityProvider: API.OperationMethod<
   CreateCapacityProviderRequest,
   CreateCapacityProviderResponse,
   CreateCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityProviderRequest,
   output: CreateCapacityProviderResponse,
@@ -7568,7 +7567,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -7606,7 +7605,7 @@ export const createDaemon: API.OperationMethod<
   CreateDaemonRequest,
   CreateDaemonResponse,
   CreateDaemonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDaemonRequest,
   output: CreateDaemonResponse,
@@ -7645,7 +7644,7 @@ export const createExpressGatewayService: API.OperationMethod<
   CreateExpressGatewayServiceRequest,
   CreateExpressGatewayServiceResponse,
   CreateExpressGatewayServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExpressGatewayServiceRequest,
   output: CreateExpressGatewayServiceResponse,
@@ -7774,7 +7773,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -7819,7 +7818,7 @@ export const createTaskSet: API.OperationMethod<
   CreateTaskSetRequest,
   CreateTaskSetResponse,
   CreateTaskSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTaskSetRequest,
   output: CreateTaskSetResponse,
@@ -7855,7 +7854,7 @@ export const deleteAccountSetting: API.OperationMethod<
   DeleteAccountSettingRequest,
   DeleteAccountSettingResponse,
   DeleteAccountSettingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountSettingRequest,
   output: DeleteAccountSettingResponse,
@@ -7885,7 +7884,7 @@ export const deleteAttributes: API.OperationMethod<
   DeleteAttributesRequest,
   DeleteAttributesResponse,
   DeleteAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttributesRequest,
   output: DeleteAttributesResponse,
@@ -7922,7 +7921,7 @@ export const deleteCapacityProvider: API.OperationMethod<
   DeleteCapacityProviderRequest,
   DeleteCapacityProviderResponse,
   DeleteCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapacityProviderRequest,
   output: DeleteCapacityProviderResponse,
@@ -7961,7 +7960,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -8001,7 +8000,7 @@ export const deleteDaemon: API.OperationMethod<
   DeleteDaemonRequest,
   DeleteDaemonResponse,
   DeleteDaemonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDaemonRequest,
   output: DeleteDaemonResponse,
@@ -8035,7 +8034,7 @@ export const deleteDaemonTaskDefinition: API.OperationMethod<
   DeleteDaemonTaskDefinitionRequest,
   DeleteDaemonTaskDefinitionResponse,
   DeleteDaemonTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDaemonTaskDefinitionRequest,
   output: DeleteDaemonTaskDefinitionResponse,
@@ -8071,7 +8070,7 @@ export const deleteExpressGatewayService: API.OperationMethod<
   DeleteExpressGatewayServiceRequest,
   DeleteExpressGatewayServiceResponse,
   DeleteExpressGatewayServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExpressGatewayServiceRequest,
   output: DeleteExpressGatewayServiceResponse,
@@ -8109,7 +8108,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -8149,7 +8148,7 @@ export const deleteTaskDefinitions: API.OperationMethod<
   DeleteTaskDefinitionsRequest,
   DeleteTaskDefinitionsResponse,
   DeleteTaskDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTaskDefinitionsRequest,
   output: DeleteTaskDefinitionsResponse,
@@ -8183,7 +8182,7 @@ export const deleteTaskSet: API.OperationMethod<
   DeleteTaskSetRequest,
   DeleteTaskSetResponse,
   DeleteTaskSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTaskSetRequest,
   output: DeleteTaskSetResponse,
@@ -8224,7 +8223,7 @@ export const deregisterContainerInstance: API.OperationMethod<
   DeregisterContainerInstanceRequest,
   DeregisterContainerInstanceResponse,
   DeregisterContainerInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterContainerInstanceRequest,
   output: DeregisterContainerInstanceResponse,
@@ -8259,7 +8258,7 @@ export const deregisterTaskDefinition: API.OperationMethod<
   DeregisterTaskDefinitionRequest,
   DeregisterTaskDefinitionResponse,
   DeregisterTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTaskDefinitionRequest,
   output: DeregisterTaskDefinitionResponse,
@@ -8289,7 +8288,7 @@ export const describeCapacityProviders: API.OperationMethod<
   DescribeCapacityProvidersRequest,
   DescribeCapacityProvidersResponse,
   DescribeCapacityProvidersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCapacityProvidersRequest,
   output: DescribeCapacityProvidersResponse,
@@ -8321,7 +8320,7 @@ export const describeClusters: API.OperationMethod<
   DescribeClustersRequest,
   DescribeClustersResponse,
   DescribeClustersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClustersRequest,
   output: DescribeClustersResponse,
@@ -8350,7 +8349,7 @@ export const describeContainerInstances: API.OperationMethod<
   DescribeContainerInstancesRequest,
   DescribeContainerInstancesResponse,
   DescribeContainerInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContainerInstancesRequest,
   output: DescribeContainerInstancesResponse,
@@ -8382,7 +8381,7 @@ export const describeDaemon: API.OperationMethod<
   DescribeDaemonRequest,
   DescribeDaemonResponse,
   DescribeDaemonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDaemonRequest,
   output: DescribeDaemonResponse,
@@ -8417,7 +8416,7 @@ export const describeDaemonDeployments: API.OperationMethod<
   DescribeDaemonDeploymentsRequest,
   DescribeDaemonDeploymentsResponse,
   DescribeDaemonDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDaemonDeploymentsRequest,
   output: DescribeDaemonDeploymentsResponse,
@@ -8451,7 +8450,7 @@ export const describeDaemonRevisions: API.OperationMethod<
   DescribeDaemonRevisionsRequest,
   DescribeDaemonRevisionsResponse,
   DescribeDaemonRevisionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDaemonRevisionsRequest,
   output: DescribeDaemonRevisionsResponse,
@@ -8481,7 +8480,7 @@ export const describeDaemonTaskDefinition: API.OperationMethod<
   DescribeDaemonTaskDefinitionRequest,
   DescribeDaemonTaskDefinitionResponse,
   DescribeDaemonTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDaemonTaskDefinitionRequest,
   output: DescribeDaemonTaskDefinitionResponse,
@@ -8516,7 +8515,7 @@ export const describeExpressGatewayService: API.OperationMethod<
   DescribeExpressGatewayServiceRequest,
   DescribeExpressGatewayServiceResponse,
   DescribeExpressGatewayServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExpressGatewayServiceRequest,
   output: DescribeExpressGatewayServiceResponse,
@@ -8552,7 +8551,7 @@ export const describeServiceDeployments: API.OperationMethod<
   DescribeServiceDeploymentsRequest,
   DescribeServiceDeploymentsResponse,
   DescribeServiceDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceDeploymentsRequest,
   output: DescribeServiceDeploymentsResponse,
@@ -8590,7 +8589,7 @@ export const describeServiceRevisions: API.OperationMethod<
   DescribeServiceRevisionsRequest,
   DescribeServiceRevisionsResponse,
   DescribeServiceRevisionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceRevisionsRequest,
   output: DescribeServiceRevisionsResponse,
@@ -8622,7 +8621,7 @@ export const describeServices: API.OperationMethod<
   DescribeServicesRequest,
   DescribeServicesResponse,
   DescribeServicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServicesRequest,
   output: DescribeServicesResponse,
@@ -8653,7 +8652,7 @@ export const describeTaskDefinition: API.OperationMethod<
   DescribeTaskDefinitionRequest,
   DescribeTaskDefinitionResponse,
   DescribeTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTaskDefinitionRequest,
   output: DescribeTaskDefinitionResponse,
@@ -8686,7 +8685,7 @@ export const describeTasks: API.OperationMethod<
   DescribeTasksRequest,
   DescribeTasksResponse,
   DescribeTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTasksRequest,
   output: DescribeTasksResponse,
@@ -8719,7 +8718,7 @@ export const describeTaskSets: API.OperationMethod<
   DescribeTaskSetsRequest,
   DescribeTaskSetsResponse,
   DescribeTaskSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTaskSetsRequest,
   output: DescribeTaskSetsResponse,
@@ -8753,7 +8752,7 @@ export const discoverPollEndpoint: API.OperationMethod<
   DiscoverPollEndpointRequest,
   DiscoverPollEndpointResponse,
   DiscoverPollEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscoverPollEndpointRequest,
   output: DiscoverPollEndpointResponse,
@@ -8787,7 +8786,7 @@ export const executeCommand: API.OperationMethod<
   ExecuteCommandRequest,
   ExecuteCommandResponse,
   ExecuteCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteCommandRequest,
   output: ExecuteCommandResponse,
@@ -8820,7 +8819,7 @@ export const getTaskProtection: API.OperationMethod<
   GetTaskProtectionRequest,
   GetTaskProtectionResponse,
   GetTaskProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaskProtectionRequest,
   output: GetTaskProtectionResponse,
@@ -8851,7 +8850,7 @@ export const listAccountSettings: API.PaginatedOperationMethod<
   ListAccountSettingsRequest,
   ListAccountSettingsResponse,
   ListAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Setting
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountSettingsRequest,
@@ -8887,7 +8886,7 @@ export const listAttributes: API.PaginatedOperationMethod<
   ListAttributesRequest,
   ListAttributesResponse,
   ListAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Attribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttributesRequest,
@@ -8923,7 +8922,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -8959,7 +8958,7 @@ export const listContainerInstances: API.PaginatedOperationMethod<
   ListContainerInstancesRequest,
   ListContainerInstancesResponse,
   ListContainerInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainerInstancesRequest,
@@ -8997,7 +8996,7 @@ export const listDaemonDeployments: API.OperationMethod<
   ListDaemonDeploymentsRequest,
   ListDaemonDeploymentsResponse,
   ListDaemonDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDaemonDeploymentsRequest,
   output: ListDaemonDeploymentsResponse,
@@ -9029,7 +9028,7 @@ export const listDaemons: API.OperationMethod<
   ListDaemonsRequest,
   ListDaemonsResponse,
   ListDaemonsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDaemonsRequest,
   output: ListDaemonsResponse,
@@ -9059,7 +9058,7 @@ export const listDaemonTaskDefinitions: API.OperationMethod<
   ListDaemonTaskDefinitionsRequest,
   ListDaemonTaskDefinitionsResponse,
   ListDaemonTaskDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDaemonTaskDefinitionsRequest,
   output: ListDaemonTaskDefinitionsResponse,
@@ -9094,7 +9093,7 @@ export const listServiceDeployments: API.OperationMethod<
   ListServiceDeploymentsRequest,
   ListServiceDeploymentsResponse,
   ListServiceDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListServiceDeploymentsRequest,
   output: ListServiceDeploymentsResponse,
@@ -9126,7 +9125,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -9163,7 +9162,7 @@ export const listServicesByNamespace: API.PaginatedOperationMethod<
   ListServicesByNamespaceRequest,
   ListServicesByNamespaceResponse,
   ListServicesByNamespaceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesByNamespaceRequest,
@@ -9200,7 +9199,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -9231,7 +9230,7 @@ export const listTaskDefinitionFamilies: API.PaginatedOperationMethod<
   ListTaskDefinitionFamiliesRequest,
   ListTaskDefinitionFamiliesResponse,
   ListTaskDefinitionFamiliesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaskDefinitionFamiliesRequest,
@@ -9266,7 +9265,7 @@ export const listTaskDefinitions: API.PaginatedOperationMethod<
   ListTaskDefinitionsRequest,
   ListTaskDefinitionsResponse,
   ListTaskDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaskDefinitionsRequest,
@@ -9305,7 +9304,7 @@ export const listTasks: API.PaginatedOperationMethod<
   ListTasksRequest,
   ListTasksResponse,
   ListTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTasksRequest,
@@ -9344,7 +9343,7 @@ export const putAccountSetting: API.OperationMethod<
   PutAccountSettingRequest,
   PutAccountSettingResponse,
   PutAccountSettingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSettingRequest,
   output: PutAccountSettingResponse,
@@ -9372,7 +9371,7 @@ export const putAccountSettingDefault: API.OperationMethod<
   PutAccountSettingDefaultRequest,
   PutAccountSettingDefaultResponse,
   PutAccountSettingDefaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSettingDefaultRequest,
   output: PutAccountSettingDefaultResponse,
@@ -9403,7 +9402,7 @@ export const putAttributes: API.OperationMethod<
   PutAttributesRequest,
   PutAttributesResponse,
   PutAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAttributesRequest,
   output: PutAttributesResponse,
@@ -9443,7 +9442,7 @@ export const putClusterCapacityProviders: API.OperationMethod<
   PutClusterCapacityProvidersRequest,
   PutClusterCapacityProvidersResponse,
   PutClusterCapacityProvidersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutClusterCapacityProvidersRequest,
   output: PutClusterCapacityProvidersResponse,
@@ -9477,7 +9476,7 @@ export const registerContainerInstance: API.OperationMethod<
   RegisterContainerInstanceRequest,
   RegisterContainerInstanceResponse,
   RegisterContainerInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterContainerInstanceRequest,
   output: RegisterContainerInstanceResponse,
@@ -9511,7 +9510,7 @@ export const registerDaemonTaskDefinition: API.OperationMethod<
   RegisterDaemonTaskDefinitionRequest,
   RegisterDaemonTaskDefinitionResponse,
   RegisterDaemonTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDaemonTaskDefinitionRequest,
   output: RegisterDaemonTaskDefinitionResponse,
@@ -9545,7 +9544,7 @@ export const registerTaskDefinition: API.OperationMethod<
   RegisterTaskDefinitionRequest,
   RegisterTaskDefinitionResponse,
   RegisterTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTaskDefinitionRequest,
   output: RegisterTaskDefinitionResponse,
@@ -9608,7 +9607,7 @@ export const runTask: API.OperationMethod<
   RunTaskRequest,
   RunTaskResponse,
   RunTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunTaskRequest,
   output: RunTaskResponse,
@@ -9653,7 +9652,7 @@ export const startTask: API.OperationMethod<
   StartTaskRequest,
   StartTaskResponse,
   StartTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTaskRequest,
   output: StartTaskResponse,
@@ -9695,7 +9694,7 @@ export const stopServiceDeployment: API.OperationMethod<
   StopServiceDeploymentRequest,
   StopServiceDeploymentResponse,
   StopServiceDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopServiceDeploymentRequest,
   output: StopServiceDeploymentResponse,
@@ -9733,7 +9732,7 @@ export const stopTask: API.OperationMethod<
   StopTaskRequest,
   StopTaskResponse,
   StopTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTaskRequest,
   output: StopTaskResponse,
@@ -9765,7 +9764,7 @@ export const submitAttachmentStateChanges: API.OperationMethod<
   SubmitAttachmentStateChangesRequest,
   SubmitAttachmentStateChangesResponse,
   SubmitAttachmentStateChangesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitAttachmentStateChangesRequest,
   output: SubmitAttachmentStateChangesResponse,
@@ -9797,7 +9796,7 @@ export const submitContainerStateChange: API.OperationMethod<
   SubmitContainerStateChangeRequest,
   SubmitContainerStateChangeResponse,
   SubmitContainerStateChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitContainerStateChangeRequest,
   output: SubmitContainerStateChangeResponse,
@@ -9829,7 +9828,7 @@ export const submitTaskStateChange: API.OperationMethod<
   SubmitTaskStateChangeRequest,
   SubmitTaskStateChangeResponse,
   SubmitTaskStateChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitTaskStateChangeRequest,
   output: SubmitTaskStateChangeResponse,
@@ -9861,7 +9860,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -9894,7 +9893,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -9928,7 +9927,7 @@ export const updateCapacityProvider: API.OperationMethod<
   UpdateCapacityProviderRequest,
   UpdateCapacityProviderResponse,
   UpdateCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapacityProviderRequest,
   output: UpdateCapacityProviderResponse,
@@ -9960,7 +9959,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -9992,7 +9991,7 @@ export const updateClusterSettings: API.OperationMethod<
   UpdateClusterSettingsRequest,
   UpdateClusterSettingsResponse,
   UpdateClusterSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterSettingsRequest,
   output: UpdateClusterSettingsResponse,
@@ -10032,7 +10031,7 @@ export const updateContainerAgent: API.OperationMethod<
   UpdateContainerAgentRequest,
   UpdateContainerAgentResponse,
   UpdateContainerAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContainerAgentRequest,
   output: UpdateContainerAgentResponse,
@@ -10083,7 +10082,7 @@ export const updateContainerInstancesState: API.OperationMethod<
   UpdateContainerInstancesStateRequest,
   UpdateContainerInstancesStateResponse,
   UpdateContainerInstancesStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContainerInstancesStateRequest,
   output: UpdateContainerInstancesStateResponse,
@@ -10123,7 +10122,7 @@ export const updateDaemon: API.OperationMethod<
   UpdateDaemonRequest,
   UpdateDaemonResponse,
   UpdateDaemonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDaemonRequest,
   output: UpdateDaemonResponse,
@@ -10164,7 +10163,7 @@ export const updateExpressGatewayService: API.OperationMethod<
   UpdateExpressGatewayServiceRequest,
   UpdateExpressGatewayServiceResponse,
   UpdateExpressGatewayServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExpressGatewayServiceRequest,
   output: UpdateExpressGatewayServiceResponse,
@@ -10245,7 +10244,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceRequest,
   UpdateServiceResponse,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceRequest,
   output: UpdateServiceResponse,
@@ -10285,7 +10284,7 @@ export const updateServicePrimaryTaskSet: API.OperationMethod<
   UpdateServicePrimaryTaskSetRequest,
   UpdateServicePrimaryTaskSetResponse,
   UpdateServicePrimaryTaskSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServicePrimaryTaskSetRequest,
   output: UpdateServicePrimaryTaskSetResponse,
@@ -10331,7 +10330,7 @@ export const updateTaskProtection: API.OperationMethod<
   UpdateTaskProtectionRequest,
   UpdateTaskProtectionResponse,
   UpdateTaskProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskProtectionRequest,
   output: UpdateTaskProtectionResponse,
@@ -10368,7 +10367,7 @@ export const updateTaskSet: API.OperationMethod<
   UpdateTaskSetRequest,
   UpdateTaskSetResponse,
   UpdateTaskSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTaskSetRequest,
   output: UpdateTaskSetResponse,

--- a/packages/aws/src/services/efs.ts
+++ b/packages/aws/src/services/efs.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "EFS",
   serviceShapeName: "MagnolioAPIService_v20150201",
@@ -1818,7 +1817,7 @@ export const createAccessPoint: API.OperationMethod<
   CreateAccessPointRequest,
   AccessPointDescription,
   CreateAccessPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPointRequest,
   output: AccessPointDescription,
@@ -1912,7 +1911,7 @@ export const createFileSystem: API.OperationMethod<
   CreateFileSystemRequest,
   FileSystemDescription,
   CreateFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFileSystemRequest,
   output: FileSystemDescription,
@@ -2063,7 +2062,7 @@ export const createMountTarget: API.OperationMethod<
   CreateMountTargetRequest,
   MountTargetDescription,
   CreateMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMountTargetRequest,
   output: MountTargetDescription,
@@ -2128,7 +2127,7 @@ export const createReplicationConfiguration: API.OperationMethod<
   CreateReplicationConfigurationRequest,
   ReplicationConfigurationDescription,
   CreateReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationConfigurationRequest,
   output: ReplicationConfigurationDescription,
@@ -2171,7 +2170,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResponse,
@@ -2197,7 +2196,7 @@ export const deleteAccessPoint: API.OperationMethod<
   DeleteAccessPointRequest,
   DeleteAccessPointResponse,
   DeleteAccessPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointRequest,
   output: DeleteAccessPointResponse,
@@ -2240,7 +2239,7 @@ export const deleteFileSystem: API.OperationMethod<
   DeleteFileSystemRequest,
   DeleteFileSystemResponse,
   DeleteFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileSystemRequest,
   output: DeleteFileSystemResponse,
@@ -2272,7 +2271,7 @@ export const deleteFileSystemPolicy: API.OperationMethod<
   DeleteFileSystemPolicyRequest,
   DeleteFileSystemPolicyResponse,
   DeleteFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileSystemPolicyRequest,
   output: DeleteFileSystemPolicyResponse,
@@ -2322,7 +2321,7 @@ export const deleteMountTarget: API.OperationMethod<
   DeleteMountTargetRequest,
   DeleteMountTargetResponse,
   DeleteMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMountTargetRequest,
   output: DeleteMountTargetResponse,
@@ -2356,7 +2355,7 @@ export const deleteReplicationConfiguration: API.OperationMethod<
   DeleteReplicationConfigurationRequest,
   DeleteReplicationConfigurationResponse,
   DeleteReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationConfigurationRequest,
   output: DeleteReplicationConfigurationResponse,
@@ -2392,7 +2391,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResponse,
@@ -2421,7 +2420,7 @@ export const describeAccessPoints: API.PaginatedOperationMethod<
   DescribeAccessPointsRequest,
   DescribeAccessPointsResponse,
   DescribeAccessPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessPointDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccessPointsRequest,
@@ -2453,7 +2452,7 @@ export const describeAccountPreferences: API.OperationMethod<
   DescribeAccountPreferencesRequest,
   DescribeAccountPreferencesResponse,
   DescribeAccountPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountPreferencesRequest,
   output: DescribeAccountPreferencesResponse,
@@ -2477,7 +2476,7 @@ export const describeBackupPolicy: API.OperationMethod<
   DescribeBackupPolicyRequest,
   BackupPolicyDescription,
   DescribeBackupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBackupPolicyRequest,
   output: BackupPolicyDescription,
@@ -2509,7 +2508,7 @@ export const describeFileSystemPolicy: API.OperationMethod<
   DescribeFileSystemPolicyRequest,
   FileSystemPolicyDescription,
   DescribeFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFileSystemPolicyRequest,
   output: FileSystemPolicyDescription,
@@ -2554,7 +2553,7 @@ export const describeFileSystems: API.PaginatedOperationMethod<
   DescribeFileSystemsRequest,
   DescribeFileSystemsResponse,
   DescribeFileSystemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FileSystemDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFileSystemsRequest,
@@ -2590,7 +2589,7 @@ export const describeLifecycleConfiguration: API.OperationMethod<
   DescribeLifecycleConfigurationRequest,
   LifecycleConfigurationDescription,
   DescribeLifecycleConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLifecycleConfigurationRequest,
   output: LifecycleConfigurationDescription,
@@ -2621,7 +2620,7 @@ export const describeMountTargets: API.PaginatedOperationMethod<
   DescribeMountTargetsRequest,
   DescribeMountTargetsResponse,
   DescribeMountTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MountTargetDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMountTargetsRequest,
@@ -2667,7 +2666,7 @@ export const describeMountTargetSecurityGroups: API.OperationMethod<
   DescribeMountTargetSecurityGroupsRequest,
   DescribeMountTargetSecurityGroupsResponse,
   DescribeMountTargetSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMountTargetSecurityGroupsRequest,
   output: DescribeMountTargetSecurityGroupsResponse,
@@ -2698,7 +2697,7 @@ export const describeReplicationConfigurations: API.PaginatedOperationMethod<
   DescribeReplicationConfigurationsRequest,
   DescribeReplicationConfigurationsResponse,
   DescribeReplicationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplicationConfigurationDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationConfigurationsRequest,
@@ -2742,7 +2741,7 @@ export const describeTags: API.PaginatedOperationMethod<
   DescribeTagsRequest,
   DescribeTagsResponse,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTagsRequest,
@@ -2775,7 +2774,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -2826,7 +2825,7 @@ export const modifyMountTargetSecurityGroups: API.OperationMethod<
   ModifyMountTargetSecurityGroupsRequest,
   ModifyMountTargetSecurityGroupsResponse,
   ModifyMountTargetSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyMountTargetSecurityGroupsRequest,
   output: ModifyMountTargetSecurityGroupsResponse,
@@ -2862,7 +2861,7 @@ export const putAccountPreferences: API.OperationMethod<
   PutAccountPreferencesRequest,
   PutAccountPreferencesResponse,
   PutAccountPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountPreferencesRequest,
   output: PutAccountPreferencesResponse,
@@ -2886,7 +2885,7 @@ export const putBackupPolicy: API.OperationMethod<
   PutBackupPolicyRequest,
   BackupPolicyDescription,
   PutBackupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBackupPolicyRequest,
   output: BackupPolicyDescription,
@@ -2927,7 +2926,7 @@ export const putFileSystemPolicy: API.OperationMethod<
   PutFileSystemPolicyRequest,
   FileSystemPolicyDescription,
   PutFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFileSystemPolicyRequest,
   output: FileSystemPolicyDescription,
@@ -3008,7 +3007,7 @@ export const putLifecycleConfiguration: API.OperationMethod<
   PutLifecycleConfigurationRequest,
   LifecycleConfigurationDescription,
   PutLifecycleConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLifecycleConfigurationRequest,
   output: LifecycleConfigurationDescription,
@@ -3039,7 +3038,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3070,7 +3069,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3102,7 +3101,7 @@ export const updateFileSystem: API.OperationMethod<
   UpdateFileSystemRequest,
   FileSystemDescription,
   UpdateFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFileSystemRequest,
   output: FileSystemDescription,
@@ -3140,7 +3139,7 @@ export const updateFileSystemProtection: API.OperationMethod<
   UpdateFileSystemProtectionRequest,
   FileSystemProtectionDescription,
   UpdateFileSystemProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFileSystemProtectionRequest,
   output: FileSystemProtectionDescription,

--- a/packages/aws/src/services/eks-auth.ts
+++ b/packages/aws/src/services/eks-auth.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "EKS Auth",
@@ -233,7 +232,7 @@ export const assumeRoleForPodIdentity: API.OperationMethod<
   AssumeRoleForPodIdentityRequest,
   AssumeRoleForPodIdentityResponse,
   AssumeRoleForPodIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeRoleForPodIdentityRequest,
   output: AssumeRoleForPodIdentityResponse,

--- a/packages/aws/src/services/eks.ts
+++ b/packages/aws/src/services/eks.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "EKS",
   serviceShapeName: "AWSWesleyFrontend",
@@ -4793,7 +4792,7 @@ export const associateAccessPolicy: API.OperationMethod<
   AssociateAccessPolicyRequest,
   AssociateAccessPolicyResponse,
   AssociateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAccessPolicyRequest,
   output: AssociateAccessPolicyResponse,
@@ -4828,7 +4827,7 @@ export const associateEncryptionConfig: API.OperationMethod<
   AssociateEncryptionConfigRequest,
   AssociateEncryptionConfigResponse,
   AssociateEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEncryptionConfigRequest,
   output: AssociateEncryptionConfigResponse,
@@ -4870,7 +4869,7 @@ export const associateIdentityProviderConfig: API.OperationMethod<
   AssociateIdentityProviderConfigRequest,
   AssociateIdentityProviderConfigResponse,
   AssociateIdentityProviderConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIdentityProviderConfigRequest,
   output: AssociateIdentityProviderConfigResponse,
@@ -4917,7 +4916,7 @@ export const createAccessEntry: API.OperationMethod<
   CreateAccessEntryRequest,
   CreateAccessEntryResponse,
   CreateAccessEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessEntryRequest,
   output: CreateAccessEntryResponse,
@@ -4953,7 +4952,7 @@ export const createAddon: API.OperationMethod<
   CreateAddonRequest,
   CreateAddonResponse,
   CreateAddonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddonRequest,
   output: CreateAddonResponse,
@@ -4992,7 +4991,7 @@ export const createCapability: API.OperationMethod<
   CreateCapabilityRequest,
   CreateCapabilityResponse,
   CreateCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapabilityRequest,
   output: CreateCapabilityResponse,
@@ -5069,7 +5068,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -5104,7 +5103,7 @@ export const createEksAnywhereSubscription: API.OperationMethod<
   CreateEksAnywhereSubscriptionRequest,
   CreateEksAnywhereSubscriptionResponse,
   CreateEksAnywhereSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEksAnywhereSubscriptionRequest,
   output: CreateEksAnywhereSubscriptionResponse,
@@ -5165,7 +5164,7 @@ export const createFargateProfile: API.OperationMethod<
   CreateFargateProfileRequest,
   CreateFargateProfileResponse,
   CreateFargateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFargateProfileRequest,
   output: CreateFargateProfileResponse,
@@ -5218,7 +5217,7 @@ export const createNodegroup: API.OperationMethod<
   CreateNodegroupRequest,
   CreateNodegroupResponse,
   CreateNodegroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNodegroupRequest,
   output: CreateNodegroupResponse,
@@ -5278,7 +5277,7 @@ export const createPodIdentityAssociation: API.OperationMethod<
   CreatePodIdentityAssociationRequest,
   CreatePodIdentityAssociationResponse,
   CreatePodIdentityAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePodIdentityAssociationRequest,
   output: CreatePodIdentityAssociationResponse,
@@ -5311,7 +5310,7 @@ export const deleteAccessEntry: API.OperationMethod<
   DeleteAccessEntryRequest,
   DeleteAccessEntryResponse,
   DeleteAccessEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessEntryRequest,
   output: DeleteAccessEntryResponse,
@@ -5338,7 +5337,7 @@ export const deleteAddon: API.OperationMethod<
   DeleteAddonRequest,
   DeleteAddonResponse,
   DeleteAddonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAddonRequest,
   output: DeleteAddonResponse,
@@ -5370,7 +5369,7 @@ export const deleteCapability: API.OperationMethod<
   DeleteCapabilityRequest,
   DeleteCapabilityResponse,
   DeleteCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapabilityRequest,
   output: DeleteCapabilityResponse,
@@ -5411,7 +5410,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -5444,7 +5443,7 @@ export const deleteEksAnywhereSubscription: API.OperationMethod<
   DeleteEksAnywhereSubscriptionRequest,
   DeleteEksAnywhereSubscriptionResponse,
   DeleteEksAnywhereSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEksAnywhereSubscriptionRequest,
   output: DeleteEksAnywhereSubscriptionResponse,
@@ -5483,7 +5482,7 @@ export const deleteFargateProfile: API.OperationMethod<
   DeleteFargateProfileRequest,
   DeleteFargateProfileResponse,
   DeleteFargateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFargateProfileRequest,
   output: DeleteFargateProfileResponse,
@@ -5514,7 +5513,7 @@ export const deleteNodegroup: API.OperationMethod<
   DeleteNodegroupRequest,
   DeleteNodegroupResponse,
   DeleteNodegroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNodegroupRequest,
   output: DeleteNodegroupResponse,
@@ -5546,7 +5545,7 @@ export const deletePodIdentityAssociation: API.OperationMethod<
   DeletePodIdentityAssociationRequest,
   DeletePodIdentityAssociationResponse,
   DeletePodIdentityAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePodIdentityAssociationRequest,
   output: DeletePodIdentityAssociationResponse,
@@ -5579,7 +5578,7 @@ export const deregisterCluster: API.OperationMethod<
   DeregisterClusterRequest,
   DeregisterClusterResponse,
   DeregisterClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterClusterRequest,
   output: DeregisterClusterResponse,
@@ -5608,7 +5607,7 @@ export const describeAccessEntry: API.OperationMethod<
   DescribeAccessEntryRequest,
   DescribeAccessEntryResponse,
   DescribeAccessEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccessEntryRequest,
   output: DescribeAccessEntryResponse,
@@ -5632,7 +5631,7 @@ export const describeAddon: API.OperationMethod<
   DescribeAddonRequest,
   DescribeAddonResponse,
   DescribeAddonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAddonRequest,
   output: DescribeAddonResponse,
@@ -5660,7 +5659,7 @@ export const describeAddonConfiguration: API.OperationMethod<
   DescribeAddonConfigurationRequest,
   DescribeAddonConfigurationResponse,
   DescribeAddonConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAddonConfigurationRequest,
   output: DescribeAddonConfigurationResponse,
@@ -5690,7 +5689,7 @@ export const describeAddonVersions: API.PaginatedOperationMethod<
   DescribeAddonVersionsRequest,
   DescribeAddonVersionsResponse,
   DescribeAddonVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddonInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAddonVersionsRequest,
@@ -5724,7 +5723,7 @@ export const describeCapability: API.OperationMethod<
   DescribeCapabilityRequest,
   DescribeCapabilityResponse,
   DescribeCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCapabilityRequest,
   output: DescribeCapabilityResponse,
@@ -5760,7 +5759,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResponse,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResponse,
@@ -5787,7 +5786,7 @@ export const describeClusterVersions: API.PaginatedOperationMethod<
   DescribeClusterVersionsRequest,
   DescribeClusterVersionsResponse,
   DescribeClusterVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterVersionInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterVersionsRequest,
@@ -5817,7 +5816,7 @@ export const describeEksAnywhereSubscription: API.OperationMethod<
   DescribeEksAnywhereSubscriptionRequest,
   DescribeEksAnywhereSubscriptionResponse,
   DescribeEksAnywhereSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEksAnywhereSubscriptionRequest,
   output: DescribeEksAnywhereSubscriptionResponse,
@@ -5845,7 +5844,7 @@ export const describeFargateProfile: API.OperationMethod<
   DescribeFargateProfileRequest,
   DescribeFargateProfileResponse,
   DescribeFargateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFargateProfileRequest,
   output: DescribeFargateProfileResponse,
@@ -5874,7 +5873,7 @@ export const describeIdentityProviderConfig: API.OperationMethod<
   DescribeIdentityProviderConfigRequest,
   DescribeIdentityProviderConfigResponse,
   DescribeIdentityProviderConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityProviderConfigRequest,
   output: DescribeIdentityProviderConfigResponse,
@@ -5903,7 +5902,7 @@ export const describeInsight: API.OperationMethod<
   DescribeInsightRequest,
   DescribeInsightResponse,
   DescribeInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInsightRequest,
   output: DescribeInsightResponse,
@@ -5931,7 +5930,7 @@ export const describeInsightsRefresh: API.OperationMethod<
   DescribeInsightsRefreshRequest,
   DescribeInsightsRefreshResponse,
   DescribeInsightsRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInsightsRefreshRequest,
   output: DescribeInsightsRefreshResponse,
@@ -5960,7 +5959,7 @@ export const describeNodegroup: API.OperationMethod<
   DescribeNodegroupRequest,
   DescribeNodegroupResponse,
   DescribeNodegroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNodegroupRequest,
   output: DescribeNodegroupResponse,
@@ -5994,7 +5993,7 @@ export const describePodIdentityAssociation: API.OperationMethod<
   DescribePodIdentityAssociationRequest,
   DescribePodIdentityAssociationResponse,
   DescribePodIdentityAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePodIdentityAssociationRequest,
   output: DescribePodIdentityAssociationResponse,
@@ -6026,7 +6025,7 @@ export const describeUpdate: API.OperationMethod<
   DescribeUpdateRequest,
   DescribeUpdateResponse,
   DescribeUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUpdateRequest,
   output: DescribeUpdateResponse,
@@ -6053,7 +6052,7 @@ export const disassociateAccessPolicy: API.OperationMethod<
   DisassociateAccessPolicyRequest,
   DisassociateAccessPolicyResponse,
   DisassociateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAccessPolicyRequest,
   output: DisassociateAccessPolicyResponse,
@@ -6083,7 +6082,7 @@ export const disassociateIdentityProviderConfig: API.OperationMethod<
   DisassociateIdentityProviderConfigRequest,
   DisassociateIdentityProviderConfigResponse,
   DisassociateIdentityProviderConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIdentityProviderConfigRequest,
   output: DisassociateIdentityProviderConfigResponse,
@@ -6114,7 +6113,7 @@ export const listAccessEntries: API.PaginatedOperationMethod<
   ListAccessEntriesRequest,
   ListAccessEntriesResponse,
   ListAccessEntriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessEntriesRequest,
@@ -6144,7 +6143,7 @@ export const listAccessPolicies: API.PaginatedOperationMethod<
   ListAccessPoliciesRequest,
   ListAccessPoliciesResponse,
   ListAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPoliciesRequest,
@@ -6175,7 +6174,7 @@ export const listAddons: API.PaginatedOperationMethod<
   ListAddonsRequest,
   ListAddonsResponse,
   ListAddonsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAddonsRequest,
@@ -6210,7 +6209,7 @@ export const listAssociatedAccessPolicies: API.PaginatedOperationMethod<
   ListAssociatedAccessPoliciesRequest,
   ListAssociatedAccessPoliciesResponse,
   ListAssociatedAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedAccessPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedAccessPoliciesRequest,
@@ -6238,7 +6237,7 @@ export const listCapabilities: API.PaginatedOperationMethod<
   ListCapabilitiesRequest,
   ListCapabilitiesResponse,
   ListCapabilitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapabilitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCapabilitiesRequest,
@@ -6268,7 +6267,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -6303,7 +6302,7 @@ export const listEksAnywhereSubscriptions: API.PaginatedOperationMethod<
   ListEksAnywhereSubscriptionsRequest,
   ListEksAnywhereSubscriptionsResponse,
   ListEksAnywhereSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EksAnywhereSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEksAnywhereSubscriptionsRequest,
@@ -6339,7 +6338,7 @@ export const listFargateProfiles: API.PaginatedOperationMethod<
   ListFargateProfilesRequest,
   ListFargateProfilesResponse,
   ListFargateProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFargateProfilesRequest,
@@ -6375,7 +6374,7 @@ export const listIdentityProviderConfigs: API.PaginatedOperationMethod<
   ListIdentityProviderConfigsRequest,
   ListIdentityProviderConfigsResponse,
   ListIdentityProviderConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdentityProviderConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentityProviderConfigsRequest,
@@ -6422,7 +6421,7 @@ export const listInsights: API.PaginatedOperationMethod<
   ListInsightsRequest,
   ListInsightsResponse,
   ListInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InsightSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInsightsRequest,
@@ -6459,7 +6458,7 @@ export const listNodegroups: API.PaginatedOperationMethod<
   ListNodegroupsRequest,
   ListNodegroupsResponse,
   ListNodegroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodegroupsRequest,
@@ -6496,7 +6495,7 @@ export const listPodIdentityAssociations: API.PaginatedOperationMethod<
   ListPodIdentityAssociationsRequest,
   ListPodIdentityAssociationsResponse,
   ListPodIdentityAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PodIdentityAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPodIdentityAssociationsRequest,
@@ -6529,7 +6528,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6553,7 +6552,7 @@ export const listUpdates: API.PaginatedOperationMethod<
   ListUpdatesRequest,
   ListUpdatesResponse,
   ListUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUpdatesRequest,
@@ -6609,7 +6608,7 @@ export const registerCluster: API.OperationMethod<
   RegisterClusterRequest,
   RegisterClusterResponse,
   RegisterClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterClusterRequest,
   output: RegisterClusterResponse,
@@ -6641,7 +6640,7 @@ export const startInsightsRefresh: API.OperationMethod<
   StartInsightsRefreshRequest,
   StartInsightsRefreshResponse,
   StartInsightsRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInsightsRefreshRequest,
   output: StartInsightsRefreshResponse,
@@ -6673,7 +6672,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6694,7 +6693,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6717,7 +6716,7 @@ export const updateAccessEntry: API.OperationMethod<
   UpdateAccessEntryRequest,
   UpdateAccessEntryResponse,
   UpdateAccessEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessEntryRequest,
   output: UpdateAccessEntryResponse,
@@ -6747,7 +6746,7 @@ export const updateAddon: API.OperationMethod<
   UpdateAddonRequest,
   UpdateAddonResponse,
   UpdateAddonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAddonRequest,
   output: UpdateAddonResponse,
@@ -6780,7 +6779,7 @@ export const updateCapability: API.OperationMethod<
   UpdateCapabilityRequest,
   UpdateCapabilityResponse,
   UpdateCapabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapabilityRequest,
   output: UpdateCapabilityResponse,
@@ -6858,7 +6857,7 @@ export const updateClusterConfig: API.OperationMethod<
   UpdateClusterConfigRequest,
   UpdateClusterConfigResponse,
   UpdateClusterConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterConfigRequest,
   output: UpdateClusterConfigResponse,
@@ -6906,7 +6905,7 @@ export const updateClusterVersion: API.OperationMethod<
   UpdateClusterVersionRequest,
   UpdateClusterVersionResponse,
   UpdateClusterVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterVersionRequest,
   output: UpdateClusterVersionResponse,
@@ -6940,7 +6939,7 @@ export const updateEksAnywhereSubscription: API.OperationMethod<
   UpdateEksAnywhereSubscriptionRequest,
   UpdateEksAnywhereSubscriptionResponse,
   UpdateEksAnywhereSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEksAnywhereSubscriptionRequest,
   output: UpdateEksAnywhereSubscriptionResponse,
@@ -6976,7 +6975,7 @@ export const updateNodegroupConfig: API.OperationMethod<
   UpdateNodegroupConfigRequest,
   UpdateNodegroupConfigResponse,
   UpdateNodegroupConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNodegroupConfigRequest,
   output: UpdateNodegroupConfigResponse,
@@ -7034,7 +7033,7 @@ export const updateNodegroupVersion: API.OperationMethod<
   UpdateNodegroupVersionRequest,
   UpdateNodegroupVersionResponse,
   UpdateNodegroupVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNodegroupVersionRequest,
   output: UpdateNodegroupVersionResponse,
@@ -7082,7 +7081,7 @@ export const updatePodIdentityAssociation: API.OperationMethod<
   UpdatePodIdentityAssociationRequest,
   UpdatePodIdentityAssociationResponse,
   UpdatePodIdentityAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePodIdentityAssociationRequest,
   output: UpdatePodIdentityAssociationResponse,

--- a/packages/aws/src/services/elastic-beanstalk.ts
+++ b/packages/aws/src/services/elastic-beanstalk.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace(
   "http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/",
 );
@@ -3154,7 +3153,7 @@ export const abortEnvironmentUpdate: API.OperationMethod<
   AbortEnvironmentUpdateMessage,
   AbortEnvironmentUpdateResponse,
   AbortEnvironmentUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortEnvironmentUpdateMessage,
   output: AbortEnvironmentUpdateResponse,
@@ -3177,7 +3176,7 @@ export const applyEnvironmentManagedAction: API.OperationMethod<
   ApplyEnvironmentManagedActionRequest,
   ApplyEnvironmentManagedActionResult,
   ApplyEnvironmentManagedActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyEnvironmentManagedActionRequest,
   output: ApplyEnvironmentManagedActionResult,
@@ -3203,7 +3202,7 @@ export const associateEnvironmentOperationsRole: API.OperationMethod<
   AssociateEnvironmentOperationsRoleMessage,
   AssociateEnvironmentOperationsRoleResponse,
   AssociateEnvironmentOperationsRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEnvironmentOperationsRoleMessage,
   output: AssociateEnvironmentOperationsRoleResponse,
@@ -3221,7 +3220,7 @@ export const checkDNSAvailability: API.OperationMethod<
   CheckDNSAvailabilityMessage,
   CheckDNSAvailabilityResultMessage,
   CheckDNSAvailabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckDNSAvailabilityMessage,
   output: CheckDNSAvailabilityResultMessage,
@@ -3247,7 +3246,7 @@ export const composeEnvironments: API.OperationMethod<
   ComposeEnvironmentsMessage,
   EnvironmentDescriptionsMessage,
   ComposeEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ComposeEnvironmentsMessage,
   output: EnvironmentDescriptionsMessage,
@@ -3268,7 +3267,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationMessage,
   ApplicationDescriptionMessage,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationMessage,
   output: ApplicationDescriptionMessage,
@@ -3310,7 +3309,7 @@ export const createApplicationVersion: API.OperationMethod<
   CreateApplicationVersionMessage,
   ApplicationVersionDescriptionMessage,
   CreateApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationVersionMessage,
   output: ApplicationVersionDescriptionMessage,
@@ -3352,7 +3351,7 @@ export const createConfigurationTemplate: API.OperationMethod<
   CreateConfigurationTemplateMessage,
   ConfigurationSettingsDescription,
   CreateConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationTemplateMessage,
   output: ConfigurationSettingsDescription,
@@ -3378,7 +3377,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentMessage,
   EnvironmentDescription,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentMessage,
   output: EnvironmentDescription,
@@ -3400,7 +3399,7 @@ export const createPlatformVersion: API.OperationMethod<
   CreatePlatformVersionRequest,
   CreatePlatformVersionResult,
   CreatePlatformVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlatformVersionRequest,
   output: CreatePlatformVersionResult,
@@ -3430,7 +3429,7 @@ export const createStorageLocation: API.OperationMethod<
   CreateStorageLocationRequest,
   CreateStorageLocationResultMessage,
   CreateStorageLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorageLocationRequest,
   output: CreateStorageLocationResultMessage,
@@ -3458,7 +3457,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationMessage,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationMessage,
   output: DeleteApplicationResponse,
@@ -3484,7 +3483,7 @@ export const deleteApplicationVersion: API.OperationMethod<
   DeleteApplicationVersionMessage,
   DeleteApplicationVersionResponse,
   DeleteApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationVersionMessage,
   output: DeleteApplicationVersionResponse,
@@ -3513,7 +3512,7 @@ export const deleteConfigurationTemplate: API.OperationMethod<
   DeleteConfigurationTemplateMessage,
   DeleteConfigurationTemplateResponse,
   DeleteConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationTemplateMessage,
   output: DeleteConfigurationTemplateResponse,
@@ -3537,7 +3536,7 @@ export const deleteEnvironmentConfiguration: API.OperationMethod<
   DeleteEnvironmentConfigurationMessage,
   DeleteEnvironmentConfigurationResponse,
   DeleteEnvironmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentConfigurationMessage,
   output: DeleteEnvironmentConfigurationResponse,
@@ -3560,7 +3559,7 @@ export const deletePlatformVersion: API.OperationMethod<
   DeletePlatformVersionRequest,
   DeletePlatformVersionResult,
   DeletePlatformVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlatformVersionRequest,
   output: DeletePlatformVersionResult,
@@ -3588,7 +3587,7 @@ export const describeAccountAttributes: API.OperationMethod<
   DescribeAccountAttributesRequest,
   DescribeAccountAttributesResult,
   DescribeAccountAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAttributesRequest,
   output: DescribeAccountAttributesResult,
@@ -3606,7 +3605,7 @@ export const describeApplications: API.OperationMethod<
   DescribeApplicationsMessage,
   ApplicationDescriptionsMessage,
   DescribeApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationsMessage,
   output: ApplicationDescriptionsMessage,
@@ -3624,7 +3623,7 @@ export const describeApplicationVersions: API.OperationMethod<
   DescribeApplicationVersionsMessage,
   ApplicationVersionDescriptionsMessage,
   DescribeApplicationVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationVersionsMessage,
   output: ApplicationVersionDescriptionsMessage,
@@ -3647,7 +3646,7 @@ export const describeConfigurationOptions: API.OperationMethod<
   DescribeConfigurationOptionsMessage,
   ConfigurationOptionsDescription,
   DescribeConfigurationOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationOptionsMessage,
   output: ConfigurationOptionsDescription,
@@ -3678,7 +3677,7 @@ export const describeConfigurationSettings: API.OperationMethod<
   DescribeConfigurationSettingsMessage,
   ConfigurationSettingsDescriptions,
   DescribeConfigurationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationSettingsMessage,
   output: ConfigurationSettingsDescriptions,
@@ -3701,7 +3700,7 @@ export const describeEnvironmentHealth: API.OperationMethod<
   DescribeEnvironmentHealthRequest,
   DescribeEnvironmentHealthResult,
   DescribeEnvironmentHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentHealthRequest,
   output: DescribeEnvironmentHealthResult,
@@ -3721,7 +3720,7 @@ export const describeEnvironmentManagedActionHistory: API.PaginatedOperationMeth
   DescribeEnvironmentManagedActionHistoryRequest,
   DescribeEnvironmentManagedActionHistoryResult,
   DescribeEnvironmentManagedActionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedActionHistoryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEnvironmentManagedActionHistoryRequest,
@@ -3748,7 +3747,7 @@ export const describeEnvironmentManagedActions: API.OperationMethod<
   DescribeEnvironmentManagedActionsRequest,
   DescribeEnvironmentManagedActionsResult,
   DescribeEnvironmentManagedActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentManagedActionsRequest,
   output: DescribeEnvironmentManagedActionsResult,
@@ -3768,7 +3767,7 @@ export const describeEnvironmentResources: API.OperationMethod<
   DescribeEnvironmentResourcesMessage,
   EnvironmentResourceDescriptionsMessage,
   DescribeEnvironmentResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentResourcesMessage,
   output: EnvironmentResourceDescriptionsMessage,
@@ -3786,7 +3785,7 @@ export const describeEnvironments: API.OperationMethod<
   DescribeEnvironmentsMessage,
   EnvironmentDescriptionsMessage,
   DescribeEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEnvironmentsMessage,
   output: EnvironmentDescriptionsMessage,
@@ -3807,7 +3806,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventDescriptionsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -3837,7 +3836,7 @@ export const describeInstancesHealth: API.OperationMethod<
   DescribeInstancesHealthRequest,
   DescribeInstancesHealthResult,
   DescribeInstancesHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstancesHealthRequest,
   output: DescribeInstancesHealthResult,
@@ -3862,7 +3861,7 @@ export const describePlatformVersion: API.OperationMethod<
   DescribePlatformVersionRequest,
   DescribePlatformVersionResult,
   DescribePlatformVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePlatformVersionRequest,
   output: DescribePlatformVersionResult,
@@ -3885,7 +3884,7 @@ export const disassociateEnvironmentOperationsRole: API.OperationMethod<
   DisassociateEnvironmentOperationsRoleMessage,
   DisassociateEnvironmentOperationsRoleResponse,
   DisassociateEnvironmentOperationsRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEnvironmentOperationsRoleMessage,
   output: DisassociateEnvironmentOperationsRoleResponse,
@@ -3904,7 +3903,7 @@ export const listAvailableSolutionStacks: API.OperationMethod<
   ListAvailableSolutionStacksRequest,
   ListAvailableSolutionStacksResultMessage,
   ListAvailableSolutionStacksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableSolutionStacksRequest,
   output: ListAvailableSolutionStacksResultMessage,
@@ -3926,7 +3925,7 @@ export const listPlatformBranches: API.PaginatedOperationMethod<
   ListPlatformBranchesRequest,
   ListPlatformBranchesResult,
   ListPlatformBranchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlatformBranchesRequest,
@@ -3958,7 +3957,7 @@ export const listPlatformVersions: API.PaginatedOperationMethod<
   ListPlatformVersionsRequest,
   ListPlatformVersionsResult,
   ListPlatformVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PlatformSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlatformVersionsRequest,
@@ -3991,7 +3990,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   ResourceTagsDescriptionMessage,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: ResourceTagsDescriptionMessage,
@@ -4016,7 +4015,7 @@ export const rebuildEnvironment: API.OperationMethod<
   RebuildEnvironmentMessage,
   RebuildEnvironmentResponse,
   RebuildEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebuildEnvironmentMessage,
   output: RebuildEnvironmentResponse,
@@ -4052,7 +4051,7 @@ export const requestEnvironmentInfo: API.OperationMethod<
   RequestEnvironmentInfoMessage,
   RequestEnvironmentInfoResponse,
   RequestEnvironmentInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestEnvironmentInfoMessage,
   output: RequestEnvironmentInfoResponse,
@@ -4071,7 +4070,7 @@ export const restartAppServer: API.OperationMethod<
   RestartAppServerMessage,
   RestartAppServerResponse,
   RestartAppServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestartAppServerMessage,
   output: RestartAppServerResponse,
@@ -4094,7 +4093,7 @@ export const retrieveEnvironmentInfo: API.OperationMethod<
   RetrieveEnvironmentInfoMessage,
   RetrieveEnvironmentInfoResultMessage,
   RetrieveEnvironmentInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveEnvironmentInfoMessage,
   output: RetrieveEnvironmentInfoResultMessage,
@@ -4112,7 +4111,7 @@ export const swapEnvironmentCNAMEs: API.OperationMethod<
   SwapEnvironmentCNAMEsMessage,
   SwapEnvironmentCNAMEsResponse,
   SwapEnvironmentCNAMEsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwapEnvironmentCNAMEsMessage,
   output: SwapEnvironmentCNAMEsResponse,
@@ -4132,7 +4131,7 @@ export const terminateEnvironment: API.OperationMethod<
   TerminateEnvironmentMessage,
   EnvironmentDescription,
   TerminateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateEnvironmentMessage,
   output: EnvironmentDescription,
@@ -4153,7 +4152,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationMessage,
   ApplicationDescriptionMessage,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationMessage,
   output: ApplicationDescriptionMessage,
@@ -4173,7 +4172,7 @@ export const updateApplicationResourceLifecycle: API.OperationMethod<
   UpdateApplicationResourceLifecycleMessage,
   ApplicationResourceLifecycleDescriptionMessage,
   UpdateApplicationResourceLifecycleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationResourceLifecycleMessage,
   output: ApplicationResourceLifecycleDescriptionMessage,
@@ -4194,7 +4193,7 @@ export const updateApplicationVersion: API.OperationMethod<
   UpdateApplicationVersionMessage,
   ApplicationVersionDescriptionMessage,
   UpdateApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationVersionMessage,
   output: ApplicationVersionDescriptionMessage,
@@ -4223,7 +4222,7 @@ export const updateConfigurationTemplate: API.OperationMethod<
   UpdateConfigurationTemplateMessage,
   ConfigurationSettingsDescription,
   UpdateConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationTemplateMessage,
   output: ConfigurationSettingsDescription,
@@ -4254,7 +4253,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentMessage,
   EnvironmentDescription,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentMessage,
   output: EnvironmentDescription,
@@ -4298,7 +4297,7 @@ export const updateTagsForResource: API.OperationMethod<
   UpdateTagsForResourceMessage,
   UpdateTagsForResourceResponse,
   UpdateTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTagsForResourceMessage,
   output: UpdateTagsForResourceResponse,
@@ -4329,7 +4328,7 @@ export const validateConfigurationSettings: API.OperationMethod<
   ValidateConfigurationSettingsMessage,
   ConfigurationSettingsValidationMessages,
   ValidateConfigurationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateConfigurationSettingsMessage,
   output: ConfigurationSettingsValidationMessages,

--- a/packages/aws/src/services/elastic-load-balancing-v2.ts
+++ b/packages/aws/src/services/elastic-load-balancing-v2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/",
@@ -3894,7 +3893,7 @@ export const addListenerCertificates: API.OperationMethod<
   AddListenerCertificatesInput,
   AddListenerCertificatesOutput,
   AddListenerCertificatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddListenerCertificatesInput,
   output: AddListenerCertificatesOutput,
@@ -3929,7 +3928,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -3960,7 +3959,7 @@ export const addTrustStoreRevocations: API.OperationMethod<
   AddTrustStoreRevocationsInput,
   AddTrustStoreRevocationsOutput,
   AddTrustStoreRevocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTrustStoreRevocationsInput,
   output: AddTrustStoreRevocationsOutput,
@@ -4019,7 +4018,7 @@ export const createListener: API.OperationMethod<
   CreateListenerInput,
   CreateListenerOutput,
   CreateListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateListenerInput,
   output: CreateListenerOutput,
@@ -4086,7 +4085,7 @@ export const createLoadBalancer: API.OperationMethod<
   CreateLoadBalancerInput,
   CreateLoadBalancerOutput,
   CreateLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoadBalancerInput,
   output: CreateLoadBalancerOutput,
@@ -4141,7 +4140,7 @@ export const createRule: API.OperationMethod<
   CreateRuleInput,
   CreateRuleOutput,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleInput,
   output: CreateRuleOutput,
@@ -4194,7 +4193,7 @@ export const createTargetGroup: API.OperationMethod<
   CreateTargetGroupInput,
   CreateTargetGroupOutput,
   CreateTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTargetGroupInput,
   output: CreateTargetGroupOutput,
@@ -4226,7 +4225,7 @@ export const createTrustStore: API.OperationMethod<
   CreateTrustStoreInput,
   CreateTrustStoreOutput,
   CreateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustStoreInput,
   output: CreateTrustStoreOutput,
@@ -4257,7 +4256,7 @@ export const deleteListener: API.OperationMethod<
   DeleteListenerInput,
   DeleteListenerOutput,
   DeleteListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteListenerInput,
   output: DeleteListenerOutput,
@@ -4287,7 +4286,7 @@ export const deleteLoadBalancer: API.OperationMethod<
   DeleteLoadBalancerInput,
   DeleteLoadBalancerOutput,
   DeleteLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoadBalancerInput,
   output: DeleteLoadBalancerOutput,
@@ -4314,7 +4313,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleInput,
   DeleteRuleOutput,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleInput,
   output: DeleteRuleOutput,
@@ -4336,7 +4335,7 @@ export const deleteSharedTrustStoreAssociation: API.OperationMethod<
   DeleteSharedTrustStoreAssociationInput,
   DeleteSharedTrustStoreAssociationOutput,
   DeleteSharedTrustStoreAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSharedTrustStoreAssociationInput,
   output: DeleteSharedTrustStoreAssociationOutput,
@@ -4363,7 +4362,7 @@ export const deleteTargetGroup: API.OperationMethod<
   DeleteTargetGroupInput,
   DeleteTargetGroupOutput,
   DeleteTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTargetGroupInput,
   output: DeleteTargetGroupOutput,
@@ -4384,7 +4383,7 @@ export const deleteTrustStore: API.OperationMethod<
   DeleteTrustStoreInput,
   DeleteTrustStoreOutput,
   DeleteTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustStoreInput,
   output: DeleteTrustStoreOutput,
@@ -4423,7 +4422,7 @@ export const deregisterTargets: API.OperationMethod<
   DeregisterTargetsInput,
   DeregisterTargetsOutput,
   DeregisterTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTargetsInput,
   output: DeregisterTargetsOutput,
@@ -4453,7 +4452,7 @@ export const describeAccountLimits: API.PaginatedOperationMethod<
   DescribeAccountLimitsInput,
   DescribeAccountLimitsOutput,
   DescribeAccountLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Limit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccountLimitsInput,
@@ -4479,7 +4478,7 @@ export const describeCapacityReservation: API.OperationMethod<
   DescribeCapacityReservationInput,
   DescribeCapacityReservationOutput,
   DescribeCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCapacityReservationInput,
   output: DescribeCapacityReservationOutput,
@@ -4499,7 +4498,7 @@ export const describeListenerAttributes: API.OperationMethod<
   DescribeListenerAttributesInput,
   DescribeListenerAttributesOutput,
   DescribeListenerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeListenerAttributesInput,
   output: DescribeListenerAttributesOutput,
@@ -4528,7 +4527,7 @@ export const describeListenerCertificates: API.PaginatedOperationMethod<
   DescribeListenerCertificatesInput,
   DescribeListenerCertificatesOutput,
   DescribeListenerCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Certificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeListenerCertificatesInput,
@@ -4558,7 +4557,7 @@ export const describeListeners: API.PaginatedOperationMethod<
   DescribeListenersInput,
   DescribeListenersOutput,
   DescribeListenersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Listener
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeListenersInput,
@@ -4600,7 +4599,7 @@ export const describeLoadBalancerAttributes: API.OperationMethod<
   DescribeLoadBalancerAttributesInput,
   DescribeLoadBalancerAttributesOutput,
   DescribeLoadBalancerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoadBalancerAttributesInput,
   output: DescribeLoadBalancerAttributesOutput,
@@ -4620,7 +4619,7 @@ export const describeLoadBalancers: API.PaginatedOperationMethod<
   DescribeLoadBalancersInput,
   DescribeLoadBalancersOutput,
   DescribeLoadBalancersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LoadBalancer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLoadBalancersInput,
@@ -4649,7 +4648,7 @@ export const describeRules: API.PaginatedOperationMethod<
   DescribeRulesInput,
   DescribeRulesOutput,
   DescribeRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Rule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRulesInput,
@@ -4682,7 +4681,7 @@ export const describeSSLPolicies: API.OperationMethod<
   DescribeSSLPoliciesInput,
   DescribeSSLPoliciesOutput,
   DescribeSSLPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSSLPoliciesInput,
   output: DescribeSSLPoliciesOutput,
@@ -4708,7 +4707,7 @@ export const describeTags: API.OperationMethod<
   DescribeTagsInput,
   DescribeTagsOutput,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagsInput,
   output: DescribeTagsOutput,
@@ -4745,7 +4744,7 @@ export const describeTargetGroupAttributes: API.OperationMethod<
   DescribeTargetGroupAttributesInput,
   DescribeTargetGroupAttributesOutput,
   DescribeTargetGroupAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTargetGroupAttributesInput,
   output: DescribeTargetGroupAttributesOutput,
@@ -4769,7 +4768,7 @@ export const describeTargetGroups: API.PaginatedOperationMethod<
   DescribeTargetGroupsInput,
   DescribeTargetGroupsOutput,
   DescribeTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTargetGroupsInput,
@@ -4797,7 +4796,7 @@ export const describeTargetHealth: API.OperationMethod<
   DescribeTargetHealthInput,
   DescribeTargetHealthOutput,
   DescribeTargetHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTargetHealthInput,
   output: DescribeTargetHealthOutput,
@@ -4821,7 +4820,7 @@ export const describeTrustStoreAssociations: API.PaginatedOperationMethod<
   DescribeTrustStoreAssociationsInput,
   DescribeTrustStoreAssociationsOutput,
   DescribeTrustStoreAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrustStoreAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrustStoreAssociationsInput,
@@ -4850,7 +4849,7 @@ export const describeTrustStoreRevocations: API.PaginatedOperationMethod<
   DescribeTrustStoreRevocationsInput,
   DescribeTrustStoreRevocationsOutput,
   DescribeTrustStoreRevocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeTrustStoreRevocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrustStoreRevocationsInput,
@@ -4877,7 +4876,7 @@ export const describeTrustStores: API.PaginatedOperationMethod<
   DescribeTrustStoresInput,
   DescribeTrustStoresOutput,
   DescribeTrustStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrustStore
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrustStoresInput,
@@ -4902,7 +4901,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -4925,7 +4924,7 @@ export const getTrustStoreCaCertificatesBundle: API.OperationMethod<
   GetTrustStoreCaCertificatesBundleInput,
   GetTrustStoreCaCertificatesBundleOutput,
   GetTrustStoreCaCertificatesBundleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustStoreCaCertificatesBundleInput,
   output: GetTrustStoreCaCertificatesBundleOutput,
@@ -4949,7 +4948,7 @@ export const getTrustStoreRevocationContent: API.OperationMethod<
   GetTrustStoreRevocationContentInput,
   GetTrustStoreRevocationContentOutput,
   GetTrustStoreRevocationContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustStoreRevocationContentInput,
   output: GetTrustStoreRevocationContentOutput,
@@ -4979,7 +4978,7 @@ export const modifyCapacityReservation: API.OperationMethod<
   ModifyCapacityReservationInput,
   ModifyCapacityReservationOutput,
   ModifyCapacityReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCapacityReservationInput,
   output: ModifyCapacityReservationOutput,
@@ -5006,7 +5005,7 @@ export const modifyIpPools: API.OperationMethod<
   ModifyIpPoolsInput,
   ModifyIpPoolsOutput,
   ModifyIpPoolsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIpPoolsInput,
   output: ModifyIpPoolsOutput,
@@ -5053,7 +5052,7 @@ export const modifyListener: API.OperationMethod<
   ModifyListenerInput,
   ModifyListenerOutput,
   ModifyListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyListenerInput,
   output: ModifyListenerOutput,
@@ -5094,7 +5093,7 @@ export const modifyListenerAttributes: API.OperationMethod<
   ModifyListenerAttributesInput,
   ModifyListenerAttributesOutput,
   ModifyListenerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyListenerAttributesInput,
   output: ModifyListenerAttributesOutput,
@@ -5119,7 +5118,7 @@ export const modifyLoadBalancerAttributes: API.OperationMethod<
   ModifyLoadBalancerAttributesInput,
   ModifyLoadBalancerAttributesOutput,
   ModifyLoadBalancerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLoadBalancerAttributesInput,
   output: ModifyLoadBalancerAttributesOutput,
@@ -5154,7 +5153,7 @@ export const modifyRule: API.OperationMethod<
   ModifyRuleInput,
   ModifyRuleOutput,
   ModifyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyRuleInput,
   output: ModifyRuleOutput,
@@ -5188,7 +5187,7 @@ export const modifyTargetGroup: API.OperationMethod<
   ModifyTargetGroupInput,
   ModifyTargetGroupOutput,
   ModifyTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTargetGroupInput,
   output: ModifyTargetGroupOutput,
@@ -5209,7 +5208,7 @@ export const modifyTargetGroupAttributes: API.OperationMethod<
   ModifyTargetGroupAttributesInput,
   ModifyTargetGroupAttributesOutput,
   ModifyTargetGroupAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTargetGroupAttributesInput,
   output: ModifyTargetGroupAttributesOutput,
@@ -5231,7 +5230,7 @@ export const modifyTrustStore: API.OperationMethod<
   ModifyTrustStoreInput,
   ModifyTrustStoreOutput,
   ModifyTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTrustStoreInput,
   output: ModifyTrustStoreOutput,
@@ -5277,7 +5276,7 @@ export const registerTargets: API.OperationMethod<
   RegisterTargetsInput,
   RegisterTargetsOutput,
   RegisterTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTargetsInput,
   output: RegisterTargetsOutput,
@@ -5304,7 +5303,7 @@ export const removeListenerCertificates: API.OperationMethod<
   RemoveListenerCertificatesInput,
   RemoveListenerCertificatesOutput,
   RemoveListenerCertificatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveListenerCertificatesInput,
   output: RemoveListenerCertificatesOutput,
@@ -5331,7 +5330,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsInput,
   RemoveTagsOutput,
   RemoveTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsInput,
   output: RemoveTagsOutput,
@@ -5359,7 +5358,7 @@ export const removeTrustStoreRevocations: API.OperationMethod<
   RemoveTrustStoreRevocationsInput,
   RemoveTrustStoreRevocationsOutput,
   RemoveTrustStoreRevocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTrustStoreRevocationsInput,
   output: RemoveTrustStoreRevocationsOutput,
@@ -5381,7 +5380,7 @@ export const setIpAddressType: API.OperationMethod<
   SetIpAddressTypeInput,
   SetIpAddressTypeOutput,
   SetIpAddressTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIpAddressTypeInput,
   output: SetIpAddressTypeOutput,
@@ -5410,7 +5409,7 @@ export const setRulePriorities: API.OperationMethod<
   SetRulePrioritiesInput,
   SetRulePrioritiesOutput,
   SetRulePrioritiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetRulePrioritiesInput,
   output: SetRulePrioritiesOutput,
@@ -5443,7 +5442,7 @@ export const setSecurityGroups: API.OperationMethod<
   SetSecurityGroupsInput,
   SetSecurityGroupsOutput,
   SetSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSecurityGroupsInput,
   output: SetSecurityGroupsOutput,
@@ -5475,7 +5474,7 @@ export const setSubnets: API.OperationMethod<
   SetSubnetsInput,
   SetSubnetsOutput,
   SetSubnetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSubnetsInput,
   output: SetSubnetsOutput,

--- a/packages/aws/src/services/elastic-load-balancing.ts
+++ b/packages/aws/src/services/elastic-load-balancing.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace(
   "http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/",
 );
@@ -1609,7 +1608,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -1638,7 +1637,7 @@ export const applySecurityGroupsToLoadBalancer: API.OperationMethod<
   ApplySecurityGroupsToLoadBalancerInput,
   ApplySecurityGroupsToLoadBalancerOutput,
   ApplySecurityGroupsToLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplySecurityGroupsToLoadBalancerInput,
   output: ApplySecurityGroupsToLoadBalancerOutput,
@@ -1669,7 +1668,7 @@ export const attachLoadBalancerToSubnets: API.OperationMethod<
   AttachLoadBalancerToSubnetsInput,
   AttachLoadBalancerToSubnetsOutput,
   AttachLoadBalancerToSubnetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachLoadBalancerToSubnetsInput,
   output: AttachLoadBalancerToSubnetsOutput,
@@ -1697,7 +1696,7 @@ export const configureHealthCheck: API.OperationMethod<
   ConfigureHealthCheckInput,
   ConfigureHealthCheckOutput,
   ConfigureHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureHealthCheckInput,
   output: ConfigureHealthCheckOutput,
@@ -1731,7 +1730,7 @@ export const createAppCookieStickinessPolicy: API.OperationMethod<
   CreateAppCookieStickinessPolicyInput,
   CreateAppCookieStickinessPolicyOutput,
   CreateAppCookieStickinessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppCookieStickinessPolicyInput,
   output: CreateAppCookieStickinessPolicyOutput,
@@ -1767,7 +1766,7 @@ export const createLBCookieStickinessPolicy: API.OperationMethod<
   CreateLBCookieStickinessPolicyInput,
   CreateLBCookieStickinessPolicyOutput,
   CreateLBCookieStickinessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLBCookieStickinessPolicyInput,
   output: CreateLBCookieStickinessPolicyOutput,
@@ -1817,7 +1816,7 @@ export const createLoadBalancer: API.OperationMethod<
   CreateAccessPointInput,
   CreateAccessPointOutput,
   CreateLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPointInput,
   output: CreateAccessPointOutput,
@@ -1857,7 +1856,7 @@ export const createLoadBalancerListeners: API.OperationMethod<
   CreateLoadBalancerListenerInput,
   CreateLoadBalancerListenerOutput,
   CreateLoadBalancerListenersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoadBalancerListenerInput,
   output: CreateLoadBalancerListenerOutput,
@@ -1889,7 +1888,7 @@ export const createLoadBalancerPolicy: API.OperationMethod<
   CreateLoadBalancerPolicyInput,
   CreateLoadBalancerPolicyOutput,
   CreateLoadBalancerPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoadBalancerPolicyInput,
   output: CreateLoadBalancerPolicyOutput,
@@ -1918,7 +1917,7 @@ export const deleteLoadBalancer: API.OperationMethod<
   DeleteAccessPointInput,
   DeleteAccessPointOutput,
   DeleteLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointInput,
   output: DeleteAccessPointOutput,
@@ -1938,7 +1937,7 @@ export const deleteLoadBalancerListeners: API.OperationMethod<
   DeleteLoadBalancerListenerInput,
   DeleteLoadBalancerListenerOutput,
   DeleteLoadBalancerListenersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoadBalancerListenerInput,
   output: DeleteLoadBalancerListenerOutput,
@@ -1959,7 +1958,7 @@ export const deleteLoadBalancerPolicy: API.OperationMethod<
   DeleteLoadBalancerPolicyInput,
   DeleteLoadBalancerPolicyOutput,
   DeleteLoadBalancerPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoadBalancerPolicyInput,
   output: DeleteLoadBalancerPolicyOutput,
@@ -1985,7 +1984,7 @@ export const deregisterInstancesFromLoadBalancer: API.OperationMethod<
   DeregisterEndPointsInput,
   DeregisterEndPointsOutput,
   DeregisterInstancesFromLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterEndPointsInput,
   output: DeregisterEndPointsOutput,
@@ -2006,7 +2005,7 @@ export const describeAccountLimits: API.OperationMethod<
   DescribeAccountLimitsInput,
   DescribeAccountLimitsOutput,
   DescribeAccountLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountLimitsInput,
   output: DescribeAccountLimitsOutput,
@@ -2027,7 +2026,7 @@ export const describeInstanceHealth: API.OperationMethod<
   DescribeEndPointStateInput,
   DescribeEndPointStateOutput,
   DescribeInstanceHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndPointStateInput,
   output: DescribeEndPointStateOutput,
@@ -2048,7 +2047,7 @@ export const describeLoadBalancerAttributes: API.OperationMethod<
   DescribeLoadBalancerAttributesInput,
   DescribeLoadBalancerAttributesOutput,
   DescribeLoadBalancerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoadBalancerAttributesInput,
   output: DescribeLoadBalancerAttributesOutput,
@@ -2077,7 +2076,7 @@ export const describeLoadBalancerPolicies: API.OperationMethod<
   DescribeLoadBalancerPoliciesInput,
   DescribeLoadBalancerPoliciesOutput,
   DescribeLoadBalancerPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoadBalancerPoliciesInput,
   output: DescribeLoadBalancerPoliciesOutput,
@@ -2106,7 +2105,7 @@ export const describeLoadBalancerPolicyTypes: API.OperationMethod<
   DescribeLoadBalancerPolicyTypesInput,
   DescribeLoadBalancerPolicyTypesOutput,
   DescribeLoadBalancerPolicyTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoadBalancerPolicyTypesInput,
   output: DescribeLoadBalancerPolicyTypesOutput,
@@ -2127,7 +2126,7 @@ export const describeLoadBalancers: API.PaginatedOperationMethod<
   DescribeAccessPointsInput,
   DescribeAccessPointsOutput,
   DescribeLoadBalancersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LoadBalancerDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccessPointsInput,
@@ -2151,7 +2150,7 @@ export const describeTags: API.OperationMethod<
   DescribeTagsInput,
   DescribeTagsOutput,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagsInput,
   output: DescribeTagsOutput,
@@ -2176,7 +2175,7 @@ export const detachLoadBalancerFromSubnets: API.OperationMethod<
   DetachLoadBalancerFromSubnetsInput,
   DetachLoadBalancerFromSubnetsOutput,
   DetachLoadBalancerFromSubnetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachLoadBalancerFromSubnetsInput,
   output: DetachLoadBalancerFromSubnetsOutput,
@@ -2208,7 +2207,7 @@ export const disableAvailabilityZonesForLoadBalancer: API.OperationMethod<
   RemoveAvailabilityZonesInput,
   RemoveAvailabilityZonesOutput,
   DisableAvailabilityZonesForLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAvailabilityZonesInput,
   output: RemoveAvailabilityZonesOutput,
@@ -2235,7 +2234,7 @@ export const enableAvailabilityZonesForLoadBalancer: API.OperationMethod<
   AddAvailabilityZonesInput,
   AddAvailabilityZonesOutput,
   EnableAvailabilityZonesForLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddAvailabilityZonesInput,
   output: AddAvailabilityZonesOutput,
@@ -2271,7 +2270,7 @@ export const modifyLoadBalancerAttributes: API.OperationMethod<
   ModifyLoadBalancerAttributesInput,
   ModifyLoadBalancerAttributesOutput,
   ModifyLoadBalancerAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLoadBalancerAttributesInput,
   output: ModifyLoadBalancerAttributesOutput,
@@ -2314,7 +2313,7 @@ export const registerInstancesWithLoadBalancer: API.OperationMethod<
   RegisterEndPointsInput,
   RegisterEndPointsOutput,
   RegisterInstancesWithLoadBalancerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterEndPointsInput,
   output: RegisterEndPointsOutput,
@@ -2332,7 +2331,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsInput,
   RemoveTagsOutput,
   RemoveTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsInput,
   output: RemoveTagsOutput,
@@ -2360,7 +2359,7 @@ export const setLoadBalancerListenerSSLCertificate: API.OperationMethod<
   SetLoadBalancerListenerSSLCertificateInput,
   SetLoadBalancerListenerSSLCertificateOutput,
   SetLoadBalancerListenerSSLCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLoadBalancerListenerSSLCertificateInput,
   output: SetLoadBalancerListenerSSLCertificateOutput,
@@ -2400,7 +2399,7 @@ export const setLoadBalancerPoliciesForBackendServer: API.OperationMethod<
   SetLoadBalancerPoliciesForBackendServerInput,
   SetLoadBalancerPoliciesForBackendServerOutput,
   SetLoadBalancerPoliciesForBackendServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLoadBalancerPoliciesForBackendServerInput,
   output: SetLoadBalancerPoliciesForBackendServerOutput,
@@ -2435,7 +2434,7 @@ export const setLoadBalancerPoliciesOfListener: API.OperationMethod<
   SetLoadBalancerPoliciesOfListenerInput,
   SetLoadBalancerPoliciesOfListenerOutput,
   SetLoadBalancerPoliciesOfListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLoadBalancerPoliciesOfListenerInput,
   output: SetLoadBalancerPoliciesOfListenerOutput,

--- a/packages/aws/src/services/elasticache.ts
+++ b/packages/aws/src/services/elasticache.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://elasticache.amazonaws.com/doc/2015-02-02/");
 const svc = T.AwsApiService({
@@ -5696,7 +5695,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceMessage,
   TagListMessage,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceMessage,
   output: TagListMessage,
@@ -5742,7 +5741,7 @@ export const authorizeCacheSecurityGroupIngress: API.OperationMethod<
   AuthorizeCacheSecurityGroupIngressMessage,
   AuthorizeCacheSecurityGroupIngressResult,
   AuthorizeCacheSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeCacheSecurityGroupIngressMessage,
   output: AuthorizeCacheSecurityGroupIngressResult,
@@ -5771,7 +5770,7 @@ export const batchApplyUpdateAction: API.OperationMethod<
   BatchApplyUpdateActionMessage,
   UpdateActionResultsMessage,
   BatchApplyUpdateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchApplyUpdateActionMessage,
   output: UpdateActionResultsMessage,
@@ -5794,7 +5793,7 @@ export const batchStopUpdateAction: API.OperationMethod<
   BatchStopUpdateActionMessage,
   UpdateActionResultsMessage,
   BatchStopUpdateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStopUpdateActionMessage,
   output: UpdateActionResultsMessage,
@@ -5816,7 +5815,7 @@ export const completeMigration: API.OperationMethod<
   CompleteMigrationMessage,
   CompleteMigrationResponse,
   CompleteMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteMigrationMessage,
   output: CompleteMigrationResponse,
@@ -5847,7 +5846,7 @@ export const copyServerlessCacheSnapshot: API.OperationMethod<
   CopyServerlessCacheSnapshotRequest,
   CopyServerlessCacheSnapshotResponse,
   CopyServerlessCacheSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyServerlessCacheSnapshotRequest,
   output: CopyServerlessCacheSnapshotResponse,
@@ -5952,7 +5951,7 @@ export const copySnapshot: API.OperationMethod<
   CopySnapshotMessage,
   CopySnapshotResult,
   CopySnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopySnapshotMessage,
   output: CopySnapshotResult,
@@ -5996,7 +5995,7 @@ export const createCacheCluster: API.OperationMethod<
   CreateCacheClusterMessage,
   CreateCacheClusterResult,
   CreateCacheClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCacheClusterMessage,
   output: CreateCacheClusterResult,
@@ -6048,7 +6047,7 @@ export const createCacheParameterGroup: API.OperationMethod<
   CreateCacheParameterGroupMessage,
   CreateCacheParameterGroupResult,
   CreateCacheParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCacheParameterGroupMessage,
   output: CreateCacheParameterGroupResult,
@@ -6084,7 +6083,7 @@ export const createCacheSecurityGroup: API.OperationMethod<
   CreateCacheSecurityGroupMessage,
   CreateCacheSecurityGroupResult,
   CreateCacheSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCacheSecurityGroupMessage,
   output: CreateCacheSecurityGroupResult,
@@ -6118,7 +6117,7 @@ export const createCacheSubnetGroup: API.OperationMethod<
   CreateCacheSubnetGroupMessage,
   CreateCacheSubnetGroupResult,
   CreateCacheSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCacheSubnetGroupMessage,
   output: CreateCacheSubnetGroupResult,
@@ -6160,7 +6159,7 @@ export const createGlobalReplicationGroup: API.OperationMethod<
   CreateGlobalReplicationGroupMessage,
   CreateGlobalReplicationGroupResult,
   CreateGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalReplicationGroupMessage,
   output: CreateGlobalReplicationGroupResult,
@@ -6238,7 +6237,7 @@ export const createReplicationGroup: API.OperationMethod<
   CreateReplicationGroupMessage,
   CreateReplicationGroupResult,
   CreateReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationGroupMessage,
   output: CreateReplicationGroupResult,
@@ -6288,7 +6287,7 @@ export const createServerlessCache: API.OperationMethod<
   CreateServerlessCacheRequest,
   CreateServerlessCacheResponse,
   CreateServerlessCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServerlessCacheRequest,
   output: CreateServerlessCacheResponse,
@@ -6327,7 +6326,7 @@ export const createServerlessCacheSnapshot: API.OperationMethod<
   CreateServerlessCacheSnapshotRequest,
   CreateServerlessCacheSnapshotResponse,
   CreateServerlessCacheSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServerlessCacheSnapshotRequest,
   output: CreateServerlessCacheSnapshotResponse,
@@ -6368,7 +6367,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotMessage,
   CreateSnapshotResult,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotMessage,
   output: CreateSnapshotResult,
@@ -6406,7 +6405,7 @@ export const createUser: API.OperationMethod<
   CreateUserMessage,
   User,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserMessage,
   output: User,
@@ -6442,7 +6441,7 @@ export const createUserGroup: API.OperationMethod<
   CreateUserGroupMessage,
   UserGroup,
   CreateUserGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserGroupMessage,
   output: UserGroup,
@@ -6474,7 +6473,7 @@ export const decreaseNodeGroupsInGlobalReplicationGroup: API.OperationMethod<
   DecreaseNodeGroupsInGlobalReplicationGroupMessage,
   DecreaseNodeGroupsInGlobalReplicationGroupResult,
   DecreaseNodeGroupsInGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecreaseNodeGroupsInGlobalReplicationGroupMessage,
   output: DecreaseNodeGroupsInGlobalReplicationGroupResult,
@@ -6513,7 +6512,7 @@ export const decreaseReplicaCount: API.OperationMethod<
   DecreaseReplicaCountMessage,
   DecreaseReplicaCountResult,
   DecreaseReplicaCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecreaseReplicaCountMessage,
   output: DecreaseReplicaCountResult,
@@ -6571,7 +6570,7 @@ export const deleteCacheCluster: API.OperationMethod<
   DeleteCacheClusterMessage,
   DeleteCacheClusterResult,
   DeleteCacheClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCacheClusterMessage,
   output: DeleteCacheClusterResult,
@@ -6604,7 +6603,7 @@ export const deleteCacheParameterGroup: API.OperationMethod<
   DeleteCacheParameterGroupMessage,
   DeleteCacheParameterGroupResponse,
   DeleteCacheParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCacheParameterGroupMessage,
   output: DeleteCacheParameterGroupResponse,
@@ -6635,7 +6634,7 @@ export const deleteCacheSecurityGroup: API.OperationMethod<
   DeleteCacheSecurityGroupMessage,
   DeleteCacheSecurityGroupResponse,
   DeleteCacheSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCacheSecurityGroupMessage,
   output: DeleteCacheSecurityGroupResponse,
@@ -6664,7 +6663,7 @@ export const deleteCacheSubnetGroup: API.OperationMethod<
   DeleteCacheSubnetGroupMessage,
   DeleteCacheSubnetGroupResponse,
   DeleteCacheSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCacheSubnetGroupMessage,
   output: DeleteCacheSubnetGroupResponse,
@@ -6704,7 +6703,7 @@ export const deleteGlobalReplicationGroup: API.OperationMethod<
   DeleteGlobalReplicationGroupMessage,
   DeleteGlobalReplicationGroupResult,
   DeleteGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalReplicationGroupMessage,
   output: DeleteGlobalReplicationGroupResult,
@@ -6747,7 +6746,7 @@ export const deleteReplicationGroup: API.OperationMethod<
   DeleteReplicationGroupMessage,
   DeleteReplicationGroupResult,
   DeleteReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationGroupMessage,
   output: DeleteReplicationGroupResult,
@@ -6784,7 +6783,7 @@ export const deleteServerlessCache: API.OperationMethod<
   DeleteServerlessCacheRequest,
   DeleteServerlessCacheResponse,
   DeleteServerlessCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServerlessCacheRequest,
   output: DeleteServerlessCacheResponse,
@@ -6815,7 +6814,7 @@ export const deleteServerlessCacheSnapshot: API.OperationMethod<
   DeleteServerlessCacheSnapshotRequest,
   DeleteServerlessCacheSnapshotResponse,
   DeleteServerlessCacheSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServerlessCacheSnapshotRequest,
   output: DeleteServerlessCacheSnapshotResponse,
@@ -6847,7 +6846,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotMessage,
   DeleteSnapshotResult,
   DeleteSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotMessage,
   output: DeleteSnapshotResult,
@@ -6878,7 +6877,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserMessage,
   User,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserMessage,
   output: User,
@@ -6909,7 +6908,7 @@ export const deleteUserGroup: API.OperationMethod<
   DeleteUserGroupMessage,
   UserGroup,
   DeleteUserGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserGroupMessage,
   output: UserGroup,
@@ -6956,7 +6955,7 @@ export const describeCacheClusters: API.PaginatedOperationMethod<
   DescribeCacheClustersMessage,
   CacheClusterMessage,
   DescribeCacheClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheClustersMessage,
@@ -6985,7 +6984,7 @@ export const describeCacheEngineVersions: API.PaginatedOperationMethod<
   DescribeCacheEngineVersionsMessage,
   CacheEngineVersionMessage,
   DescribeCacheEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheEngineVersionsMessage,
@@ -7015,7 +7014,7 @@ export const describeCacheParameterGroups: API.PaginatedOperationMethod<
   DescribeCacheParameterGroupsMessage,
   CacheParameterGroupsMessage,
   DescribeCacheParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheParameterGroupsMessage,
@@ -7048,7 +7047,7 @@ export const describeCacheParameters: API.PaginatedOperationMethod<
   DescribeCacheParametersMessage,
   CacheParameterGroupDetails,
   DescribeCacheParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheParametersMessage,
@@ -7083,7 +7082,7 @@ export const describeCacheSecurityGroups: API.PaginatedOperationMethod<
   DescribeCacheSecurityGroupsMessage,
   CacheSecurityGroupMessage,
   DescribeCacheSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheSecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheSecurityGroupsMessage,
@@ -7117,7 +7116,7 @@ export const describeCacheSubnetGroups: API.PaginatedOperationMethod<
   DescribeCacheSubnetGroupsMessage,
   CacheSubnetGroupMessage,
   DescribeCacheSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheSubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCacheSubnetGroupsMessage,
@@ -7146,7 +7145,7 @@ export const describeEngineDefaultParameters: API.PaginatedOperationMethod<
   DescribeEngineDefaultParametersMessage,
   DescribeEngineDefaultParametersResult,
   DescribeEngineDefaultParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineDefaultParametersMessage,
@@ -7182,7 +7181,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -7215,7 +7214,7 @@ export const describeGlobalReplicationGroups: API.PaginatedOperationMethod<
   DescribeGlobalReplicationGroupsMessage,
   DescribeGlobalReplicationGroupsResult,
   DescribeGlobalReplicationGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalReplicationGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGlobalReplicationGroupsMessage,
@@ -7252,7 +7251,7 @@ export const describeReplicationGroups: API.PaginatedOperationMethod<
   DescribeReplicationGroupsMessage,
   ReplicationGroupMessage,
   DescribeReplicationGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplicationGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationGroupsMessage,
@@ -7286,7 +7285,7 @@ export const describeReservedCacheNodes: API.PaginatedOperationMethod<
   DescribeReservedCacheNodesMessage,
   ReservedCacheNodeMessage,
   DescribeReservedCacheNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedCacheNode
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedCacheNodesMessage,
@@ -7319,7 +7318,7 @@ export const describeReservedCacheNodesOfferings: API.PaginatedOperationMethod<
   DescribeReservedCacheNodesOfferingsMessage,
   ReservedCacheNodesOfferingMessage,
   DescribeReservedCacheNodesOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedCacheNodesOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedCacheNodesOfferingsMessage,
@@ -7354,7 +7353,7 @@ export const describeServerlessCaches: API.PaginatedOperationMethod<
   DescribeServerlessCachesRequest,
   DescribeServerlessCachesResponse,
   DescribeServerlessCachesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerlessCache
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServerlessCachesRequest,
@@ -7391,7 +7390,7 @@ export const describeServerlessCacheSnapshots: API.PaginatedOperationMethod<
   DescribeServerlessCacheSnapshotsRequest,
   DescribeServerlessCacheSnapshotsResponse,
   DescribeServerlessCacheSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerlessCacheSnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServerlessCacheSnapshotsRequest,
@@ -7425,7 +7424,7 @@ export const describeServiceUpdates: API.PaginatedOperationMethod<
   DescribeServiceUpdatesMessage,
   ServiceUpdatesMessage,
   DescribeServiceUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceUpdate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServiceUpdatesMessage,
@@ -7464,7 +7463,7 @@ export const describeSnapshots: API.PaginatedOperationMethod<
   DescribeSnapshotsMessage,
   DescribeSnapshotsListMessage,
   DescribeSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotsMessage,
@@ -7497,7 +7496,7 @@ export const describeUpdateActions: API.PaginatedOperationMethod<
   DescribeUpdateActionsMessage,
   UpdateActionsMessage,
   DescribeUpdateActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UpdateAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUpdateActionsMessage,
@@ -7529,7 +7528,7 @@ export const describeUserGroups: API.PaginatedOperationMethod<
   DescribeUserGroupsMessage,
   DescribeUserGroupsResult,
   DescribeUserGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUserGroupsMessage,
@@ -7562,7 +7561,7 @@ export const describeUsers: API.PaginatedOperationMethod<
   DescribeUsersMessage,
   DescribeUsersResult,
   DescribeUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUsersMessage,
@@ -7598,7 +7597,7 @@ export const disassociateGlobalReplicationGroup: API.OperationMethod<
   DisassociateGlobalReplicationGroupMessage,
   DisassociateGlobalReplicationGroupResult,
   DisassociateGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateGlobalReplicationGroupMessage,
   output: DisassociateGlobalReplicationGroupResult,
@@ -7626,7 +7625,7 @@ export const exportServerlessCacheSnapshot: API.OperationMethod<
   ExportServerlessCacheSnapshotRequest,
   ExportServerlessCacheSnapshotResponse,
   ExportServerlessCacheSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportServerlessCacheSnapshotRequest,
   output: ExportServerlessCacheSnapshotResponse,
@@ -7655,7 +7654,7 @@ export const failoverGlobalReplicationGroup: API.OperationMethod<
   FailoverGlobalReplicationGroupMessage,
   FailoverGlobalReplicationGroupResult,
   FailoverGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverGlobalReplicationGroupMessage,
   output: FailoverGlobalReplicationGroupResult,
@@ -7682,7 +7681,7 @@ export const increaseNodeGroupsInGlobalReplicationGroup: API.OperationMethod<
   IncreaseNodeGroupsInGlobalReplicationGroupMessage,
   IncreaseNodeGroupsInGlobalReplicationGroupResult,
   IncreaseNodeGroupsInGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IncreaseNodeGroupsInGlobalReplicationGroupMessage,
   output: IncreaseNodeGroupsInGlobalReplicationGroupResult,
@@ -7720,7 +7719,7 @@ export const increaseReplicaCount: API.OperationMethod<
   IncreaseReplicaCountMessage,
   IncreaseReplicaCountResult,
   IncreaseReplicaCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IncreaseReplicaCountMessage,
   output: IncreaseReplicaCountResult,
@@ -7762,7 +7761,7 @@ export const listAllowedNodeTypeModifications: API.OperationMethod<
   ListAllowedNodeTypeModificationsMessage,
   AllowedNodeTypeModificationsMessage,
   ListAllowedNodeTypeModificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAllowedNodeTypeModificationsMessage,
   output: AllowedNodeTypeModificationsMessage,
@@ -7810,7 +7809,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   TagListMessage,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: TagListMessage,
@@ -7857,7 +7856,7 @@ export const modifyCacheCluster: API.OperationMethod<
   ModifyCacheClusterMessage,
   ModifyCacheClusterResult,
   ModifyCacheClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCacheClusterMessage,
   output: ModifyCacheClusterResult,
@@ -7894,7 +7893,7 @@ export const modifyCacheParameterGroup: API.OperationMethod<
   ModifyCacheParameterGroupMessage,
   CacheParameterGroupNameMessage,
   ModifyCacheParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCacheParameterGroupMessage,
   output: CacheParameterGroupNameMessage,
@@ -7924,7 +7923,7 @@ export const modifyCacheSubnetGroup: API.OperationMethod<
   ModifyCacheSubnetGroupMessage,
   ModifyCacheSubnetGroupResult,
   ModifyCacheSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCacheSubnetGroupMessage,
   output: ModifyCacheSubnetGroupResult,
@@ -7952,7 +7951,7 @@ export const modifyGlobalReplicationGroup: API.OperationMethod<
   ModifyGlobalReplicationGroupMessage,
   ModifyGlobalReplicationGroupResult,
   ModifyGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyGlobalReplicationGroupMessage,
   output: ModifyGlobalReplicationGroupResult,
@@ -7999,7 +7998,7 @@ export const modifyReplicationGroup: API.OperationMethod<
   ModifyReplicationGroupMessage,
   ModifyReplicationGroupResult,
   ModifyReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationGroupMessage,
   output: ModifyReplicationGroupResult,
@@ -8046,7 +8045,7 @@ export const modifyReplicationGroupShardConfiguration: API.OperationMethod<
   ModifyReplicationGroupShardConfigurationMessage,
   ModifyReplicationGroupShardConfigurationResult,
   ModifyReplicationGroupShardConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyReplicationGroupShardConfigurationMessage,
   output: ModifyReplicationGroupShardConfigurationResult,
@@ -8084,7 +8083,7 @@ export const modifyServerlessCache: API.OperationMethod<
   ModifyServerlessCacheRequest,
   ModifyServerlessCacheResponse,
   ModifyServerlessCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyServerlessCacheRequest,
   output: ModifyServerlessCacheResponse,
@@ -8117,7 +8116,7 @@ export const modifyUser: API.OperationMethod<
   ModifyUserMessage,
   User,
   ModifyUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyUserMessage,
   output: User,
@@ -8150,7 +8149,7 @@ export const modifyUserGroup: API.OperationMethod<
   ModifyUserGroupMessage,
   UserGroup,
   ModifyUserGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyUserGroupMessage,
   output: UserGroup,
@@ -8185,7 +8184,7 @@ export const purchaseReservedCacheNodesOffering: API.OperationMethod<
   PurchaseReservedCacheNodesOfferingMessage,
   PurchaseReservedCacheNodesOfferingResult,
   PurchaseReservedCacheNodesOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedCacheNodesOfferingMessage,
   output: PurchaseReservedCacheNodesOfferingResult,
@@ -8215,7 +8214,7 @@ export const rebalanceSlotsInGlobalReplicationGroup: API.OperationMethod<
   RebalanceSlotsInGlobalReplicationGroupMessage,
   RebalanceSlotsInGlobalReplicationGroupResult,
   RebalanceSlotsInGlobalReplicationGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebalanceSlotsInGlobalReplicationGroupMessage,
   output: RebalanceSlotsInGlobalReplicationGroupResult,
@@ -8255,7 +8254,7 @@ export const rebootCacheCluster: API.OperationMethod<
   RebootCacheClusterMessage,
   RebootCacheClusterResult,
   RebootCacheClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootCacheClusterMessage,
   output: RebootCacheClusterResult,
@@ -8294,7 +8293,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceMessage,
   TagListMessage,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceMessage,
   output: TagListMessage,
@@ -8338,7 +8337,7 @@ export const resetCacheParameterGroup: API.OperationMethod<
   ResetCacheParameterGroupMessage,
   CacheParameterGroupNameMessage,
   ResetCacheParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetCacheParameterGroupMessage,
   output: CacheParameterGroupNameMessage,
@@ -8369,7 +8368,7 @@ export const revokeCacheSecurityGroupIngress: API.OperationMethod<
   RevokeCacheSecurityGroupIngressMessage,
   RevokeCacheSecurityGroupIngressResult,
   RevokeCacheSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeCacheSecurityGroupIngressMessage,
   output: RevokeCacheSecurityGroupIngressResult,
@@ -8398,7 +8397,7 @@ export const startMigration: API.OperationMethod<
   StartMigrationMessage,
   StartMigrationResponse,
   StartMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMigrationMessage,
   output: StartMigrationResponse,
@@ -8481,7 +8480,7 @@ export const testFailover: API.OperationMethod<
   TestFailoverMessage,
   TestFailoverResult,
   TestFailoverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestFailoverMessage,
   output: TestFailoverResult,
@@ -8514,7 +8513,7 @@ export const testMigration: API.OperationMethod<
   TestMigrationMessage,
   TestMigrationResponse,
   TestMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestMigrationMessage,
   output: TestMigrationResponse,

--- a/packages/aws/src/services/elasticsearch-service.ts
+++ b/packages/aws/src/services/elasticsearch-service.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://es.amazonaws.com/doc/2015-01-01/");
 const svc = T.AwsApiService({
@@ -3754,7 +3753,7 @@ export const acceptInboundCrossClusterSearchConnection: API.OperationMethod<
   AcceptInboundCrossClusterSearchConnectionRequest,
   AcceptInboundCrossClusterSearchConnectionResponse,
   AcceptInboundCrossClusterSearchConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInboundCrossClusterSearchConnectionRequest,
   output: AcceptInboundCrossClusterSearchConnectionResponse,
@@ -3782,7 +3781,7 @@ export const addTags: API.OperationMethod<
   AddTagsRequest,
   AddTagsResponse,
   AddTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsRequest,
   output: AddTagsResponse,
@@ -3812,7 +3811,7 @@ export const associatePackage: API.OperationMethod<
   AssociatePackageRequest,
   AssociatePackageResponse,
   AssociatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePackageRequest,
   output: AssociatePackageResponse,
@@ -3844,7 +3843,7 @@ export const authorizeVpcEndpointAccess: API.OperationMethod<
   AuthorizeVpcEndpointAccessRequest,
   AuthorizeVpcEndpointAccessResponse,
   AuthorizeVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeVpcEndpointAccessRequest,
   output: AuthorizeVpcEndpointAccessResponse,
@@ -3875,7 +3874,7 @@ export const cancelDomainConfigChange: API.OperationMethod<
   CancelDomainConfigChangeRequest,
   CancelDomainConfigChangeResponse,
   CancelDomainConfigChangeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDomainConfigChangeRequest,
   output: CancelDomainConfigChangeResponse,
@@ -3904,7 +3903,7 @@ export const cancelElasticsearchServiceSoftwareUpdate: API.OperationMethod<
   CancelElasticsearchServiceSoftwareUpdateRequest,
   CancelElasticsearchServiceSoftwareUpdateResponse,
   CancelElasticsearchServiceSoftwareUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelElasticsearchServiceSoftwareUpdateRequest,
   output: CancelElasticsearchServiceSoftwareUpdateResponse,
@@ -3936,7 +3935,7 @@ export const createElasticsearchDomain: API.OperationMethod<
   CreateElasticsearchDomainRequest,
   CreateElasticsearchDomainResponse,
   CreateElasticsearchDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateElasticsearchDomainRequest,
   output: CreateElasticsearchDomainResponse,
@@ -3967,7 +3966,7 @@ export const createOutboundCrossClusterSearchConnection: API.OperationMethod<
   CreateOutboundCrossClusterSearchConnectionRequest,
   CreateOutboundCrossClusterSearchConnectionResponse,
   CreateOutboundCrossClusterSearchConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOutboundCrossClusterSearchConnectionRequest,
   output: CreateOutboundCrossClusterSearchConnectionResponse,
@@ -3998,7 +3997,7 @@ export const createPackage: API.OperationMethod<
   CreatePackageRequest,
   CreatePackageResponse,
   CreatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageRequest,
   output: CreatePackageResponse,
@@ -4031,7 +4030,7 @@ export const createVpcEndpoint: API.OperationMethod<
   CreateVpcEndpointRequest,
   CreateVpcEndpointResponse,
   CreateVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointRequest,
   output: CreateVpcEndpointResponse,
@@ -4061,7 +4060,7 @@ export const deleteElasticsearchDomain: API.OperationMethod<
   DeleteElasticsearchDomainRequest,
   DeleteElasticsearchDomainResponse,
   DeleteElasticsearchDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteElasticsearchDomainRequest,
   output: DeleteElasticsearchDomainResponse,
@@ -4088,7 +4087,7 @@ export const deleteElasticsearchServiceRole: API.OperationMethod<
   DeleteElasticsearchServiceRoleRequest,
   DeleteElasticsearchServiceRoleResponse,
   DeleteElasticsearchServiceRoleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteElasticsearchServiceRoleRequest,
   output: DeleteElasticsearchServiceRoleResponse,
@@ -4109,7 +4108,7 @@ export const deleteInboundCrossClusterSearchConnection: API.OperationMethod<
   DeleteInboundCrossClusterSearchConnectionRequest,
   DeleteInboundCrossClusterSearchConnectionResponse,
   DeleteInboundCrossClusterSearchConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInboundCrossClusterSearchConnectionRequest,
   output: DeleteInboundCrossClusterSearchConnectionResponse,
@@ -4130,7 +4129,7 @@ export const deleteOutboundCrossClusterSearchConnection: API.OperationMethod<
   DeleteOutboundCrossClusterSearchConnectionRequest,
   DeleteOutboundCrossClusterSearchConnectionResponse,
   DeleteOutboundCrossClusterSearchConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutboundCrossClusterSearchConnectionRequest,
   output: DeleteOutboundCrossClusterSearchConnectionResponse,
@@ -4155,7 +4154,7 @@ export const deletePackage: API.OperationMethod<
   DeletePackageRequest,
   DeletePackageResponse,
   DeletePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageRequest,
   output: DeletePackageResponse,
@@ -4185,7 +4184,7 @@ export const deleteVpcEndpoint: API.OperationMethod<
   DeleteVpcEndpointRequest,
   DeleteVpcEndpointResponse,
   DeleteVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointRequest,
   output: DeleteVpcEndpointResponse,
@@ -4213,7 +4212,7 @@ export const describeDomainAutoTunes: API.PaginatedOperationMethod<
   DescribeDomainAutoTunesRequest,
   DescribeDomainAutoTunesResponse,
   DescribeDomainAutoTunesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDomainAutoTunesRequest,
@@ -4248,7 +4247,7 @@ export const describeDomainChangeProgress: API.OperationMethod<
   DescribeDomainChangeProgressRequest,
   DescribeDomainChangeProgressResponse,
   DescribeDomainChangeProgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainChangeProgressRequest,
   output: DescribeDomainChangeProgressResponse,
@@ -4276,7 +4275,7 @@ export const describeElasticsearchDomain: API.OperationMethod<
   DescribeElasticsearchDomainRequest,
   DescribeElasticsearchDomainResponse,
   DescribeElasticsearchDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeElasticsearchDomainRequest,
   output: DescribeElasticsearchDomainResponse,
@@ -4304,7 +4303,7 @@ export const describeElasticsearchDomainConfig: API.OperationMethod<
   DescribeElasticsearchDomainConfigRequest,
   DescribeElasticsearchDomainConfigResponse,
   DescribeElasticsearchDomainConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeElasticsearchDomainConfigRequest,
   output: DescribeElasticsearchDomainConfigResponse,
@@ -4331,7 +4330,7 @@ export const describeElasticsearchDomains: API.OperationMethod<
   DescribeElasticsearchDomainsRequest,
   DescribeElasticsearchDomainsResponse,
   DescribeElasticsearchDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeElasticsearchDomainsRequest,
   output: DescribeElasticsearchDomainsResponse,
@@ -4361,7 +4360,7 @@ export const describeElasticsearchInstanceTypeLimits: API.OperationMethod<
   DescribeElasticsearchInstanceTypeLimitsRequest,
   DescribeElasticsearchInstanceTypeLimitsResponse,
   DescribeElasticsearchInstanceTypeLimitsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeElasticsearchInstanceTypeLimitsRequest,
   output: DescribeElasticsearchInstanceTypeLimitsResponse,
@@ -4389,7 +4388,7 @@ export const describeInboundCrossClusterSearchConnections: API.PaginatedOperatio
   DescribeInboundCrossClusterSearchConnectionsRequest,
   DescribeInboundCrossClusterSearchConnectionsResponse,
   DescribeInboundCrossClusterSearchConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInboundCrossClusterSearchConnectionsRequest,
@@ -4416,7 +4415,7 @@ export const describeOutboundCrossClusterSearchConnections: API.PaginatedOperati
   DescribeOutboundCrossClusterSearchConnectionsRequest,
   DescribeOutboundCrossClusterSearchConnectionsResponse,
   DescribeOutboundCrossClusterSearchConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOutboundCrossClusterSearchConnectionsRequest,
@@ -4446,7 +4445,7 @@ export const describePackages: API.PaginatedOperationMethod<
   DescribePackagesRequest,
   DescribePackagesResponse,
   DescribePackagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePackagesRequest,
@@ -4481,7 +4480,7 @@ export const describeReservedElasticsearchInstanceOfferings: API.PaginatedOperat
   DescribeReservedElasticsearchInstanceOfferingsRequest,
   DescribeReservedElasticsearchInstanceOfferingsResponse,
   DescribeReservedElasticsearchInstanceOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedElasticsearchInstanceOfferingsRequest,
@@ -4515,7 +4514,7 @@ export const describeReservedElasticsearchInstances: API.PaginatedOperationMetho
   DescribeReservedElasticsearchInstancesRequest,
   DescribeReservedElasticsearchInstancesResponse,
   DescribeReservedElasticsearchInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedElasticsearchInstancesRequest,
@@ -4549,7 +4548,7 @@ export const describeVpcEndpoints: API.OperationMethod<
   DescribeVpcEndpointsRequest,
   DescribeVpcEndpointsResponse,
   DescribeVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEndpointsRequest,
   output: DescribeVpcEndpointsResponse,
@@ -4579,7 +4578,7 @@ export const dissociatePackage: API.OperationMethod<
   DissociatePackageRequest,
   DissociatePackageResponse,
   DissociatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DissociatePackageRequest,
   output: DissociatePackageResponse,
@@ -4615,7 +4614,7 @@ export const getCompatibleElasticsearchVersions: API.OperationMethod<
   GetCompatibleElasticsearchVersionsRequest,
   GetCompatibleElasticsearchVersionsResponse,
   GetCompatibleElasticsearchVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCompatibleElasticsearchVersionsRequest,
   output: GetCompatibleElasticsearchVersionsResponse,
@@ -4645,7 +4644,7 @@ export const getPackageVersionHistory: API.PaginatedOperationMethod<
   GetPackageVersionHistoryRequest,
   GetPackageVersionHistoryResponse,
   GetPackageVersionHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPackageVersionHistoryRequest,
@@ -4681,7 +4680,7 @@ export const getUpgradeHistory: API.PaginatedOperationMethod<
   GetUpgradeHistoryRequest,
   GetUpgradeHistoryResponse,
   GetUpgradeHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUpgradeHistoryRequest,
@@ -4717,7 +4716,7 @@ export const getUpgradeStatus: API.OperationMethod<
   GetUpgradeStatusRequest,
   GetUpgradeStatusResponse,
   GetUpgradeStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUpgradeStatusRequest,
   output: GetUpgradeStatusResponse,
@@ -4744,7 +4743,7 @@ export const listDomainNames: API.OperationMethod<
   ListDomainNamesRequest,
   ListDomainNamesResponse,
   ListDomainNamesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDomainNamesRequest,
   output: ListDomainNamesResponse,
@@ -4768,7 +4767,7 @@ export const listDomainsForPackage: API.PaginatedOperationMethod<
   ListDomainsForPackageRequest,
   ListDomainsForPackageResponse,
   ListDomainsForPackageError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsForPackageRequest,
@@ -4803,7 +4802,7 @@ export const listElasticsearchInstanceTypes: API.PaginatedOperationMethod<
   ListElasticsearchInstanceTypesRequest,
   ListElasticsearchInstanceTypesResponse,
   ListElasticsearchInstanceTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListElasticsearchInstanceTypesRequest,
@@ -4837,7 +4836,7 @@ export const listElasticsearchVersions: API.PaginatedOperationMethod<
   ListElasticsearchVersionsRequest,
   ListElasticsearchVersionsResponse,
   ListElasticsearchVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListElasticsearchVersionsRequest,
@@ -4872,7 +4871,7 @@ export const listPackagesForDomain: API.PaginatedOperationMethod<
   ListPackagesForDomainRequest,
   ListPackagesForDomainResponse,
   ListPackagesForDomainError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagesForDomainRequest,
@@ -4907,7 +4906,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -4936,7 +4935,7 @@ export const listVpcEndpointAccess: API.OperationMethod<
   ListVpcEndpointAccessRequest,
   ListVpcEndpointAccessResponse,
   ListVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointAccessRequest,
   output: ListVpcEndpointAccessResponse,
@@ -4963,7 +4962,7 @@ export const listVpcEndpoints: API.OperationMethod<
   ListVpcEndpointsRequest,
   ListVpcEndpointsResponse,
   ListVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointsRequest,
   output: ListVpcEndpointsResponse,
@@ -4986,7 +4985,7 @@ export const listVpcEndpointsForDomain: API.OperationMethod<
   ListVpcEndpointsForDomainRequest,
   ListVpcEndpointsForDomainResponse,
   ListVpcEndpointsForDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointsForDomainRequest,
   output: ListVpcEndpointsForDomainResponse,
@@ -5016,7 +5015,7 @@ export const purchaseReservedElasticsearchInstanceOffering: API.OperationMethod<
   PurchaseReservedElasticsearchInstanceOfferingRequest,
   PurchaseReservedElasticsearchInstanceOfferingResponse,
   PurchaseReservedElasticsearchInstanceOfferingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedElasticsearchInstanceOfferingRequest,
   output: PurchaseReservedElasticsearchInstanceOfferingResponse,
@@ -5044,7 +5043,7 @@ export const rejectInboundCrossClusterSearchConnection: API.OperationMethod<
   RejectInboundCrossClusterSearchConnectionRequest,
   RejectInboundCrossClusterSearchConnectionResponse,
   RejectInboundCrossClusterSearchConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectInboundCrossClusterSearchConnectionRequest,
   output: RejectInboundCrossClusterSearchConnectionResponse,
@@ -5066,7 +5065,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsRequest,
   RemoveTagsResponse,
   RemoveTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsRequest,
   output: RemoveTagsResponse,
@@ -5091,7 +5090,7 @@ export const revokeVpcEndpointAccess: API.OperationMethod<
   RevokeVpcEndpointAccessRequest,
   RevokeVpcEndpointAccessResponse,
   RevokeVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeVpcEndpointAccessRequest,
   output: RevokeVpcEndpointAccessResponse,
@@ -5120,7 +5119,7 @@ export const startElasticsearchServiceSoftwareUpdate: API.OperationMethod<
   StartElasticsearchServiceSoftwareUpdateRequest,
   StartElasticsearchServiceSoftwareUpdateResponse,
   StartElasticsearchServiceSoftwareUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartElasticsearchServiceSoftwareUpdateRequest,
   output: StartElasticsearchServiceSoftwareUpdateResponse,
@@ -5150,7 +5149,7 @@ export const updateElasticsearchDomainConfig: API.OperationMethod<
   UpdateElasticsearchDomainConfigRequest,
   UpdateElasticsearchDomainConfigResponse,
   UpdateElasticsearchDomainConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateElasticsearchDomainConfigRequest,
   output: UpdateElasticsearchDomainConfigResponse,
@@ -5182,7 +5181,7 @@ export const updatePackage: API.OperationMethod<
   UpdatePackageRequest,
   UpdatePackageResponse,
   UpdatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageRequest,
   output: UpdatePackageResponse,
@@ -5214,7 +5213,7 @@ export const updateVpcEndpoint: API.OperationMethod<
   UpdateVpcEndpointRequest,
   UpdateVpcEndpointResponse,
   UpdateVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcEndpointRequest,
   output: UpdateVpcEndpointResponse,
@@ -5246,7 +5245,7 @@ export const upgradeElasticsearchDomain: API.OperationMethod<
   UpgradeElasticsearchDomainRequest,
   UpgradeElasticsearchDomainResponse,
   UpgradeElasticsearchDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeElasticsearchDomainRequest,
   output: UpgradeElasticsearchDomainResponse,

--- a/packages/aws/src/services/elementalinference.ts
+++ b/packages/aws/src/services/elementalinference.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ElementalInference",
   serviceShapeName: "ElementalInference",
@@ -922,7 +921,7 @@ export const associateFeed: API.OperationMethod<
   AssociateFeedRequest,
   AssociateFeedResponse,
   AssociateFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFeedRequest,
   output: AssociateFeedResponse,
@@ -955,7 +954,7 @@ export const createDictionary: API.OperationMethod<
   CreateDictionaryRequest,
   CreateDictionaryResponse,
   CreateDictionaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDictionaryRequest,
   output: CreateDictionaryResponse,
@@ -989,7 +988,7 @@ export const createFeed: API.OperationMethod<
   CreateFeedRequest,
   CreateFeedResponse,
   CreateFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFeedRequest,
   output: CreateFeedResponse,
@@ -1021,7 +1020,7 @@ export const deleteDictionary: API.OperationMethod<
   DeleteDictionaryRequest,
   DeleteDictionaryResponse,
   DeleteDictionaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDictionaryRequest,
   output: DeleteDictionaryResponse,
@@ -1053,7 +1052,7 @@ export const deleteFeed: API.OperationMethod<
   DeleteFeedRequest,
   DeleteFeedResponse,
   DeleteFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFeedRequest,
   output: DeleteFeedResponse,
@@ -1085,7 +1084,7 @@ export const disassociateFeed: API.OperationMethod<
   DisassociateFeedRequest,
   DisassociateFeedResponse,
   DisassociateFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFeedRequest,
   output: DisassociateFeedResponse,
@@ -1116,7 +1115,7 @@ export const exportDictionaryEntries: API.OperationMethod<
   ExportDictionaryEntriesRequest,
   ExportDictionaryEntriesResponse,
   ExportDictionaryEntriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportDictionaryEntriesRequest,
   output: ExportDictionaryEntriesResponse,
@@ -1146,7 +1145,7 @@ export const getDictionary: API.OperationMethod<
   GetDictionaryRequest,
   GetDictionaryResponse,
   GetDictionaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDictionaryRequest,
   output: GetDictionaryResponse,
@@ -1175,7 +1174,7 @@ export const getFeed: API.OperationMethod<
   GetFeedRequest,
   GetFeedResponse,
   GetFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFeedRequest,
   output: GetFeedResponse,
@@ -1203,7 +1202,7 @@ export const listDictionaries: API.PaginatedOperationMethod<
   ListDictionariesRequest,
   ListDictionariesResponse,
   ListDictionariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DictionarySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDictionariesRequest,
@@ -1239,7 +1238,7 @@ export const listFeeds: API.PaginatedOperationMethod<
   ListFeedsRequest,
   ListFeedsResponse,
   ListFeedsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FeedSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFeedsRequest,
@@ -1276,7 +1275,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1307,7 +1306,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1339,7 +1338,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1371,7 +1370,7 @@ export const updateDictionary: API.OperationMethod<
   UpdateDictionaryRequest,
   UpdateDictionaryResponse,
   UpdateDictionaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDictionaryRequest,
   output: UpdateDictionaryResponse,
@@ -1410,7 +1409,7 @@ export const updateFeed: API.OperationMethod<
   UpdateFeedRequest,
   UpdateFeedResponse,
   UpdateFeedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFeedRequest,
   output: UpdateFeedResponse,

--- a/packages/aws/src/services/emr-containers.ts
+++ b/packages/aws/src/services/emr-containers.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "EMR containers",
@@ -1678,7 +1677,7 @@ export const cancelJobRun: API.OperationMethod<
   CancelJobRunRequest,
   CancelJobRunResponse,
   CancelJobRunError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRunRequest,
   output: CancelJobRunResponse,
@@ -1708,7 +1707,7 @@ export const createJobTemplate: API.OperationMethod<
   CreateJobTemplateRequest,
   CreateJobTemplateResponse,
   CreateJobTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobTemplateRequest,
   output: CreateJobTemplateResponse,
@@ -1737,7 +1736,7 @@ export const createManagedEndpoint: API.OperationMethod<
   CreateManagedEndpointRequest,
   CreateManagedEndpointResponse,
   CreateManagedEndpointError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateManagedEndpointRequest,
   output: CreateManagedEndpointResponse,
@@ -1767,7 +1766,7 @@ export const createSecurityConfiguration: API.OperationMethod<
   CreateSecurityConfigurationRequest,
   CreateSecurityConfigurationResponse,
   CreateSecurityConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityConfigurationRequest,
   output: CreateSecurityConfigurationResponse,
@@ -1798,7 +1797,7 @@ export const createVirtualCluster: API.OperationMethod<
   CreateVirtualClusterRequest,
   CreateVirtualClusterResponse,
   CreateVirtualClusterError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualClusterRequest,
   output: CreateVirtualClusterResponse,
@@ -1829,7 +1828,7 @@ export const deleteJobTemplate: API.OperationMethod<
   DeleteJobTemplateRequest,
   DeleteJobTemplateResponse,
   DeleteJobTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobTemplateRequest,
   output: DeleteJobTemplateResponse,
@@ -1856,7 +1855,7 @@ export const deleteManagedEndpoint: API.OperationMethod<
   DeleteManagedEndpointRequest,
   DeleteManagedEndpointResponse,
   DeleteManagedEndpointError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteManagedEndpointRequest,
   output: DeleteManagedEndpointResponse,
@@ -1885,7 +1884,7 @@ export const deleteVirtualCluster: API.OperationMethod<
   DeleteVirtualClusterRequest,
   DeleteVirtualClusterResponse,
   DeleteVirtualClusterError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualClusterRequest,
   output: DeleteVirtualClusterResponse,
@@ -1913,7 +1912,7 @@ export const describeJobRun: API.OperationMethod<
   DescribeJobRunRequest,
   DescribeJobRunResponse,
   DescribeJobRunError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRunRequest,
   output: DescribeJobRunResponse,
@@ -1944,7 +1943,7 @@ export const describeJobTemplate: API.OperationMethod<
   DescribeJobTemplateRequest,
   DescribeJobTemplateResponse,
   DescribeJobTemplateError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobTemplateRequest,
   output: DescribeJobTemplateResponse,
@@ -1973,7 +1972,7 @@ export const describeManagedEndpoint: API.OperationMethod<
   DescribeManagedEndpointRequest,
   DescribeManagedEndpointResponse,
   DescribeManagedEndpointError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedEndpointRequest,
   output: DescribeManagedEndpointResponse,
@@ -2005,7 +2004,7 @@ export const describeSecurityConfiguration: API.OperationMethod<
   DescribeSecurityConfigurationRequest,
   DescribeSecurityConfigurationResponse,
   DescribeSecurityConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityConfigurationRequest,
   output: DescribeSecurityConfigurationResponse,
@@ -2038,7 +2037,7 @@ export const describeVirtualCluster: API.OperationMethod<
   DescribeVirtualClusterRequest,
   DescribeVirtualClusterResponse,
   DescribeVirtualClusterError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVirtualClusterRequest,
   output: DescribeVirtualClusterResponse,
@@ -2067,7 +2066,7 @@ export const getManagedEndpointSessionCredentials: API.OperationMethod<
   GetManagedEndpointSessionCredentialsRequest,
   GetManagedEndpointSessionCredentialsResponse,
   GetManagedEndpointSessionCredentialsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedEndpointSessionCredentialsRequest,
   output: GetManagedEndpointSessionCredentialsResponse,
@@ -2096,7 +2095,7 @@ export const listJobRuns: API.PaginatedOperationMethod<
   ListJobRunsRequest,
   ListJobRunsResponse,
   ListJobRunsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   JobRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunsRequest,
@@ -2132,7 +2131,7 @@ export const listJobTemplates: API.PaginatedOperationMethod<
   ListJobTemplatesRequest,
   ListJobTemplatesResponse,
   ListJobTemplatesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   JobTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobTemplatesRequest,
@@ -2166,7 +2165,7 @@ export const listManagedEndpoints: API.PaginatedOperationMethod<
   ListManagedEndpointsRequest,
   ListManagedEndpointsResponse,
   ListManagedEndpointsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Endpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedEndpointsRequest,
@@ -2203,7 +2202,7 @@ export const listSecurityConfigurations: API.PaginatedOperationMethod<
   ListSecurityConfigurationsRequest,
   ListSecurityConfigurationsResponse,
   ListSecurityConfigurationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityConfigurationsRequest,
@@ -2237,7 +2236,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2269,7 +2268,7 @@ export const listVirtualClusters: API.PaginatedOperationMethod<
   ListVirtualClustersRequest,
   ListVirtualClustersResponse,
   ListVirtualClustersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   VirtualCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualClustersRequest,
@@ -2304,7 +2303,7 @@ export const startJobRun: API.OperationMethod<
   StartJobRunRequest,
   StartJobRunResponse,
   StartJobRunError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRunRequest,
   output: StartJobRunResponse,
@@ -2341,7 +2340,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2371,7 +2370,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/emr-serverless.ts
+++ b/packages/aws/src/services/emr-serverless.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "EMR Serverless",
@@ -1756,7 +1755,7 @@ export const cancelJobRun: API.OperationMethod<
   CancelJobRunRequest,
   CancelJobRunResponse,
   CancelJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRunRequest,
   output: CancelJobRunResponse,
@@ -1783,7 +1782,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1810,7 +1809,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1836,7 +1835,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -1866,7 +1865,7 @@ export const getDashboardForJobRun: API.OperationMethod<
   GetDashboardForJobRunRequest,
   GetDashboardForJobRunResponse,
   GetDashboardForJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardForJobRunRequest,
   output: GetDashboardForJobRunResponse,
@@ -1892,7 +1891,7 @@ export const getJobRun: API.OperationMethod<
   GetJobRunRequest,
   GetJobRunResponse,
   GetJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRunRequest,
   output: GetJobRunResponse,
@@ -1922,7 +1921,7 @@ export const getResourceDashboard: API.OperationMethod<
   GetResourceDashboardRequest,
   GetResourceDashboardResponse,
   GetResourceDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceDashboardRequest,
   output: GetResourceDashboardResponse,
@@ -1948,7 +1947,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -1974,7 +1973,7 @@ export const getSessionEndpoint: API.OperationMethod<
   GetSessionEndpointRequest,
   GetSessionEndpointResponse,
   GetSessionEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionEndpointRequest,
   output: GetSessionEndpointResponse,
@@ -1999,7 +1998,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -2028,7 +2027,7 @@ export const listJobRunAttempts: API.PaginatedOperationMethod<
   ListJobRunAttemptsRequest,
   ListJobRunAttemptsResponse,
   ListJobRunAttemptsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobRunAttemptSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunAttemptsRequest,
@@ -2060,7 +2059,7 @@ export const listJobRuns: API.PaginatedOperationMethod<
   ListJobRunsRequest,
   ListJobRunsResponse,
   ListJobRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobRunsRequest,
@@ -2089,7 +2088,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -2122,7 +2121,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2149,7 +2148,7 @@ export const startApplication: API.OperationMethod<
   StartApplicationRequest,
   StartApplicationResponse,
   StartApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationRequest,
   output: StartApplicationResponse,
@@ -2177,7 +2176,7 @@ export const startJobRun: API.OperationMethod<
   StartJobRunRequest,
   StartJobRunResponse,
   StartJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRunRequest,
   output: StartJobRunResponse,
@@ -2206,7 +2205,7 @@ export const startSession: API.OperationMethod<
   StartSessionRequest,
   StartSessionResponse,
   StartSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionRequest,
   output: StartSessionResponse,
@@ -2234,7 +2233,7 @@ export const stopApplication: API.OperationMethod<
   StopApplicationRequest,
   StopApplicationResponse,
   StopApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopApplicationRequest,
   output: StopApplicationResponse,
@@ -2260,7 +2259,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2286,7 +2285,7 @@ export const terminateSession: API.OperationMethod<
   TerminateSessionRequest,
   TerminateSessionResponse,
   TerminateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateSessionRequest,
   output: TerminateSessionResponse,
@@ -2312,7 +2311,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2338,7 +2337,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,

--- a/packages/aws/src/services/emr.ts
+++ b/packages/aws/src/services/emr.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://elasticmapreduce.amazonaws.com/doc/2009-03-31",
@@ -5106,7 +5105,7 @@ export const addInstanceFleet: API.OperationMethod<
   AddInstanceFleetInput,
   AddInstanceFleetOutput,
   AddInstanceFleetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddInstanceFleetInput,
   output: AddInstanceFleetOutput,
@@ -5124,7 +5123,7 @@ export const addInstanceGroups: API.OperationMethod<
   AddInstanceGroupsInput,
   AddInstanceGroupsOutput,
   AddInstanceGroupsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddInstanceGroupsInput,
   output: AddInstanceGroupsOutput,
@@ -5163,7 +5162,7 @@ export const addJobFlowSteps: API.OperationMethod<
   AddJobFlowStepsInput,
   AddJobFlowStepsOutput,
   AddJobFlowStepsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddJobFlowStepsInput,
   output: AddJobFlowStepsOutput,
@@ -5188,7 +5187,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -5213,7 +5212,7 @@ export const cancelSteps: API.OperationMethod<
   CancelStepsInput,
   CancelStepsOutput,
   CancelStepsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelStepsInput,
   output: CancelStepsOutput,
@@ -5234,7 +5233,7 @@ export const createPersistentAppUI: API.OperationMethod<
   CreatePersistentAppUIInput,
   CreatePersistentAppUIOutput,
   CreatePersistentAppUIError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePersistentAppUIInput,
   output: CreatePersistentAppUIOutput,
@@ -5257,7 +5256,7 @@ export const createSecurityConfiguration: API.OperationMethod<
   CreateSecurityConfigurationInput,
   CreateSecurityConfigurationOutput,
   CreateSecurityConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityConfigurationInput,
   output: CreateSecurityConfigurationOutput,
@@ -5284,7 +5283,7 @@ export const createStudio: API.OperationMethod<
   CreateStudioInput,
   CreateStudioOutput,
   CreateStudioError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStudioInput,
   output: CreateStudioOutput,
@@ -5314,7 +5313,7 @@ export const createStudioSessionMapping: API.OperationMethod<
   CreateStudioSessionMappingInput,
   CreateStudioSessionMappingResponse,
   CreateStudioSessionMappingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStudioSessionMappingInput,
   output: CreateStudioSessionMappingResponse,
@@ -5336,7 +5335,7 @@ export const deleteSecurityConfiguration: API.OperationMethod<
   DeleteSecurityConfigurationInput,
   DeleteSecurityConfigurationOutput,
   DeleteSecurityConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityConfigurationInput,
   output: DeleteSecurityConfigurationOutput,
@@ -5362,7 +5361,7 @@ export const deleteStudio: API.OperationMethod<
   DeleteStudioInput,
   DeleteStudioResponse,
   DeleteStudioError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStudioInput,
   output: DeleteStudioResponse,
@@ -5383,7 +5382,7 @@ export const deleteStudioSessionMapping: API.OperationMethod<
   DeleteStudioSessionMappingInput,
   DeleteStudioSessionMappingResponse,
   DeleteStudioSessionMappingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStudioSessionMappingInput,
   output: DeleteStudioSessionMappingResponse,
@@ -5406,7 +5405,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterInput,
   DescribeClusterOutput,
   DescribeClusterError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterInput,
   output: DescribeClusterOutput,
@@ -5443,7 +5442,7 @@ export const describeJobFlows: API.OperationMethod<
   DescribeJobFlowsInput,
   DescribeJobFlowsOutput,
   DescribeJobFlowsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobFlowsInput,
   output: DescribeJobFlowsOutput,
@@ -5464,7 +5463,7 @@ export const describeNotebookExecution: API.OperationMethod<
   DescribeNotebookExecutionInput,
   DescribeNotebookExecutionOutput,
   DescribeNotebookExecutionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotebookExecutionInput,
   output: DescribeNotebookExecutionOutput,
@@ -5485,7 +5484,7 @@ export const describePersistentAppUI: API.OperationMethod<
   DescribePersistentAppUIInput,
   DescribePersistentAppUIOutput,
   DescribePersistentAppUIError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePersistentAppUIInput,
   output: DescribePersistentAppUIOutput,
@@ -5508,7 +5507,7 @@ export const describeReleaseLabel: API.OperationMethod<
   DescribeReleaseLabelInput,
   DescribeReleaseLabelOutput,
   DescribeReleaseLabelError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReleaseLabelInput,
   output: DescribeReleaseLabelOutput,
@@ -5531,7 +5530,7 @@ export const describeSecurityConfiguration: API.OperationMethod<
   DescribeSecurityConfigurationInput,
   DescribeSecurityConfigurationOutput,
   DescribeSecurityConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityConfigurationInput,
   output: DescribeSecurityConfigurationOutput,
@@ -5556,7 +5555,7 @@ export const describeStep: API.OperationMethod<
   DescribeStepInput,
   DescribeStepOutput,
   DescribeStepError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStepInput,
   output: DescribeStepOutput,
@@ -5579,7 +5578,7 @@ export const describeStudio: API.OperationMethod<
   DescribeStudioInput,
   DescribeStudioOutput,
   DescribeStudioError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStudioInput,
   output: DescribeStudioOutput,
@@ -5597,7 +5596,7 @@ export const getAutoTerminationPolicy: API.OperationMethod<
   GetAutoTerminationPolicyInput,
   GetAutoTerminationPolicyOutput,
   GetAutoTerminationPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoTerminationPolicyInput,
   output: GetAutoTerminationPolicyOutput,
@@ -5620,7 +5619,7 @@ export const getBlockPublicAccessConfiguration: API.OperationMethod<
   GetBlockPublicAccessConfigurationInput,
   GetBlockPublicAccessConfigurationOutput,
   GetBlockPublicAccessConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlockPublicAccessConfigurationInput,
   output: GetBlockPublicAccessConfigurationOutput,
@@ -5644,7 +5643,7 @@ export const getClusterSessionCredentials: API.OperationMethod<
   GetClusterSessionCredentialsInput,
   GetClusterSessionCredentialsOutput,
   GetClusterSessionCredentialsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterSessionCredentialsInput,
   output: GetClusterSessionCredentialsOutput,
@@ -5662,7 +5661,7 @@ export const getManagedScalingPolicy: API.OperationMethod<
   GetManagedScalingPolicyInput,
   GetManagedScalingPolicyOutput,
   GetManagedScalingPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedScalingPolicyInput,
   output: GetManagedScalingPolicyOutput,
@@ -5683,7 +5682,7 @@ export const getOnClusterAppUIPresignedURL: API.OperationMethod<
   GetOnClusterAppUIPresignedURLInput,
   GetOnClusterAppUIPresignedURLOutput,
   GetOnClusterAppUIPresignedURLError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOnClusterAppUIPresignedURLInput,
   output: GetOnClusterAppUIPresignedURLOutput,
@@ -5704,7 +5703,7 @@ export const getPersistentAppUIPresignedURL: API.OperationMethod<
   GetPersistentAppUIPresignedURLInput,
   GetPersistentAppUIPresignedURLOutput,
   GetPersistentAppUIPresignedURLError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPersistentAppUIPresignedURLInput,
   output: GetPersistentAppUIPresignedURLOutput,
@@ -5725,7 +5724,7 @@ export const getSession: API.OperationMethod<
   GetSessionInput,
   GetSessionOutput,
   GetSessionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionInput,
   output: GetSessionOutput,
@@ -5746,7 +5745,7 @@ export const getSessionEndpoint: API.OperationMethod<
   GetSessionEndpointInput,
   GetSessionEndpointOutput,
   GetSessionEndpointError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionEndpointInput,
   output: GetSessionEndpointOutput,
@@ -5768,7 +5767,7 @@ export const getStudioSessionMapping: API.OperationMethod<
   GetStudioSessionMappingInput,
   GetStudioSessionMappingOutput,
   GetStudioSessionMappingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStudioSessionMappingInput,
   output: GetStudioSessionMappingOutput,
@@ -5789,7 +5788,7 @@ export const listBootstrapActions: API.PaginatedOperationMethod<
   ListBootstrapActionsInput,
   ListBootstrapActionsOutput,
   ListBootstrapActionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Command
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBootstrapActionsInput,
@@ -5820,7 +5819,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersInput,
   ListClustersOutput,
   ListClustersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersInput,
@@ -5850,7 +5849,7 @@ export const listInstanceFleets: API.PaginatedOperationMethod<
   ListInstanceFleetsInput,
   ListInstanceFleetsOutput,
   ListInstanceFleetsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceFleet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceFleetsInput,
@@ -5877,7 +5876,7 @@ export const listInstanceGroups: API.PaginatedOperationMethod<
   ListInstanceGroupsInput,
   ListInstanceGroupsOutput,
   ListInstanceGroupsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceGroupsInput,
@@ -5907,7 +5906,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesInput,
   ListInstancesOutput,
   ListInstancesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Instance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesInput,
@@ -5937,7 +5936,7 @@ export const listNotebookExecutions: API.PaginatedOperationMethod<
   ListNotebookExecutionsInput,
   ListNotebookExecutionsOutput,
   ListNotebookExecutionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   NotebookExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotebookExecutionsInput,
@@ -5965,7 +5964,7 @@ export const listReleaseLabels: API.PaginatedOperationMethod<
   ListReleaseLabelsInput,
   ListReleaseLabelsOutput,
   ListReleaseLabelsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReleaseLabelsInput,
@@ -5995,7 +5994,7 @@ export const listSecurityConfigurations: API.PaginatedOperationMethod<
   ListSecurityConfigurationsInput,
   ListSecurityConfigurationsOutput,
   ListSecurityConfigurationsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SecurityConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityConfigurationsInput,
@@ -6022,7 +6021,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsInput,
   ListSessionsOutput,
   ListSessionsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Session
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsInput,
@@ -6054,7 +6053,7 @@ export const listSteps: API.PaginatedOperationMethod<
   ListStepsInput,
   ListStepsOutput,
   ListStepsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   StepSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStepsInput,
@@ -6082,7 +6081,7 @@ export const listStudios: API.PaginatedOperationMethod<
   ListStudiosInput,
   ListStudiosOutput,
   ListStudiosError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   StudioSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStudiosInput,
@@ -6110,7 +6109,7 @@ export const listStudioSessionMappings: API.PaginatedOperationMethod<
   ListStudioSessionMappingsInput,
   ListStudioSessionMappingsOutput,
   ListStudioSessionMappingsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   SessionMappingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStudioSessionMappingsInput,
@@ -6138,7 +6137,7 @@ export const listSupportedInstanceTypes: API.PaginatedOperationMethod<
   ListSupportedInstanceTypesInput,
   ListSupportedInstanceTypesOutput,
   ListSupportedInstanceTypesError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSupportedInstanceTypesInput,
@@ -6162,7 +6161,7 @@ export const modifyCluster: API.OperationMethod<
   ModifyClusterInput,
   ModifyClusterOutput,
   ModifyClusterError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterInput,
   output: ModifyClusterOutput,
@@ -6188,7 +6187,7 @@ export const modifyInstanceFleet: API.OperationMethod<
   ModifyInstanceFleetInput,
   ModifyInstanceFleetResponse,
   ModifyInstanceFleetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceFleetInput,
   output: ModifyInstanceFleetResponse,
@@ -6208,7 +6207,7 @@ export const modifyInstanceGroups: API.OperationMethod<
   ModifyInstanceGroupsInput,
   ModifyInstanceGroupsResponse,
   ModifyInstanceGroupsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyInstanceGroupsInput,
   output: ModifyInstanceGroupsResponse,
@@ -6229,7 +6228,7 @@ export const putAutoScalingPolicy: API.OperationMethod<
   PutAutoScalingPolicyInput,
   PutAutoScalingPolicyOutput,
   PutAutoScalingPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAutoScalingPolicyInput,
   output: PutAutoScalingPolicyOutput,
@@ -6254,7 +6253,7 @@ export const putAutoTerminationPolicy: API.OperationMethod<
   PutAutoTerminationPolicyInput,
   PutAutoTerminationPolicyOutput,
   PutAutoTerminationPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAutoTerminationPolicyInput,
   output: PutAutoTerminationPolicyOutput,
@@ -6278,7 +6277,7 @@ export const putBlockPublicAccessConfiguration: API.OperationMethod<
   PutBlockPublicAccessConfigurationInput,
   PutBlockPublicAccessConfigurationOutput,
   PutBlockPublicAccessConfigurationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBlockPublicAccessConfigurationInput,
   output: PutBlockPublicAccessConfigurationOutput,
@@ -6299,7 +6298,7 @@ export const putManagedScalingPolicy: API.OperationMethod<
   PutManagedScalingPolicyInput,
   PutManagedScalingPolicyOutput,
   PutManagedScalingPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutManagedScalingPolicyInput,
   output: PutManagedScalingPolicyOutput,
@@ -6317,7 +6316,7 @@ export const removeAutoScalingPolicy: API.OperationMethod<
   RemoveAutoScalingPolicyInput,
   RemoveAutoScalingPolicyOutput,
   RemoveAutoScalingPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAutoScalingPolicyInput,
   output: RemoveAutoScalingPolicyOutput,
@@ -6335,7 +6334,7 @@ export const removeAutoTerminationPolicy: API.OperationMethod<
   RemoveAutoTerminationPolicyInput,
   RemoveAutoTerminationPolicyOutput,
   RemoveAutoTerminationPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAutoTerminationPolicyInput,
   output: RemoveAutoTerminationPolicyOutput,
@@ -6353,7 +6352,7 @@ export const removeManagedScalingPolicy: API.OperationMethod<
   RemoveManagedScalingPolicyInput,
   RemoveManagedScalingPolicyOutput,
   RemoveManagedScalingPolicyError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveManagedScalingPolicyInput,
   output: RemoveManagedScalingPolicyOutput,
@@ -6379,7 +6378,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsInput,
   RemoveTagsOutput,
   RemoveTagsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsInput,
   output: RemoveTagsOutput,
@@ -6421,7 +6420,7 @@ export const runJobFlow: API.OperationMethod<
   RunJobFlowInput,
   RunJobFlowOutput,
   RunJobFlowError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunJobFlowInput,
   output: RunJobFlowOutput,
@@ -6445,7 +6444,7 @@ export const setKeepJobFlowAliveWhenNoSteps: API.OperationMethod<
   SetKeepJobFlowAliveWhenNoStepsInput,
   SetKeepJobFlowAliveWhenNoStepsResponse,
   SetKeepJobFlowAliveWhenNoStepsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetKeepJobFlowAliveWhenNoStepsInput,
   output: SetKeepJobFlowAliveWhenNoStepsResponse,
@@ -6484,7 +6483,7 @@ export const setTerminationProtection: API.OperationMethod<
   SetTerminationProtectionInput,
   SetTerminationProtectionResponse,
   SetTerminationProtectionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTerminationProtectionInput,
   output: SetTerminationProtectionResponse,
@@ -6517,7 +6516,7 @@ export const setUnhealthyNodeReplacement: API.OperationMethod<
   SetUnhealthyNodeReplacementInput,
   SetUnhealthyNodeReplacementResponse,
   SetUnhealthyNodeReplacementError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetUnhealthyNodeReplacementInput,
   output: SetUnhealthyNodeReplacementResponse,
@@ -6548,7 +6547,7 @@ export const setVisibleToAllUsers: API.OperationMethod<
   SetVisibleToAllUsersInput,
   SetVisibleToAllUsersResponse,
   SetVisibleToAllUsersError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetVisibleToAllUsersInput,
   output: SetVisibleToAllUsersResponse,
@@ -6569,7 +6568,7 @@ export const startNotebookExecution: API.OperationMethod<
   StartNotebookExecutionInput,
   StartNotebookExecutionOutput,
   StartNotebookExecutionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNotebookExecutionInput,
   output: StartNotebookExecutionOutput,
@@ -6590,7 +6589,7 @@ export const startSession: API.OperationMethod<
   StartSessionInput,
   StartSessionOutput,
   StartSessionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionInput,
   output: StartSessionOutput,
@@ -6611,7 +6610,7 @@ export const stopNotebookExecution: API.OperationMethod<
   StopNotebookExecutionInput,
   StopNotebookExecutionResponse,
   StopNotebookExecutionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopNotebookExecutionInput,
   output: StopNotebookExecutionResponse,
@@ -6639,7 +6638,7 @@ export const terminateJobFlows: API.OperationMethod<
   TerminateJobFlowsInput,
   TerminateJobFlowsResponse,
   TerminateJobFlowsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateJobFlowsInput,
   output: TerminateJobFlowsResponse,
@@ -6660,7 +6659,7 @@ export const terminateSession: API.OperationMethod<
   TerminateSessionInput,
   TerminateSessionOutput,
   TerminateSessionError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateSessionInput,
   output: TerminateSessionOutput,
@@ -6683,7 +6682,7 @@ export const updateStudio: API.OperationMethod<
   UpdateStudioInput,
   UpdateStudioResponse,
   UpdateStudioError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStudioInput,
   output: UpdateStudioResponse,
@@ -6704,7 +6703,7 @@ export const updateStudioSessionMapping: API.OperationMethod<
   UpdateStudioSessionMappingInput,
   UpdateStudioSessionMappingResponse,
   UpdateStudioSessionMappingError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStudioSessionMappingInput,
   output: UpdateStudioSessionMappingResponse,

--- a/packages/aws/src/services/entityresolution.ts
+++ b/packages/aws/src/services/entityresolution.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "EntityResolution",
   serviceShapeName: "AWSVeniceService",
@@ -2492,7 +2491,7 @@ export const addPolicyStatement: API.OperationMethod<
   AddPolicyStatementInput,
   AddPolicyStatementOutput,
   AddPolicyStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddPolicyStatementInput,
   output: AddPolicyStatementOutput,
@@ -2521,7 +2520,7 @@ export const batchDeleteUniqueId: API.OperationMethod<
   BatchDeleteUniqueIdInput,
   BatchDeleteUniqueIdOutput,
   BatchDeleteUniqueIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteUniqueIdInput,
   output: BatchDeleteUniqueIdOutput,
@@ -2552,7 +2551,7 @@ export const createIdMappingWorkflow: API.OperationMethod<
   CreateIdMappingWorkflowInput,
   CreateIdMappingWorkflowOutput,
   CreateIdMappingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdMappingWorkflowInput,
   output: CreateIdMappingWorkflowOutput,
@@ -2584,7 +2583,7 @@ export const createIdNamespace: API.OperationMethod<
   CreateIdNamespaceInput,
   CreateIdNamespaceOutput,
   CreateIdNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdNamespaceInput,
   output: CreateIdNamespaceOutput,
@@ -2618,7 +2617,7 @@ export const createMatchingWorkflow: API.OperationMethod<
   CreateMatchingWorkflowInput,
   CreateMatchingWorkflowOutput,
   CreateMatchingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMatchingWorkflowInput,
   output: CreateMatchingWorkflowOutput,
@@ -2650,7 +2649,7 @@ export const createSchemaMapping: API.OperationMethod<
   CreateSchemaMappingInput,
   CreateSchemaMappingOutput,
   CreateSchemaMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchemaMappingInput,
   output: CreateSchemaMappingOutput,
@@ -2681,7 +2680,7 @@ export const deleteIdMappingWorkflow: API.OperationMethod<
   DeleteIdMappingWorkflowInput,
   DeleteIdMappingWorkflowOutput,
   DeleteIdMappingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdMappingWorkflowInput,
   output: DeleteIdMappingWorkflowOutput,
@@ -2711,7 +2710,7 @@ export const deleteIdNamespace: API.OperationMethod<
   DeleteIdNamespaceInput,
   DeleteIdNamespaceOutput,
   DeleteIdNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdNamespaceInput,
   output: DeleteIdNamespaceOutput,
@@ -2741,7 +2740,7 @@ export const deleteMatchingWorkflow: API.OperationMethod<
   DeleteMatchingWorkflowInput,
   DeleteMatchingWorkflowOutput,
   DeleteMatchingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMatchingWorkflowInput,
   output: DeleteMatchingWorkflowOutput,
@@ -2772,7 +2771,7 @@ export const deletePolicyStatement: API.OperationMethod<
   DeletePolicyStatementInput,
   DeletePolicyStatementOutput,
   DeletePolicyStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyStatementInput,
   output: DeletePolicyStatementOutput,
@@ -2803,7 +2802,7 @@ export const deleteSchemaMapping: API.OperationMethod<
   DeleteSchemaMappingInput,
   DeleteSchemaMappingOutput,
   DeleteSchemaMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaMappingInput,
   output: DeleteSchemaMappingOutput,
@@ -2835,7 +2834,7 @@ export const generateMatchId: API.OperationMethod<
   GenerateMatchIdInput,
   GenerateMatchIdOutput,
   GenerateMatchIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMatchIdInput,
   output: GenerateMatchIdOutput,
@@ -2865,7 +2864,7 @@ export const getIdMappingJob: API.OperationMethod<
   GetIdMappingJobInput,
   GetIdMappingJobOutput,
   GetIdMappingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdMappingJobInput,
   output: GetIdMappingJobOutput,
@@ -2895,7 +2894,7 @@ export const getIdMappingWorkflow: API.OperationMethod<
   GetIdMappingWorkflowInput,
   GetIdMappingWorkflowOutput,
   GetIdMappingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdMappingWorkflowInput,
   output: GetIdMappingWorkflowOutput,
@@ -2925,7 +2924,7 @@ export const getIdNamespace: API.OperationMethod<
   GetIdNamespaceInput,
   GetIdNamespaceOutput,
   GetIdNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdNamespaceInput,
   output: GetIdNamespaceOutput,
@@ -2957,7 +2956,7 @@ export const getMatchId: API.OperationMethod<
   GetMatchIdInput,
   GetMatchIdOutput,
   GetMatchIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMatchIdInput,
   output: GetMatchIdOutput,
@@ -2987,7 +2986,7 @@ export const getMatchingJob: API.OperationMethod<
   GetMatchingJobInput,
   GetMatchingJobOutput,
   GetMatchingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMatchingJobInput,
   output: GetMatchingJobOutput,
@@ -3017,7 +3016,7 @@ export const getMatchingWorkflow: API.OperationMethod<
   GetMatchingWorkflowInput,
   GetMatchingWorkflowOutput,
   GetMatchingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMatchingWorkflowInput,
   output: GetMatchingWorkflowOutput,
@@ -3047,7 +3046,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyInput,
   GetPolicyOutput,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyInput,
   output: GetPolicyOutput,
@@ -3077,7 +3076,7 @@ export const getProviderService: API.OperationMethod<
   GetProviderServiceInput,
   GetProviderServiceOutput,
   GetProviderServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProviderServiceInput,
   output: GetProviderServiceOutput,
@@ -3107,7 +3106,7 @@ export const getSchemaMapping: API.OperationMethod<
   GetSchemaMappingInput,
   GetSchemaMappingOutput,
   GetSchemaMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaMappingInput,
   output: GetSchemaMappingOutput,
@@ -3137,7 +3136,7 @@ export const listIdMappingJobs: API.PaginatedOperationMethod<
   ListIdMappingJobsInput,
   ListIdMappingJobsOutput,
   ListIdMappingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdMappingJobsInput,
@@ -3173,7 +3172,7 @@ export const listIdMappingWorkflows: API.PaginatedOperationMethod<
   ListIdMappingWorkflowsInput,
   ListIdMappingWorkflowsOutput,
   ListIdMappingWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdMappingWorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdMappingWorkflowsInput,
@@ -3208,7 +3207,7 @@ export const listIdNamespaces: API.PaginatedOperationMethod<
   ListIdNamespacesInput,
   ListIdNamespacesOutput,
   ListIdNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdNamespaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdNamespacesInput,
@@ -3244,7 +3243,7 @@ export const listMatchingJobs: API.PaginatedOperationMethod<
   ListMatchingJobsInput,
   ListMatchingJobsOutput,
   ListMatchingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMatchingJobsInput,
@@ -3280,7 +3279,7 @@ export const listMatchingWorkflows: API.PaginatedOperationMethod<
   ListMatchingWorkflowsInput,
   ListMatchingWorkflowsOutput,
   ListMatchingWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MatchingWorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMatchingWorkflowsInput,
@@ -3315,7 +3314,7 @@ export const listProviderServices: API.PaginatedOperationMethod<
   ListProviderServicesInput,
   ListProviderServicesOutput,
   ListProviderServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProviderServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProviderServicesInput,
@@ -3350,7 +3349,7 @@ export const listSchemaMappings: API.PaginatedOperationMethod<
   ListSchemaMappingsInput,
   ListSchemaMappingsOutput,
   ListSchemaMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaMappingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemaMappingsInput,
@@ -3384,7 +3383,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -3413,7 +3412,7 @@ export const putPolicy: API.OperationMethod<
   PutPolicyInput,
   PutPolicyOutput,
   PutPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPolicyInput,
   output: PutPolicyOutput,
@@ -3446,7 +3445,7 @@ export const startIdMappingJob: API.OperationMethod<
   StartIdMappingJobInput,
   StartIdMappingJobOutput,
   StartIdMappingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartIdMappingJobInput,
   output: StartIdMappingJobOutput,
@@ -3480,7 +3479,7 @@ export const startMatchingJob: API.OperationMethod<
   StartMatchingJobInput,
   StartMatchingJobOutput,
   StartMatchingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMatchingJobInput,
   output: StartMatchingJobOutput,
@@ -3510,7 +3509,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -3535,7 +3534,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -3561,7 +3560,7 @@ export const updateIdMappingWorkflow: API.OperationMethod<
   UpdateIdMappingWorkflowInput,
   UpdateIdMappingWorkflowOutput,
   UpdateIdMappingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdMappingWorkflowInput,
   output: UpdateIdMappingWorkflowOutput,
@@ -3591,7 +3590,7 @@ export const updateIdNamespace: API.OperationMethod<
   UpdateIdNamespaceInput,
   UpdateIdNamespaceOutput,
   UpdateIdNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdNamespaceInput,
   output: UpdateIdNamespaceOutput,
@@ -3623,7 +3622,7 @@ export const updateMatchingWorkflow: API.OperationMethod<
   UpdateMatchingWorkflowInput,
   UpdateMatchingWorkflowOutput,
   UpdateMatchingWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMatchingWorkflowInput,
   output: UpdateMatchingWorkflowOutput,
@@ -3656,7 +3655,7 @@ export const updateSchemaMapping: API.OperationMethod<
   UpdateSchemaMappingInput,
   UpdateSchemaMappingOutput,
   UpdateSchemaMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSchemaMappingInput,
   output: UpdateSchemaMappingOutput,

--- a/packages/aws/src/services/eventbridge.ts
+++ b/packages/aws/src/services/eventbridge.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://events.amazonaws.com/doc/2015-10-07");
 const svc = T.AwsApiService({
@@ -3712,7 +3711,7 @@ export const activateEventSource: API.OperationMethod<
   ActivateEventSourceRequest,
   ActivateEventSourceResponse,
   ActivateEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateEventSourceRequest,
   output: ActivateEventSourceResponse,
@@ -3741,7 +3740,7 @@ export const cancelReplay: API.OperationMethod<
   CancelReplayRequest,
   CancelReplayResponse,
   CancelReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelReplayRequest,
   output: CancelReplayResponse,
@@ -3776,7 +3775,7 @@ export const createApiDestination: API.OperationMethod<
   CreateApiDestinationRequest,
   CreateApiDestinationResponse,
   CreateApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApiDestinationRequest,
   output: CreateApiDestinationResponse,
@@ -3815,7 +3814,7 @@ export const createArchive: API.OperationMethod<
   CreateArchiveRequest,
   CreateArchiveResponse,
   CreateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateArchiveRequest,
   output: CreateArchiveResponse,
@@ -3850,7 +3849,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -3884,7 +3883,7 @@ export const createEndpoint: API.OperationMethod<
   CreateEndpointRequest,
   CreateEndpointResponse,
   CreateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointRequest,
   output: CreateEndpointResponse,
@@ -3916,7 +3915,7 @@ export const createEventBus: API.OperationMethod<
   CreateEventBusRequest,
   CreateEventBusResponse,
   CreateEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventBusRequest,
   output: CreateEventBusResponse,
@@ -3982,7 +3981,7 @@ export const createPartnerEventSource: API.OperationMethod<
   CreatePartnerEventSourceRequest,
   CreatePartnerEventSourceResponse,
   CreatePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerEventSourceRequest,
   output: CreatePartnerEventSourceResponse,
@@ -4018,7 +4017,7 @@ export const deactivateEventSource: API.OperationMethod<
   DeactivateEventSourceRequest,
   DeactivateEventSourceResponse,
   DeactivateEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateEventSourceRequest,
   output: DeactivateEventSourceResponse,
@@ -4047,7 +4046,7 @@ export const deauthorizeConnection: API.OperationMethod<
   DeauthorizeConnectionRequest,
   DeauthorizeConnectionResponse,
   DeauthorizeConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeauthorizeConnectionRequest,
   output: DeauthorizeConnectionResponse,
@@ -4073,7 +4072,7 @@ export const deleteApiDestination: API.OperationMethod<
   DeleteApiDestinationRequest,
   DeleteApiDestinationResponse,
   DeleteApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApiDestinationRequest,
   output: DeleteApiDestinationResponse,
@@ -4099,7 +4098,7 @@ export const deleteArchive: API.OperationMethod<
   DeleteArchiveRequest,
   DeleteArchiveResponse,
   DeleteArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArchiveRequest,
   output: DeleteArchiveResponse,
@@ -4125,7 +4124,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -4155,7 +4154,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointRequest,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointRequest,
   output: DeleteEndpointResponse,
@@ -4183,7 +4182,7 @@ export const deleteEventBus: API.OperationMethod<
   DeleteEventBusRequest,
   DeleteEventBusResponse,
   DeleteEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventBusRequest,
   output: DeleteEventBusResponse,
@@ -4214,7 +4213,7 @@ export const deletePartnerEventSource: API.OperationMethod<
   DeletePartnerEventSourceRequest,
   DeletePartnerEventSourceResponse,
   DeletePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartnerEventSourceRequest,
   output: DeletePartnerEventSourceResponse,
@@ -4256,7 +4255,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -4282,7 +4281,7 @@ export const describeApiDestination: API.OperationMethod<
   DescribeApiDestinationRequest,
   DescribeApiDestinationResponse,
   DescribeApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApiDestinationRequest,
   output: DescribeApiDestinationResponse,
@@ -4304,7 +4303,7 @@ export const describeArchive: API.OperationMethod<
   DescribeArchiveRequest,
   DescribeArchiveResponse,
   DescribeArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeArchiveRequest,
   output: DescribeArchiveResponse,
@@ -4329,7 +4328,7 @@ export const describeConnection: API.OperationMethod<
   DescribeConnectionRequest,
   DescribeConnectionResponse,
   DescribeConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionRequest,
   output: DescribeConnectionResponse,
@@ -4355,7 +4354,7 @@ export const describeEndpoint: API.OperationMethod<
   DescribeEndpointRequest,
   DescribeEndpointResponse,
   DescribeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointRequest,
   output: DescribeEndpointResponse,
@@ -4383,7 +4382,7 @@ export const describeEventBus: API.OperationMethod<
   DescribeEventBusRequest,
   DescribeEventBusResponse,
   DescribeEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventBusRequest,
   output: DescribeEventBusResponse,
@@ -4406,7 +4405,7 @@ export const describeEventSource: API.OperationMethod<
   DescribeEventSourceRequest,
   DescribeEventSourceResponse,
   DescribeEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventSourceRequest,
   output: DescribeEventSourceResponse,
@@ -4434,7 +4433,7 @@ export const describePartnerEventSource: API.OperationMethod<
   DescribePartnerEventSourceRequest,
   DescribePartnerEventSourceResponse,
   DescribePartnerEventSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePartnerEventSourceRequest,
   output: DescribePartnerEventSourceResponse,
@@ -4467,7 +4466,7 @@ export const describeReplay: API.OperationMethod<
   DescribeReplayRequest,
   DescribeReplayResponse,
   DescribeReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReplayRequest,
   output: DescribeReplayResponse,
@@ -4491,7 +4490,7 @@ export const describeRule: API.OperationMethod<
   DescribeRuleRequest,
   DescribeRuleResponse,
   DescribeRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleRequest,
   output: DescribeRuleResponse,
@@ -4518,7 +4517,7 @@ export const disableRule: API.OperationMethod<
   DisableRuleRequest,
   DisableRuleResponse,
   DisableRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRuleRequest,
   output: DisableRuleResponse,
@@ -4549,7 +4548,7 @@ export const enableRule: API.OperationMethod<
   EnableRuleRequest,
   EnableRuleResponse,
   EnableRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRuleRequest,
   output: EnableRuleResponse,
@@ -4572,7 +4571,7 @@ export const listApiDestinations: API.OperationMethod<
   ListApiDestinationsRequest,
   ListApiDestinationsResponse,
   ListApiDestinationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListApiDestinationsRequest,
   output: ListApiDestinationsResponse,
@@ -4594,7 +4593,7 @@ export const listArchives: API.OperationMethod<
   ListArchivesRequest,
   ListArchivesResponse,
   ListArchivesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListArchivesRequest,
   output: ListArchivesResponse,
@@ -4612,7 +4611,7 @@ export const listConnections: API.OperationMethod<
   ListConnectionsRequest,
   ListConnectionsResponse,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectionsRequest,
   output: ListConnectionsResponse,
@@ -4635,7 +4634,7 @@ export const listEndpoints: API.OperationMethod<
   ListEndpointsRequest,
   ListEndpointsResponse,
   ListEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEndpointsRequest,
   output: ListEndpointsResponse,
@@ -4654,7 +4653,7 @@ export const listEventBuses: API.OperationMethod<
   ListEventBusesRequest,
   ListEventBusesResponse,
   ListEventBusesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEventBusesRequest,
   output: ListEventBusesResponse,
@@ -4676,7 +4675,7 @@ export const listEventSources: API.OperationMethod<
   ListEventSourcesRequest,
   ListEventSourcesResponse,
   ListEventSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEventSourcesRequest,
   output: ListEventSourcesResponse,
@@ -4699,7 +4698,7 @@ export const listPartnerEventSourceAccounts: API.OperationMethod<
   ListPartnerEventSourceAccountsRequest,
   ListPartnerEventSourceAccountsResponse,
   ListPartnerEventSourceAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPartnerEventSourceAccountsRequest,
   output: ListPartnerEventSourceAccountsResponse,
@@ -4725,7 +4724,7 @@ export const listPartnerEventSources: API.OperationMethod<
   ListPartnerEventSourcesRequest,
   ListPartnerEventSourcesResponse,
   ListPartnerEventSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPartnerEventSourcesRequest,
   output: ListPartnerEventSourcesResponse,
@@ -4744,7 +4743,7 @@ export const listReplays: API.OperationMethod<
   ListReplaysRequest,
   ListReplaysResponse,
   ListReplaysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReplaysRequest,
   output: ListReplaysResponse,
@@ -4768,7 +4767,7 @@ export const listRuleNamesByTarget: API.OperationMethod<
   ListRuleNamesByTargetRequest,
   ListRuleNamesByTargetResponse,
   ListRuleNamesByTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleNamesByTargetRequest,
   output: ListRuleNamesByTargetResponse,
@@ -4795,7 +4794,7 @@ export const listRules: API.OperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRulesRequest,
   output: ListRulesResponse,
@@ -4818,7 +4817,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4841,7 +4840,7 @@ export const listTargetsByRule: API.OperationMethod<
   ListTargetsByRuleRequest,
   ListTargetsByRuleResponse,
   ListTargetsByRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTargetsByRuleRequest,
   output: ListTargetsByRuleResponse,
@@ -4872,7 +4871,7 @@ export const putEvents: API.OperationMethod<
   PutEventsRequest,
   PutEventsResponse,
   PutEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventsRequest,
   output: PutEventsResponse,
@@ -4896,7 +4895,7 @@ export const putPartnerEvents: API.OperationMethod<
   PutPartnerEventsRequest,
   PutPartnerEventsResponse,
   PutPartnerEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPartnerEventsRequest,
   output: PutPartnerEventsResponse,
@@ -4939,7 +4938,7 @@ export const putPermission: API.OperationMethod<
   PutPermissionRequest,
   PutPermissionResponse,
   PutPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionRequest,
   output: PutPermissionResponse,
@@ -5022,7 +5021,7 @@ export const putRule: API.OperationMethod<
   PutRuleRequest,
   PutRuleResponse,
   PutRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRuleRequest,
   output: PutRuleResponse,
@@ -5150,7 +5149,7 @@ export const putTargets: API.OperationMethod<
   PutTargetsRequest,
   PutTargetsResponse,
   PutTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTargetsRequest,
   output: PutTargetsResponse,
@@ -5182,7 +5181,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionRequest,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionRequest,
   output: RemovePermissionResponse,
@@ -5223,7 +5222,7 @@ export const removeTargets: API.OperationMethod<
   RemoveTargetsRequest,
   RemoveTargetsResponse,
   RemoveTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTargetsRequest,
   output: RemoveTargetsResponse,
@@ -5260,7 +5259,7 @@ export const startReplay: API.OperationMethod<
   StartReplayRequest,
   StartReplayResponse,
   StartReplayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplayRequest,
   output: StartReplayResponse,
@@ -5303,7 +5302,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5335,7 +5334,7 @@ export const testEventPattern: API.OperationMethod<
   TestEventPatternRequest,
   TestEventPatternResponse,
   TestEventPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestEventPatternRequest,
   output: TestEventPatternResponse,
@@ -5359,7 +5358,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5388,7 +5387,7 @@ export const updateApiDestination: API.OperationMethod<
   UpdateApiDestinationRequest,
   UpdateApiDestinationResponse,
   UpdateApiDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApiDestinationRequest,
   output: UpdateApiDestinationResponse,
@@ -5417,7 +5416,7 @@ export const updateArchive: API.OperationMethod<
   UpdateArchiveRequest,
   UpdateArchiveResponse,
   UpdateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateArchiveRequest,
   output: UpdateArchiveResponse,
@@ -5448,7 +5447,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   UpdateConnectionResponse,
   UpdateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: UpdateConnectionResponse,
@@ -5481,7 +5480,7 @@ export const updateEndpoint: API.OperationMethod<
   UpdateEndpointRequest,
   UpdateEndpointResponse,
   UpdateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointRequest,
   output: UpdateEndpointResponse,
@@ -5508,7 +5507,7 @@ export const updateEventBus: API.OperationMethod<
   UpdateEventBusRequest,
   UpdateEventBusResponse,
   UpdateEventBusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventBusRequest,
   output: UpdateEventBusResponse,

--- a/packages/aws/src/services/evs.ts
+++ b/packages/aws/src/services/evs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "evs",
@@ -1304,7 +1303,7 @@ export const associateEipToVlan: API.OperationMethod<
   AssociateEipToVlanRequest,
   AssociateEipToVlanResponse,
   AssociateEipToVlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEipToVlanRequest,
   output: AssociateEipToVlanResponse,
@@ -1326,7 +1325,7 @@ export const createEntitlement: API.OperationMethod<
   CreateEntitlementRequest,
   CreateEntitlementResponse,
   CreateEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEntitlementRequest,
   output: CreateEntitlementResponse,
@@ -1352,7 +1351,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   CreateEnvironmentResponse,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: CreateEnvironmentResponse,
@@ -1378,7 +1377,7 @@ export const createEnvironmentConnector: API.OperationMethod<
   CreateEnvironmentConnectorRequest,
   CreateEnvironmentConnectorResponse,
   CreateEnvironmentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentConnectorRequest,
   output: CreateEnvironmentConnectorResponse,
@@ -1409,7 +1408,7 @@ export const createEnvironmentHost: API.OperationMethod<
   CreateEnvironmentHostRequest,
   CreateEnvironmentHostResponse,
   CreateEnvironmentHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentHostRequest,
   output: CreateEnvironmentHostResponse,
@@ -1431,7 +1430,7 @@ export const deleteEntitlement: API.OperationMethod<
   DeleteEntitlementRequest,
   DeleteEntitlementResponse,
   DeleteEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEntitlementRequest,
   output: DeleteEntitlementResponse,
@@ -1456,7 +1455,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -1480,7 +1479,7 @@ export const deleteEnvironmentConnector: API.OperationMethod<
   DeleteEnvironmentConnectorRequest,
   DeleteEnvironmentConnectorResponse,
   DeleteEnvironmentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentConnectorRequest,
   output: DeleteEnvironmentConnectorResponse,
@@ -1503,7 +1502,7 @@ export const deleteEnvironmentHost: API.OperationMethod<
   DeleteEnvironmentHostRequest,
   DeleteEnvironmentHostResponse,
   DeleteEnvironmentHostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentHostRequest,
   output: DeleteEnvironmentHostResponse,
@@ -1525,7 +1524,7 @@ export const disassociateEipFromVlan: API.OperationMethod<
   DisassociateEipFromVlanRequest,
   DisassociateEipFromVlanResponse,
   DisassociateEipFromVlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEipFromVlanRequest,
   output: DisassociateEipFromVlanResponse,
@@ -1549,7 +1548,7 @@ export const getDepotUrl: API.OperationMethod<
   GetDepotUrlRequest,
   GetDepotUrlResponse,
   GetDepotUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDepotUrlRequest,
   output: GetDepotUrlResponse,
@@ -1570,7 +1569,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -1591,7 +1590,7 @@ export const getVersions: API.OperationMethod<
   GetVersionsRequest,
   GetVersionsResponse,
   GetVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVersionsRequest,
   output: GetVersionsResponse,
@@ -1612,7 +1611,7 @@ export const listEnvironmentConnectors: API.PaginatedOperationMethod<
   ListEnvironmentConnectorsRequest,
   ListEnvironmentConnectorsResponse,
   ListEnvironmentConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Connector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentConnectorsRequest,
@@ -1640,7 +1639,7 @@ export const listEnvironmentHosts: API.PaginatedOperationMethod<
   ListEnvironmentHostsRequest,
   ListEnvironmentHostsResponse,
   ListEnvironmentHostsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Host
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentHostsRequest,
@@ -1665,7 +1664,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -1693,7 +1692,7 @@ export const listEnvironmentVlans: API.PaginatedOperationMethod<
   ListEnvironmentVlansRequest,
   ListEnvironmentVlansResponse,
   ListEnvironmentVlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Vlan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentVlansRequest,
@@ -1718,7 +1717,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1739,7 +1738,7 @@ export const listVmEntitlements: API.PaginatedOperationMethod<
   ListVmEntitlementsRequest,
   ListVmEntitlementsResponse,
   ListVmEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VmEntitlement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVmEntitlementsRequest,
@@ -1769,7 +1768,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1795,7 +1794,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1819,7 +1818,7 @@ export const updateEnvironmentConnector: API.OperationMethod<
   UpdateEnvironmentConnectorRequest,
   UpdateEnvironmentConnectorResponse,
   UpdateEnvironmentConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentConnectorRequest,
   output: UpdateEnvironmentConnectorResponse,

--- a/packages/aws/src/services/finspace-data.ts
+++ b/packages/aws/src/services/finspace-data.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "finspace data",
@@ -1829,7 +1828,7 @@ export const associateUserToPermissionGroup: API.OperationMethod<
   AssociateUserToPermissionGroupRequest,
   AssociateUserToPermissionGroupResponse,
   AssociateUserToPermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateUserToPermissionGroupRequest,
   output: AssociateUserToPermissionGroupResponse,
@@ -1862,7 +1861,7 @@ export const createChangeset: API.OperationMethod<
   CreateChangesetRequest,
   CreateChangesetResponse,
   CreateChangesetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChangesetRequest,
   output: CreateChangesetResponse,
@@ -1896,7 +1895,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -1929,7 +1928,7 @@ export const createDataView: API.OperationMethod<
   CreateDataViewRequest,
   CreateDataViewResponse,
   CreateDataViewError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataViewRequest,
   output: CreateDataViewResponse,
@@ -1961,7 +1960,7 @@ export const createPermissionGroup: API.OperationMethod<
   CreatePermissionGroupRequest,
   CreatePermissionGroupResponse,
   CreatePermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePermissionGroupRequest,
   output: CreatePermissionGroupResponse,
@@ -1993,7 +1992,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -2026,7 +2025,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -2060,7 +2059,7 @@ export const deletePermissionGroup: API.OperationMethod<
   DeletePermissionGroupRequest,
   DeletePermissionGroupResponse,
   DeletePermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionGroupRequest,
   output: DeletePermissionGroupResponse,
@@ -2093,7 +2092,7 @@ export const disableUser: API.OperationMethod<
   DisableUserRequest,
   DisableUserResponse,
   DisableUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableUserRequest,
   output: DisableUserResponse,
@@ -2125,7 +2124,7 @@ export const disassociateUserFromPermissionGroup: API.OperationMethod<
   DisassociateUserFromPermissionGroupRequest,
   DisassociateUserFromPermissionGroupResponse,
   DisassociateUserFromPermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateUserFromPermissionGroupRequest,
   output: DisassociateUserFromPermissionGroupResponse,
@@ -2158,7 +2157,7 @@ export const enableUser: API.OperationMethod<
   EnableUserRequest,
   EnableUserResponse,
   EnableUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableUserRequest,
   output: EnableUserResponse,
@@ -2191,7 +2190,7 @@ export const getChangeset: API.OperationMethod<
   GetChangesetRequest,
   GetChangesetResponse,
   GetChangesetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangesetRequest,
   output: GetChangesetResponse,
@@ -2223,7 +2222,7 @@ export const getDataset: API.OperationMethod<
   GetDatasetRequest,
   GetDatasetResponse,
   GetDatasetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatasetRequest,
   output: GetDatasetResponse,
@@ -2254,7 +2253,7 @@ export const getDataView: API.OperationMethod<
   GetDataViewRequest,
   GetDataViewResponse,
   GetDataViewError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataViewRequest,
   output: GetDataViewResponse,
@@ -2288,7 +2287,7 @@ export const getExternalDataViewAccessDetails: API.OperationMethod<
   GetExternalDataViewAccessDetailsRequest,
   GetExternalDataViewAccessDetailsResponse,
   GetExternalDataViewAccessDetailsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExternalDataViewAccessDetailsRequest,
   output: GetExternalDataViewAccessDetailsResponse,
@@ -2318,7 +2317,7 @@ export const getPermissionGroup: API.OperationMethod<
   GetPermissionGroupRequest,
   GetPermissionGroupResponse,
   GetPermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionGroupRequest,
   output: GetPermissionGroupResponse,
@@ -2347,7 +2346,7 @@ export const getProgrammaticAccessCredentials: API.OperationMethod<
   GetProgrammaticAccessCredentialsRequest,
   GetProgrammaticAccessCredentialsResponse,
   GetProgrammaticAccessCredentialsError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProgrammaticAccessCredentialsRequest,
   output: GetProgrammaticAccessCredentialsResponse,
@@ -2376,7 +2375,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -2406,7 +2405,7 @@ export const getWorkingLocation: API.OperationMethod<
   GetWorkingLocationRequest,
   GetWorkingLocationResponse,
   GetWorkingLocationError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkingLocationRequest,
   output: GetWorkingLocationResponse,
@@ -2436,7 +2435,7 @@ export const listChangesets: API.PaginatedOperationMethod<
   ListChangesetsRequest,
   ListChangesetsResponse,
   ListChangesetsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ChangesetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChangesetsRequest,
@@ -2474,7 +2473,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Dataset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -2511,7 +2510,7 @@ export const listDataViews: API.PaginatedOperationMethod<
   ListDataViewsRequest,
   ListDataViewsResponse,
   ListDataViewsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DataViewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataViewsRequest,
@@ -2547,7 +2546,7 @@ export const listPermissionGroups: API.PaginatedOperationMethod<
   ListPermissionGroupsRequest,
   ListPermissionGroupsResponse,
   ListPermissionGroupsError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PermissionGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionGroupsRequest,
@@ -2583,7 +2582,7 @@ export const listPermissionGroupsByUser: API.OperationMethod<
   ListPermissionGroupsByUserRequest,
   ListPermissionGroupsByUserResponse,
   ListPermissionGroupsByUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPermissionGroupsByUserRequest,
   output: ListPermissionGroupsByUserResponse,
@@ -2612,7 +2611,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Creds | Region | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -2648,7 +2647,7 @@ export const listUsersByPermissionGroup: API.OperationMethod<
   ListUsersByPermissionGroupRequest,
   ListUsersByPermissionGroupResponse,
   ListUsersByPermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUsersByPermissionGroupRequest,
   output: ListUsersByPermissionGroupResponse,
@@ -2679,7 +2678,7 @@ export const resetUserPassword: API.OperationMethod<
   ResetUserPasswordRequest,
   ResetUserPasswordResponse,
   ResetUserPasswordError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetUserPasswordRequest,
   output: ResetUserPasswordResponse,
@@ -2711,7 +2710,7 @@ export const updateChangeset: API.OperationMethod<
   UpdateChangesetRequest,
   UpdateChangesetResponse,
   UpdateChangesetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChangesetRequest,
   output: UpdateChangesetResponse,
@@ -2743,7 +2742,7 @@ export const updateDataset: API.OperationMethod<
   UpdateDatasetRequest,
   UpdateDatasetResponse,
   UpdateDatasetError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetRequest,
   output: UpdateDatasetResponse,
@@ -2775,7 +2774,7 @@ export const updatePermissionGroup: API.OperationMethod<
   UpdatePermissionGroupRequest,
   UpdatePermissionGroupResponse,
   UpdatePermissionGroupError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePermissionGroupRequest,
   output: UpdatePermissionGroupResponse,
@@ -2807,7 +2806,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/finspace.ts
+++ b/packages/aws/src/services/finspace.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "finspace",
@@ -3493,7 +3492,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   CreateEnvironmentResponse,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: CreateEnvironmentResponse,
@@ -3526,7 +3525,7 @@ export const createKxChangeset: API.OperationMethod<
   CreateKxChangesetRequest,
   CreateKxChangesetResponse,
   CreateKxChangesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxChangesetRequest,
   output: CreateKxChangesetResponse,
@@ -3560,7 +3559,7 @@ export const createKxCluster: API.OperationMethod<
   CreateKxClusterRequest,
   CreateKxClusterResponse,
   CreateKxClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxClusterRequest,
   output: CreateKxClusterResponse,
@@ -3595,7 +3594,7 @@ export const createKxDatabase: API.OperationMethod<
   CreateKxDatabaseRequest,
   CreateKxDatabaseResponse,
   CreateKxDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxDatabaseRequest,
   output: CreateKxDatabaseResponse,
@@ -3631,7 +3630,7 @@ export const createKxDataview: API.OperationMethod<
   CreateKxDataviewRequest,
   CreateKxDataviewResponse,
   CreateKxDataviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxDataviewRequest,
   output: CreateKxDataviewResponse,
@@ -3666,7 +3665,7 @@ export const createKxEnvironment: API.OperationMethod<
   CreateKxEnvironmentRequest,
   CreateKxEnvironmentResponse,
   CreateKxEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxEnvironmentRequest,
   output: CreateKxEnvironmentResponse,
@@ -3700,7 +3699,7 @@ export const createKxScalingGroup: API.OperationMethod<
   CreateKxScalingGroupRequest,
   CreateKxScalingGroupResponse,
   CreateKxScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxScalingGroupRequest,
   output: CreateKxScalingGroupResponse,
@@ -3735,7 +3734,7 @@ export const createKxUser: API.OperationMethod<
   CreateKxUserRequest,
   CreateKxUserResponse,
   CreateKxUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxUserRequest,
   output: CreateKxUserResponse,
@@ -3771,7 +3770,7 @@ export const createKxVolume: API.OperationMethod<
   CreateKxVolumeRequest,
   CreateKxVolumeResponse,
   CreateKxVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKxVolumeRequest,
   output: CreateKxVolumeResponse,
@@ -3804,7 +3803,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -3836,7 +3835,7 @@ export const deleteKxCluster: API.OperationMethod<
   DeleteKxClusterRequest,
   DeleteKxClusterResponse,
   DeleteKxClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxClusterRequest,
   output: DeleteKxClusterResponse,
@@ -3868,7 +3867,7 @@ export const deleteKxClusterNode: API.OperationMethod<
   DeleteKxClusterNodeRequest,
   DeleteKxClusterNodeResponse,
   DeleteKxClusterNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxClusterNodeRequest,
   output: DeleteKxClusterNodeResponse,
@@ -3899,7 +3898,7 @@ export const deleteKxDatabase: API.OperationMethod<
   DeleteKxDatabaseRequest,
   DeleteKxDatabaseResponse,
   DeleteKxDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxDatabaseRequest,
   output: DeleteKxDatabaseResponse,
@@ -3931,7 +3930,7 @@ export const deleteKxDataview: API.OperationMethod<
   DeleteKxDataviewRequest,
   DeleteKxDataviewResponse,
   DeleteKxDataviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxDataviewRequest,
   output: DeleteKxDataviewResponse,
@@ -3963,7 +3962,7 @@ export const deleteKxEnvironment: API.OperationMethod<
   DeleteKxEnvironmentRequest,
   DeleteKxEnvironmentResponse,
   DeleteKxEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxEnvironmentRequest,
   output: DeleteKxEnvironmentResponse,
@@ -3996,7 +3995,7 @@ export const deleteKxScalingGroup: API.OperationMethod<
   DeleteKxScalingGroupRequest,
   DeleteKxScalingGroupResponse,
   DeleteKxScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxScalingGroupRequest,
   output: DeleteKxScalingGroupResponse,
@@ -4029,7 +4028,7 @@ export const deleteKxUser: API.OperationMethod<
   DeleteKxUserRequest,
   DeleteKxUserResponse,
   DeleteKxUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxUserRequest,
   output: DeleteKxUserResponse,
@@ -4062,7 +4061,7 @@ export const deleteKxVolume: API.OperationMethod<
   DeleteKxVolumeRequest,
   DeleteKxVolumeResponse,
   DeleteKxVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKxVolumeRequest,
   output: DeleteKxVolumeResponse,
@@ -4093,7 +4092,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -4122,7 +4121,7 @@ export const getKxChangeset: API.OperationMethod<
   GetKxChangesetRequest,
   GetKxChangesetResponse,
   GetKxChangesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxChangesetRequest,
   output: GetKxChangesetResponse,
@@ -4154,7 +4153,7 @@ export const getKxCluster: API.OperationMethod<
   GetKxClusterRequest,
   GetKxClusterResponse,
   GetKxClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxClusterRequest,
   output: GetKxClusterResponse,
@@ -4186,7 +4185,7 @@ export const getKxConnectionString: API.OperationMethod<
   GetKxConnectionStringRequest,
   GetKxConnectionStringResponse,
   GetKxConnectionStringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxConnectionStringRequest,
   output: GetKxConnectionStringResponse,
@@ -4216,7 +4215,7 @@ export const getKxDatabase: API.OperationMethod<
   GetKxDatabaseRequest,
   GetKxDatabaseResponse,
   GetKxDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxDatabaseRequest,
   output: GetKxDatabaseResponse,
@@ -4246,7 +4245,7 @@ export const getKxDataview: API.OperationMethod<
   GetKxDataviewRequest,
   GetKxDataviewResponse,
   GetKxDataviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxDataviewRequest,
   output: GetKxDataviewResponse,
@@ -4276,7 +4275,7 @@ export const getKxEnvironment: API.OperationMethod<
   GetKxEnvironmentRequest,
   GetKxEnvironmentResponse,
   GetKxEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxEnvironmentRequest,
   output: GetKxEnvironmentResponse,
@@ -4308,7 +4307,7 @@ export const getKxScalingGroup: API.OperationMethod<
   GetKxScalingGroupRequest,
   GetKxScalingGroupResponse,
   GetKxScalingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxScalingGroupRequest,
   output: GetKxScalingGroupResponse,
@@ -4340,7 +4339,7 @@ export const getKxUser: API.OperationMethod<
   GetKxUserRequest,
   GetKxUserResponse,
   GetKxUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxUserRequest,
   output: GetKxUserResponse,
@@ -4372,7 +4371,7 @@ export const getKxVolume: API.OperationMethod<
   GetKxVolumeRequest,
   GetKxVolumeResponse,
   GetKxVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKxVolumeRequest,
   output: GetKxVolumeResponse,
@@ -4402,7 +4401,7 @@ export const listEnvironments: API.OperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEnvironmentsRequest,
   output: ListEnvironmentsResponse,
@@ -4426,7 +4425,7 @@ export const listKxChangesets: API.PaginatedOperationMethod<
   ListKxChangesetsRequest,
   ListKxChangesetsResponse,
   ListKxChangesetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxChangesetsRequest,
@@ -4463,7 +4462,7 @@ export const listKxClusterNodes: API.PaginatedOperationMethod<
   ListKxClusterNodesRequest,
   ListKxClusterNodesResponse,
   ListKxClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxClusterNodesRequest,
@@ -4502,7 +4501,7 @@ export const listKxClusters: API.OperationMethod<
   ListKxClustersRequest,
   ListKxClustersResponse,
   ListKxClustersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListKxClustersRequest,
   output: ListKxClustersResponse,
@@ -4534,7 +4533,7 @@ export const listKxDatabases: API.PaginatedOperationMethod<
   ListKxDatabasesRequest,
   ListKxDatabasesResponse,
   ListKxDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxDatabasesRequest,
@@ -4570,7 +4569,7 @@ export const listKxDataviews: API.PaginatedOperationMethod<
   ListKxDataviewsRequest,
   ListKxDataviewsResponse,
   ListKxDataviewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxDataviewsRequest,
@@ -4604,7 +4603,7 @@ export const listKxEnvironments: API.PaginatedOperationMethod<
   ListKxEnvironmentsRequest,
   ListKxEnvironmentsResponse,
   ListKxEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KxEnvironment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxEnvironmentsRequest,
@@ -4637,7 +4636,7 @@ export const listKxScalingGroups: API.PaginatedOperationMethod<
   ListKxScalingGroupsRequest,
   ListKxScalingGroupsResponse,
   ListKxScalingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKxScalingGroupsRequest,
@@ -4675,7 +4674,7 @@ export const listKxUsers: API.OperationMethod<
   ListKxUsersRequest,
   ListKxUsersResponse,
   ListKxUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListKxUsersRequest,
   output: ListKxUsersResponse,
@@ -4707,7 +4706,7 @@ export const listKxVolumes: API.OperationMethod<
   ListKxVolumesRequest,
   ListKxVolumesResponse,
   ListKxVolumesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListKxVolumesRequest,
   output: ListKxVolumesResponse,
@@ -4737,7 +4736,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4763,7 +4762,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4789,7 +4788,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4817,7 +4816,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentRequest,
   UpdateEnvironmentResponse,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentRequest,
   output: UpdateEnvironmentResponse,
@@ -4850,7 +4849,7 @@ export const updateKxClusterCodeConfiguration: API.OperationMethod<
   UpdateKxClusterCodeConfigurationRequest,
   UpdateKxClusterCodeConfigurationResponse,
   UpdateKxClusterCodeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxClusterCodeConfigurationRequest,
   output: UpdateKxClusterCodeConfigurationResponse,
@@ -4886,7 +4885,7 @@ export const updateKxClusterDatabases: API.OperationMethod<
   UpdateKxClusterDatabasesRequest,
   UpdateKxClusterDatabasesResponse,
   UpdateKxClusterDatabasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxClusterDatabasesRequest,
   output: UpdateKxClusterDatabasesResponse,
@@ -4919,7 +4918,7 @@ export const updateKxDatabase: API.OperationMethod<
   UpdateKxDatabaseRequest,
   UpdateKxDatabaseResponse,
   UpdateKxDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxDatabaseRequest,
   output: UpdateKxDatabaseResponse,
@@ -4952,7 +4951,7 @@ export const updateKxDataview: API.OperationMethod<
   UpdateKxDataviewRequest,
   UpdateKxDataviewResponse,
   UpdateKxDataviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxDataviewRequest,
   output: UpdateKxDataviewResponse,
@@ -4985,7 +4984,7 @@ export const updateKxEnvironment: API.OperationMethod<
   UpdateKxEnvironmentRequest,
   UpdateKxEnvironmentResponse,
   UpdateKxEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxEnvironmentRequest,
   output: UpdateKxEnvironmentResponse,
@@ -5019,7 +5018,7 @@ export const updateKxEnvironmentNetwork: API.OperationMethod<
   UpdateKxEnvironmentNetworkRequest,
   UpdateKxEnvironmentNetworkResponse,
   UpdateKxEnvironmentNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxEnvironmentNetworkRequest,
   output: UpdateKxEnvironmentNetworkResponse,
@@ -5052,7 +5051,7 @@ export const updateKxUser: API.OperationMethod<
   UpdateKxUserRequest,
   UpdateKxUserResponse,
   UpdateKxUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxUserRequest,
   output: UpdateKxUserResponse,
@@ -5087,7 +5086,7 @@ export const updateKxVolume: API.OperationMethod<
   UpdateKxVolumeRequest,
   UpdateKxVolumeResponse,
   UpdateKxVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKxVolumeRequest,
   output: UpdateKxVolumeResponse,

--- a/packages/aws/src/services/firehose.ts
+++ b/packages/aws/src/services/firehose.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://firehose.amazonaws.com/doc/2015-08-04");
 const svc = T.AwsApiService({
@@ -2964,7 +2963,7 @@ export const createDeliveryStream: API.OperationMethod<
   CreateDeliveryStreamInput,
   CreateDeliveryStreamOutput,
   CreateDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeliveryStreamInput,
   output: CreateDeliveryStreamOutput,
@@ -3005,7 +3004,7 @@ export const deleteDeliveryStream: API.OperationMethod<
   DeleteDeliveryStreamInput,
   DeleteDeliveryStreamOutput,
   DeleteDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeliveryStreamInput,
   output: DeleteDeliveryStreamOutput,
@@ -3032,7 +3031,7 @@ export const describeDeliveryStream: API.OperationMethod<
   DescribeDeliveryStreamInput,
   DescribeDeliveryStreamOutput,
   DescribeDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeliveryStreamInput,
   output: DescribeDeliveryStreamOutput,
@@ -3058,7 +3057,7 @@ export const listDeliveryStreams: API.OperationMethod<
   ListDeliveryStreamsInput,
   ListDeliveryStreamsOutput,
   ListDeliveryStreamsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeliveryStreamsInput,
   output: ListDeliveryStreamsOutput,
@@ -3081,7 +3080,7 @@ export const listTagsForDeliveryStream: API.OperationMethod<
   ListTagsForDeliveryStreamInput,
   ListTagsForDeliveryStreamOutput,
   ListTagsForDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForDeliveryStreamInput,
   output: ListTagsForDeliveryStreamOutput,
@@ -3157,7 +3156,7 @@ export const putRecord: API.OperationMethod<
   PutRecordInput,
   PutRecordOutput,
   PutRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecordInput,
   output: PutRecordOutput,
@@ -3256,7 +3255,7 @@ export const putRecordBatch: API.OperationMethod<
   PutRecordBatchInput,
   PutRecordBatchOutput,
   PutRecordBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecordBatchInput,
   output: PutRecordBatchOutput,
@@ -3331,7 +3330,7 @@ export const startDeliveryStreamEncryption: API.OperationMethod<
   StartDeliveryStreamEncryptionInput,
   StartDeliveryStreamEncryptionOutput,
   StartDeliveryStreamEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeliveryStreamEncryptionInput,
   output: StartDeliveryStreamEncryptionOutput,
@@ -3382,7 +3381,7 @@ export const stopDeliveryStreamEncryption: API.OperationMethod<
   StopDeliveryStreamEncryptionInput,
   StopDeliveryStreamEncryptionOutput,
   StopDeliveryStreamEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDeliveryStreamEncryptionInput,
   output: StopDeliveryStreamEncryptionOutput,
@@ -3421,7 +3420,7 @@ export const tagDeliveryStream: API.OperationMethod<
   TagDeliveryStreamInput,
   TagDeliveryStreamOutput,
   TagDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagDeliveryStreamInput,
   output: TagDeliveryStreamOutput,
@@ -3454,7 +3453,7 @@ export const untagDeliveryStream: API.OperationMethod<
   UntagDeliveryStreamInput,
   UntagDeliveryStreamOutput,
   UntagDeliveryStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagDeliveryStreamInput,
   output: UntagDeliveryStreamOutput,
@@ -3509,7 +3508,7 @@ export const updateDestination: API.OperationMethod<
   UpdateDestinationInput,
   UpdateDestinationOutput,
   UpdateDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDestinationInput,
   output: UpdateDestinationOutput,

--- a/packages/aws/src/services/fis.ts
+++ b/packages/aws/src/services/fis.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "fis",
   serviceShapeName: "FaultInjectionSimulator",
@@ -2378,7 +2377,7 @@ export const createExperimentTemplate: API.OperationMethod<
   CreateExperimentTemplateRequest,
   CreateExperimentTemplateResponse,
   CreateExperimentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExperimentTemplateRequest,
   output: CreateExperimentTemplateResponse,
@@ -2409,7 +2408,7 @@ export const createTargetAccountConfiguration: API.OperationMethod<
   CreateTargetAccountConfigurationRequest,
   CreateTargetAccountConfigurationResponse,
   CreateTargetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTargetAccountConfigurationRequest,
   output: CreateTargetAccountConfigurationResponse,
@@ -2435,7 +2434,7 @@ export const deleteExperimentTemplate: API.OperationMethod<
   DeleteExperimentTemplateRequest,
   DeleteExperimentTemplateResponse,
   DeleteExperimentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExperimentTemplateRequest,
   output: DeleteExperimentTemplateResponse,
@@ -2456,7 +2455,7 @@ export const deleteTargetAccountConfiguration: API.OperationMethod<
   DeleteTargetAccountConfigurationRequest,
   DeleteTargetAccountConfigurationResponse,
   DeleteTargetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTargetAccountConfigurationRequest,
   output: DeleteTargetAccountConfigurationResponse,
@@ -2477,7 +2476,7 @@ export const getAction: API.OperationMethod<
   GetActionRequest,
   GetActionResponse,
   GetActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActionRequest,
   output: GetActionResponse,
@@ -2498,7 +2497,7 @@ export const getExperiment: API.OperationMethod<
   GetExperimentRequest,
   GetExperimentResponse,
   GetExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExperimentRequest,
   output: GetExperimentResponse,
@@ -2519,7 +2518,7 @@ export const getExperimentTargetAccountConfiguration: API.OperationMethod<
   GetExperimentTargetAccountConfigurationRequest,
   GetExperimentTargetAccountConfigurationResponse,
   GetExperimentTargetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExperimentTargetAccountConfigurationRequest,
   output: GetExperimentTargetAccountConfigurationResponse,
@@ -2540,7 +2539,7 @@ export const getExperimentTemplate: API.OperationMethod<
   GetExperimentTemplateRequest,
   GetExperimentTemplateResponse,
   GetExperimentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExperimentTemplateRequest,
   output: GetExperimentTemplateResponse,
@@ -2558,7 +2557,7 @@ export const getSafetyLever: API.OperationMethod<
   GetSafetyLeverRequest,
   GetSafetyLeverResponse,
   GetSafetyLeverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSafetyLeverRequest,
   output: GetSafetyLeverResponse,
@@ -2579,7 +2578,7 @@ export const getTargetAccountConfiguration: API.OperationMethod<
   GetTargetAccountConfigurationRequest,
   GetTargetAccountConfigurationResponse,
   GetTargetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTargetAccountConfigurationRequest,
   output: GetTargetAccountConfigurationResponse,
@@ -2600,7 +2599,7 @@ export const getTargetResourceType: API.OperationMethod<
   GetTargetResourceTypeRequest,
   GetTargetResourceTypeResponse,
   GetTargetResourceTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTargetResourceTypeRequest,
   output: GetTargetResourceTypeResponse,
@@ -2618,7 +2617,7 @@ export const listActions: API.PaginatedOperationMethod<
   ListActionsRequest,
   ListActionsResponse,
   ListActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionsRequest,
@@ -2646,7 +2645,7 @@ export const listExperimentResolvedTargets: API.PaginatedOperationMethod<
   ListExperimentResolvedTargetsRequest,
   ListExperimentResolvedTargetsResponse,
   ListExperimentResolvedTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolvedTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentResolvedTargetsRequest,
@@ -2671,7 +2670,7 @@ export const listExperiments: API.PaginatedOperationMethod<
   ListExperimentsRequest,
   ListExperimentsResponse,
   ListExperimentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentsRequest,
@@ -2699,7 +2698,7 @@ export const listExperimentTargetAccountConfigurations: API.OperationMethod<
   ListExperimentTargetAccountConfigurationsRequest,
   ListExperimentTargetAccountConfigurationsResponse,
   ListExperimentTargetAccountConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListExperimentTargetAccountConfigurationsRequest,
   output: ListExperimentTargetAccountConfigurationsResponse,
@@ -2717,7 +2716,7 @@ export const listExperimentTemplates: API.PaginatedOperationMethod<
   ListExperimentTemplatesRequest,
   ListExperimentTemplatesResponse,
   ListExperimentTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentTemplatesRequest,
@@ -2742,7 +2741,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2763,7 +2762,7 @@ export const listTargetAccountConfigurations: API.PaginatedOperationMethod<
   ListTargetAccountConfigurationsRequest,
   ListTargetAccountConfigurationsResponse,
   ListTargetAccountConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetAccountConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetAccountConfigurationsRequest,
@@ -2788,7 +2787,7 @@ export const listTargetResourceTypes: API.PaginatedOperationMethod<
   ListTargetResourceTypesRequest,
   ListTargetResourceTypesResponse,
   ListTargetResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetResourceTypeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetResourceTypesRequest,
@@ -2818,7 +2817,7 @@ export const startExperiment: API.OperationMethod<
   StartExperimentRequest,
   StartExperimentResponse,
   StartExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExperimentRequest,
   output: StartExperimentResponse,
@@ -2844,7 +2843,7 @@ export const stopExperiment: API.OperationMethod<
   StopExperimentRequest,
   StopExperimentResponse,
   StopExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopExperimentRequest,
   output: StopExperimentResponse,
@@ -2862,7 +2861,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2880,7 +2879,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2902,7 +2901,7 @@ export const updateExperimentTemplate: API.OperationMethod<
   UpdateExperimentTemplateRequest,
   UpdateExperimentTemplateResponse,
   UpdateExperimentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExperimentTemplateRequest,
   output: UpdateExperimentTemplateResponse,
@@ -2928,7 +2927,7 @@ export const updateSafetyLeverState: API.OperationMethod<
   UpdateSafetyLeverStateRequest,
   UpdateSafetyLeverStateResponse,
   UpdateSafetyLeverStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSafetyLeverStateRequest,
   output: UpdateSafetyLeverStateResponse,
@@ -2949,7 +2948,7 @@ export const updateTargetAccountConfiguration: API.OperationMethod<
   UpdateTargetAccountConfigurationRequest,
   UpdateTargetAccountConfigurationResponse,
   UpdateTargetAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTargetAccountConfigurationRequest,
   output: UpdateTargetAccountConfigurationResponse,

--- a/packages/aws/src/services/fms.ts
+++ b/packages/aws/src/services/fms.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "FMS",
   serviceShapeName: "AWSFMS_20180101",
@@ -2978,7 +2977,7 @@ export const associateAdminAccount: API.OperationMethod<
   AssociateAdminAccountRequest,
   AssociateAdminAccountResponse,
   AssociateAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAdminAccountRequest,
   output: AssociateAdminAccountResponse,
@@ -3007,7 +3006,7 @@ export const associateThirdPartyFirewall: API.OperationMethod<
   AssociateThirdPartyFirewallRequest,
   AssociateThirdPartyFirewallResponse,
   AssociateThirdPartyFirewallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateThirdPartyFirewallRequest,
   output: AssociateThirdPartyFirewallResponse,
@@ -3036,7 +3035,7 @@ export const batchAssociateResource: API.OperationMethod<
   BatchAssociateResourceRequest,
   BatchAssociateResourceResponse,
   BatchAssociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateResourceRequest,
   output: BatchAssociateResourceResponse,
@@ -3065,7 +3064,7 @@ export const batchDisassociateResource: API.OperationMethod<
   BatchDisassociateResourceRequest,
   BatchDisassociateResourceResponse,
   BatchDisassociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateResourceRequest,
   output: BatchDisassociateResourceResponse,
@@ -3092,7 +3091,7 @@ export const deleteAppsList: API.OperationMethod<
   DeleteAppsListRequest,
   DeleteAppsListResponse,
   DeleteAppsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppsListRequest,
   output: DeleteAppsListResponse,
@@ -3119,7 +3118,7 @@ export const deleteNotificationChannel: API.OperationMethod<
   DeleteNotificationChannelRequest,
   DeleteNotificationChannelResponse,
   DeleteNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationChannelRequest,
   output: DeleteNotificationChannelResponse,
@@ -3147,7 +3146,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -3175,7 +3174,7 @@ export const deleteProtocolsList: API.OperationMethod<
   DeleteProtocolsListRequest,
   DeleteProtocolsListResponse,
   DeleteProtocolsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProtocolsListRequest,
   output: DeleteProtocolsListResponse,
@@ -3202,7 +3201,7 @@ export const deleteResourceSet: API.OperationMethod<
   DeleteResourceSetRequest,
   DeleteResourceSetResponse,
   DeleteResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceSetRequest,
   output: DeleteResourceSetResponse,
@@ -3231,7 +3230,7 @@ export const disassociateAdminAccount: API.OperationMethod<
   DisassociateAdminAccountRequest,
   DisassociateAdminAccountResponse,
   DisassociateAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAdminAccountRequest,
   output: DisassociateAdminAccountResponse,
@@ -3258,7 +3257,7 @@ export const disassociateThirdPartyFirewall: API.OperationMethod<
   DisassociateThirdPartyFirewallRequest,
   DisassociateThirdPartyFirewallResponse,
   DisassociateThirdPartyFirewallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateThirdPartyFirewallRequest,
   output: DisassociateThirdPartyFirewallResponse,
@@ -3286,7 +3285,7 @@ export const getAdminAccount: API.OperationMethod<
   GetAdminAccountRequest,
   GetAdminAccountResponse,
   GetAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdminAccountRequest,
   output: GetAdminAccountResponse,
@@ -3314,7 +3313,7 @@ export const getAdminScope: API.OperationMethod<
   GetAdminScopeRequest,
   GetAdminScopeResponse,
   GetAdminScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdminScopeRequest,
   output: GetAdminScopeResponse,
@@ -3342,7 +3341,7 @@ export const getAppsList: API.OperationMethod<
   GetAppsListRequest,
   GetAppsListResponse,
   GetAppsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppsListRequest,
   output: GetAppsListResponse,
@@ -3372,7 +3371,7 @@ export const getComplianceDetail: API.OperationMethod<
   GetComplianceDetailRequest,
   GetComplianceDetailResponse,
   GetComplianceDetailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComplianceDetailRequest,
   output: GetComplianceDetailResponse,
@@ -3401,7 +3400,7 @@ export const getNotificationChannel: API.OperationMethod<
   GetNotificationChannelRequest,
   GetNotificationChannelResponse,
   GetNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationChannelRequest,
   output: GetNotificationChannelResponse,
@@ -3428,7 +3427,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -3456,7 +3455,7 @@ export const getProtectionStatus: API.OperationMethod<
   GetProtectionStatusRequest,
   GetProtectionStatusResponse,
   GetProtectionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProtectionStatusRequest,
   output: GetProtectionStatusResponse,
@@ -3482,7 +3481,7 @@ export const getProtocolsList: API.OperationMethod<
   GetProtocolsListRequest,
   GetProtocolsListResponse,
   GetProtocolsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProtocolsListRequest,
   output: GetProtocolsListResponse,
@@ -3509,7 +3508,7 @@ export const getResourceSet: API.OperationMethod<
   GetResourceSetRequest,
   GetResourceSetResponse,
   GetResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSetRequest,
   output: GetResourceSetResponse,
@@ -3537,7 +3536,7 @@ export const getThirdPartyFirewallAssociationStatus: API.OperationMethod<
   GetThirdPartyFirewallAssociationStatusRequest,
   GetThirdPartyFirewallAssociationStatusResponse,
   GetThirdPartyFirewallAssociationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThirdPartyFirewallAssociationStatusRequest,
   output: GetThirdPartyFirewallAssociationStatusResponse,
@@ -3564,7 +3563,7 @@ export const getViolationDetails: API.OperationMethod<
   GetViolationDetailsRequest,
   GetViolationDetailsResponse,
   GetViolationDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetViolationDetailsRequest,
   output: GetViolationDetailsResponse,
@@ -3593,7 +3592,7 @@ export const listAdminAccountsForOrganization: API.PaginatedOperationMethod<
   ListAdminAccountsForOrganizationRequest,
   ListAdminAccountsForOrganizationResponse,
   ListAdminAccountsForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdminAccountSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdminAccountsForOrganizationRequest,
@@ -3627,7 +3626,7 @@ export const listAdminsManagingAccount: API.PaginatedOperationMethod<
   ListAdminsManagingAccountRequest,
   ListAdminsManagingAccountResponse,
   ListAdminsManagingAccountError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AWSAccountId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdminsManagingAccountRequest,
@@ -3661,7 +3660,7 @@ export const listAppsLists: API.PaginatedOperationMethod<
   ListAppsListsRequest,
   ListAppsListsResponse,
   ListAppsListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppsListDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppsListsRequest,
@@ -3696,7 +3695,7 @@ export const listComplianceStatus: API.PaginatedOperationMethod<
   ListComplianceStatusRequest,
   ListComplianceStatusResponse,
   ListComplianceStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyComplianceStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComplianceStatusRequest,
@@ -3725,7 +3724,7 @@ export const listDiscoveredResources: API.OperationMethod<
   ListDiscoveredResourcesRequest,
   ListDiscoveredResourcesResponse,
   ListDiscoveredResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDiscoveredResourcesRequest,
   output: ListDiscoveredResourcesResponse,
@@ -3753,7 +3752,7 @@ export const listMemberAccounts: API.PaginatedOperationMethod<
   ListMemberAccountsRequest,
   ListMemberAccountsResponse,
   ListMemberAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AWSAccountId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMemberAccountsRequest,
@@ -3783,7 +3782,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -3817,7 +3816,7 @@ export const listProtocolsLists: API.PaginatedOperationMethod<
   ListProtocolsListsRequest,
   ListProtocolsListsResponse,
   ListProtocolsListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtocolsListDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtocolsListsRequest,
@@ -3851,7 +3850,7 @@ export const listResourceSetResources: API.OperationMethod<
   ListResourceSetResourcesRequest,
   ListResourceSetResourcesResponse,
   ListResourceSetResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceSetResourcesRequest,
   output: ListResourceSetResourcesResponse,
@@ -3878,7 +3877,7 @@ export const listResourceSets: API.OperationMethod<
   ListResourceSetsRequest,
   ListResourceSetsResponse,
   ListResourceSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceSetsRequest,
   output: ListResourceSetsResponse,
@@ -3905,7 +3904,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3933,7 +3932,7 @@ export const listThirdPartyFirewallFirewallPolicies: API.PaginatedOperationMetho
   ListThirdPartyFirewallFirewallPoliciesRequest,
   ListThirdPartyFirewallFirewallPoliciesResponse,
   ListThirdPartyFirewallFirewallPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThirdPartyFirewallFirewallPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThirdPartyFirewallFirewallPoliciesRequest,
@@ -3969,7 +3968,7 @@ export const putAdminAccount: API.OperationMethod<
   PutAdminAccountRequest,
   PutAdminAccountResponse,
   PutAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAdminAccountRequest,
   output: PutAdminAccountResponse,
@@ -3998,7 +3997,7 @@ export const putAppsList: API.OperationMethod<
   PutAppsListRequest,
   PutAppsListResponse,
   PutAppsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAppsListRequest,
   output: PutAppsListResponse,
@@ -4030,7 +4029,7 @@ export const putNotificationChannel: API.OperationMethod<
   PutNotificationChannelRequest,
   PutNotificationChannelResponse,
   PutNotificationChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutNotificationChannelRequest,
   output: PutNotificationChannelResponse,
@@ -4096,7 +4095,7 @@ export const putPolicy: API.OperationMethod<
   PutPolicyRequest,
   PutPolicyResponse,
   PutPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPolicyRequest,
   output: PutPolicyResponse,
@@ -4127,7 +4126,7 @@ export const putProtocolsList: API.OperationMethod<
   PutProtocolsListRequest,
   PutProtocolsListResponse,
   PutProtocolsListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProtocolsListRequest,
   output: PutProtocolsListResponse,
@@ -4158,7 +4157,7 @@ export const putResourceSet: API.OperationMethod<
   PutResourceSetRequest,
   PutResourceSetResponse,
   PutResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourceSetRequest,
   output: PutResourceSetResponse,
@@ -4187,7 +4186,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4216,7 +4215,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/forecast.ts
+++ b/packages/aws/src/services/forecast.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "forecast",
@@ -3163,7 +3162,7 @@ export const createAutoPredictor: API.OperationMethod<
   CreateAutoPredictorRequest,
   CreateAutoPredictorResponse,
   CreateAutoPredictorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutoPredictorRequest,
   output: CreateAutoPredictorResponse,
@@ -3226,7 +3225,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -3264,7 +3263,7 @@ export const createDatasetGroup: API.OperationMethod<
   CreateDatasetGroupRequest,
   CreateDatasetGroupResponse,
   CreateDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetGroupRequest,
   output: CreateDatasetGroupResponse,
@@ -3315,7 +3314,7 @@ export const createDatasetImportJob: API.OperationMethod<
   CreateDatasetImportJobRequest,
   CreateDatasetImportJobResponse,
   CreateDatasetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetImportJobRequest,
   output: CreateDatasetImportJobResponse,
@@ -3424,7 +3423,7 @@ export const createExplainability: API.OperationMethod<
   CreateExplainabilityRequest,
   CreateExplainabilityResponse,
   CreateExplainabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExplainabilityRequest,
   output: CreateExplainabilityResponse,
@@ -3462,7 +3461,7 @@ export const createExplainabilityExport: API.OperationMethod<
   CreateExplainabilityExportRequest,
   CreateExplainabilityExportResponse,
   CreateExplainabilityExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExplainabilityExportRequest,
   output: CreateExplainabilityExportResponse,
@@ -3514,7 +3513,7 @@ export const createForecast: API.OperationMethod<
   CreateForecastRequest,
   CreateForecastResponse,
   CreateForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateForecastRequest,
   output: CreateForecastResponse,
@@ -3561,7 +3560,7 @@ export const createForecastExportJob: API.OperationMethod<
   CreateForecastExportJobRequest,
   CreateForecastExportJobResponse,
   CreateForecastExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateForecastExportJobRequest,
   output: CreateForecastExportJobResponse,
@@ -3592,7 +3591,7 @@ export const createMonitor: API.OperationMethod<
   CreateMonitorRequest,
   CreateMonitorResponse,
   CreateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitorRequest,
   output: CreateMonitorResponse,
@@ -3673,7 +3672,7 @@ export const createPredictor: API.OperationMethod<
   CreatePredictorRequest,
   CreatePredictorResponse,
   CreatePredictorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePredictorRequest,
   output: CreatePredictorResponse,
@@ -3718,7 +3717,7 @@ export const createPredictorBacktestExportJob: API.OperationMethod<
   CreatePredictorBacktestExportJobRequest,
   CreatePredictorBacktestExportJobResponse,
   CreatePredictorBacktestExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePredictorBacktestExportJobRequest,
   output: CreatePredictorBacktestExportJobResponse,
@@ -3764,7 +3763,7 @@ export const createWhatIfAnalysis: API.OperationMethod<
   CreateWhatIfAnalysisRequest,
   CreateWhatIfAnalysisResponse,
   CreateWhatIfAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatIfAnalysisRequest,
   output: CreateWhatIfAnalysisResponse,
@@ -3795,7 +3794,7 @@ export const createWhatIfForecast: API.OperationMethod<
   CreateWhatIfForecastRequest,
   CreateWhatIfForecastResponse,
   CreateWhatIfForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatIfForecastRequest,
   output: CreateWhatIfForecastResponse,
@@ -3843,7 +3842,7 @@ export const createWhatIfForecastExport: API.OperationMethod<
   CreateWhatIfForecastExportRequest,
   CreateWhatIfForecastExportResponse,
   CreateWhatIfForecastExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatIfForecastExportRequest,
   output: CreateWhatIfForecastExportResponse,
@@ -3877,7 +3876,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -3907,7 +3906,7 @@ export const deleteDatasetGroup: API.OperationMethod<
   DeleteDatasetGroupRequest,
   DeleteDatasetGroupResponse,
   DeleteDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetGroupRequest,
   output: DeleteDatasetGroupResponse,
@@ -3936,7 +3935,7 @@ export const deleteDatasetImportJob: API.OperationMethod<
   DeleteDatasetImportJobRequest,
   DeleteDatasetImportJobResponse,
   DeleteDatasetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetImportJobRequest,
   output: DeleteDatasetImportJobResponse,
@@ -3965,7 +3964,7 @@ export const deleteExplainability: API.OperationMethod<
   DeleteExplainabilityRequest,
   DeleteExplainabilityResponse,
   DeleteExplainabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExplainabilityRequest,
   output: DeleteExplainabilityResponse,
@@ -3991,7 +3990,7 @@ export const deleteExplainabilityExport: API.OperationMethod<
   DeleteExplainabilityExportRequest,
   DeleteExplainabilityExportResponse,
   DeleteExplainabilityExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExplainabilityExportRequest,
   output: DeleteExplainabilityExportResponse,
@@ -4022,7 +4021,7 @@ export const deleteForecast: API.OperationMethod<
   DeleteForecastRequest,
   DeleteForecastResponse,
   DeleteForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteForecastRequest,
   output: DeleteForecastResponse,
@@ -4050,7 +4049,7 @@ export const deleteForecastExportJob: API.OperationMethod<
   DeleteForecastExportJobRequest,
   DeleteForecastExportJobResponse,
   DeleteForecastExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteForecastExportJobRequest,
   output: DeleteForecastExportJobResponse,
@@ -4076,7 +4075,7 @@ export const deleteMonitor: API.OperationMethod<
   DeleteMonitorRequest,
   DeleteMonitorResponse,
   DeleteMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitorRequest,
   output: DeleteMonitorResponse,
@@ -4103,7 +4102,7 @@ export const deletePredictor: API.OperationMethod<
   DeletePredictorRequest,
   DeletePredictorResponse,
   DeletePredictorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePredictorRequest,
   output: DeletePredictorResponse,
@@ -4129,7 +4128,7 @@ export const deletePredictorBacktestExportJob: API.OperationMethod<
   DeletePredictorBacktestExportJobRequest,
   DeletePredictorBacktestExportJobResponse,
   DeletePredictorBacktestExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePredictorBacktestExportJobRequest,
   output: DeletePredictorBacktestExportJobResponse,
@@ -4175,7 +4174,7 @@ export const deleteResourceTree: API.OperationMethod<
   DeleteResourceTreeRequest,
   DeleteResourceTreeResponse,
   DeleteResourceTreeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceTreeRequest,
   output: DeleteResourceTreeResponse,
@@ -4204,7 +4203,7 @@ export const deleteWhatIfAnalysis: API.OperationMethod<
   DeleteWhatIfAnalysisRequest,
   DeleteWhatIfAnalysisResponse,
   DeleteWhatIfAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatIfAnalysisRequest,
   output: DeleteWhatIfAnalysisResponse,
@@ -4233,7 +4232,7 @@ export const deleteWhatIfForecast: API.OperationMethod<
   DeleteWhatIfForecastRequest,
   DeleteWhatIfForecastResponse,
   DeleteWhatIfForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatIfForecastRequest,
   output: DeleteWhatIfForecastResponse,
@@ -4260,7 +4259,7 @@ export const deleteWhatIfForecastExport: API.OperationMethod<
   DeleteWhatIfForecastExportRequest,
   DeleteWhatIfForecastExportResponse,
   DeleteWhatIfForecastExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatIfForecastExportRequest,
   output: DeleteWhatIfForecastExportResponse,
@@ -4285,7 +4284,7 @@ export const describeAutoPredictor: API.OperationMethod<
   DescribeAutoPredictorRequest,
   DescribeAutoPredictorResponse,
   DescribeAutoPredictorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutoPredictorRequest,
   output: DescribeAutoPredictorResponse,
@@ -4315,7 +4314,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -4348,7 +4347,7 @@ export const describeDatasetGroup: API.OperationMethod<
   DescribeDatasetGroupRequest,
   DescribeDatasetGroupResponse,
   DescribeDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetGroupRequest,
   output: DescribeDatasetGroupResponse,
@@ -4385,7 +4384,7 @@ export const describeDatasetImportJob: API.OperationMethod<
   DescribeDatasetImportJobRequest,
   DescribeDatasetImportJobResponse,
   DescribeDatasetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetImportJobRequest,
   output: DescribeDatasetImportJobResponse,
@@ -4406,7 +4405,7 @@ export const describeExplainability: API.OperationMethod<
   DescribeExplainabilityRequest,
   DescribeExplainabilityResponse,
   DescribeExplainabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExplainabilityRequest,
   output: DescribeExplainabilityResponse,
@@ -4427,7 +4426,7 @@ export const describeExplainabilityExport: API.OperationMethod<
   DescribeExplainabilityExportRequest,
   DescribeExplainabilityExportResponse,
   DescribeExplainabilityExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExplainabilityExportRequest,
   output: DescribeExplainabilityExportResponse,
@@ -4462,7 +4461,7 @@ export const describeForecast: API.OperationMethod<
   DescribeForecastRequest,
   DescribeForecastResponse,
   DescribeForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeForecastRequest,
   output: DescribeForecastResponse,
@@ -4495,7 +4494,7 @@ export const describeForecastExportJob: API.OperationMethod<
   DescribeForecastExportJobRequest,
   DescribeForecastExportJobResponse,
   DescribeForecastExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeForecastExportJobRequest,
   output: DescribeForecastExportJobResponse,
@@ -4530,7 +4529,7 @@ export const describeMonitor: API.OperationMethod<
   DescribeMonitorRequest,
   DescribeMonitorResponse,
   DescribeMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMonitorRequest,
   output: DescribeMonitorResponse,
@@ -4572,7 +4571,7 @@ export const describePredictor: API.OperationMethod<
   DescribePredictorRequest,
   DescribePredictorResponse,
   DescribePredictorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePredictorRequest,
   output: DescribePredictorResponse,
@@ -4605,7 +4604,7 @@ export const describePredictorBacktestExportJob: API.OperationMethod<
   DescribePredictorBacktestExportJobRequest,
   DescribePredictorBacktestExportJobResponse,
   DescribePredictorBacktestExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePredictorBacktestExportJobRequest,
   output: DescribePredictorBacktestExportJobResponse,
@@ -4636,7 +4635,7 @@ export const describeWhatIfAnalysis: API.OperationMethod<
   DescribeWhatIfAnalysisRequest,
   DescribeWhatIfAnalysisResponse,
   DescribeWhatIfAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWhatIfAnalysisRequest,
   output: DescribeWhatIfAnalysisResponse,
@@ -4667,7 +4666,7 @@ export const describeWhatIfForecast: API.OperationMethod<
   DescribeWhatIfForecastRequest,
   DescribeWhatIfForecastResponse,
   DescribeWhatIfForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWhatIfForecastRequest,
   output: DescribeWhatIfForecastResponse,
@@ -4698,7 +4697,7 @@ export const describeWhatIfForecastExport: API.OperationMethod<
   DescribeWhatIfForecastExportRequest,
   DescribeWhatIfForecastExportResponse,
   DescribeWhatIfForecastExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWhatIfForecastExportRequest,
   output: DescribeWhatIfForecastExportResponse,
@@ -4737,7 +4736,7 @@ export const getAccuracyMetrics: API.OperationMethod<
   GetAccuracyMetricsRequest,
   GetAccuracyMetricsResponse,
   GetAccuracyMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccuracyMetricsRequest,
   output: GetAccuracyMetricsResponse,
@@ -4763,7 +4762,7 @@ export const listDatasetGroups: API.PaginatedOperationMethod<
   ListDatasetGroupsRequest,
   ListDatasetGroupsResponse,
   ListDatasetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetGroupsRequest,
@@ -4795,7 +4794,7 @@ export const listDatasetImportJobs: API.PaginatedOperationMethod<
   ListDatasetImportJobsRequest,
   ListDatasetImportJobsResponse,
   ListDatasetImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetImportJobsRequest,
@@ -4822,7 +4821,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -4855,7 +4854,7 @@ export const listExplainabilities: API.PaginatedOperationMethod<
   ListExplainabilitiesRequest,
   ListExplainabilitiesResponse,
   ListExplainabilitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExplainabilitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExplainabilitiesRequest,
@@ -4887,7 +4886,7 @@ export const listExplainabilityExports: API.PaginatedOperationMethod<
   ListExplainabilityExportsRequest,
   ListExplainabilityExportsResponse,
   ListExplainabilityExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExplainabilityExportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExplainabilityExportsRequest,
@@ -4918,7 +4917,7 @@ export const listForecastExportJobs: API.PaginatedOperationMethod<
   ListForecastExportJobsRequest,
   ListForecastExportJobsResponse,
   ListForecastExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ForecastExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListForecastExportJobsRequest,
@@ -4950,7 +4949,7 @@ export const listForecasts: API.PaginatedOperationMethod<
   ListForecastsRequest,
   ListForecastsResponse,
   ListForecastsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ForecastSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListForecastsRequest,
@@ -4983,7 +4982,7 @@ export const listMonitorEvaluations: API.PaginatedOperationMethod<
   ListMonitorEvaluationsRequest,
   ListMonitorEvaluationsResponse,
   ListMonitorEvaluationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PredictorMonitorEvaluation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorEvaluationsRequest,
@@ -5016,7 +5015,7 @@ export const listMonitors: API.PaginatedOperationMethod<
   ListMonitorsRequest,
   ListMonitorsResponse,
   ListMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorsRequest,
@@ -5048,7 +5047,7 @@ export const listPredictorBacktestExportJobs: API.PaginatedOperationMethod<
   ListPredictorBacktestExportJobsRequest,
   ListPredictorBacktestExportJobsResponse,
   ListPredictorBacktestExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PredictorBacktestExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPredictorBacktestExportJobsRequest,
@@ -5081,7 +5080,7 @@ export const listPredictors: API.PaginatedOperationMethod<
   ListPredictorsRequest,
   ListPredictorsResponse,
   ListPredictorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PredictorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPredictorsRequest,
@@ -5109,7 +5108,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5130,7 +5129,7 @@ export const listWhatIfAnalyses: API.PaginatedOperationMethod<
   ListWhatIfAnalysesRequest,
   ListWhatIfAnalysesResponse,
   ListWhatIfAnalysesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WhatIfAnalysisSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatIfAnalysesRequest,
@@ -5158,7 +5157,7 @@ export const listWhatIfForecastExports: API.PaginatedOperationMethod<
   ListWhatIfForecastExportsRequest,
   ListWhatIfForecastExportsResponse,
   ListWhatIfForecastExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WhatIfForecastExportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatIfForecastExportsRequest,
@@ -5186,7 +5185,7 @@ export const listWhatIfForecasts: API.PaginatedOperationMethod<
   ListWhatIfForecastsRequest,
   ListWhatIfForecastsResponse,
   ListWhatIfForecastsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WhatIfForecastSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatIfForecastsRequest,
@@ -5216,7 +5215,7 @@ export const resumeResource: API.OperationMethod<
   ResumeResourceRequest,
   ResumeResourceResponse,
   ResumeResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeResourceRequest,
   output: ResumeResourceResponse,
@@ -5264,7 +5263,7 @@ export const stopResource: API.OperationMethod<
   StopResourceRequest,
   StopResourceResponse,
   StopResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopResourceRequest,
   output: StopResourceResponse,
@@ -5293,7 +5292,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5318,7 +5317,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5344,7 +5343,7 @@ export const updateDatasetGroup: API.OperationMethod<
   UpdateDatasetGroupRequest,
   UpdateDatasetGroupResponse,
   UpdateDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetGroupRequest,
   output: UpdateDatasetGroupResponse,

--- a/packages/aws/src/services/forecastquery.ts
+++ b/packages/aws/src/services/forecastquery.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "forecastquery",
   serviceShapeName: "AmazonForecastRuntime",
@@ -229,7 +228,7 @@ export const queryForecast: API.OperationMethod<
   QueryForecastRequest,
   QueryForecastResponse,
   QueryForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: QueryForecastRequest,
   output: QueryForecastResponse,
@@ -259,7 +258,7 @@ export const queryWhatIfForecast: API.OperationMethod<
   QueryWhatIfForecastRequest,
   QueryWhatIfForecastResponse,
   QueryWhatIfForecastError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: QueryWhatIfForecastRequest,
   output: QueryWhatIfForecastResponse,

--- a/packages/aws/src/services/frauddetector.ts
+++ b/packages/aws/src/services/frauddetector.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://hawksnest.amazonaws.com/doc/2019-11-15");
 const svc = T.AwsApiService({
@@ -3928,7 +3927,7 @@ export const batchCreateVariable: API.OperationMethod<
   BatchCreateVariableRequest,
   BatchCreateVariableResult,
   BatchCreateVariableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateVariableRequest,
   output: BatchCreateVariableResult,
@@ -3956,7 +3955,7 @@ export const batchGetVariable: API.OperationMethod<
   BatchGetVariableRequest,
   BatchGetVariableResult,
   BatchGetVariableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetVariableRequest,
   output: BatchGetVariableResult,
@@ -3985,7 +3984,7 @@ export const cancelBatchImportJob: API.OperationMethod<
   CancelBatchImportJobRequest,
   CancelBatchImportJobResult,
   CancelBatchImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelBatchImportJobRequest,
   output: CancelBatchImportJobResult,
@@ -4015,7 +4014,7 @@ export const cancelBatchPredictionJob: API.OperationMethod<
   CancelBatchPredictionJobRequest,
   CancelBatchPredictionJobResult,
   CancelBatchPredictionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelBatchPredictionJobRequest,
   output: CancelBatchPredictionJobResult,
@@ -4045,7 +4044,7 @@ export const createBatchImportJob: API.OperationMethod<
   CreateBatchImportJobRequest,
   CreateBatchImportJobResult,
   CreateBatchImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchImportJobRequest,
   output: CreateBatchImportJobResult,
@@ -4075,7 +4074,7 @@ export const createBatchPredictionJob: API.OperationMethod<
   CreateBatchPredictionJobRequest,
   CreateBatchPredictionJobResult,
   CreateBatchPredictionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchPredictionJobRequest,
   output: CreateBatchPredictionJobResult,
@@ -4105,7 +4104,7 @@ export const createDetectorVersion: API.OperationMethod<
   CreateDetectorVersionRequest,
   CreateDetectorVersionResult,
   CreateDetectorVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDetectorVersionRequest,
   output: CreateDetectorVersionResult,
@@ -4137,7 +4136,7 @@ export const createList: API.OperationMethod<
   CreateListRequest,
   CreateListResult,
   CreateListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateListRequest,
   output: CreateListResult,
@@ -4165,7 +4164,7 @@ export const createModel: API.OperationMethod<
   CreateModelRequest,
   CreateModelResult,
   CreateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelRequest,
   output: CreateModelResult,
@@ -4194,7 +4193,7 @@ export const createModelVersion: API.OperationMethod<
   CreateModelVersionRequest,
   CreateModelVersionResult,
   CreateModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelVersionRequest,
   output: CreateModelVersionResult,
@@ -4223,7 +4222,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResult,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResult,
@@ -4251,7 +4250,7 @@ export const createVariable: API.OperationMethod<
   CreateVariableRequest,
   CreateVariableResult,
   CreateVariableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVariableRequest,
   output: CreateVariableResult,
@@ -4279,7 +4278,7 @@ export const deleteBatchImportJob: API.OperationMethod<
   DeleteBatchImportJobRequest,
   DeleteBatchImportJobResult,
   DeleteBatchImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBatchImportJobRequest,
   output: DeleteBatchImportJobResult,
@@ -4307,7 +4306,7 @@ export const deleteBatchPredictionJob: API.OperationMethod<
   DeleteBatchPredictionJobRequest,
   DeleteBatchPredictionJobResult,
   DeleteBatchPredictionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBatchPredictionJobRequest,
   output: DeleteBatchPredictionJobResult,
@@ -4338,7 +4337,7 @@ export const deleteDetector: API.OperationMethod<
   DeleteDetectorRequest,
   DeleteDetectorResult,
   DeleteDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDetectorRequest,
   output: DeleteDetectorResult,
@@ -4371,7 +4370,7 @@ export const deleteDetectorVersion: API.OperationMethod<
   DeleteDetectorVersionRequest,
   DeleteDetectorVersionResult,
   DeleteDetectorVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDetectorVersionRequest,
   output: DeleteDetectorVersionResult,
@@ -4406,7 +4405,7 @@ export const deleteEntityType: API.OperationMethod<
   DeleteEntityTypeRequest,
   DeleteEntityTypeResult,
   DeleteEntityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEntityTypeRequest,
   output: DeleteEntityTypeResult,
@@ -4438,7 +4437,7 @@ export const deleteEvent: API.OperationMethod<
   DeleteEventRequest,
   DeleteEventResult,
   DeleteEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventRequest,
   output: DeleteEventResult,
@@ -4468,7 +4467,7 @@ export const deleteEventsByEventType: API.OperationMethod<
   DeleteEventsByEventTypeRequest,
   DeleteEventsByEventTypeResult,
   DeleteEventsByEventTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventsByEventTypeRequest,
   output: DeleteEventsByEventTypeResult,
@@ -4503,7 +4502,7 @@ export const deleteEventType: API.OperationMethod<
   DeleteEventTypeRequest,
   DeleteEventTypeResult,
   DeleteEventTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventTypeRequest,
   output: DeleteEventTypeResult,
@@ -4535,7 +4534,7 @@ export const deleteExternalModel: API.OperationMethod<
   DeleteExternalModelRequest,
   DeleteExternalModelResult,
   DeleteExternalModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExternalModelRequest,
   output: DeleteExternalModelResult,
@@ -4570,7 +4569,7 @@ export const deleteLabel: API.OperationMethod<
   DeleteLabelRequest,
   DeleteLabelResult,
   DeleteLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLabelRequest,
   output: DeleteLabelResult,
@@ -4601,7 +4600,7 @@ export const deleteList: API.OperationMethod<
   DeleteListRequest,
   DeleteListResult,
   DeleteListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteListRequest,
   output: DeleteListResult,
@@ -4635,7 +4634,7 @@ export const deleteModel: API.OperationMethod<
   DeleteModelRequest,
   DeleteModelResult,
   DeleteModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelRequest,
   output: DeleteModelResult,
@@ -4669,7 +4668,7 @@ export const deleteModelVersion: API.OperationMethod<
   DeleteModelVersionRequest,
   DeleteModelVersionResult,
   DeleteModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelVersionRequest,
   output: DeleteModelVersionResult,
@@ -4703,7 +4702,7 @@ export const deleteOutcome: API.OperationMethod<
   DeleteOutcomeRequest,
   DeleteOutcomeResult,
   DeleteOutcomeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutcomeRequest,
   output: DeleteOutcomeResult,
@@ -4735,7 +4734,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResult,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResult,
@@ -4771,7 +4770,7 @@ export const deleteVariable: API.OperationMethod<
   DeleteVariableRequest,
   DeleteVariableResult,
   DeleteVariableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVariableRequest,
   output: DeleteVariableResult,
@@ -4801,7 +4800,7 @@ export const describeDetector: API.OperationMethod<
   DescribeDetectorRequest,
   DescribeDetectorResult,
   DescribeDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDetectorRequest,
   output: DescribeDetectorResult,
@@ -4831,7 +4830,7 @@ export const describeModelVersions: API.PaginatedOperationMethod<
   DescribeModelVersionsRequest,
   DescribeModelVersionsResult,
   DescribeModelVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeModelVersionsRequest,
@@ -4870,7 +4869,7 @@ export const getBatchImportJobs: API.PaginatedOperationMethod<
   GetBatchImportJobsRequest,
   GetBatchImportJobsResult,
   GetBatchImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBatchImportJobsRequest,
@@ -4906,7 +4905,7 @@ export const getBatchPredictionJobs: API.PaginatedOperationMethod<
   GetBatchPredictionJobsRequest,
   GetBatchPredictionJobsResult,
   GetBatchPredictionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBatchPredictionJobsRequest,
@@ -4942,7 +4941,7 @@ export const getDeleteEventsByEventTypeStatus: API.OperationMethod<
   GetDeleteEventsByEventTypeStatusRequest,
   GetDeleteEventsByEventTypeStatusResult,
   GetDeleteEventsByEventTypeStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeleteEventsByEventTypeStatusRequest,
   output: GetDeleteEventsByEventTypeStatusResult,
@@ -4977,7 +4976,7 @@ export const getDetectors: API.PaginatedOperationMethod<
   GetDetectorsRequest,
   GetDetectorsResult,
   GetDetectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDetectorsRequest,
@@ -5013,7 +5012,7 @@ export const getDetectorVersion: API.OperationMethod<
   GetDetectorVersionRequest,
   GetDetectorVersionResult,
   GetDetectorVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDetectorVersionRequest,
   output: GetDetectorVersionResult,
@@ -5048,7 +5047,7 @@ export const getEntityTypes: API.PaginatedOperationMethod<
   GetEntityTypesRequest,
   GetEntityTypesResult,
   GetEntityTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEntityTypesRequest,
@@ -5084,7 +5083,7 @@ export const getEvent: API.OperationMethod<
   GetEventRequest,
   GetEventResult,
   GetEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventRequest,
   output: GetEventResult,
@@ -5116,7 +5115,7 @@ export const getEventPrediction: API.OperationMethod<
   GetEventPredictionRequest,
   GetEventPredictionResult,
   GetEventPredictionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventPredictionRequest,
   output: GetEventPredictionResult,
@@ -5148,7 +5147,7 @@ export const getEventPredictionMetadata: API.OperationMethod<
   GetEventPredictionMetadataRequest,
   GetEventPredictionMetadataResult,
   GetEventPredictionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventPredictionMetadataRequest,
   output: GetEventPredictionMetadataResult,
@@ -5183,7 +5182,7 @@ export const getEventTypes: API.PaginatedOperationMethod<
   GetEventTypesRequest,
   GetEventTypesResult,
   GetEventTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEventTypesRequest,
@@ -5224,7 +5223,7 @@ export const getExternalModels: API.PaginatedOperationMethod<
   GetExternalModelsRequest,
   GetExternalModelsResult,
   GetExternalModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetExternalModelsRequest,
@@ -5259,7 +5258,7 @@ export const getKMSEncryptionKey: API.OperationMethod<
   GetKMSEncryptionKeyRequest,
   GetKMSEncryptionKeyResult,
   GetKMSEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKMSEncryptionKeyRequest,
   output: GetKMSEncryptionKeyResult,
@@ -5293,7 +5292,7 @@ export const getLabels: API.PaginatedOperationMethod<
   GetLabelsRequest,
   GetLabelsResult,
   GetLabelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLabelsRequest,
@@ -5329,7 +5328,7 @@ export const getListElements: API.PaginatedOperationMethod<
   GetListElementsRequest,
   GetListElementsResult,
   GetListElementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetListElementsRequest,
@@ -5365,7 +5364,7 @@ export const getListsMetadata: API.PaginatedOperationMethod<
   GetListsMetadataRequest,
   GetListsMetadataResult,
   GetListsMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetListsMetadataRequest,
@@ -5408,7 +5407,7 @@ export const getModels: API.PaginatedOperationMethod<
   GetModelsRequest,
   GetModelsResult,
   GetModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetModelsRequest,
@@ -5444,7 +5443,7 @@ export const getModelVersion: API.OperationMethod<
   GetModelVersionRequest,
   GetModelVersionResult,
   GetModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelVersionRequest,
   output: GetModelVersionResult,
@@ -5479,7 +5478,7 @@ export const getOutcomes: API.PaginatedOperationMethod<
   GetOutcomesRequest,
   GetOutcomesResult,
   GetOutcomesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOutcomesRequest,
@@ -5517,7 +5516,7 @@ export const getRules: API.PaginatedOperationMethod<
   GetRulesRequest,
   GetRulesResult,
   GetRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRulesRequest,
@@ -5558,7 +5557,7 @@ export const getVariables: API.PaginatedOperationMethod<
   GetVariablesRequest,
   GetVariablesResult,
   GetVariablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetVariablesRequest,
@@ -5604,7 +5603,7 @@ export const listEventPredictions: API.PaginatedOperationMethod<
   ListEventPredictionsRequest,
   ListEventPredictionsResult,
   ListEventPredictionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventPredictionsRequest,
@@ -5640,7 +5639,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -5675,7 +5674,7 @@ export const putDetector: API.OperationMethod<
   PutDetectorRequest,
   PutDetectorResult,
   PutDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDetectorRequest,
   output: PutDetectorResult,
@@ -5705,7 +5704,7 @@ export const putEntityType: API.OperationMethod<
   PutEntityTypeRequest,
   PutEntityTypeResult,
   PutEntityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEntityTypeRequest,
   output: PutEntityTypeResult,
@@ -5735,7 +5734,7 @@ export const putEventType: API.OperationMethod<
   PutEventTypeRequest,
   PutEventTypeResult,
   PutEventTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventTypeRequest,
   output: PutEventTypeResult,
@@ -5765,7 +5764,7 @@ export const putExternalModel: API.OperationMethod<
   PutExternalModelRequest,
   PutExternalModelResult,
   PutExternalModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutExternalModelRequest,
   output: PutExternalModelResult,
@@ -5796,7 +5795,7 @@ export const putKMSEncryptionKey: API.OperationMethod<
   PutKMSEncryptionKeyRequest,
   PutKMSEncryptionKeyResult,
   PutKMSEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutKMSEncryptionKeyRequest,
   output: PutKMSEncryptionKeyResult,
@@ -5827,7 +5826,7 @@ export const putLabel: API.OperationMethod<
   PutLabelRequest,
   PutLabelResult,
   PutLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLabelRequest,
   output: PutLabelResult,
@@ -5857,7 +5856,7 @@ export const putOutcome: API.OperationMethod<
   PutOutcomeRequest,
   PutOutcomeResult,
   PutOutcomeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOutcomeRequest,
   output: PutOutcomeResult,
@@ -5888,7 +5887,7 @@ export const sendEvent: API.OperationMethod<
   SendEventRequest,
   SendEventResult,
   SendEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEventRequest,
   output: SendEventResult,
@@ -5918,7 +5917,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -5946,7 +5945,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -5976,7 +5975,7 @@ export const updateDetectorVersion: API.OperationMethod<
   UpdateDetectorVersionRequest,
   UpdateDetectorVersionResult,
   UpdateDetectorVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDetectorVersionRequest,
   output: UpdateDetectorVersionResult,
@@ -6008,7 +6007,7 @@ export const updateDetectorVersionMetadata: API.OperationMethod<
   UpdateDetectorVersionMetadataRequest,
   UpdateDetectorVersionMetadataResult,
   UpdateDetectorVersionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDetectorVersionMetadataRequest,
   output: UpdateDetectorVersionMetadataResult,
@@ -6040,7 +6039,7 @@ export const updateDetectorVersionStatus: API.OperationMethod<
   UpdateDetectorVersionStatusRequest,
   UpdateDetectorVersionStatusResult,
   UpdateDetectorVersionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDetectorVersionStatusRequest,
   output: UpdateDetectorVersionStatusResult,
@@ -6072,7 +6071,7 @@ export const updateEventLabel: API.OperationMethod<
   UpdateEventLabelRequest,
   UpdateEventLabelResult,
   UpdateEventLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventLabelRequest,
   output: UpdateEventLabelResult,
@@ -6104,7 +6103,7 @@ export const updateList: API.OperationMethod<
   UpdateListRequest,
   UpdateListResult,
   UpdateListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateListRequest,
   output: UpdateListResult,
@@ -6136,7 +6135,7 @@ export const updateModel: API.OperationMethod<
   UpdateModelRequest,
   UpdateModelResult,
   UpdateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelRequest,
   output: UpdateModelResult,
@@ -6168,7 +6167,7 @@ export const updateModelVersion: API.OperationMethod<
   UpdateModelVersionRequest,
   UpdateModelVersionResult,
   UpdateModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelVersionRequest,
   output: UpdateModelVersionResult,
@@ -6208,7 +6207,7 @@ export const updateModelVersionStatus: API.OperationMethod<
   UpdateModelVersionStatusRequest,
   UpdateModelVersionStatusResult,
   UpdateModelVersionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelVersionStatusRequest,
   output: UpdateModelVersionStatusResult,
@@ -6240,7 +6239,7 @@ export const updateRuleMetadata: API.OperationMethod<
   UpdateRuleMetadataRequest,
   UpdateRuleMetadataResult,
   UpdateRuleMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleMetadataRequest,
   output: UpdateRuleMetadataResult,
@@ -6272,7 +6271,7 @@ export const updateRuleVersion: API.OperationMethod<
   UpdateRuleVersionRequest,
   UpdateRuleVersionResult,
   UpdateRuleVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleVersionRequest,
   output: UpdateRuleVersionResult,
@@ -6304,7 +6303,7 @@ export const updateVariable: API.OperationMethod<
   UpdateVariableRequest,
   UpdateVariableResult,
   UpdateVariableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVariableRequest,
   output: UpdateVariableResult,

--- a/packages/aws/src/services/freetier.ts
+++ b/packages/aws/src/services/freetier.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "FreeTier",
   serviceShapeName: "AWSFreeTierService",
@@ -476,7 +475,7 @@ export const getAccountActivity: API.OperationMethod<
   GetAccountActivityRequest,
   GetAccountActivityResponse,
   GetAccountActivityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountActivityRequest,
   output: GetAccountActivityResponse,
@@ -505,7 +504,7 @@ export const getAccountPlanState: API.OperationMethod<
   GetAccountPlanStateRequest,
   GetAccountPlanStateResponse,
   GetAccountPlanStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountPlanStateRequest,
   output: GetAccountPlanStateResponse,
@@ -533,7 +532,7 @@ export const getFreeTierUsage: API.PaginatedOperationMethod<
   GetFreeTierUsageRequest,
   GetFreeTierUsageResponse,
   GetFreeTierUsageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FreeTierUsage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFreeTierUsageRequest,
@@ -562,7 +561,7 @@ export const listAccountActivities: API.PaginatedOperationMethod<
   ListAccountActivitiesRequest,
   ListAccountActivitiesResponse,
   ListAccountActivitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActivitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountActivitiesRequest,
@@ -593,7 +592,7 @@ export const upgradeAccountPlan: API.OperationMethod<
   UpgradeAccountPlanRequest,
   UpgradeAccountPlanResponse,
   UpgradeAccountPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeAccountPlanRequest,
   output: UpgradeAccountPlanResponse,

--- a/packages/aws/src/services/fsx.ts
+++ b/packages/aws/src/services/fsx.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "FSx",
@@ -5903,7 +5902,7 @@ export const associateFileSystemAliases: API.OperationMethod<
   AssociateFileSystemAliasesRequest,
   AssociateFileSystemAliasesResponse,
   AssociateFileSystemAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFileSystemAliasesRequest,
   output: AssociateFileSystemAliasesResponse,
@@ -5938,7 +5937,7 @@ export const cancelDataRepositoryTask: API.OperationMethod<
   CancelDataRepositoryTaskRequest,
   CancelDataRepositoryTaskResponse,
   CancelDataRepositoryTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDataRepositoryTaskRequest,
   output: CancelDataRepositoryTaskResponse,
@@ -5998,7 +5997,7 @@ export const copyBackup: API.OperationMethod<
   CopyBackupRequest,
   CopyBackupResponse,
   CopyBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyBackupRequest,
   output: CopyBackupResponse,
@@ -6035,7 +6034,7 @@ export const copySnapshotAndUpdateVolume: API.OperationMethod<
   CopySnapshotAndUpdateVolumeRequest,
   CopySnapshotAndUpdateVolumeResponse,
   CopySnapshotAndUpdateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopySnapshotAndUpdateVolumeRequest,
   output: CopySnapshotAndUpdateVolumeResponse,
@@ -6090,7 +6089,7 @@ export const createAndAttachS3AccessPoint: API.OperationMethod<
   CreateAndAttachS3AccessPointRequest,
   CreateAndAttachS3AccessPointResponse,
   CreateAndAttachS3AccessPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAndAttachS3AccessPointRequest,
   output: CreateAndAttachS3AccessPointResponse,
@@ -6173,7 +6172,7 @@ export const createBackup: API.OperationMethod<
   CreateBackupRequest,
   CreateBackupResponse,
   CreateBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBackupRequest,
   output: CreateBackupResponse,
@@ -6223,7 +6222,7 @@ export const createDataRepositoryAssociation: API.OperationMethod<
   CreateDataRepositoryAssociationRequest,
   CreateDataRepositoryAssociationResponse,
   CreateDataRepositoryAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataRepositoryAssociationRequest,
   output: CreateDataRepositoryAssociationResponse,
@@ -6273,7 +6272,7 @@ export const createDataRepositoryTask: API.OperationMethod<
   CreateDataRepositoryTaskRequest,
   CreateDataRepositoryTaskResponse,
   CreateDataRepositoryTaskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataRepositoryTaskRequest,
   output: CreateDataRepositoryTaskResponse,
@@ -6326,7 +6325,7 @@ export const createFileCache: API.OperationMethod<
   CreateFileCacheRequest,
   CreateFileCacheResponse,
   CreateFileCacheError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFileCacheRequest,
   output: CreateFileCacheResponse,
@@ -6399,7 +6398,7 @@ export const createFileSystem: API.OperationMethod<
   CreateFileSystemRequest,
   CreateFileSystemResponse,
   CreateFileSystemError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFileSystemRequest,
   output: CreateFileSystemResponse,
@@ -6468,7 +6467,7 @@ export const createFileSystemFromBackup: API.OperationMethod<
   CreateFileSystemFromBackupRequest,
   CreateFileSystemFromBackupResponse,
   CreateFileSystemFromBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFileSystemFromBackupRequest,
   output: CreateFileSystemFromBackupResponse,
@@ -6528,7 +6527,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotRequest,
   CreateSnapshotResponse,
   CreateSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotRequest,
   output: CreateSnapshotResponse,
@@ -6560,7 +6559,7 @@ export const createStorageVirtualMachine: API.OperationMethod<
   CreateStorageVirtualMachineRequest,
   CreateStorageVirtualMachineResponse,
   CreateStorageVirtualMachineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorageVirtualMachineRequest,
   output: CreateStorageVirtualMachineResponse,
@@ -6595,7 +6594,7 @@ export const createVolume: API.OperationMethod<
   CreateVolumeRequest,
   CreateVolumeResponse,
   CreateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVolumeRequest,
   output: CreateVolumeResponse,
@@ -6632,7 +6631,7 @@ export const createVolumeFromBackup: API.OperationMethod<
   CreateVolumeFromBackupRequest,
   CreateVolumeFromBackupResponse,
   CreateVolumeFromBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVolumeFromBackupRequest,
   output: CreateVolumeFromBackupResponse,
@@ -6674,7 +6673,7 @@ export const deleteBackup: API.OperationMethod<
   DeleteBackupRequest,
   DeleteBackupResponse,
   DeleteBackupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBackupRequest,
   output: DeleteBackupResponse,
@@ -6712,7 +6711,7 @@ export const deleteDataRepositoryAssociation: API.OperationMethod<
   DeleteDataRepositoryAssociationRequest,
   DeleteDataRepositoryAssociationResponse,
   DeleteDataRepositoryAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataRepositoryAssociationRequest,
   output: DeleteDataRepositoryAssociationResponse,
@@ -6753,7 +6752,7 @@ export const deleteFileCache: API.OperationMethod<
   DeleteFileCacheRequest,
   DeleteFileCacheResponse,
   DeleteFileCacheError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileCacheRequest,
   output: DeleteFileCacheResponse,
@@ -6828,7 +6827,7 @@ export const deleteFileSystem: API.OperationMethod<
   DeleteFileSystemRequest,
   DeleteFileSystemResponse,
   DeleteFileSystemError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileSystemRequest,
   output: DeleteFileSystemResponse,
@@ -6861,7 +6860,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
   DeleteSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotRequest,
   output: DeleteSnapshotResponse,
@@ -6885,7 +6884,7 @@ export const deleteStorageVirtualMachine: API.OperationMethod<
   DeleteStorageVirtualMachineRequest,
   DeleteStorageVirtualMachineResponse,
   DeleteStorageVirtualMachineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageVirtualMachineRequest,
   output: DeleteStorageVirtualMachineResponse,
@@ -6915,7 +6914,7 @@ export const deleteVolume: API.OperationMethod<
   DeleteVolumeRequest,
   DeleteVolumeResponse,
   DeleteVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVolumeRequest,
   output: DeleteVolumeResponse,
@@ -6969,7 +6968,7 @@ export const describeBackups: API.PaginatedOperationMethod<
   DescribeBackupsRequest,
   DescribeBackupsResponse,
   DescribeBackupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBackupsRequest,
@@ -7025,7 +7024,7 @@ export const describeDataRepositoryAssociations: API.PaginatedOperationMethod<
   DescribeDataRepositoryAssociationsRequest,
   DescribeDataRepositoryAssociationsResponse,
   DescribeDataRepositoryAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataRepositoryAssociationsRequest,
@@ -7070,7 +7069,7 @@ export const describeDataRepositoryTasks: API.PaginatedOperationMethod<
   DescribeDataRepositoryTasksRequest,
   DescribeDataRepositoryTasksResponse,
   DescribeDataRepositoryTasksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataRepositoryTasksRequest,
@@ -7129,7 +7128,7 @@ export const describeFileCaches: API.PaginatedOperationMethod<
   DescribeFileCachesRequest,
   DescribeFileCachesResponse,
   DescribeFileCachesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFileCachesRequest,
@@ -7159,7 +7158,7 @@ export const describeFileSystemAliases: API.PaginatedOperationMethod<
   DescribeFileSystemAliasesRequest,
   DescribeFileSystemAliasesResponse,
   DescribeFileSystemAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFileSystemAliasesRequest,
@@ -7213,7 +7212,7 @@ export const describeFileSystems: API.PaginatedOperationMethod<
   DescribeFileSystemsRequest,
   DescribeFileSystemsResponse,
   DescribeFileSystemsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFileSystemsRequest,
@@ -7246,7 +7245,7 @@ export const describeS3AccessPointAttachments: API.PaginatedOperationMethod<
   DescribeS3AccessPointAttachmentsRequest,
   DescribeS3AccessPointAttachmentsResponse,
   DescribeS3AccessPointAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   S3AccessPointAttachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeS3AccessPointAttachmentsRequest,
@@ -7280,7 +7279,7 @@ export const describeSharedVpcConfiguration: API.OperationMethod<
   DescribeSharedVpcConfigurationRequest,
   DescribeSharedVpcConfigurationResponse,
   DescribeSharedVpcConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSharedVpcConfigurationRequest,
   output: DescribeSharedVpcConfigurationResponse,
@@ -7327,7 +7326,7 @@ export const describeSnapshots: API.PaginatedOperationMethod<
   DescribeSnapshotsRequest,
   DescribeSnapshotsResponse,
   DescribeSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotsRequest,
@@ -7356,7 +7355,7 @@ export const describeStorageVirtualMachines: API.PaginatedOperationMethod<
   DescribeStorageVirtualMachinesRequest,
   DescribeStorageVirtualMachinesResponse,
   DescribeStorageVirtualMachinesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StorageVirtualMachine
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStorageVirtualMachinesRequest,
@@ -7386,7 +7385,7 @@ export const describeVolumes: API.PaginatedOperationMethod<
   DescribeVolumesRequest,
   DescribeVolumesResponse,
   DescribeVolumesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Volume
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVolumesRequest,
@@ -7423,7 +7422,7 @@ export const detachAndDeleteS3AccessPoint: API.OperationMethod<
   DetachAndDeleteS3AccessPointRequest,
   DetachAndDeleteS3AccessPointResponse,
   DetachAndDeleteS3AccessPointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachAndDeleteS3AccessPointRequest,
   output: DetachAndDeleteS3AccessPointResponse,
@@ -7460,7 +7459,7 @@ export const disassociateFileSystemAliases: API.OperationMethod<
   DisassociateFileSystemAliasesRequest,
   DisassociateFileSystemAliasesResponse,
   DisassociateFileSystemAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFileSystemAliasesRequest,
   output: DisassociateFileSystemAliasesResponse,
@@ -7506,7 +7505,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -7543,7 +7542,7 @@ export const releaseFileSystemNfsV3Locks: API.OperationMethod<
   ReleaseFileSystemNfsV3LocksRequest,
   ReleaseFileSystemNfsV3LocksResponse,
   ReleaseFileSystemNfsV3LocksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseFileSystemNfsV3LocksRequest,
   output: ReleaseFileSystemNfsV3LocksResponse,
@@ -7573,7 +7572,7 @@ export const restoreVolumeFromSnapshot: API.OperationMethod<
   RestoreVolumeFromSnapshotRequest,
   RestoreVolumeFromSnapshotResponse,
   RestoreVolumeFromSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreVolumeFromSnapshotRequest,
   output: RestoreVolumeFromSnapshotResponse,
@@ -7601,7 +7600,7 @@ export const startMisconfiguredStateRecovery: API.OperationMethod<
   StartMisconfiguredStateRecoveryRequest,
   StartMisconfiguredStateRecoveryResponse,
   StartMisconfiguredStateRecoveryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMisconfiguredStateRecoveryRequest,
   output: StartMisconfiguredStateRecoveryResponse,
@@ -7625,7 +7624,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7655,7 +7654,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7688,7 +7687,7 @@ export const updateDataRepositoryAssociation: API.OperationMethod<
   UpdateDataRepositoryAssociationRequest,
   UpdateDataRepositoryAssociationResponse,
   UpdateDataRepositoryAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataRepositoryAssociationRequest,
   output: UpdateDataRepositoryAssociationResponse,
@@ -7721,7 +7720,7 @@ export const updateFileCache: API.OperationMethod<
   UpdateFileCacheRequest,
   UpdateFileCacheResponse,
   UpdateFileCacheError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFileCacheRequest,
   output: UpdateFileCacheResponse,
@@ -7861,7 +7860,7 @@ export const updateFileSystem: API.OperationMethod<
   UpdateFileSystemRequest,
   UpdateFileSystemResponse,
   UpdateFileSystemError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFileSystemRequest,
   output: UpdateFileSystemResponse,
@@ -7900,7 +7899,7 @@ export const updateSharedVpcConfiguration: API.OperationMethod<
   UpdateSharedVpcConfigurationRequest,
   UpdateSharedVpcConfigurationResponse,
   UpdateSharedVpcConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSharedVpcConfigurationRequest,
   output: UpdateSharedVpcConfigurationResponse,
@@ -7923,7 +7922,7 @@ export const updateSnapshot: API.OperationMethod<
   UpdateSnapshotRequest,
   UpdateSnapshotResponse,
   UpdateSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSnapshotRequest,
   output: UpdateSnapshotResponse,
@@ -7952,7 +7951,7 @@ export const updateStorageVirtualMachine: API.OperationMethod<
   UpdateStorageVirtualMachineRequest,
   UpdateStorageVirtualMachineResponse,
   UpdateStorageVirtualMachineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStorageVirtualMachineRequest,
   output: UpdateStorageVirtualMachineResponse,
@@ -7982,7 +7981,7 @@ export const updateVolume: API.OperationMethod<
   UpdateVolumeRequest,
   UpdateVolumeResponse,
   UpdateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVolumeRequest,
   output: UpdateVolumeResponse,

--- a/packages/aws/src/services/gamelift.ts
+++ b/packages/aws/src/services/gamelift.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://gamelift.amazonaws.com/doc/");
 const svc = T.AwsApiService({
@@ -7882,7 +7881,7 @@ export const acceptMatch: API.OperationMethod<
   AcceptMatchInput,
   AcceptMatchOutput,
   AcceptMatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptMatchInput,
   output: AcceptMatchOutput,
@@ -7949,7 +7948,7 @@ export const claimGameServer: API.OperationMethod<
   ClaimGameServerInput,
   ClaimGameServerOutput,
   ClaimGameServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClaimGameServerInput,
   output: ClaimGameServerOutput,
@@ -8002,7 +8001,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasInput,
   CreateAliasOutput,
   CreateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasInput,
   output: CreateAliasOutput,
@@ -8070,7 +8069,7 @@ export const createBuild: API.OperationMethod<
   CreateBuildInput,
   CreateBuildOutput,
   CreateBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBuildInput,
   output: CreateBuildOutput,
@@ -8176,7 +8175,7 @@ export const createContainerFleet: API.OperationMethod<
   CreateContainerFleetInput,
   CreateContainerFleetOutput,
   CreateContainerFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerFleetInput,
   output: CreateContainerFleetOutput,
@@ -8302,7 +8301,7 @@ export const createContainerGroupDefinition: API.OperationMethod<
   CreateContainerGroupDefinitionInput,
   CreateContainerGroupDefinitionOutput,
   CreateContainerGroupDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerGroupDefinitionInput,
   output: CreateContainerGroupDefinitionOutput,
@@ -8411,7 +8410,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetInput,
   CreateFleetOutput,
   CreateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetInput,
   output: CreateFleetOutput,
@@ -8474,7 +8473,7 @@ export const createFleetLocations: API.OperationMethod<
   CreateFleetLocationsInput,
   CreateFleetLocationsOutput,
   CreateFleetLocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetLocationsInput,
   output: CreateFleetLocationsOutput,
@@ -8545,7 +8544,7 @@ export const createGameServerGroup: API.OperationMethod<
   CreateGameServerGroupInput,
   CreateGameServerGroupOutput,
   CreateGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGameServerGroupInput,
   output: CreateGameServerGroupOutput,
@@ -8621,7 +8620,7 @@ export const createGameSession: API.OperationMethod<
   CreateGameSessionInput,
   CreateGameSessionOutput,
   CreateGameSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGameSessionInput,
   output: CreateGameSessionOutput,
@@ -8732,7 +8731,7 @@ export const createGameSessionQueue: API.OperationMethod<
   CreateGameSessionQueueInput,
   CreateGameSessionQueueOutput,
   CreateGameSessionQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGameSessionQueueInput,
   output: CreateGameSessionQueueOutput,
@@ -8766,7 +8765,7 @@ export const createLocation: API.OperationMethod<
   CreateLocationInput,
   CreateLocationOutput,
   CreateLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLocationInput,
   output: CreateLocationOutput,
@@ -8824,7 +8823,7 @@ export const createMatchmakingConfiguration: API.OperationMethod<
   CreateMatchmakingConfigurationInput,
   CreateMatchmakingConfigurationOutput,
   CreateMatchmakingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMatchmakingConfigurationInput,
   output: CreateMatchmakingConfigurationOutput,
@@ -8877,7 +8876,7 @@ export const createMatchmakingRuleSet: API.OperationMethod<
   CreateMatchmakingRuleSetInput,
   CreateMatchmakingRuleSetOutput,
   CreateMatchmakingRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMatchmakingRuleSetInput,
   output: CreateMatchmakingRuleSetOutput,
@@ -8929,7 +8928,7 @@ export const createPlayerSession: API.OperationMethod<
   CreatePlayerSessionInput,
   CreatePlayerSessionOutput,
   CreatePlayerSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlayerSessionInput,
   output: CreatePlayerSessionOutput,
@@ -8983,7 +8982,7 @@ export const createPlayerSessions: API.OperationMethod<
   CreatePlayerSessionsInput,
   CreatePlayerSessionsOutput,
   CreatePlayerSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlayerSessionsInput,
   output: CreatePlayerSessionsOutput,
@@ -9048,7 +9047,7 @@ export const createScript: API.OperationMethod<
   CreateScriptInput,
   CreateScriptOutput,
   CreateScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScriptInput,
   output: CreateScriptOutput,
@@ -9122,7 +9121,7 @@ export const createVpcPeeringAuthorization: API.OperationMethod<
   CreateVpcPeeringAuthorizationInput,
   CreateVpcPeeringAuthorizationOutput,
   CreateVpcPeeringAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcPeeringAuthorizationInput,
   output: CreateVpcPeeringAuthorizationOutput,
@@ -9190,7 +9189,7 @@ export const createVpcPeeringConnection: API.OperationMethod<
   CreateVpcPeeringConnectionInput,
   CreateVpcPeeringConnectionOutput,
   CreateVpcPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcPeeringConnectionInput,
   output: CreateVpcPeeringConnectionOutput,
@@ -9227,7 +9226,7 @@ export const deleteAlias: API.OperationMethod<
   DeleteAliasInput,
   DeleteAliasResponse,
   DeleteAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAliasInput,
   output: DeleteAliasResponse,
@@ -9270,7 +9269,7 @@ export const deleteBuild: API.OperationMethod<
   DeleteBuildInput,
   DeleteBuildResponse,
   DeleteBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBuildInput,
   output: DeleteBuildResponse,
@@ -9313,7 +9312,7 @@ export const deleteContainerFleet: API.OperationMethod<
   DeleteContainerFleetInput,
   DeleteContainerFleetOutput,
   DeleteContainerFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerFleetInput,
   output: DeleteContainerFleetOutput,
@@ -9375,7 +9374,7 @@ export const deleteContainerGroupDefinition: API.OperationMethod<
   DeleteContainerGroupDefinitionInput,
   DeleteContainerGroupDefinitionOutput,
   DeleteContainerGroupDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerGroupDefinitionInput,
   output: DeleteContainerGroupDefinitionOutput,
@@ -9424,7 +9423,7 @@ export const deleteFleet: API.OperationMethod<
   DeleteFleetInput,
   DeleteFleetResponse,
   DeleteFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetInput,
   output: DeleteFleetResponse,
@@ -9470,7 +9469,7 @@ export const deleteFleetLocations: API.OperationMethod<
   DeleteFleetLocationsInput,
   DeleteFleetLocationsOutput,
   DeleteFleetLocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetLocationsInput,
   output: DeleteFleetLocationsOutput,
@@ -9528,7 +9527,7 @@ export const deleteGameServerGroup: API.OperationMethod<
   DeleteGameServerGroupInput,
   DeleteGameServerGroupOutput,
   DeleteGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGameServerGroupInput,
   output: DeleteGameServerGroupOutput,
@@ -9560,7 +9559,7 @@ export const deleteGameSessionQueue: API.OperationMethod<
   DeleteGameSessionQueueInput,
   DeleteGameSessionQueueOutput,
   DeleteGameSessionQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGameSessionQueueInput,
   output: DeleteGameSessionQueueOutput,
@@ -9594,7 +9593,7 @@ export const deleteLocation: API.OperationMethod<
   DeleteLocationInput,
   DeleteLocationOutput,
   DeleteLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLocationInput,
   output: DeleteLocationOutput,
@@ -9627,7 +9626,7 @@ export const deleteMatchmakingConfiguration: API.OperationMethod<
   DeleteMatchmakingConfigurationInput,
   DeleteMatchmakingConfigurationOutput,
   DeleteMatchmakingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMatchmakingConfigurationInput,
   output: DeleteMatchmakingConfigurationOutput,
@@ -9666,7 +9665,7 @@ export const deleteMatchmakingRuleSet: API.OperationMethod<
   DeleteMatchmakingRuleSetInput,
   DeleteMatchmakingRuleSetOutput,
   DeleteMatchmakingRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMatchmakingRuleSetInput,
   output: DeleteMatchmakingRuleSetOutput,
@@ -9703,7 +9702,7 @@ export const deleteScalingPolicy: API.OperationMethod<
   DeleteScalingPolicyInput,
   DeleteScalingPolicyResponse,
   DeleteScalingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScalingPolicyInput,
   output: DeleteScalingPolicyResponse,
@@ -9750,7 +9749,7 @@ export const deleteScript: API.OperationMethod<
   DeleteScriptInput,
   DeleteScriptResponse,
   DeleteScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScriptInput,
   output: DeleteScriptResponse,
@@ -9786,7 +9785,7 @@ export const deleteVpcPeeringAuthorization: API.OperationMethod<
   DeleteVpcPeeringAuthorizationInput,
   DeleteVpcPeeringAuthorizationOutput,
   DeleteVpcPeeringAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcPeeringAuthorizationInput,
   output: DeleteVpcPeeringAuthorizationOutput,
@@ -9825,7 +9824,7 @@ export const deleteVpcPeeringConnection: API.OperationMethod<
   DeleteVpcPeeringConnectionInput,
   DeleteVpcPeeringConnectionOutput,
   DeleteVpcPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcPeeringConnectionInput,
   output: DeleteVpcPeeringConnectionOutput,
@@ -9861,7 +9860,7 @@ export const deregisterCompute: API.OperationMethod<
   DeregisterComputeInput,
   DeregisterComputeOutput,
   DeregisterComputeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterComputeInput,
   output: DeregisterComputeOutput,
@@ -9902,7 +9901,7 @@ export const deregisterGameServer: API.OperationMethod<
   DeregisterGameServerInput,
   DeregisterGameServerResponse,
   DeregisterGameServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterGameServerInput,
   output: DeregisterGameServerResponse,
@@ -9940,7 +9939,7 @@ export const describeAlias: API.OperationMethod<
   DescribeAliasInput,
   DescribeAliasOutput,
   DescribeAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAliasInput,
   output: DescribeAliasOutput,
@@ -9978,7 +9977,7 @@ export const describeBuild: API.OperationMethod<
   DescribeBuildInput,
   DescribeBuildOutput,
   DescribeBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBuildInput,
   output: DescribeBuildOutput,
@@ -10037,7 +10036,7 @@ export const describeCompute: API.OperationMethod<
   DescribeComputeInput,
   DescribeComputeOutput,
   DescribeComputeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComputeInput,
   output: DescribeComputeOutput,
@@ -10084,7 +10083,7 @@ export const describeContainerFleet: API.OperationMethod<
   DescribeContainerFleetInput,
   DescribeContainerFleetOutput,
   DescribeContainerFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContainerFleetInput,
   output: DescribeContainerFleetOutput,
@@ -10134,7 +10133,7 @@ export const describeContainerGroupDefinition: API.OperationMethod<
   DescribeContainerGroupDefinitionInput,
   DescribeContainerGroupDefinitionOutput,
   DescribeContainerGroupDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContainerGroupDefinitionInput,
   output: DescribeContainerGroupDefinitionOutput,
@@ -10199,7 +10198,7 @@ export const describeContainerGroupPortMappings: API.OperationMethod<
   DescribeContainerGroupPortMappingsInput,
   DescribeContainerGroupPortMappingsOutput,
   DescribeContainerGroupPortMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContainerGroupPortMappingsInput,
   output: DescribeContainerGroupPortMappingsOutput,
@@ -10280,7 +10279,7 @@ export const describeEC2InstanceLimits: API.OperationMethod<
   DescribeEC2InstanceLimitsInput,
   DescribeEC2InstanceLimitsOutput,
   DescribeEC2InstanceLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEC2InstanceLimitsInput,
   output: DescribeEC2InstanceLimitsOutput,
@@ -10332,7 +10331,7 @@ export const describeFleetAttributes: API.PaginatedOperationMethod<
   DescribeFleetAttributesInput,
   DescribeFleetAttributesOutput,
   DescribeFleetAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetAttributes
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetAttributesInput,
@@ -10401,7 +10400,7 @@ export const describeFleetCapacity: API.PaginatedOperationMethod<
   DescribeFleetCapacityInput,
   DescribeFleetCapacityOutput,
   DescribeFleetCapacityError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetCapacity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetCapacityInput,
@@ -10452,7 +10451,7 @@ export const describeFleetDeployment: API.OperationMethod<
   DescribeFleetDeploymentInput,
   DescribeFleetDeploymentOutput,
   DescribeFleetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetDeploymentInput,
   output: DescribeFleetDeploymentOutput,
@@ -10497,7 +10496,7 @@ export const describeFleetEvents: API.PaginatedOperationMethod<
   DescribeFleetEventsInput,
   DescribeFleetEventsOutput,
   DescribeFleetEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetEventsInput,
@@ -10558,7 +10557,7 @@ export const describeFleetLocationAttributes: API.PaginatedOperationMethod<
   DescribeFleetLocationAttributesInput,
   DescribeFleetLocationAttributesOutput,
   DescribeFleetLocationAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetLocationAttributesInput,
@@ -10617,7 +10616,7 @@ export const describeFleetLocationCapacity: API.OperationMethod<
   DescribeFleetLocationCapacityInput,
   DescribeFleetLocationCapacityOutput,
   DescribeFleetLocationCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetLocationCapacityInput,
   output: DescribeFleetLocationCapacityOutput,
@@ -10667,7 +10666,7 @@ export const describeFleetLocationUtilization: API.OperationMethod<
   DescribeFleetLocationUtilizationInput,
   DescribeFleetLocationUtilizationOutput,
   DescribeFleetLocationUtilizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetLocationUtilizationInput,
   output: DescribeFleetLocationUtilizationOutput,
@@ -10720,7 +10719,7 @@ export const describeFleetPortSettings: API.OperationMethod<
   DescribeFleetPortSettingsInput,
   DescribeFleetPortSettingsOutput,
   DescribeFleetPortSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetPortSettingsInput,
   output: DescribeFleetPortSettingsOutput,
@@ -10780,7 +10779,7 @@ export const describeFleetUtilization: API.PaginatedOperationMethod<
   DescribeFleetUtilizationInput,
   DescribeFleetUtilizationOutput,
   DescribeFleetUtilizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetUtilization
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFleetUtilizationInput,
@@ -10827,7 +10826,7 @@ export const describeGameServer: API.OperationMethod<
   DescribeGameServerInput,
   DescribeGameServerOutput,
   DescribeGameServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGameServerInput,
   output: DescribeGameServerOutput,
@@ -10869,7 +10868,7 @@ export const describeGameServerGroup: API.OperationMethod<
   DescribeGameServerGroupInput,
   DescribeGameServerGroupOutput,
   DescribeGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGameServerGroupInput,
   output: DescribeGameServerGroupOutput,
@@ -10918,7 +10917,7 @@ export const describeGameServerInstances: API.PaginatedOperationMethod<
   DescribeGameServerInstancesInput,
   DescribeGameServerInstancesOutput,
   DescribeGameServerInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameServerInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGameServerInstancesInput,
@@ -10986,7 +10985,7 @@ export const describeGameSessionDetails: API.PaginatedOperationMethod<
   DescribeGameSessionDetailsInput,
   DescribeGameSessionDetailsOutput,
   DescribeGameSessionDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameSessionDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGameSessionDetailsInput,
@@ -11036,7 +11035,7 @@ export const describeGameSessionPlacement: API.OperationMethod<
   DescribeGameSessionPlacementInput,
   DescribeGameSessionPlacementOutput,
   DescribeGameSessionPlacementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGameSessionPlacementInput,
   output: DescribeGameSessionPlacementOutput,
@@ -11073,7 +11072,7 @@ export const describeGameSessionQueues: API.PaginatedOperationMethod<
   DescribeGameSessionQueuesInput,
   DescribeGameSessionQueuesOutput,
   DescribeGameSessionQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameSessionQueue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGameSessionQueuesInput,
@@ -11148,7 +11147,7 @@ export const describeGameSessions: API.PaginatedOperationMethod<
   DescribeGameSessionsInput,
   DescribeGameSessionsOutput,
   DescribeGameSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameSession
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGameSessionsInput,
@@ -11221,7 +11220,7 @@ export const describeInstances: API.PaginatedOperationMethod<
   DescribeInstancesInput,
   DescribeInstancesOutput,
   DescribeInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Instance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancesInput,
@@ -11276,7 +11275,7 @@ export const describeMatchmaking: API.OperationMethod<
   DescribeMatchmakingInput,
   DescribeMatchmakingOutput,
   DescribeMatchmakingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMatchmakingInput,
   output: DescribeMatchmakingOutput,
@@ -11316,7 +11315,7 @@ export const describeMatchmakingConfigurations: API.PaginatedOperationMethod<
   DescribeMatchmakingConfigurationsInput,
   DescribeMatchmakingConfigurationsOutput,
   DescribeMatchmakingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MatchmakingConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMatchmakingConfigurationsInput,
@@ -11360,7 +11359,7 @@ export const describeMatchmakingRuleSets: API.PaginatedOperationMethod<
   DescribeMatchmakingRuleSetsInput,
   DescribeMatchmakingRuleSetsOutput,
   DescribeMatchmakingRuleSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MatchmakingRuleSet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMatchmakingRuleSetsInput,
@@ -11420,7 +11419,7 @@ export const describePlayerSessions: API.PaginatedOperationMethod<
   DescribePlayerSessionsInput,
   DescribePlayerSessionsOutput,
   DescribePlayerSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PlayerSession
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePlayerSessionsInput,
@@ -11475,7 +11474,7 @@ export const describeRuntimeConfiguration: API.OperationMethod<
   DescribeRuntimeConfigurationInput,
   DescribeRuntimeConfigurationOutput,
   DescribeRuntimeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuntimeConfigurationInput,
   output: DescribeRuntimeConfigurationOutput,
@@ -11514,7 +11513,7 @@ export const describeScalingPolicies: API.PaginatedOperationMethod<
   DescribeScalingPoliciesInput,
   DescribeScalingPoliciesOutput,
   DescribeScalingPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScalingPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScalingPoliciesInput,
@@ -11563,7 +11562,7 @@ export const describeScript: API.OperationMethod<
   DescribeScriptInput,
   DescribeScriptOutput,
   DescribeScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScriptInput,
   output: DescribeScriptOutput,
@@ -11598,7 +11597,7 @@ export const describeVpcPeeringAuthorizations: API.OperationMethod<
   DescribeVpcPeeringAuthorizationsInput,
   DescribeVpcPeeringAuthorizationsOutput,
   DescribeVpcPeeringAuthorizationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcPeeringAuthorizationsInput,
   output: DescribeVpcPeeringAuthorizationsOutput,
@@ -11638,7 +11637,7 @@ export const describeVpcPeeringConnections: API.OperationMethod<
   DescribeVpcPeeringConnectionsInput,
   DescribeVpcPeeringConnectionsOutput,
   DescribeVpcPeeringConnectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcPeeringConnectionsInput,
   output: DescribeVpcPeeringConnectionsOutput,
@@ -11692,7 +11691,7 @@ export const getComputeAccess: API.OperationMethod<
   GetComputeAccessInput,
   GetComputeAccessOutput,
   GetComputeAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComputeAccessInput,
   output: GetComputeAccessOutput,
@@ -11751,7 +11750,7 @@ export const getComputeAuthToken: API.OperationMethod<
   GetComputeAuthTokenInput,
   GetComputeAuthTokenOutput,
   GetComputeAuthTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComputeAuthTokenInput,
   output: GetComputeAuthTokenOutput,
@@ -11790,7 +11789,7 @@ export const getGameSessionLogUrl: API.OperationMethod<
   GetGameSessionLogUrlInput,
   GetGameSessionLogUrlOutput,
   GetGameSessionLogUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGameSessionLogUrlInput,
   output: GetGameSessionLogUrlOutput,
@@ -11849,7 +11848,7 @@ export const getInstanceAccess: API.OperationMethod<
   GetInstanceAccessInput,
   GetInstanceAccessOutput,
   GetInstanceAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceAccessInput,
   output: GetInstanceAccessOutput,
@@ -11892,7 +11891,7 @@ export const getPlayerConnectionDetails: API.OperationMethod<
   GetPlayerConnectionDetailsInput,
   GetPlayerConnectionDetailsOutput,
   GetPlayerConnectionDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlayerConnectionDetailsInput,
   output: GetPlayerConnectionDetailsOutput,
@@ -11932,7 +11931,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesInput,
   ListAliasesOutput,
   ListAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Alias
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesInput,
@@ -11978,7 +11977,7 @@ export const listBuilds: API.PaginatedOperationMethod<
   ListBuildsInput,
   ListBuildsOutput,
   ListBuildsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Build
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuildsInput,
@@ -12037,7 +12036,7 @@ export const listCompute: API.PaginatedOperationMethod<
   ListComputeInput,
   ListComputeOutput,
   ListComputeError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Compute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputeInput,
@@ -12095,7 +12094,7 @@ export const listContainerFleets: API.PaginatedOperationMethod<
   ListContainerFleetsInput,
   ListContainerFleetsOutput,
   ListContainerFleetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContainerFleet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainerFleetsInput,
@@ -12150,7 +12149,7 @@ export const listContainerGroupDefinitions: API.PaginatedOperationMethod<
   ListContainerGroupDefinitionsInput,
   ListContainerGroupDefinitionsOutput,
   ListContainerGroupDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContainerGroupDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainerGroupDefinitionsInput,
@@ -12207,7 +12206,7 @@ export const listContainerGroupDefinitionVersions: API.PaginatedOperationMethod<
   ListContainerGroupDefinitionVersionsInput,
   ListContainerGroupDefinitionVersionsOutput,
   ListContainerGroupDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContainerGroupDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainerGroupDefinitionVersionsInput,
@@ -12261,7 +12260,7 @@ export const listFleetDeployments: API.PaginatedOperationMethod<
   ListFleetDeploymentsInput,
   ListFleetDeploymentsOutput,
   ListFleetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetDeployment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetDeploymentsInput,
@@ -12321,7 +12320,7 @@ export const listFleets: API.PaginatedOperationMethod<
   ListFleetsInput,
   ListFleetsOutput,
   ListFleetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetsInput,
@@ -12357,7 +12356,7 @@ export const listGameServerGroups: API.PaginatedOperationMethod<
   ListGameServerGroupsInput,
   ListGameServerGroupsOutput,
   ListGameServerGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameServerGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGameServerGroupsInput,
@@ -12400,7 +12399,7 @@ export const listGameServers: API.PaginatedOperationMethod<
   ListGameServersInput,
   ListGameServersOutput,
   ListGameServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGameServersInput,
@@ -12442,7 +12441,7 @@ export const listLocations: API.PaginatedOperationMethod<
   ListLocationsInput,
   ListLocationsOutput,
   ListLocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocationModel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLocationsInput,
@@ -12486,7 +12485,7 @@ export const listScripts: API.PaginatedOperationMethod<
   ListScriptsInput,
   ListScriptsOutput,
   ListScriptsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Script
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScriptsInput,
@@ -12538,7 +12537,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -12637,7 +12636,7 @@ export const putScalingPolicy: API.OperationMethod<
   PutScalingPolicyInput,
   PutScalingPolicyOutput,
   PutScalingPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutScalingPolicyInput,
   output: PutScalingPolicyOutput,
@@ -12697,7 +12696,7 @@ export const registerCompute: API.OperationMethod<
   RegisterComputeInput,
   RegisterComputeOutput,
   RegisterComputeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterComputeInput,
   output: RegisterComputeOutput,
@@ -12749,7 +12748,7 @@ export const registerGameServer: API.OperationMethod<
   RegisterGameServerInput,
   RegisterGameServerOutput,
   RegisterGameServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterGameServerInput,
   output: RegisterGameServerOutput,
@@ -12792,7 +12791,7 @@ export const requestUploadCredentials: API.OperationMethod<
   RequestUploadCredentialsInput,
   RequestUploadCredentialsOutput,
   RequestUploadCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestUploadCredentialsInput,
   output: RequestUploadCredentialsOutput,
@@ -12832,7 +12831,7 @@ export const resolveAlias: API.OperationMethod<
   ResolveAliasInput,
   ResolveAliasOutput,
   ResolveAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResolveAliasInput,
   output: ResolveAliasOutput,
@@ -12878,7 +12877,7 @@ export const resumeGameServerGroup: API.OperationMethod<
   ResumeGameServerGroupInput,
   ResumeGameServerGroupOutput,
   ResumeGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeGameServerGroupInput,
   output: ResumeGameServerGroupOutput,
@@ -12978,7 +12977,7 @@ export const searchGameSessions: API.PaginatedOperationMethod<
   SearchGameSessionsInput,
   SearchGameSessionsOutput,
   SearchGameSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GameSession
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchGameSessionsInput,
@@ -13037,7 +13036,7 @@ export const startFleetActions: API.OperationMethod<
   StartFleetActionsInput,
   StartFleetActionsOutput,
   StartFleetActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFleetActionsInput,
   output: StartFleetActionsOutput,
@@ -13144,7 +13143,7 @@ export const startGameSessionPlacement: API.OperationMethod<
   StartGameSessionPlacementInput,
   StartGameSessionPlacementOutput,
   StartGameSessionPlacementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartGameSessionPlacementInput,
   output: StartGameSessionPlacementOutput,
@@ -13210,7 +13209,7 @@ export const startMatchBackfill: API.OperationMethod<
   StartMatchBackfillInput,
   StartMatchBackfillOutput,
   StartMatchBackfillError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMatchBackfillInput,
   output: StartMatchBackfillOutput,
@@ -13265,7 +13264,7 @@ export const startMatchmaking: API.OperationMethod<
   StartMatchmakingInput,
   StartMatchmakingOutput,
   StartMatchmakingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMatchmakingInput,
   output: StartMatchmakingOutput,
@@ -13320,7 +13319,7 @@ export const stopFleetActions: API.OperationMethod<
   StopFleetActionsInput,
   StopFleetActionsOutput,
   StopFleetActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFleetActionsInput,
   output: StopFleetActionsOutput,
@@ -13361,7 +13360,7 @@ export const stopGameSessionPlacement: API.OperationMethod<
   StopGameSessionPlacementInput,
   StopGameSessionPlacementOutput,
   StopGameSessionPlacementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopGameSessionPlacementInput,
   output: StopGameSessionPlacementOutput,
@@ -13406,7 +13405,7 @@ export const stopMatchmaking: API.OperationMethod<
   StopMatchmakingInput,
   StopMatchmakingOutput,
   StopMatchmakingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMatchmakingInput,
   output: StopMatchmakingOutput,
@@ -13457,7 +13456,7 @@ export const suspendGameServerGroup: API.OperationMethod<
   SuspendGameServerGroupInput,
   SuspendGameServerGroupOutput,
   SuspendGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SuspendGameServerGroupInput,
   output: SuspendGameServerGroupOutput,
@@ -13506,7 +13505,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -13581,7 +13580,7 @@ export const terminateGameSession: API.OperationMethod<
   TerminateGameSessionInput,
   TerminateGameSessionOutput,
   TerminateGameSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateGameSessionInput,
   output: TerminateGameSessionOutput,
@@ -13631,7 +13630,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -13670,7 +13669,7 @@ export const updateAlias: API.OperationMethod<
   UpdateAliasInput,
   UpdateAliasOutput,
   UpdateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAliasInput,
   output: UpdateAliasOutput,
@@ -13709,7 +13708,7 @@ export const updateBuild: API.OperationMethod<
   UpdateBuildInput,
   UpdateBuildOutput,
   UpdateBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBuildInput,
   output: UpdateBuildOutput,
@@ -13789,7 +13788,7 @@ export const updateContainerFleet: API.OperationMethod<
   UpdateContainerFleetInput,
   UpdateContainerFleetOutput,
   UpdateContainerFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContainerFleetInput,
   output: UpdateContainerFleetOutput,
@@ -13859,7 +13858,7 @@ export const updateContainerGroupDefinition: API.OperationMethod<
   UpdateContainerGroupDefinitionInput,
   UpdateContainerGroupDefinitionOutput,
   UpdateContainerGroupDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContainerGroupDefinitionInput,
   output: UpdateContainerGroupDefinitionOutput,
@@ -13910,7 +13909,7 @@ export const updateFleetAttributes: API.OperationMethod<
   UpdateFleetAttributesInput,
   UpdateFleetAttributesOutput,
   UpdateFleetAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetAttributesInput,
   output: UpdateFleetAttributesOutput,
@@ -13995,7 +13994,7 @@ export const updateFleetCapacity: API.OperationMethod<
   UpdateFleetCapacityInput,
   UpdateFleetCapacityOutput,
   UpdateFleetCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetCapacityInput,
   output: UpdateFleetCapacityOutput,
@@ -14049,7 +14048,7 @@ export const updateFleetPortSettings: API.OperationMethod<
   UpdateFleetPortSettingsInput,
   UpdateFleetPortSettingsOutput,
   UpdateFleetPortSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetPortSettingsInput,
   output: UpdateFleetPortSettingsOutput,
@@ -14110,7 +14109,7 @@ export const updateGameServer: API.OperationMethod<
   UpdateGameServerInput,
   UpdateGameServerOutput,
   UpdateGameServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGameServerInput,
   output: UpdateGameServerOutput,
@@ -14159,7 +14158,7 @@ export const updateGameServerGroup: API.OperationMethod<
   UpdateGameServerGroupInput,
   UpdateGameServerGroupOutput,
   UpdateGameServerGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGameServerGroupInput,
   output: UpdateGameServerGroupOutput,
@@ -14199,7 +14198,7 @@ export const updateGameSession: API.OperationMethod<
   UpdateGameSessionInput,
   UpdateGameSessionOutput,
   UpdateGameSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGameSessionInput,
   output: UpdateGameSessionOutput,
@@ -14239,7 +14238,7 @@ export const updateGameSessionQueue: API.OperationMethod<
   UpdateGameSessionQueueInput,
   UpdateGameSessionQueueOutput,
   UpdateGameSessionQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGameSessionQueueInput,
   output: UpdateGameSessionQueueOutput,
@@ -14276,7 +14275,7 @@ export const updateMatchmakingConfiguration: API.OperationMethod<
   UpdateMatchmakingConfigurationInput,
   UpdateMatchmakingConfigurationOutput,
   UpdateMatchmakingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMatchmakingConfigurationInput,
   output: UpdateMatchmakingConfigurationOutput,
@@ -14327,7 +14326,7 @@ export const updateRuntimeConfiguration: API.OperationMethod<
   UpdateRuntimeConfigurationInput,
   UpdateRuntimeConfigurationOutput,
   UpdateRuntimeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuntimeConfigurationInput,
   output: UpdateRuntimeConfigurationOutput,
@@ -14379,7 +14378,7 @@ export const updateScript: API.OperationMethod<
   UpdateScriptInput,
   UpdateScriptOutput,
   UpdateScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScriptInput,
   output: UpdateScriptOutput,
@@ -14415,7 +14414,7 @@ export const validateMatchmakingRuleSet: API.OperationMethod<
   ValidateMatchmakingRuleSetInput,
   ValidateMatchmakingRuleSetOutput,
   ValidateMatchmakingRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateMatchmakingRuleSetInput,
   output: ValidateMatchmakingRuleSetOutput,

--- a/packages/aws/src/services/gameliftstreams.ts
+++ b/packages/aws/src/services/gameliftstreams.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "GameLiftStreams",
@@ -1513,7 +1512,7 @@ export const addStreamGroupLocations: API.OperationMethod<
   AddStreamGroupLocationsInput,
   AddStreamGroupLocationsOutput,
   AddStreamGroupLocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddStreamGroupLocationsInput,
   output: AddStreamGroupLocationsOutput,
@@ -1547,7 +1546,7 @@ export const associateApplications: API.OperationMethod<
   AssociateApplicationsInput,
   AssociateApplicationsOutput,
   AssociateApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApplicationsInput,
   output: AssociateApplicationsOutput,
@@ -1585,7 +1584,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationInput,
   CreateApplicationOutput,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationInput,
   output: CreateApplicationOutput,
@@ -1634,7 +1633,7 @@ export const createStreamGroup: API.OperationMethod<
   CreateStreamGroupInput,
   CreateStreamGroupOutput,
   CreateStreamGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamGroupInput,
   output: CreateStreamGroupOutput,
@@ -1693,7 +1692,7 @@ export const createStreamSessionConnection: API.OperationMethod<
   CreateStreamSessionConnectionInput,
   CreateStreamSessionConnectionOutput,
   CreateStreamSessionConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamSessionConnectionInput,
   output: CreateStreamSessionConnectionOutput,
@@ -1737,7 +1736,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationInput,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationInput,
   output: DeleteApplicationResponse,
@@ -1769,7 +1768,7 @@ export const deleteStreamGroup: API.OperationMethod<
   DeleteStreamGroupInput,
   DeleteStreamGroupResponse,
   DeleteStreamGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamGroupInput,
   output: DeleteStreamGroupResponse,
@@ -1802,7 +1801,7 @@ export const disassociateApplications: API.OperationMethod<
   DisassociateApplicationsInput,
   DisassociateApplicationsOutput,
   DisassociateApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApplicationsInput,
   output: DisassociateApplicationsOutput,
@@ -1846,7 +1845,7 @@ export const exportStreamSessionFiles: API.OperationMethod<
   ExportStreamSessionFilesInput,
   ExportStreamSessionFilesOutput,
   ExportStreamSessionFilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportStreamSessionFilesInput,
   output: ExportStreamSessionFilesOutput,
@@ -1876,7 +1875,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationInput,
   GetApplicationOutput,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationInput,
   output: GetApplicationOutput,
@@ -1906,7 +1905,7 @@ export const getStreamGroup: API.OperationMethod<
   GetStreamGroupInput,
   GetStreamGroupOutput,
   GetStreamGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamGroupInput,
   output: GetStreamGroupOutput,
@@ -1936,7 +1935,7 @@ export const getStreamSession: API.OperationMethod<
   GetStreamSessionInput,
   GetStreamSessionOutput,
   GetStreamSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamSessionInput,
   output: GetStreamSessionOutput,
@@ -1965,7 +1964,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsInput,
   ListApplicationsOutput,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsInput,
@@ -2000,7 +1999,7 @@ export const listStreamGroups: API.PaginatedOperationMethod<
   ListStreamGroupsInput,
   ListStreamGroupsOutput,
   ListStreamGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamGroupsInput,
@@ -2040,7 +2039,7 @@ export const listStreamSessions: API.PaginatedOperationMethod<
   ListStreamSessionsInput,
   ListStreamSessionsOutput,
   ListStreamSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamSessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamSessionsInput,
@@ -2080,7 +2079,7 @@ export const listStreamSessionsByAccount: API.PaginatedOperationMethod<
   ListStreamSessionsByAccountInput,
   ListStreamSessionsByAccountOutput,
   ListStreamSessionsByAccountError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamSessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamSessionsByAccountInput,
@@ -2121,7 +2120,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2152,7 +2151,7 @@ export const removeStreamGroupLocations: API.OperationMethod<
   RemoveStreamGroupLocationsInput,
   RemoveStreamGroupLocationsResponse,
   RemoveStreamGroupLocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveStreamGroupLocationsInput,
   output: RemoveStreamGroupLocationsResponse,
@@ -2237,7 +2236,7 @@ export const startStreamSession: API.OperationMethod<
   StartStreamSessionInput,
   StartStreamSessionOutput,
   StartStreamSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartStreamSessionInput,
   output: StartStreamSessionOutput,
@@ -2277,7 +2276,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2306,7 +2305,7 @@ export const terminateStreamSession: API.OperationMethod<
   TerminateStreamSessionInput,
   TerminateStreamSessionResponse,
   TerminateStreamSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateStreamSessionInput,
   output: TerminateStreamSessionResponse,
@@ -2335,7 +2334,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2366,7 +2365,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationInput,
   UpdateApplicationOutput,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationInput,
   output: UpdateApplicationOutput,
@@ -2410,7 +2409,7 @@ export const updateStreamGroup: API.OperationMethod<
   UpdateStreamGroupInput,
   UpdateStreamGroupOutput,
   UpdateStreamGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamGroupInput,
   output: UpdateStreamGroupOutput,

--- a/packages/aws/src/services/geo-maps.ts
+++ b/packages/aws/src/services/geo-maps.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Geo Maps",
@@ -513,7 +512,7 @@ export const getGlyphs: API.OperationMethod<
   GetGlyphsRequest,
   GetGlyphsResponse,
   GetGlyphsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlyphsRequest,
   output: GetGlyphsResponse,
@@ -533,7 +532,7 @@ export const getSprites: API.OperationMethod<
   GetSpritesRequest,
   GetSpritesResponse,
   GetSpritesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpritesRequest,
   output: GetSpritesResponse,
@@ -566,7 +565,7 @@ export const getStaticMap: API.OperationMethod<
   GetStaticMapRequest,
   GetStaticMapResponse,
   GetStaticMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStaticMapRequest,
   output: GetStaticMapResponse,
@@ -591,7 +590,7 @@ export const getStyleDescriptor: API.OperationMethod<
   GetStyleDescriptorRequest,
   GetStyleDescriptorResponse,
   GetStyleDescriptorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStyleDescriptorRequest,
   output: GetStyleDescriptorResponse,
@@ -617,7 +616,7 @@ export const getTile: API.OperationMethod<
   GetTileRequest,
   GetTileResponse,
   GetTileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTileRequest,
   output: GetTileResponse,

--- a/packages/aws/src/services/geo-places.ts
+++ b/packages/aws/src/services/geo-places.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Geo Places",
@@ -1767,7 +1766,7 @@ export const autocomplete: API.OperationMethod<
   AutocompleteRequest,
   AutocompleteResponse,
   AutocompleteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AutocompleteRequest,
   output: AutocompleteResponse,
@@ -1797,7 +1796,7 @@ export const geocode: API.OperationMethod<
   GeocodeRequest,
   GeocodeResponse,
   GeocodeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GeocodeRequest,
   output: GeocodeResponse,
@@ -1827,7 +1826,7 @@ export const getPlace: API.OperationMethod<
   GetPlaceRequest,
   GetPlaceResponse,
   GetPlaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlaceRequest,
   output: GetPlaceResponse,
@@ -1857,7 +1856,7 @@ export const reverseGeocode: API.OperationMethod<
   ReverseGeocodeRequest,
   ReverseGeocodeResponse,
   ReverseGeocodeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReverseGeocodeRequest,
   output: ReverseGeocodeResponse,
@@ -1887,7 +1886,7 @@ export const searchNearby: API.OperationMethod<
   SearchNearbyRequest,
   SearchNearbyResponse,
   SearchNearbyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchNearbyRequest,
   output: SearchNearbyResponse,
@@ -1917,7 +1916,7 @@ export const searchText: API.OperationMethod<
   SearchTextRequest,
   SearchTextResponse,
   SearchTextError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchTextRequest,
   output: SearchTextResponse,
@@ -1947,7 +1946,7 @@ export const suggest: API.OperationMethod<
   SuggestRequest,
   SuggestResponse,
   SuggestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SuggestRequest,
   output: SuggestResponse,

--- a/packages/aws/src/services/geo-routes.ts
+++ b/packages/aws/src/services/geo-routes.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Geo Routes",
@@ -5350,7 +5349,7 @@ export const calculateIsolines: API.OperationMethod<
   CalculateIsolinesRequest,
   CalculateIsolinesResponse,
   CalculateIsolinesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CalculateIsolinesRequest,
   output: CalculateIsolinesResponse,
@@ -5380,7 +5379,7 @@ export const calculateRouteMatrix: API.OperationMethod<
   CalculateRouteMatrixRequest,
   CalculateRouteMatrixResponse,
   CalculateRouteMatrixError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CalculateRouteMatrixRequest,
   output: CalculateRouteMatrixResponse,
@@ -5410,7 +5409,7 @@ export const calculateRoutes: API.OperationMethod<
   CalculateRoutesRequest,
   CalculateRoutesResponse,
   CalculateRoutesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CalculateRoutesRequest,
   output: CalculateRoutesResponse,
@@ -5440,7 +5439,7 @@ export const optimizeWaypoints: API.OperationMethod<
   OptimizeWaypointsRequest,
   OptimizeWaypointsResponse,
   OptimizeWaypointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OptimizeWaypointsRequest,
   output: OptimizeWaypointsResponse,
@@ -5470,7 +5469,7 @@ export const snapToRoads: API.OperationMethod<
   SnapToRoadsRequest,
   SnapToRoadsResponse,
   SnapToRoadsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SnapToRoadsRequest,
   output: SnapToRoadsResponse,

--- a/packages/aws/src/services/glacier.ts
+++ b/packages/aws/src/services/glacier.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://glacier.amazonaws.com/doc/2012-06-01/");
 const svc = T.AwsApiService({ sdkId: "Glacier", serviceShapeName: "Glacier" });
 const auth = T.AwsAuthSigv4({ name: "glacier" });
@@ -1807,7 +1806,7 @@ export const abortMultipartUpload: API.OperationMethod<
   AbortMultipartUploadInput,
   AbortMultipartUploadResponse,
   AbortMultipartUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortMultipartUploadInput,
   output: AbortMultipartUploadResponse,
@@ -1852,7 +1851,7 @@ export const abortVaultLock: API.OperationMethod<
   AbortVaultLockInput,
   AbortVaultLockResponse,
   AbortVaultLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortVaultLockInput,
   output: AbortVaultLockResponse,
@@ -1887,7 +1886,7 @@ export const addTagsToVault: API.OperationMethod<
   AddTagsToVaultInput,
   AddTagsToVaultResponse,
   AddTagsToVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToVaultInput,
   output: AddTagsToVaultResponse,
@@ -1956,7 +1955,7 @@ export const completeMultipartUpload: API.OperationMethod<
   CompleteMultipartUploadInput,
   ArchiveCreationOutput,
   CompleteMultipartUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteMultipartUploadInput,
   output: ArchiveCreationOutput,
@@ -2001,7 +2000,7 @@ export const completeVaultLock: API.OperationMethod<
   CompleteVaultLockInput,
   CompleteVaultLockResponse,
   CompleteVaultLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteVaultLockInput,
   output: CompleteVaultLockResponse,
@@ -2052,7 +2051,7 @@ export const createVault: API.OperationMethod<
   CreateVaultInput,
   CreateVaultOutput,
   CreateVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVaultInput,
   output: CreateVaultOutput,
@@ -2105,7 +2104,7 @@ export const deleteArchive: API.OperationMethod<
   DeleteArchiveInput,
   DeleteArchiveResponse,
   DeleteArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArchiveInput,
   output: DeleteArchiveResponse,
@@ -2155,7 +2154,7 @@ export const deleteVault: API.OperationMethod<
   DeleteVaultInput,
   DeleteVaultResponse,
   DeleteVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVaultInput,
   output: DeleteVaultResponse,
@@ -2192,7 +2191,7 @@ export const deleteVaultAccessPolicy: API.OperationMethod<
   DeleteVaultAccessPolicyInput,
   DeleteVaultAccessPolicyResponse,
   DeleteVaultAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVaultAccessPolicyInput,
   output: DeleteVaultAccessPolicyResponse,
@@ -2235,7 +2234,7 @@ export const deleteVaultNotifications: API.OperationMethod<
   DeleteVaultNotificationsInput,
   DeleteVaultNotificationsResponse,
   DeleteVaultNotificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVaultNotificationsInput,
   output: DeleteVaultNotificationsResponse,
@@ -2286,7 +2285,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobInput,
   GlacierJobDescription,
   DescribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobInput,
   output: GlacierJobDescription,
@@ -2334,7 +2333,7 @@ export const describeVault: API.OperationMethod<
   DescribeVaultInput,
   DescribeVaultOutput,
   DescribeVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVaultInput,
   output: DescribeVaultOutput,
@@ -2365,7 +2364,7 @@ export const getDataRetrievalPolicy: API.OperationMethod<
   GetDataRetrievalPolicyInput,
   GetDataRetrievalPolicyOutput,
   GetDataRetrievalPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataRetrievalPolicyInput,
   output: GetDataRetrievalPolicyOutput,
@@ -2433,7 +2432,7 @@ export const getJobOutput: API.OperationMethod<
   GetJobOutputInput,
   GetJobOutputOutput,
   GetJobOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobOutputInput,
   output: GetJobOutputOutput,
@@ -2468,7 +2467,7 @@ export const getVaultAccessPolicy: API.OperationMethod<
   GetVaultAccessPolicyInput,
   GetVaultAccessPolicyOutput,
   GetVaultAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVaultAccessPolicyInput,
   output: GetVaultAccessPolicyOutput,
@@ -2520,7 +2519,7 @@ export const getVaultLock: API.OperationMethod<
   GetVaultLockInput,
   GetVaultLockOutput,
   GetVaultLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVaultLockInput,
   output: GetVaultLockOutput,
@@ -2566,7 +2565,7 @@ export const getVaultNotifications: API.OperationMethod<
   GetVaultNotificationsInput,
   GetVaultNotificationsOutput,
   GetVaultNotificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVaultNotificationsInput,
   output: GetVaultNotificationsOutput,
@@ -2601,7 +2600,7 @@ export const initiateJob: API.OperationMethod<
   InitiateJobInput,
   InitiateJobOutput,
   InitiateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateJobInput,
   output: InitiateJobOutput,
@@ -2665,7 +2664,7 @@ export const initiateMultipartUpload: API.OperationMethod<
   InitiateMultipartUploadInput,
   InitiateMultipartUploadOutput,
   InitiateMultipartUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateMultipartUploadInput,
   output: InitiateMultipartUploadOutput,
@@ -2726,7 +2725,7 @@ export const initiateVaultLock: API.OperationMethod<
   InitiateVaultLockInput,
   InitiateVaultLockOutput,
   InitiateVaultLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateVaultLockInput,
   output: InitiateVaultLockOutput,
@@ -2789,7 +2788,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsInput,
   ListJobsOutput,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlacierJobDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsInput,
@@ -2851,7 +2850,7 @@ export const listMultipartUploads: API.PaginatedOperationMethod<
   ListMultipartUploadsInput,
   ListMultipartUploadsOutput,
   ListMultipartUploadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UploadListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultipartUploadsInput,
@@ -2910,7 +2909,7 @@ export const listParts: API.PaginatedOperationMethod<
   ListPartsInput,
   ListPartsOutput,
   ListPartsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PartListElement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPartsInput,
@@ -2947,7 +2946,7 @@ export const listProvisionedCapacity: API.OperationMethod<
   ListProvisionedCapacityInput,
   ListProvisionedCapacityOutput,
   ListProvisionedCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProvisionedCapacityInput,
   output: ListProvisionedCapacityOutput,
@@ -2978,7 +2977,7 @@ export const listTagsForVault: API.OperationMethod<
   ListTagsForVaultInput,
   ListTagsForVaultOutput,
   ListTagsForVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForVaultInput,
   output: ListTagsForVaultOutput,
@@ -3027,7 +3026,7 @@ export const listVaults: API.PaginatedOperationMethod<
   ListVaultsInput,
   ListVaultsOutput,
   ListVaultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeVaultOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVaultsInput,
@@ -3064,7 +3063,7 @@ export const purchaseProvisionedCapacity: API.OperationMethod<
   PurchaseProvisionedCapacityInput,
   PurchaseProvisionedCapacityOutput,
   PurchaseProvisionedCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseProvisionedCapacityInput,
   output: PurchaseProvisionedCapacityOutput,
@@ -3097,7 +3096,7 @@ export const removeTagsFromVault: API.OperationMethod<
   RemoveTagsFromVaultInput,
   RemoveTagsFromVaultResponse,
   RemoveTagsFromVaultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromVaultInput,
   output: RemoveTagsFromVaultResponse,
@@ -3132,7 +3131,7 @@ export const setDataRetrievalPolicy: API.OperationMethod<
   SetDataRetrievalPolicyInput,
   SetDataRetrievalPolicyResponse,
   SetDataRetrievalPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDataRetrievalPolicyInput,
   output: SetDataRetrievalPolicyResponse,
@@ -3166,7 +3165,7 @@ export const setVaultAccessPolicy: API.OperationMethod<
   SetVaultAccessPolicyInput,
   SetVaultAccessPolicyResponse,
   SetVaultAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetVaultAccessPolicyInput,
   output: SetVaultAccessPolicyResponse,
@@ -3226,7 +3225,7 @@ export const setVaultNotifications: API.OperationMethod<
   SetVaultNotificationsInput,
   SetVaultNotificationsResponse,
   SetVaultNotificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetVaultNotificationsInput,
   output: SetVaultNotificationsResponse,
@@ -3289,7 +3288,7 @@ export const uploadArchive: API.OperationMethod<
   UploadArchiveInput,
   ArchiveCreationOutput,
   UploadArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadArchiveInput,
   output: ArchiveCreationOutput,
@@ -3362,7 +3361,7 @@ export const uploadMultipartPart: API.OperationMethod<
   UploadMultipartPartInput,
   UploadMultipartPartOutput,
   UploadMultipartPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadMultipartPartInput,
   output: UploadMultipartPartOutput,

--- a/packages/aws/src/services/global-accelerator.ts
+++ b/packages/aws/src/services/global-accelerator.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Global Accelerator",
   serviceShapeName: "GlobalAccelerator_V20180706",
@@ -2138,7 +2137,7 @@ export const addCustomRoutingEndpoints: API.OperationMethod<
   AddCustomRoutingEndpointsRequest,
   AddCustomRoutingEndpointsResponse,
   AddCustomRoutingEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddCustomRoutingEndpointsRequest,
   output: AddCustomRoutingEndpointsResponse,
@@ -2188,7 +2187,7 @@ export const addEndpoints: API.OperationMethod<
   AddEndpointsRequest,
   AddEndpointsResponse,
   AddEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddEndpointsRequest,
   output: AddEndpointsResponse,
@@ -2227,7 +2226,7 @@ export const advertiseByoipCidr: API.OperationMethod<
   AdvertiseByoipCidrRequest,
   AdvertiseByoipCidrResponse,
   AdvertiseByoipCidrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AdvertiseByoipCidrRequest,
   output: AdvertiseByoipCidrResponse,
@@ -2261,7 +2260,7 @@ export const allowCustomRoutingTraffic: API.OperationMethod<
   AllowCustomRoutingTrafficRequest,
   AllowCustomRoutingTrafficResponse,
   AllowCustomRoutingTrafficError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllowCustomRoutingTrafficRequest,
   output: AllowCustomRoutingTrafficResponse,
@@ -2294,7 +2293,7 @@ export const createAccelerator: API.OperationMethod<
   CreateAcceleratorRequest,
   CreateAcceleratorResponse,
   CreateAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAcceleratorRequest,
   output: CreateAcceleratorResponse,
@@ -2343,7 +2342,7 @@ export const createCrossAccountAttachment: API.OperationMethod<
   CreateCrossAccountAttachmentRequest,
   CreateCrossAccountAttachmentResponse,
   CreateCrossAccountAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCrossAccountAttachmentRequest,
   output: CreateCrossAccountAttachmentResponse,
@@ -2383,7 +2382,7 @@ export const createCustomRoutingAccelerator: API.OperationMethod<
   CreateCustomRoutingAcceleratorRequest,
   CreateCustomRoutingAcceleratorResponse,
   CreateCustomRoutingAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomRoutingAcceleratorRequest,
   output: CreateCustomRoutingAcceleratorResponse,
@@ -2418,7 +2417,7 @@ export const createCustomRoutingEndpointGroup: API.OperationMethod<
   CreateCustomRoutingEndpointGroupRequest,
   CreateCustomRoutingEndpointGroupResponse,
   CreateCustomRoutingEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomRoutingEndpointGroupRequest,
   output: CreateCustomRoutingEndpointGroupResponse,
@@ -2452,7 +2451,7 @@ export const createCustomRoutingListener: API.OperationMethod<
   CreateCustomRoutingListenerRequest,
   CreateCustomRoutingListenerResponse,
   CreateCustomRoutingListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomRoutingListenerRequest,
   output: CreateCustomRoutingListenerResponse,
@@ -2489,7 +2488,7 @@ export const createEndpointGroup: API.OperationMethod<
   CreateEndpointGroupRequest,
   CreateEndpointGroupResponse,
   CreateEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointGroupRequest,
   output: CreateEndpointGroupResponse,
@@ -2522,7 +2521,7 @@ export const createListener: API.OperationMethod<
   CreateListenerRequest,
   CreateListenerResponse,
   CreateListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateListenerRequest,
   output: CreateListenerResponse,
@@ -2565,7 +2564,7 @@ export const deleteAccelerator: API.OperationMethod<
   DeleteAcceleratorRequest,
   DeleteAcceleratorResponse,
   DeleteAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAcceleratorRequest,
   output: DeleteAcceleratorResponse,
@@ -2602,7 +2601,7 @@ export const deleteCrossAccountAttachment: API.OperationMethod<
   DeleteCrossAccountAttachmentRequest,
   DeleteCrossAccountAttachmentResponse,
   DeleteCrossAccountAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCrossAccountAttachmentRequest,
   output: DeleteCrossAccountAttachmentResponse,
@@ -2645,7 +2644,7 @@ export const deleteCustomRoutingAccelerator: API.OperationMethod<
   DeleteCustomRoutingAcceleratorRequest,
   DeleteCustomRoutingAcceleratorResponse,
   DeleteCustomRoutingAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomRoutingAcceleratorRequest,
   output: DeleteCustomRoutingAcceleratorResponse,
@@ -2674,7 +2673,7 @@ export const deleteCustomRoutingEndpointGroup: API.OperationMethod<
   DeleteCustomRoutingEndpointGroupRequest,
   DeleteCustomRoutingEndpointGroupResponse,
   DeleteCustomRoutingEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomRoutingEndpointGroupRequest,
   output: DeleteCustomRoutingEndpointGroupResponse,
@@ -2701,7 +2700,7 @@ export const deleteCustomRoutingListener: API.OperationMethod<
   DeleteCustomRoutingListenerRequest,
   DeleteCustomRoutingListenerResponse,
   DeleteCustomRoutingListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomRoutingListenerRequest,
   output: DeleteCustomRoutingListenerResponse,
@@ -2728,7 +2727,7 @@ export const deleteEndpointGroup: API.OperationMethod<
   DeleteEndpointGroupRequest,
   DeleteEndpointGroupResponse,
   DeleteEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointGroupRequest,
   output: DeleteEndpointGroupResponse,
@@ -2755,7 +2754,7 @@ export const deleteListener: API.OperationMethod<
   DeleteListenerRequest,
   DeleteListenerResponse,
   DeleteListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteListenerRequest,
   output: DeleteListenerResponse,
@@ -2788,7 +2787,7 @@ export const denyCustomRoutingTraffic: API.OperationMethod<
   DenyCustomRoutingTrafficRequest,
   DenyCustomRoutingTrafficResponse,
   DenyCustomRoutingTrafficError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DenyCustomRoutingTrafficRequest,
   output: DenyCustomRoutingTrafficResponse,
@@ -2823,7 +2822,7 @@ export const deprovisionByoipCidr: API.OperationMethod<
   DeprovisionByoipCidrRequest,
   DeprovisionByoipCidrResponse,
   DeprovisionByoipCidrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprovisionByoipCidrRequest,
   output: DeprovisionByoipCidrResponse,
@@ -2851,7 +2850,7 @@ export const describeAccelerator: API.OperationMethod<
   DescribeAcceleratorRequest,
   DescribeAcceleratorResponse,
   DescribeAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAcceleratorRequest,
   output: DescribeAcceleratorResponse,
@@ -2877,7 +2876,7 @@ export const describeAcceleratorAttributes: API.OperationMethod<
   DescribeAcceleratorAttributesRequest,
   DescribeAcceleratorAttributesResponse,
   DescribeAcceleratorAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAcceleratorAttributesRequest,
   output: DescribeAcceleratorAttributesResponse,
@@ -2904,7 +2903,7 @@ export const describeCrossAccountAttachment: API.OperationMethod<
   DescribeCrossAccountAttachmentRequest,
   DescribeCrossAccountAttachmentResponse,
   DescribeCrossAccountAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCrossAccountAttachmentRequest,
   output: DescribeCrossAccountAttachmentResponse,
@@ -2931,7 +2930,7 @@ export const describeCustomRoutingAccelerator: API.OperationMethod<
   DescribeCustomRoutingAcceleratorRequest,
   DescribeCustomRoutingAcceleratorResponse,
   DescribeCustomRoutingAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomRoutingAcceleratorRequest,
   output: DescribeCustomRoutingAcceleratorResponse,
@@ -2957,7 +2956,7 @@ export const describeCustomRoutingAcceleratorAttributes: API.OperationMethod<
   DescribeCustomRoutingAcceleratorAttributesRequest,
   DescribeCustomRoutingAcceleratorAttributesResponse,
   DescribeCustomRoutingAcceleratorAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomRoutingAcceleratorAttributesRequest,
   output: DescribeCustomRoutingAcceleratorAttributesResponse,
@@ -2983,7 +2982,7 @@ export const describeCustomRoutingEndpointGroup: API.OperationMethod<
   DescribeCustomRoutingEndpointGroupRequest,
   DescribeCustomRoutingEndpointGroupResponse,
   DescribeCustomRoutingEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomRoutingEndpointGroupRequest,
   output: DescribeCustomRoutingEndpointGroupResponse,
@@ -3009,7 +3008,7 @@ export const describeCustomRoutingListener: API.OperationMethod<
   DescribeCustomRoutingListenerRequest,
   DescribeCustomRoutingListenerResponse,
   DescribeCustomRoutingListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomRoutingListenerRequest,
   output: DescribeCustomRoutingListenerResponse,
@@ -3035,7 +3034,7 @@ export const describeEndpointGroup: API.OperationMethod<
   DescribeEndpointGroupRequest,
   DescribeEndpointGroupResponse,
   DescribeEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointGroupRequest,
   output: DescribeEndpointGroupResponse,
@@ -3061,7 +3060,7 @@ export const describeListener: API.OperationMethod<
   DescribeListenerRequest,
   DescribeListenerResponse,
   DescribeListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeListenerRequest,
   output: DescribeListenerResponse,
@@ -3087,7 +3086,7 @@ export const listAccelerators: API.PaginatedOperationMethod<
   ListAcceleratorsRequest,
   ListAcceleratorsResponse,
   ListAcceleratorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Accelerator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAcceleratorsRequest,
@@ -3122,7 +3121,7 @@ export const listByoipCidrs: API.PaginatedOperationMethod<
   ListByoipCidrsRequest,
   ListByoipCidrsResponse,
   ListByoipCidrsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ByoipCidr
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListByoipCidrsRequest,
@@ -3157,7 +3156,7 @@ export const listCrossAccountAttachments: API.PaginatedOperationMethod<
   ListCrossAccountAttachmentsRequest,
   ListCrossAccountAttachmentsResponse,
   ListCrossAccountAttachmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Attachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCrossAccountAttachmentsRequest,
@@ -3194,7 +3193,7 @@ export const listCrossAccountResourceAccounts: API.OperationMethod<
   ListCrossAccountResourceAccountsRequest,
   ListCrossAccountResourceAccountsResponse,
   ListCrossAccountResourceAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCrossAccountResourceAccountsRequest,
   output: ListCrossAccountResourceAccountsResponse,
@@ -3218,7 +3217,7 @@ export const listCrossAccountResources: API.PaginatedOperationMethod<
   ListCrossAccountResourcesRequest,
   ListCrossAccountResourcesResponse,
   ListCrossAccountResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CrossAccountResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCrossAccountResourcesRequest,
@@ -3253,7 +3252,7 @@ export const listCustomRoutingAccelerators: API.PaginatedOperationMethod<
   ListCustomRoutingAcceleratorsRequest,
   ListCustomRoutingAcceleratorsResponse,
   ListCustomRoutingAcceleratorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomRoutingAccelerator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomRoutingAcceleratorsRequest,
@@ -3287,7 +3286,7 @@ export const listCustomRoutingEndpointGroups: API.PaginatedOperationMethod<
   ListCustomRoutingEndpointGroupsRequest,
   ListCustomRoutingEndpointGroupsResponse,
   ListCustomRoutingEndpointGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomRoutingEndpointGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomRoutingEndpointGroupsRequest,
@@ -3322,7 +3321,7 @@ export const listCustomRoutingListeners: API.PaginatedOperationMethod<
   ListCustomRoutingListenersRequest,
   ListCustomRoutingListenersResponse,
   ListCustomRoutingListenersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomRoutingListener
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomRoutingListenersRequest,
@@ -3368,7 +3367,7 @@ export const listCustomRoutingPortMappings: API.PaginatedOperationMethod<
   ListCustomRoutingPortMappingsRequest,
   ListCustomRoutingPortMappingsResponse,
   ListCustomRoutingPortMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PortMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomRoutingPortMappingsRequest,
@@ -3407,7 +3406,7 @@ export const listCustomRoutingPortMappingsByDestination: API.PaginatedOperationM
   ListCustomRoutingPortMappingsByDestinationRequest,
   ListCustomRoutingPortMappingsByDestinationResponse,
   ListCustomRoutingPortMappingsByDestinationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DestinationPortMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomRoutingPortMappingsByDestinationRequest,
@@ -3442,7 +3441,7 @@ export const listEndpointGroups: API.PaginatedOperationMethod<
   ListEndpointGroupsRequest,
   ListEndpointGroupsResponse,
   ListEndpointGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointGroupsRequest,
@@ -3477,7 +3476,7 @@ export const listListeners: API.PaginatedOperationMethod<
   ListListenersRequest,
   ListListenersResponse,
   ListListenersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Listener
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListListenersRequest,
@@ -3517,7 +3516,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3554,7 +3553,7 @@ export const provisionByoipCidr: API.OperationMethod<
   ProvisionByoipCidrRequest,
   ProvisionByoipCidrResponse,
   ProvisionByoipCidrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionByoipCidrRequest,
   output: ProvisionByoipCidrResponse,
@@ -3585,7 +3584,7 @@ export const removeCustomRoutingEndpoints: API.OperationMethod<
   RemoveCustomRoutingEndpointsRequest,
   RemoveCustomRoutingEndpointsResponse,
   RemoveCustomRoutingEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveCustomRoutingEndpointsRequest,
   output: RemoveCustomRoutingEndpointsResponse,
@@ -3629,7 +3628,7 @@ export const removeEndpoints: API.OperationMethod<
   RemoveEndpointsRequest,
   RemoveEndpointsResponse,
   RemoveEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveEndpointsRequest,
   output: RemoveEndpointsResponse,
@@ -3660,7 +3659,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3690,7 +3689,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3735,7 +3734,7 @@ export const updateAccelerator: API.OperationMethod<
   UpdateAcceleratorRequest,
   UpdateAcceleratorResponse,
   UpdateAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAcceleratorRequest,
   output: UpdateAcceleratorResponse,
@@ -3766,7 +3765,7 @@ export const updateAcceleratorAttributes: API.OperationMethod<
   UpdateAcceleratorAttributesRequest,
   UpdateAcceleratorAttributesResponse,
   UpdateAcceleratorAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAcceleratorAttributesRequest,
   output: UpdateAcceleratorAttributesResponse,
@@ -3803,7 +3802,7 @@ export const updateCrossAccountAttachment: API.OperationMethod<
   UpdateCrossAccountAttachmentRequest,
   UpdateCrossAccountAttachmentResponse,
   UpdateCrossAccountAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCrossAccountAttachmentRequest,
   output: UpdateCrossAccountAttachmentResponse,
@@ -3834,7 +3833,7 @@ export const updateCustomRoutingAccelerator: API.OperationMethod<
   UpdateCustomRoutingAcceleratorRequest,
   UpdateCustomRoutingAcceleratorResponse,
   UpdateCustomRoutingAcceleratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomRoutingAcceleratorRequest,
   output: UpdateCustomRoutingAcceleratorResponse,
@@ -3864,7 +3863,7 @@ export const updateCustomRoutingAcceleratorAttributes: API.OperationMethod<
   UpdateCustomRoutingAcceleratorAttributesRequest,
   UpdateCustomRoutingAcceleratorAttributesResponse,
   UpdateCustomRoutingAcceleratorAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomRoutingAcceleratorAttributesRequest,
   output: UpdateCustomRoutingAcceleratorAttributesResponse,
@@ -3894,7 +3893,7 @@ export const updateCustomRoutingListener: API.OperationMethod<
   UpdateCustomRoutingListenerRequest,
   UpdateCustomRoutingListenerResponse,
   UpdateCustomRoutingListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomRoutingListenerRequest,
   output: UpdateCustomRoutingListenerResponse,
@@ -3924,7 +3923,7 @@ export const updateEndpointGroup: API.OperationMethod<
   UpdateEndpointGroupRequest,
   UpdateEndpointGroupResponse,
   UpdateEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointGroupRequest,
   output: UpdateEndpointGroupResponse,
@@ -3954,7 +3953,7 @@ export const updateListener: API.OperationMethod<
   UpdateListenerRequest,
   UpdateListenerResponse,
   UpdateListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateListenerRequest,
   output: UpdateListenerResponse,
@@ -3992,7 +3991,7 @@ export const withdrawByoipCidr: API.OperationMethod<
   WithdrawByoipCidrRequest,
   WithdrawByoipCidrResponse,
   WithdrawByoipCidrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: WithdrawByoipCidrRequest,
   output: WithdrawByoipCidrResponse,

--- a/packages/aws/src/services/glue.ts
+++ b/packages/aws/src/services/glue.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Glue", serviceShapeName: "AWSGlue" });
 const auth = T.AwsAuthSigv4({ name: "glue" });
@@ -18622,7 +18621,7 @@ export const associateGlossaryTerms: API.OperationMethod<
   AssociateGlossaryTermsRequest,
   AssociateGlossaryTermsResponse,
   AssociateGlossaryTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateGlossaryTermsRequest,
   output: AssociateGlossaryTermsResponse,
@@ -18655,7 +18654,7 @@ export const batchCreatePartition: API.OperationMethod<
   BatchCreatePartitionRequest,
   BatchCreatePartitionResponse,
   BatchCreatePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreatePartitionRequest,
   output: BatchCreatePartitionResponse,
@@ -18684,7 +18683,7 @@ export const batchDeleteConnection: API.OperationMethod<
   BatchDeleteConnectionRequest,
   BatchDeleteConnectionResponse,
   BatchDeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteConnectionRequest,
   output: BatchDeleteConnectionResponse,
@@ -18707,7 +18706,7 @@ export const batchDeletePartition: API.OperationMethod<
   BatchDeletePartitionRequest,
   BatchDeletePartitionResponse,
   BatchDeletePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeletePartitionRequest,
   output: BatchDeletePartitionResponse,
@@ -18747,7 +18746,7 @@ export const batchDeleteTable: API.OperationMethod<
   BatchDeleteTableRequest,
   BatchDeleteTableResponse,
   BatchDeleteTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteTableRequest,
   output: BatchDeleteTableResponse,
@@ -18777,7 +18776,7 @@ export const batchDeleteTableVersion: API.OperationMethod<
   BatchDeleteTableVersionRequest,
   BatchDeleteTableVersionResponse,
   BatchDeleteTableVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteTableVersionRequest,
   output: BatchDeleteTableVersionResponse,
@@ -18804,7 +18803,7 @@ export const batchGetBlueprints: API.OperationMethod<
   BatchGetBlueprintsRequest,
   BatchGetBlueprintsResponse,
   BatchGetBlueprintsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetBlueprintsRequest,
   output: BatchGetBlueprintsResponse,
@@ -18829,7 +18828,7 @@ export const batchGetCrawlers: API.OperationMethod<
   BatchGetCrawlersRequest,
   BatchGetCrawlersResponse,
   BatchGetCrawlersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCrawlersRequest,
   output: BatchGetCrawlersResponse,
@@ -18851,7 +18850,7 @@ export const batchGetCustomEntityTypes: API.OperationMethod<
   BatchGetCustomEntityTypesRequest,
   BatchGetCustomEntityTypesResponse,
   BatchGetCustomEntityTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCustomEntityTypesRequest,
   output: BatchGetCustomEntityTypesResponse,
@@ -18877,7 +18876,7 @@ export const batchGetDataQualityResult: API.OperationMethod<
   BatchGetDataQualityResultRequest,
   BatchGetDataQualityResultResponse,
   BatchGetDataQualityResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDataQualityResultRequest,
   output: BatchGetDataQualityResultResponse,
@@ -18907,7 +18906,7 @@ export const batchGetDevEndpoints: API.OperationMethod<
   BatchGetDevEndpointsRequest,
   BatchGetDevEndpointsResponse,
   BatchGetDevEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDevEndpointsRequest,
   output: BatchGetDevEndpointsResponse,
@@ -18936,7 +18935,7 @@ export const batchGetIterableForms: API.OperationMethod<
   BatchGetIterableFormsRequest,
   BatchGetIterableFormsResponse,
   BatchGetIterableFormsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetIterableFormsRequest,
   output: BatchGetIterableFormsResponse,
@@ -18964,7 +18963,7 @@ export const batchGetJobs: API.OperationMethod<
   BatchGetJobsRequest,
   BatchGetJobsResponse,
   BatchGetJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetJobsRequest,
   output: BatchGetJobsResponse,
@@ -18995,7 +18994,7 @@ export const batchGetPartition: API.OperationMethod<
   BatchGetPartitionRequest,
   BatchGetPartitionResponse,
   BatchGetPartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPartitionRequest,
   output: BatchGetPartitionResponse,
@@ -19028,7 +19027,7 @@ export const batchGetTableOptimizer: API.OperationMethod<
   BatchGetTableOptimizerRequest,
   BatchGetTableOptimizerResponse,
   BatchGetTableOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTableOptimizerRequest,
   output: BatchGetTableOptimizerResponse,
@@ -19056,7 +19055,7 @@ export const batchGetTriggers: API.OperationMethod<
   BatchGetTriggersRequest,
   BatchGetTriggersResponse,
   BatchGetTriggersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTriggersRequest,
   output: BatchGetTriggersResponse,
@@ -19082,7 +19081,7 @@ export const batchGetWorkflows: API.OperationMethod<
   BatchGetWorkflowsRequest,
   BatchGetWorkflowsResponse,
   BatchGetWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetWorkflowsRequest,
   output: BatchGetWorkflowsResponse,
@@ -19111,7 +19110,7 @@ export const batchPutDataQualityStatisticAnnotation: API.OperationMethod<
   BatchPutDataQualityStatisticAnnotationRequest,
   BatchPutDataQualityStatisticAnnotationResponse,
   BatchPutDataQualityStatisticAnnotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutDataQualityStatisticAnnotationRequest,
   output: BatchPutDataQualityStatisticAnnotationResponse,
@@ -19138,7 +19137,7 @@ export const batchStopJobRun: API.OperationMethod<
   BatchStopJobRunRequest,
   BatchStopJobRunResponse,
   BatchStopJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStopJobRunRequest,
   output: BatchStopJobRunResponse,
@@ -19166,7 +19165,7 @@ export const batchUpdatePartition: API.OperationMethod<
   BatchUpdatePartitionRequest,
   BatchUpdatePartitionResponse,
   BatchUpdatePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdatePartitionRequest,
   output: BatchUpdatePartitionResponse,
@@ -19195,7 +19194,7 @@ export const cancelDataQualityRuleRecommendationRun: API.OperationMethod<
   CancelDataQualityRuleRecommendationRunRequest,
   CancelDataQualityRuleRecommendationRunResponse,
   CancelDataQualityRuleRecommendationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDataQualityRuleRecommendationRunRequest,
   output: CancelDataQualityRuleRecommendationRunResponse,
@@ -19223,7 +19222,7 @@ export const cancelDataQualityRulesetEvaluationRun: API.OperationMethod<
   CancelDataQualityRulesetEvaluationRunRequest,
   CancelDataQualityRulesetEvaluationRunResponse,
   CancelDataQualityRulesetEvaluationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDataQualityRulesetEvaluationRunRequest,
   output: CancelDataQualityRulesetEvaluationRunResponse,
@@ -19253,7 +19252,7 @@ export const cancelMLTaskRun: API.OperationMethod<
   CancelMLTaskRunRequest,
   CancelMLTaskRunResponse,
   CancelMLTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMLTaskRunRequest,
   output: CancelMLTaskRunResponse,
@@ -19283,7 +19282,7 @@ export const cancelStatement: API.OperationMethod<
   CancelStatementRequest,
   CancelStatementResponse,
   CancelStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelStatementRequest,
   output: CancelStatementResponse,
@@ -19312,7 +19311,7 @@ export const checkSchemaVersionValidity: API.OperationMethod<
   CheckSchemaVersionValidityInput,
   CheckSchemaVersionValidityResponse,
   CheckSchemaVersionValidityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckSchemaVersionValidityInput,
   output: CheckSchemaVersionValidityResponse,
@@ -19340,7 +19339,7 @@ export const createBlueprint: API.OperationMethod<
   CreateBlueprintRequest,
   CreateBlueprintResponse,
   CreateBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBlueprintRequest,
   output: CreateBlueprintResponse,
@@ -19376,7 +19375,7 @@ export const createCatalog: API.OperationMethod<
   CreateCatalogRequest,
   CreateCatalogResponse,
   CreateCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCatalogRequest,
   output: CreateCatalogResponse,
@@ -19412,7 +19411,7 @@ export const createClassifier: API.OperationMethod<
   CreateClassifierRequest,
   CreateClassifierResponse,
   CreateClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClassifierRequest,
   output: CreateClassifierResponse,
@@ -19442,7 +19441,7 @@ export const createColumnStatisticsTaskSettings: API.OperationMethod<
   CreateColumnStatisticsTaskSettingsRequest,
   CreateColumnStatisticsTaskSettingsResponse,
   CreateColumnStatisticsTaskSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateColumnStatisticsTaskSettingsRequest,
   output: CreateColumnStatisticsTaskSettingsResponse,
@@ -19476,7 +19475,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -19509,7 +19508,7 @@ export const createCrawler: API.OperationMethod<
   CreateCrawlerRequest,
   CreateCrawlerResponse,
   CreateCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCrawlerRequest,
   output: CreateCrawlerResponse,
@@ -19544,7 +19543,7 @@ export const createCustomEntityType: API.OperationMethod<
   CreateCustomEntityTypeRequest,
   CreateCustomEntityTypeResponse,
   CreateCustomEntityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomEntityTypeRequest,
   output: CreateCustomEntityTypeResponse,
@@ -19581,7 +19580,7 @@ export const createDatabase: API.OperationMethod<
   CreateDatabaseRequest,
   CreateDatabaseResponse,
   CreateDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatabaseRequest,
   output: CreateDatabaseResponse,
@@ -19618,7 +19617,7 @@ export const createDataQualityRuleset: API.OperationMethod<
   CreateDataQualityRulesetRequest,
   CreateDataQualityRulesetResponse,
   CreateDataQualityRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataQualityRulesetRequest,
   output: CreateDataQualityRulesetResponse,
@@ -19651,7 +19650,7 @@ export const createDevEndpoint: API.OperationMethod<
   CreateDevEndpointRequest,
   CreateDevEndpointResponse,
   CreateDevEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDevEndpointRequest,
   output: CreateDevEndpointResponse,
@@ -19685,7 +19684,7 @@ export const createGlossary: API.OperationMethod<
   CreateGlossaryRequest,
   CreateGlossaryResponse,
   CreateGlossaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlossaryRequest,
   output: CreateGlossaryResponse,
@@ -19718,7 +19717,7 @@ export const createGlossaryTerm: API.OperationMethod<
   CreateGlossaryTermRequest,
   CreateGlossaryTermResponse,
   CreateGlossaryTermError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlossaryTermRequest,
   output: CreateGlossaryTermResponse,
@@ -19752,7 +19751,7 @@ export const createGlueIdentityCenterConfiguration: API.OperationMethod<
   CreateGlueIdentityCenterConfigurationRequest,
   CreateGlueIdentityCenterConfigurationResponse,
   CreateGlueIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlueIdentityCenterConfigurationRequest,
   output: CreateGlueIdentityCenterConfigurationResponse,
@@ -19790,7 +19789,7 @@ export const createIntegration: API.OperationMethod<
   CreateIntegrationRequest,
   CreateIntegrationResponse,
   CreateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationRequest,
   output: CreateIntegrationResponse,
@@ -19830,7 +19829,7 @@ export const createIntegrationResourceProperty: API.OperationMethod<
   CreateIntegrationResourcePropertyRequest,
   CreateIntegrationResourcePropertyResponse,
   CreateIntegrationResourcePropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationResourcePropertyRequest,
   output: CreateIntegrationResourcePropertyResponse,
@@ -19865,7 +19864,7 @@ export const createIntegrationTableProperties: API.OperationMethod<
   CreateIntegrationTablePropertiesRequest,
   CreateIntegrationTablePropertiesResponse,
   CreateIntegrationTablePropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationTablePropertiesRequest,
   output: CreateIntegrationTablePropertiesResponse,
@@ -19900,7 +19899,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -19947,7 +19946,7 @@ export const createMLTransform: API.OperationMethod<
   CreateMLTransformRequest,
   CreateMLTransformResponse,
   CreateMLTransformError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMLTransformRequest,
   output: CreateMLTransformResponse,
@@ -19981,7 +19980,7 @@ export const createPartition: API.OperationMethod<
   CreatePartitionRequest,
   CreatePartitionResponse,
   CreatePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartitionRequest,
   output: CreatePartitionResponse,
@@ -20015,7 +20014,7 @@ export const createPartitionIndex: API.OperationMethod<
   CreatePartitionIndexRequest,
   CreatePartitionIndexResponse,
   CreatePartitionIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartitionIndexRequest,
   output: CreatePartitionIndexResponse,
@@ -20048,7 +20047,7 @@ export const createRegistry: API.OperationMethod<
   CreateRegistryInput,
   CreateRegistryResponse,
   CreateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistryInput,
   output: CreateRegistryResponse,
@@ -20085,7 +20084,7 @@ export const createSchema: API.OperationMethod<
   CreateSchemaInput,
   CreateSchemaResponse,
   CreateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchemaInput,
   output: CreateSchemaResponse,
@@ -20115,7 +20114,7 @@ export const createScript: API.OperationMethod<
   CreateScriptRequest,
   CreateScriptResponse,
   CreateScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScriptRequest,
   output: CreateScriptResponse,
@@ -20143,7 +20142,7 @@ export const createSecurityConfiguration: API.OperationMethod<
   CreateSecurityConfigurationRequest,
   CreateSecurityConfigurationResponse,
   CreateSecurityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityConfigurationRequest,
   output: CreateSecurityConfigurationResponse,
@@ -20177,7 +20176,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionResponse,
   CreateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionResponse,
@@ -20217,7 +20216,7 @@ export const createTable: API.OperationMethod<
   CreateTableRequest,
   CreateTableResponse,
   CreateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableRequest,
   output: CreateTableResponse,
@@ -20255,7 +20254,7 @@ export const createTableOptimizer: API.OperationMethod<
   CreateTableOptimizerRequest,
   CreateTableOptimizerResponse,
   CreateTableOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableOptimizerRequest,
   output: CreateTableOptimizerResponse,
@@ -20292,7 +20291,7 @@ export const createTrigger: API.OperationMethod<
   CreateTriggerRequest,
   CreateTriggerResponse,
   CreateTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTriggerRequest,
   output: CreateTriggerResponse,
@@ -20326,7 +20325,7 @@ export const createUsageProfile: API.OperationMethod<
   CreateUsageProfileRequest,
   CreateUsageProfileResponse,
   CreateUsageProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsageProfileRequest,
   output: CreateUsageProfileResponse,
@@ -20359,7 +20358,7 @@ export const createUserDefinedFunction: API.OperationMethod<
   CreateUserDefinedFunctionRequest,
   CreateUserDefinedFunctionResponse,
   CreateUserDefinedFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserDefinedFunctionRequest,
   output: CreateUserDefinedFunctionResponse,
@@ -20392,7 +20391,7 @@ export const createWorkflow: API.OperationMethod<
   CreateWorkflowRequest,
   CreateWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRequest,
   output: CreateWorkflowResponse,
@@ -20423,7 +20422,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetRequest,
   DeleteAssetResponse,
   DeleteAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetRequest,
   output: DeleteAssetResponse,
@@ -20453,7 +20452,7 @@ export const deleteAssetType: API.OperationMethod<
   DeleteAssetTypeRequest,
   DeleteAssetTypeResponse,
   DeleteAssetTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetTypeRequest,
   output: DeleteAssetTypeResponse,
@@ -20484,7 +20483,7 @@ export const deleteAttachment: API.OperationMethod<
   DeleteAttachmentRequest,
   DeleteAttachmentResponse,
   DeleteAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttachmentRequest,
   output: DeleteAttachmentResponse,
@@ -20513,7 +20512,7 @@ export const deleteBlueprint: API.OperationMethod<
   DeleteBlueprintRequest,
   DeleteBlueprintResponse,
   DeleteBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBlueprintRequest,
   output: DeleteBlueprintResponse,
@@ -20548,7 +20547,7 @@ export const deleteCatalog: API.OperationMethod<
   DeleteCatalogRequest,
   DeleteCatalogResponse,
   DeleteCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCatalogRequest,
   output: DeleteCatalogResponse,
@@ -20578,7 +20577,7 @@ export const deleteClassifier: API.OperationMethod<
   DeleteClassifierRequest,
   DeleteClassifierResponse,
   DeleteClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClassifierRequest,
   output: DeleteClassifierResponse,
@@ -20604,7 +20603,7 @@ export const deleteColumnStatisticsForPartition: API.OperationMethod<
   DeleteColumnStatisticsForPartitionRequest,
   DeleteColumnStatisticsForPartitionResponse,
   DeleteColumnStatisticsForPartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteColumnStatisticsForPartitionRequest,
   output: DeleteColumnStatisticsForPartitionResponse,
@@ -20636,7 +20635,7 @@ export const deleteColumnStatisticsForTable: API.OperationMethod<
   DeleteColumnStatisticsForTableRequest,
   DeleteColumnStatisticsForTableResponse,
   DeleteColumnStatisticsForTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteColumnStatisticsForTableRequest,
   output: DeleteColumnStatisticsForTableResponse,
@@ -20664,7 +20663,7 @@ export const deleteColumnStatisticsTaskSettings: API.OperationMethod<
   DeleteColumnStatisticsTaskSettingsRequest,
   DeleteColumnStatisticsTaskSettingsResponse,
   DeleteColumnStatisticsTaskSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteColumnStatisticsTaskSettingsRequest,
   output: DeleteColumnStatisticsTaskSettingsResponse,
@@ -20689,7 +20688,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -20716,7 +20715,7 @@ export const deleteConnectionType: API.OperationMethod<
   DeleteConnectionTypeRequest,
   DeleteConnectionTypeResponse,
   DeleteConnectionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionTypeRequest,
   output: DeleteConnectionTypeResponse,
@@ -20747,7 +20746,7 @@ export const deleteCrawler: API.OperationMethod<
   DeleteCrawlerRequest,
   DeleteCrawlerResponse,
   DeleteCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCrawlerRequest,
   output: DeleteCrawlerResponse,
@@ -20776,7 +20775,7 @@ export const deleteCustomEntityType: API.OperationMethod<
   DeleteCustomEntityTypeRequest,
   DeleteCustomEntityTypeResponse,
   DeleteCustomEntityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomEntityTypeRequest,
   output: DeleteCustomEntityTypeResponse,
@@ -20820,7 +20819,7 @@ export const deleteDatabase: API.OperationMethod<
   DeleteDatabaseRequest,
   DeleteDatabaseResponse,
   DeleteDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatabaseRequest,
   output: DeleteDatabaseResponse,
@@ -20851,7 +20850,7 @@ export const deleteDataQualityRuleset: API.OperationMethod<
   DeleteDataQualityRulesetRequest,
   DeleteDataQualityRulesetResponse,
   DeleteDataQualityRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataQualityRulesetRequest,
   output: DeleteDataQualityRulesetResponse,
@@ -20879,7 +20878,7 @@ export const deleteDevEndpoint: API.OperationMethod<
   DeleteDevEndpointRequest,
   DeleteDevEndpointResponse,
   DeleteDevEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDevEndpointRequest,
   output: DeleteDevEndpointResponse,
@@ -20909,7 +20908,7 @@ export const deleteFormType: API.OperationMethod<
   DeleteFormTypeRequest,
   DeleteFormTypeResponse,
   DeleteFormTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFormTypeRequest,
   output: DeleteFormTypeResponse,
@@ -20941,7 +20940,7 @@ export const deleteGlossary: API.OperationMethod<
   DeleteGlossaryRequest,
   DeleteGlossaryResponse,
   DeleteGlossaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlossaryRequest,
   output: DeleteGlossaryResponse,
@@ -20972,7 +20971,7 @@ export const deleteGlossaryTerm: API.OperationMethod<
   DeleteGlossaryTermRequest,
   DeleteGlossaryTermResponse,
   DeleteGlossaryTermError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlossaryTermRequest,
   output: DeleteGlossaryTermResponse,
@@ -21004,7 +21003,7 @@ export const deleteGlueIdentityCenterConfiguration: API.OperationMethod<
   DeleteGlueIdentityCenterConfigurationRequest,
   DeleteGlueIdentityCenterConfigurationResponse,
   DeleteGlueIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlueIdentityCenterConfigurationRequest,
   output: DeleteGlueIdentityCenterConfigurationResponse,
@@ -21041,7 +21040,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationRequest,
   DeleteIntegrationResponse,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationRequest,
   output: DeleteIntegrationResponse,
@@ -21079,7 +21078,7 @@ export const deleteIntegrationResourceProperty: API.OperationMethod<
   DeleteIntegrationResourcePropertyRequest,
   DeleteIntegrationResourcePropertyResponse,
   DeleteIntegrationResourcePropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationResourcePropertyRequest,
   output: DeleteIntegrationResourcePropertyResponse,
@@ -21113,7 +21112,7 @@ export const deleteIntegrationTableProperties: API.OperationMethod<
   DeleteIntegrationTablePropertiesRequest,
   DeleteIntegrationTablePropertiesResponse,
   DeleteIntegrationTablePropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationTablePropertiesRequest,
   output: DeleteIntegrationTablePropertiesResponse,
@@ -21144,7 +21143,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -21176,7 +21175,7 @@ export const deleteMLTransform: API.OperationMethod<
   DeleteMLTransformRequest,
   DeleteMLTransformResponse,
   DeleteMLTransformError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMLTransformRequest,
   output: DeleteMLTransformResponse,
@@ -21204,7 +21203,7 @@ export const deletePartition: API.OperationMethod<
   DeletePartitionRequest,
   DeletePartitionResponse,
   DeletePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartitionRequest,
   output: DeletePartitionResponse,
@@ -21234,7 +21233,7 @@ export const deletePartitionIndex: API.OperationMethod<
   DeletePartitionIndexRequest,
   DeletePartitionIndexResponse,
   DeletePartitionIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartitionIndexRequest,
   output: DeletePartitionIndexResponse,
@@ -21264,7 +21263,7 @@ export const deleteRegistry: API.OperationMethod<
   DeleteRegistryInput,
   DeleteRegistryResponse,
   DeleteRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistryInput,
   output: DeleteRegistryResponse,
@@ -21293,7 +21292,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -21322,7 +21321,7 @@ export const deleteSchema: API.OperationMethod<
   DeleteSchemaInput,
   DeleteSchemaResponse,
   DeleteSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaInput,
   output: DeleteSchemaResponse,
@@ -21356,7 +21355,7 @@ export const deleteSchemaVersions: API.OperationMethod<
   DeleteSchemaVersionsInput,
   DeleteSchemaVersionsResponse,
   DeleteSchemaVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaVersionsInput,
   output: DeleteSchemaVersionsResponse,
@@ -21384,7 +21383,7 @@ export const deleteSecurityConfiguration: API.OperationMethod<
   DeleteSecurityConfigurationRequest,
   DeleteSecurityConfigurationResponse,
   DeleteSecurityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityConfigurationRequest,
   output: DeleteSecurityConfigurationResponse,
@@ -21414,7 +21413,7 @@ export const deleteSession: API.OperationMethod<
   DeleteSessionRequest,
   DeleteSessionResponse,
   DeleteSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSessionRequest,
   output: DeleteSessionResponse,
@@ -21458,7 +21457,7 @@ export const deleteTable: API.OperationMethod<
   DeleteTableRequest,
   DeleteTableResponse,
   DeleteTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableRequest,
   output: DeleteTableResponse,
@@ -21491,7 +21490,7 @@ export const deleteTableOptimizer: API.OperationMethod<
   DeleteTableOptimizerRequest,
   DeleteTableOptimizerResponse,
   DeleteTableOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableOptimizerRequest,
   output: DeleteTableOptimizerResponse,
@@ -21520,7 +21519,7 @@ export const deleteTableVersion: API.OperationMethod<
   DeleteTableVersionRequest,
   DeleteTableVersionResponse,
   DeleteTableVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableVersionRequest,
   output: DeleteTableVersionResponse,
@@ -21549,7 +21548,7 @@ export const deleteTrigger: API.OperationMethod<
   DeleteTriggerRequest,
   DeleteTriggerResponse,
   DeleteTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTriggerRequest,
   output: DeleteTriggerResponse,
@@ -21577,7 +21576,7 @@ export const deleteUsageProfile: API.OperationMethod<
   DeleteUsageProfileRequest,
   DeleteUsageProfileResponse,
   DeleteUsageProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsageProfileRequest,
   output: DeleteUsageProfileResponse,
@@ -21605,7 +21604,7 @@ export const deleteUserDefinedFunction: API.OperationMethod<
   DeleteUserDefinedFunctionRequest,
   DeleteUserDefinedFunctionResponse,
   DeleteUserDefinedFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserDefinedFunctionRequest,
   output: DeleteUserDefinedFunctionResponse,
@@ -21633,7 +21632,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -21663,7 +21662,7 @@ export const describeConnectionType: API.OperationMethod<
   DescribeConnectionTypeRequest,
   DescribeConnectionTypeResponse,
   DescribeConnectionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionTypeRequest,
   output: DescribeConnectionTypeResponse,
@@ -21696,7 +21695,7 @@ export const describeEntity: API.PaginatedOperationMethod<
   DescribeEntityRequest,
   DescribeEntityResponse,
   DescribeEntityError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Field
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEntityRequest,
@@ -21738,7 +21737,7 @@ export const describeInboundIntegrations: API.OperationMethod<
   DescribeInboundIntegrationsRequest,
   DescribeInboundIntegrationsResponse,
   DescribeInboundIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInboundIntegrationsRequest,
   output: DescribeInboundIntegrationsResponse,
@@ -21774,7 +21773,7 @@ export const describeIntegrations: API.OperationMethod<
   DescribeIntegrationsRequest,
   DescribeIntegrationsResponse,
   DescribeIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIntegrationsRequest,
   output: DescribeIntegrationsResponse,
@@ -21807,7 +21806,7 @@ export const disassociateGlossaryTerms: API.OperationMethod<
   DisassociateGlossaryTermsRequest,
   DisassociateGlossaryTermsResponse,
   DisassociateGlossaryTermsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateGlossaryTermsRequest,
   output: DisassociateGlossaryTermsResponse,
@@ -21838,7 +21837,7 @@ export const getAsset: API.OperationMethod<
   GetAssetInput,
   GetAssetOutput,
   GetAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetInput,
   output: GetAssetOutput,
@@ -21868,7 +21867,7 @@ export const getAssetType: API.OperationMethod<
   GetAssetTypeRequest,
   GetAssetTypeResponse,
   GetAssetTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetTypeRequest,
   output: GetAssetTypeResponse,
@@ -21897,7 +21896,7 @@ export const getBlueprint: API.OperationMethod<
   GetBlueprintRequest,
   GetBlueprintResponse,
   GetBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlueprintRequest,
   output: GetBlueprintResponse,
@@ -21924,7 +21923,7 @@ export const getBlueprintRun: API.OperationMethod<
   GetBlueprintRunRequest,
   GetBlueprintRunResponse,
   GetBlueprintRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlueprintRunRequest,
   output: GetBlueprintRunResponse,
@@ -21951,7 +21950,7 @@ export const getBlueprintRuns: API.PaginatedOperationMethod<
   GetBlueprintRunsRequest,
   GetBlueprintRunsResponse,
   GetBlueprintRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBlueprintRunsRequest,
@@ -21989,7 +21988,7 @@ export const getCatalog: API.OperationMethod<
   GetCatalogRequest,
   GetCatalogResponse,
   GetCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCatalogRequest,
   output: GetCatalogResponse,
@@ -22019,7 +22018,7 @@ export const getCatalogImportStatus: API.OperationMethod<
   GetCatalogImportStatusRequest,
   GetCatalogImportStatusResponse,
   GetCatalogImportStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCatalogImportStatusRequest,
   output: GetCatalogImportStatusResponse,
@@ -22046,7 +22045,7 @@ export const getCatalogs: API.OperationMethod<
   GetCatalogsRequest,
   GetCatalogsResponse,
   GetCatalogsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCatalogsRequest,
   output: GetCatalogsResponse,
@@ -22076,7 +22075,7 @@ export const getClassifier: API.OperationMethod<
   GetClassifierRequest,
   GetClassifierResponse,
   GetClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClassifierRequest,
   output: GetClassifierResponse,
@@ -22094,7 +22093,7 @@ export const getClassifiers: API.PaginatedOperationMethod<
   GetClassifiersRequest,
   GetClassifiersResponse,
   GetClassifiersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetClassifiersRequest,
@@ -22126,7 +22125,7 @@ export const getColumnStatisticsForPartition: API.OperationMethod<
   GetColumnStatisticsForPartitionRequest,
   GetColumnStatisticsForPartitionResponse,
   GetColumnStatisticsForPartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetColumnStatisticsForPartitionRequest,
   output: GetColumnStatisticsForPartitionResponse,
@@ -22158,7 +22157,7 @@ export const getColumnStatisticsForTable: API.OperationMethod<
   GetColumnStatisticsForTableRequest,
   GetColumnStatisticsForTableResponse,
   GetColumnStatisticsForTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetColumnStatisticsForTableRequest,
   output: GetColumnStatisticsForTableResponse,
@@ -22186,7 +22185,7 @@ export const getColumnStatisticsTaskRun: API.OperationMethod<
   GetColumnStatisticsTaskRunRequest,
   GetColumnStatisticsTaskRunResponse,
   GetColumnStatisticsTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetColumnStatisticsTaskRunRequest,
   output: GetColumnStatisticsTaskRunResponse,
@@ -22210,7 +22209,7 @@ export const getColumnStatisticsTaskRuns: API.PaginatedOperationMethod<
   GetColumnStatisticsTaskRunsRequest,
   GetColumnStatisticsTaskRunsResponse,
   GetColumnStatisticsTaskRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetColumnStatisticsTaskRunsRequest,
@@ -22238,7 +22237,7 @@ export const getColumnStatisticsTaskSettings: API.OperationMethod<
   GetColumnStatisticsTaskSettingsRequest,
   GetColumnStatisticsTaskSettingsResponse,
   GetColumnStatisticsTaskSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetColumnStatisticsTaskSettingsRequest,
   output: GetColumnStatisticsTaskSettingsResponse,
@@ -22265,7 +22264,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -22293,7 +22292,7 @@ export const getConnections: API.PaginatedOperationMethod<
   GetConnectionsRequest,
   GetConnectionsResponse,
   GetConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConnectionsRequest,
@@ -22325,7 +22324,7 @@ export const getCrawler: API.OperationMethod<
   GetCrawlerRequest,
   GetCrawlerResponse,
   GetCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCrawlerRequest,
   output: GetCrawlerResponse,
@@ -22343,7 +22342,7 @@ export const getCrawlerMetrics: API.PaginatedOperationMethod<
   GetCrawlerMetricsRequest,
   GetCrawlerMetricsResponse,
   GetCrawlerMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCrawlerMetricsRequest,
@@ -22368,7 +22367,7 @@ export const getCrawlers: API.PaginatedOperationMethod<
   GetCrawlersRequest,
   GetCrawlersResponse,
   GetCrawlersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCrawlersRequest,
@@ -22398,7 +22397,7 @@ export const getCustomEntityType: API.OperationMethod<
   GetCustomEntityTypeRequest,
   GetCustomEntityTypeResponse,
   GetCustomEntityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomEntityTypeRequest,
   output: GetCustomEntityTypeResponse,
@@ -22428,7 +22427,7 @@ export const getDashboardUrl: API.OperationMethod<
   GetDashboardUrlRequest,
   GetDashboardUrlResponse,
   GetDashboardUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardUrlRequest,
   output: GetDashboardUrlResponse,
@@ -22460,7 +22459,7 @@ export const getDatabase: API.OperationMethod<
   GetDatabaseRequest,
   GetDatabaseResponse,
   GetDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatabaseRequest,
   output: GetDatabaseResponse,
@@ -22494,7 +22493,7 @@ export const getDatabases: API.PaginatedOperationMethod<
   GetDatabasesRequest,
   GetDatabasesResponse,
   GetDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDatabasesRequest,
@@ -22530,7 +22529,7 @@ export const getDataCatalogEncryptionSettings: API.OperationMethod<
   GetDataCatalogEncryptionSettingsRequest,
   GetDataCatalogEncryptionSettingsResponse,
   GetDataCatalogEncryptionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataCatalogEncryptionSettingsRequest,
   output: GetDataCatalogEncryptionSettingsResponse,
@@ -22556,7 +22555,7 @@ export const getDataflowGraph: API.OperationMethod<
   GetDataflowGraphRequest,
   GetDataflowGraphResponse,
   GetDataflowGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataflowGraphRequest,
   output: GetDataflowGraphResponse,
@@ -22583,7 +22582,7 @@ export const getDataQualityModel: API.OperationMethod<
   GetDataQualityModelRequest,
   GetDataQualityModelResponse,
   GetDataQualityModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityModelRequest,
   output: GetDataQualityModelResponse,
@@ -22611,7 +22610,7 @@ export const getDataQualityModelResult: API.OperationMethod<
   GetDataQualityModelResultRequest,
   GetDataQualityModelResultResponse,
   GetDataQualityModelResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityModelResultRequest,
   output: GetDataQualityModelResultResponse,
@@ -22639,7 +22638,7 @@ export const getDataQualityResult: API.OperationMethod<
   GetDataQualityResultRequest,
   GetDataQualityResultResponse,
   GetDataQualityResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityResultRequest,
   output: GetDataQualityResultResponse,
@@ -22667,7 +22666,7 @@ export const getDataQualityRuleRecommendationRun: API.OperationMethod<
   GetDataQualityRuleRecommendationRunRequest,
   GetDataQualityRuleRecommendationRunResponse,
   GetDataQualityRuleRecommendationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityRuleRecommendationRunRequest,
   output: GetDataQualityRuleRecommendationRunResponse,
@@ -22695,7 +22694,7 @@ export const getDataQualityRuleset: API.OperationMethod<
   GetDataQualityRulesetRequest,
   GetDataQualityRulesetResponse,
   GetDataQualityRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityRulesetRequest,
   output: GetDataQualityRulesetResponse,
@@ -22723,7 +22722,7 @@ export const getDataQualityRulesetEvaluationRun: API.OperationMethod<
   GetDataQualityRulesetEvaluationRunRequest,
   GetDataQualityRulesetEvaluationRunResponse,
   GetDataQualityRulesetEvaluationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataQualityRulesetEvaluationRunRequest,
   output: GetDataQualityRulesetEvaluationRunResponse,
@@ -22755,7 +22754,7 @@ export const getDevEndpoint: API.OperationMethod<
   GetDevEndpointRequest,
   GetDevEndpointResponse,
   GetDevEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDevEndpointRequest,
   output: GetDevEndpointResponse,
@@ -22787,7 +22786,7 @@ export const getDevEndpoints: API.PaginatedOperationMethod<
   GetDevEndpointsRequest,
   GetDevEndpointsResponse,
   GetDevEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDevEndpointsRequest,
@@ -22828,7 +22827,7 @@ export const getEntityRecords: API.OperationMethod<
   GetEntityRecordsRequest,
   GetEntityRecordsResponse,
   GetEntityRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEntityRecordsRequest,
   output: GetEntityRecordsResponse,
@@ -22860,7 +22859,7 @@ export const getFormType: API.OperationMethod<
   GetFormTypeRequest,
   GetFormTypeResponse,
   GetFormTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFormTypeRequest,
   output: GetFormTypeResponse,
@@ -22889,7 +22888,7 @@ export const getGlossary: API.OperationMethod<
   GetGlossaryRequest,
   GetGlossaryResponse,
   GetGlossaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlossaryRequest,
   output: GetGlossaryResponse,
@@ -22917,7 +22916,7 @@ export const getGlossaryTerm: API.OperationMethod<
   GetGlossaryTermRequest,
   GetGlossaryTermResponse,
   GetGlossaryTermError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlossaryTermRequest,
   output: GetGlossaryTermResponse,
@@ -22948,7 +22947,7 @@ export const getGlueIdentityCenterConfiguration: API.OperationMethod<
   GetGlueIdentityCenterConfigurationRequest,
   GetGlueIdentityCenterConfigurationResponse,
   GetGlueIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlueIdentityCenterConfigurationRequest,
   output: GetGlueIdentityCenterConfigurationResponse,
@@ -22981,7 +22980,7 @@ export const getIntegrationResourceProperty: API.OperationMethod<
   GetIntegrationResourcePropertyRequest,
   GetIntegrationResourcePropertyResponse,
   GetIntegrationResourcePropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationResourcePropertyRequest,
   output: GetIntegrationResourcePropertyResponse,
@@ -23015,7 +23014,7 @@ export const getIntegrationTableProperties: API.OperationMethod<
   GetIntegrationTablePropertiesRequest,
   GetIntegrationTablePropertiesResponse,
   GetIntegrationTablePropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationTablePropertiesRequest,
   output: GetIntegrationTablePropertiesResponse,
@@ -23046,7 +23045,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -23083,7 +23082,7 @@ export const getJobBookmark: API.OperationMethod<
   GetJobBookmarkRequest,
   GetJobBookmarkResponse,
   GetJobBookmarkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobBookmarkRequest,
   output: GetJobBookmarkResponse,
@@ -23112,7 +23111,7 @@ export const getJobRun: API.OperationMethod<
   GetJobRunRequest,
   GetJobRunResponse,
   GetJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRunRequest,
   output: GetJobRunResponse,
@@ -23142,7 +23141,7 @@ export const getJobRuns: API.PaginatedOperationMethod<
   GetJobRunsRequest,
   GetJobRunsResponse,
   GetJobRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetJobRunsRequest,
@@ -23177,7 +23176,7 @@ export const getJobs: API.PaginatedOperationMethod<
   GetJobsRequest,
   GetJobsResponse,
   GetJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetJobsRequest,
@@ -23212,7 +23211,7 @@ export const getMapping: API.OperationMethod<
   GetMappingRequest,
   GetMappingResponse,
   GetMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMappingRequest,
   output: GetMappingResponse,
@@ -23240,7 +23239,7 @@ export const getMaterializedViewRefreshTaskRun: API.OperationMethod<
   GetMaterializedViewRefreshTaskRunRequest,
   GetMaterializedViewRefreshTaskRunResponse,
   GetMaterializedViewRefreshTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaterializedViewRefreshTaskRunRequest,
   output: GetMaterializedViewRefreshTaskRunResponse,
@@ -23272,7 +23271,7 @@ export const getMLTaskRun: API.OperationMethod<
   GetMLTaskRunRequest,
   GetMLTaskRunResponse,
   GetMLTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLTaskRunRequest,
   output: GetMLTaskRunResponse,
@@ -23306,7 +23305,7 @@ export const getMLTaskRuns: API.PaginatedOperationMethod<
   GetMLTaskRunsRequest,
   GetMLTaskRunsResponse,
   GetMLTaskRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMLTaskRunsRequest,
@@ -23344,7 +23343,7 @@ export const getMLTransform: API.OperationMethod<
   GetMLTransformRequest,
   GetMLTransformResponse,
   GetMLTransformError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLTransformRequest,
   output: GetMLTransformResponse,
@@ -23376,7 +23375,7 @@ export const getMLTransforms: API.PaginatedOperationMethod<
   GetMLTransformsRequest,
   GetMLTransformsResponse,
   GetMLTransformsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMLTransformsRequest,
@@ -23413,7 +23412,7 @@ export const getPartition: API.OperationMethod<
   GetPartitionRequest,
   GetPartitionResponse,
   GetPartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPartitionRequest,
   output: GetPartitionResponse,
@@ -23445,7 +23444,7 @@ export const getPartitionIndexes: API.PaginatedOperationMethod<
   GetPartitionIndexesRequest,
   GetPartitionIndexesResponse,
   GetPartitionIndexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PartitionIndexDescriptor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPartitionIndexesRequest,
@@ -23485,7 +23484,7 @@ export const getPartitions: API.PaginatedOperationMethod<
   GetPartitionsRequest,
   GetPartitionsResponse,
   GetPartitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPartitionsRequest,
@@ -23523,7 +23522,7 @@ export const getPlan: API.OperationMethod<
   GetPlanRequest,
   GetPlanResponse,
   GetPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlanRequest,
   output: GetPlanResponse,
@@ -23550,7 +23549,7 @@ export const getRegistry: API.OperationMethod<
   GetRegistryInput,
   GetRegistryResponse,
   GetRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistryInput,
   output: GetRegistryResponse,
@@ -23584,7 +23583,7 @@ export const getResourcePolicies: API.PaginatedOperationMethod<
   GetResourcePoliciesRequest,
   GetResourcePoliciesResponse,
   GetResourcePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GluePolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcePoliciesRequest,
@@ -23619,7 +23618,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -23647,7 +23646,7 @@ export const getSchema: API.OperationMethod<
   GetSchemaInput,
   GetSchemaResponse,
   GetSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaInput,
   output: GetSchemaResponse,
@@ -23675,7 +23674,7 @@ export const getSchemaByDefinition: API.OperationMethod<
   GetSchemaByDefinitionInput,
   GetSchemaByDefinitionResponse,
   GetSchemaByDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaByDefinitionInput,
   output: GetSchemaByDefinitionResponse,
@@ -23703,7 +23702,7 @@ export const getSchemaVersion: API.OperationMethod<
   GetSchemaVersionInput,
   GetSchemaVersionResponse,
   GetSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaVersionInput,
   output: GetSchemaVersionResponse,
@@ -23733,7 +23732,7 @@ export const getSchemaVersionsDiff: API.OperationMethod<
   GetSchemaVersionsDiffInput,
   GetSchemaVersionsDiffResponse,
   GetSchemaVersionsDiffError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaVersionsDiffInput,
   output: GetSchemaVersionsDiffResponse,
@@ -23761,7 +23760,7 @@ export const getSecurityConfiguration: API.OperationMethod<
   GetSecurityConfigurationRequest,
   GetSecurityConfigurationResponse,
   GetSecurityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityConfigurationRequest,
   output: GetSecurityConfigurationResponse,
@@ -23789,7 +23788,7 @@ export const getSecurityConfigurations: API.PaginatedOperationMethod<
   GetSecurityConfigurationsRequest,
   GetSecurityConfigurationsResponse,
   GetSecurityConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSecurityConfigurationsRequest,
@@ -23825,7 +23824,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -23857,7 +23856,7 @@ export const getSessionEndpoint: API.OperationMethod<
   GetSessionEndpointRequest,
   GetSessionEndpointResponse,
   GetSessionEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionEndpointRequest,
   output: GetSessionEndpointResponse,
@@ -23890,7 +23889,7 @@ export const getStatement: API.OperationMethod<
   GetStatementRequest,
   GetStatementResponse,
   GetStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStatementRequest,
   output: GetStatementResponse,
@@ -23925,7 +23924,7 @@ export const getTable: API.OperationMethod<
   GetTableRequest,
   GetTableResponse,
   GetTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRequest,
   output: GetTableResponse,
@@ -23958,7 +23957,7 @@ export const getTableOptimizer: API.OperationMethod<
   GetTableOptimizerRequest,
   GetTableOptimizerResponse,
   GetTableOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableOptimizerRequest,
   output: GetTableOptimizerResponse,
@@ -23991,7 +23990,7 @@ export const getTables: API.PaginatedOperationMethod<
   GetTablesRequest,
   GetTablesResponse,
   GetTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTablesRequest,
@@ -24029,7 +24028,7 @@ export const getTableVersion: API.OperationMethod<
   GetTableVersionRequest,
   GetTableVersionResponse,
   GetTableVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableVersionRequest,
   output: GetTableVersionResponse,
@@ -24060,7 +24059,7 @@ export const getTableVersions: API.PaginatedOperationMethod<
   GetTableVersionsRequest,
   GetTableVersionsResponse,
   GetTableVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTableVersionsRequest,
@@ -24095,7 +24094,7 @@ export const getTags: API.OperationMethod<
   GetTagsRequest,
   GetTagsResponse,
   GetTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagsRequest,
   output: GetTagsResponse,
@@ -24123,7 +24122,7 @@ export const getTrigger: API.OperationMethod<
   GetTriggerRequest,
   GetTriggerResponse,
   GetTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTriggerRequest,
   output: GetTriggerResponse,
@@ -24151,7 +24150,7 @@ export const getTriggers: API.PaginatedOperationMethod<
   GetTriggersRequest,
   GetTriggersResponse,
   GetTriggersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Trigger
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTriggersRequest,
@@ -24193,7 +24192,7 @@ export const getUnfilteredPartitionMetadata: API.OperationMethod<
   GetUnfilteredPartitionMetadataRequest,
   GetUnfilteredPartitionMetadataResponse,
   GetUnfilteredPartitionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUnfilteredPartitionMetadataRequest,
   output: GetUnfilteredPartitionMetadataResponse,
@@ -24232,7 +24231,7 @@ export const getUnfilteredPartitionsMetadata: API.PaginatedOperationMethod<
   GetUnfilteredPartitionsMetadataRequest,
   GetUnfilteredPartitionsMetadataResponse,
   GetUnfilteredPartitionsMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUnfilteredPartitionsMetadataRequest,
@@ -24276,7 +24275,7 @@ export const getUnfilteredTableMetadata: API.OperationMethod<
   GetUnfilteredTableMetadataRequest,
   GetUnfilteredTableMetadataResponse,
   GetUnfilteredTableMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUnfilteredTableMetadataRequest,
   output: GetUnfilteredTableMetadataResponse,
@@ -24309,7 +24308,7 @@ export const getUsageProfile: API.OperationMethod<
   GetUsageProfileRequest,
   GetUsageProfileResponse,
   GetUsageProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsageProfileRequest,
   output: GetUsageProfileResponse,
@@ -24339,7 +24338,7 @@ export const getUserDefinedFunction: API.OperationMethod<
   GetUserDefinedFunctionRequest,
   GetUserDefinedFunctionResponse,
   GetUserDefinedFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserDefinedFunctionRequest,
   output: GetUserDefinedFunctionResponse,
@@ -24369,7 +24368,7 @@ export const getUserDefinedFunctions: API.PaginatedOperationMethod<
   GetUserDefinedFunctionsRequest,
   GetUserDefinedFunctionsResponse,
   GetUserDefinedFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUserDefinedFunctionsRequest,
@@ -24404,7 +24403,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -24432,7 +24431,7 @@ export const getWorkflowRun: API.OperationMethod<
   GetWorkflowRunRequest,
   GetWorkflowRunResponse,
   GetWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRunRequest,
   output: GetWorkflowRunResponse,
@@ -24460,7 +24459,7 @@ export const getWorkflowRunProperties: API.OperationMethod<
   GetWorkflowRunPropertiesRequest,
   GetWorkflowRunPropertiesResponse,
   GetWorkflowRunPropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRunPropertiesRequest,
   output: GetWorkflowRunPropertiesResponse,
@@ -24488,7 +24487,7 @@ export const getWorkflowRuns: API.PaginatedOperationMethod<
   GetWorkflowRunsRequest,
   GetWorkflowRunsResponse,
   GetWorkflowRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetWorkflowRunsRequest,
@@ -24521,7 +24520,7 @@ export const importCatalogToGlue: API.OperationMethod<
   ImportCatalogToGlueRequest,
   ImportCatalogToGlueResponse,
   ImportCatalogToGlueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCatalogToGlueRequest,
   output: ImportCatalogToGlueResponse,
@@ -24544,7 +24543,7 @@ export const listAssetTypes: API.PaginatedOperationMethod<
   ListAssetTypesRequest,
   ListAssetTypesResponse,
   ListAssetTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetTypeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetTypesRequest,
@@ -24578,7 +24577,7 @@ export const listBlueprints: API.PaginatedOperationMethod<
   ListBlueprintsRequest,
   ListBlueprintsResponse,
   ListBlueprintsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrchestrationNameString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBlueprintsRequest,
@@ -24609,7 +24608,7 @@ export const listColumnStatisticsTaskRuns: API.PaginatedOperationMethod<
   ListColumnStatisticsTaskRunsRequest,
   ListColumnStatisticsTaskRunsResponse,
   ListColumnStatisticsTaskRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListColumnStatisticsTaskRunsRequest,
@@ -24638,7 +24637,7 @@ export const listConnectionTypes: API.PaginatedOperationMethod<
   ListConnectionTypesRequest,
   ListConnectionTypesResponse,
   ListConnectionTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionTypeBrief
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionTypesRequest,
@@ -24669,7 +24668,7 @@ export const listCrawlers: API.PaginatedOperationMethod<
   ListCrawlersRequest,
   ListCrawlersResponse,
   ListCrawlersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCrawlersRequest,
@@ -24707,7 +24706,7 @@ export const listCrawls: API.OperationMethod<
   ListCrawlsRequest,
   ListCrawlsResponse,
   ListCrawlsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCrawlsRequest,
   output: ListCrawlsResponse,
@@ -24733,7 +24732,7 @@ export const listCustomEntityTypes: API.PaginatedOperationMethod<
   ListCustomEntityTypesRequest,
   ListCustomEntityTypesResponse,
   ListCustomEntityTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomEntityTypesRequest,
@@ -24765,7 +24764,7 @@ export const listDataQualityResults: API.PaginatedOperationMethod<
   ListDataQualityResultsRequest,
   ListDataQualityResultsResponse,
   ListDataQualityResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataQualityResultsRequest,
@@ -24797,7 +24796,7 @@ export const listDataQualityRuleRecommendationRuns: API.PaginatedOperationMethod
   ListDataQualityRuleRecommendationRunsRequest,
   ListDataQualityRuleRecommendationRunsResponse,
   ListDataQualityRuleRecommendationRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataQualityRuleRecommendationRunsRequest,
@@ -24829,7 +24828,7 @@ export const listDataQualityRulesetEvaluationRuns: API.PaginatedOperationMethod<
   ListDataQualityRulesetEvaluationRunsRequest,
   ListDataQualityRulesetEvaluationRunsResponse,
   ListDataQualityRulesetEvaluationRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataQualityRulesetEvaluationRunsRequest,
@@ -24862,7 +24861,7 @@ export const listDataQualityRulesets: API.PaginatedOperationMethod<
   ListDataQualityRulesetsRequest,
   ListDataQualityRulesetsResponse,
   ListDataQualityRulesetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataQualityRulesetsRequest,
@@ -24894,7 +24893,7 @@ export const listDataQualityStatisticAnnotations: API.OperationMethod<
   ListDataQualityStatisticAnnotationsRequest,
   ListDataQualityStatisticAnnotationsResponse,
   ListDataQualityStatisticAnnotationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataQualityStatisticAnnotationsRequest,
   output: ListDataQualityStatisticAnnotationsResponse,
@@ -24916,7 +24915,7 @@ export const listDataQualityStatistics: API.OperationMethod<
   ListDataQualityStatisticsRequest,
   ListDataQualityStatisticsResponse,
   ListDataQualityStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataQualityStatisticsRequest,
   output: ListDataQualityStatisticsResponse,
@@ -24949,7 +24948,7 @@ export const listDevEndpoints: API.PaginatedOperationMethod<
   ListDevEndpointsRequest,
   ListDevEndpointsResponse,
   ListDevEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevEndpointsRequest,
@@ -24986,7 +24985,7 @@ export const listEntities: API.PaginatedOperationMethod<
   ListEntitiesRequest,
   ListEntitiesResponse,
   ListEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Entity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitiesRequest,
@@ -25023,7 +25022,7 @@ export const listFormTypes: API.PaginatedOperationMethod<
   ListFormTypesRequest,
   ListFormTypesResponse,
   ListFormTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FormTypeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFormTypesRequest,
@@ -25058,7 +25057,7 @@ export const listGlossaries: API.PaginatedOperationMethod<
   ListGlossariesRequest,
   ListGlossariesResponse,
   ListGlossariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlossaryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGlossariesRequest,
@@ -25093,7 +25092,7 @@ export const listGlossaryTerms: API.PaginatedOperationMethod<
   ListGlossaryTermsRequest,
   ListGlossaryTermsResponse,
   ListGlossaryTermsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlossaryTermItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGlossaryTermsRequest,
@@ -25131,7 +25130,7 @@ export const listIntegrationResourceProperties: API.OperationMethod<
   ListIntegrationResourcePropertiesRequest,
   ListIntegrationResourcePropertiesResponse,
   ListIntegrationResourcePropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIntegrationResourcePropertiesRequest,
   output: ListIntegrationResourcePropertiesResponse,
@@ -25163,7 +25162,7 @@ export const listIterableForms: API.PaginatedOperationMethod<
   ListIterableFormsRequest,
   ListIterableFormsResponse,
   ListIterableFormsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IterableFormListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIterableFormsRequest,
@@ -25203,7 +25202,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NameString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -25237,7 +25236,7 @@ export const listMaterializedViewRefreshTaskRuns: API.PaginatedOperationMethod<
   ListMaterializedViewRefreshTaskRunsRequest,
   ListMaterializedViewRefreshTaskRunsResponse,
   ListMaterializedViewRefreshTaskRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MaterializedViewRefreshTaskRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMaterializedViewRefreshTaskRunsRequest,
@@ -25274,7 +25273,7 @@ export const listMLTransforms: API.PaginatedOperationMethod<
   ListMLTransformsRequest,
   ListMLTransformsResponse,
   ListMLTransformsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMLTransformsRequest,
@@ -25307,7 +25306,7 @@ export const listRegistries: API.PaginatedOperationMethod<
   ListRegistriesInput,
   ListRegistriesResponse,
   ListRegistriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistryListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegistriesInput,
@@ -25343,7 +25342,7 @@ export const listSchemas: API.PaginatedOperationMethod<
   ListSchemasInput,
   ListSchemasResponse,
   ListSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemasInput,
@@ -25378,7 +25377,7 @@ export const listSchemaVersions: API.PaginatedOperationMethod<
   ListSchemaVersionsInput,
   ListSchemaVersionsResponse,
   ListSchemaVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaVersionListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemaVersionsInput,
@@ -25413,7 +25412,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -25449,7 +25448,7 @@ export const listStatements: API.OperationMethod<
   ListStatementsRequest,
   ListStatementsResponse,
   ListStatementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStatementsRequest,
   output: ListStatementsResponse,
@@ -25481,7 +25480,7 @@ export const listTableOptimizerRuns: API.PaginatedOperationMethod<
   ListTableOptimizerRunsRequest,
   ListTableOptimizerRunsResponse,
   ListTableOptimizerRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableOptimizerRun
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTableOptimizerRunsRequest,
@@ -25522,7 +25521,7 @@ export const listTriggers: API.PaginatedOperationMethod<
   ListTriggersRequest,
   ListTriggersResponse,
   ListTriggersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NameString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTriggersRequest,
@@ -25557,7 +25556,7 @@ export const listUsageProfiles: API.PaginatedOperationMethod<
   ListUsageProfilesRequest,
   ListUsageProfilesResponse,
   ListUsageProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsageProfileDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsageProfilesRequest,
@@ -25591,7 +25590,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NameString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -25632,7 +25631,7 @@ export const modifyIntegration: API.OperationMethod<
   ModifyIntegrationRequest,
   ModifyIntegrationResponse,
   ModifyIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIntegrationRequest,
   output: ModifyIntegrationResponse,
@@ -25669,7 +25668,7 @@ export const putAsset: API.OperationMethod<
   PutAssetRequest,
   PutAssetResponse,
   PutAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAssetRequest,
   output: PutAssetResponse,
@@ -25700,7 +25699,7 @@ export const putAssetType: API.OperationMethod<
   PutAssetTypeRequest,
   PutAssetTypeResponse,
   PutAssetTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAssetTypeRequest,
   output: PutAssetTypeResponse,
@@ -25731,7 +25730,7 @@ export const putAttachment: API.OperationMethod<
   PutAttachmentRequest,
   PutAttachmentResponse,
   PutAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAttachmentRequest,
   output: PutAttachmentResponse,
@@ -25761,7 +25760,7 @@ export const putDataCatalogEncryptionSettings: API.OperationMethod<
   PutDataCatalogEncryptionSettingsRequest,
   PutDataCatalogEncryptionSettingsResponse,
   PutDataCatalogEncryptionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataCatalogEncryptionSettingsRequest,
   output: PutDataCatalogEncryptionSettingsResponse,
@@ -25787,7 +25786,7 @@ export const putDataQualityProfileAnnotation: API.OperationMethod<
   PutDataQualityProfileAnnotationRequest,
   PutDataQualityProfileAnnotationResponse,
   PutDataQualityProfileAnnotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataQualityProfileAnnotationRequest,
   output: PutDataQualityProfileAnnotationResponse,
@@ -25815,7 +25814,7 @@ export const putFormType: API.OperationMethod<
   PutFormTypeRequest,
   PutFormTypeResponse,
   PutFormTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFormTypeRequest,
   output: PutFormTypeResponse,
@@ -25845,7 +25844,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -25875,7 +25874,7 @@ export const putSchemaVersionMetadata: API.OperationMethod<
   PutSchemaVersionMetadataInput,
   PutSchemaVersionMetadataResponse,
   PutSchemaVersionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSchemaVersionMetadataInput,
   output: PutSchemaVersionMetadataResponse,
@@ -25907,7 +25906,7 @@ export const putWorkflowRunProperties: API.OperationMethod<
   PutWorkflowRunPropertiesRequest,
   PutWorkflowRunPropertiesResponse,
   PutWorkflowRunPropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutWorkflowRunPropertiesRequest,
   output: PutWorkflowRunPropertiesResponse,
@@ -25937,7 +25936,7 @@ export const querySchemaVersionMetadata: API.OperationMethod<
   QuerySchemaVersionMetadataInput,
   QuerySchemaVersionMetadataResponse,
   QuerySchemaVersionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: QuerySchemaVersionMetadataInput,
   output: QuerySchemaVersionMetadataResponse,
@@ -25970,7 +25969,7 @@ export const registerConnectionType: API.OperationMethod<
   RegisterConnectionTypeRequest,
   RegisterConnectionTypeResponse,
   RegisterConnectionTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterConnectionTypeRequest,
   output: RegisterConnectionTypeResponse,
@@ -26006,7 +26005,7 @@ export const registerSchemaVersion: API.OperationMethod<
   RegisterSchemaVersionInput,
   RegisterSchemaVersionResponse,
   RegisterSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterSchemaVersionInput,
   output: RegisterSchemaVersionResponse,
@@ -26035,7 +26034,7 @@ export const removeSchemaVersionMetadata: API.OperationMethod<
   RemoveSchemaVersionMetadataInput,
   RemoveSchemaVersionMetadataResponse,
   RemoveSchemaVersionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveSchemaVersionMetadataInput,
   output: RemoveSchemaVersionMetadataResponse,
@@ -26070,7 +26069,7 @@ export const resetJobBookmark: API.OperationMethod<
   ResetJobBookmarkRequest,
   ResetJobBookmarkResponse,
   ResetJobBookmarkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetJobBookmarkRequest,
   output: ResetJobBookmarkResponse,
@@ -26100,7 +26099,7 @@ export const resumeWorkflowRun: API.OperationMethod<
   ResumeWorkflowRunRequest,
   ResumeWorkflowRunResponse,
   ResumeWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeWorkflowRunRequest,
   output: ResumeWorkflowRunResponse,
@@ -26136,7 +26135,7 @@ export const runStatement: API.OperationMethod<
   RunStatementRequest,
   RunStatementResponse,
   RunStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunStatementRequest,
   output: RunStatementResponse,
@@ -26170,7 +26169,7 @@ export const searchAssets: API.PaginatedOperationMethod<
   SearchAssetsInput,
   SearchAssetsOutput,
   SearchAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchResultItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAssetsInput,
@@ -26206,7 +26205,7 @@ export const searchTables: API.PaginatedOperationMethod<
   SearchTablesRequest,
   SearchTablesResponse,
   SearchTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTablesRequest,
@@ -26241,7 +26240,7 @@ export const startBlueprintRun: API.OperationMethod<
   StartBlueprintRunRequest,
   StartBlueprintRunResponse,
   StartBlueprintRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBlueprintRunRequest,
   output: StartBlueprintRunResponse,
@@ -26273,7 +26272,7 @@ export const startColumnStatisticsTaskRun: API.OperationMethod<
   StartColumnStatisticsTaskRunRequest,
   StartColumnStatisticsTaskRunResponse,
   StartColumnStatisticsTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartColumnStatisticsTaskRunRequest,
   output: StartColumnStatisticsTaskRunResponse,
@@ -26303,7 +26302,7 @@ export const startColumnStatisticsTaskRunSchedule: API.OperationMethod<
   StartColumnStatisticsTaskRunScheduleRequest,
   StartColumnStatisticsTaskRunScheduleResponse,
   StartColumnStatisticsTaskRunScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartColumnStatisticsTaskRunScheduleRequest,
   output: StartColumnStatisticsTaskRunScheduleResponse,
@@ -26332,7 +26331,7 @@ export const startCrawler: API.OperationMethod<
   StartCrawlerRequest,
   StartCrawlerResponse,
   StartCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCrawlerRequest,
   output: StartCrawlerResponse,
@@ -26362,7 +26361,7 @@ export const startCrawlerSchedule: API.OperationMethod<
   StartCrawlerScheduleRequest,
   StartCrawlerScheduleResponse,
   StartCrawlerScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCrawlerScheduleRequest,
   output: StartCrawlerScheduleResponse,
@@ -26393,7 +26392,7 @@ export const startDataQualityRuleRecommendationRun: API.OperationMethod<
   StartDataQualityRuleRecommendationRunRequest,
   StartDataQualityRuleRecommendationRunResponse,
   StartDataQualityRuleRecommendationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataQualityRuleRecommendationRunRequest,
   output: StartDataQualityRuleRecommendationRunResponse,
@@ -26422,7 +26421,7 @@ export const startDataQualityRulesetEvaluationRun: API.OperationMethod<
   StartDataQualityRulesetEvaluationRunRequest,
   StartDataQualityRulesetEvaluationRunResponse,
   StartDataQualityRulesetEvaluationRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataQualityRulesetEvaluationRunRequest,
   output: StartDataQualityRulesetEvaluationRunResponse,
@@ -26459,7 +26458,7 @@ export const startExportLabelsTaskRun: API.OperationMethod<
   StartExportLabelsTaskRunRequest,
   StartExportLabelsTaskRunResponse,
   StartExportLabelsTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExportLabelsTaskRunRequest,
   output: StartExportLabelsTaskRunResponse,
@@ -26512,7 +26511,7 @@ export const startImportLabelsTaskRun: API.OperationMethod<
   StartImportLabelsTaskRunRequest,
   StartImportLabelsTaskRunResponse,
   StartImportLabelsTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportLabelsTaskRunRequest,
   output: StartImportLabelsTaskRunResponse,
@@ -26544,7 +26543,7 @@ export const startJobRun: API.OperationMethod<
   StartJobRunRequest,
   StartJobRunResponse,
   StartJobRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRunRequest,
   output: StartJobRunResponse,
@@ -26577,7 +26576,7 @@ export const startMaterializedViewRefreshTaskRun: API.OperationMethod<
   StartMaterializedViewRefreshTaskRunRequest,
   StartMaterializedViewRefreshTaskRunResponse,
   StartMaterializedViewRefreshTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMaterializedViewRefreshTaskRunRequest,
   output: StartMaterializedViewRefreshTaskRunResponse,
@@ -26616,7 +26615,7 @@ export const startMLEvaluationTaskRun: API.OperationMethod<
   StartMLEvaluationTaskRunRequest,
   StartMLEvaluationTaskRunResponse,
   StartMLEvaluationTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMLEvaluationTaskRunRequest,
   output: StartMLEvaluationTaskRunResponse,
@@ -26663,7 +26662,7 @@ export const startMLLabelingSetGenerationTaskRun: API.OperationMethod<
   StartMLLabelingSetGenerationTaskRunRequest,
   StartMLLabelingSetGenerationTaskRunResponse,
   StartMLLabelingSetGenerationTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMLLabelingSetGenerationTaskRunRequest,
   output: StartMLLabelingSetGenerationTaskRunResponse,
@@ -26696,7 +26695,7 @@ export const startTrigger: API.OperationMethod<
   StartTriggerRequest,
   StartTriggerResponse,
   StartTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTriggerRequest,
   output: StartTriggerResponse,
@@ -26728,7 +26727,7 @@ export const startWorkflowRun: API.OperationMethod<
   StartWorkflowRunRequest,
   StartWorkflowRunResponse,
   StartWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkflowRunRequest,
   output: StartWorkflowRunResponse,
@@ -26758,7 +26757,7 @@ export const stopColumnStatisticsTaskRun: API.OperationMethod<
   StopColumnStatisticsTaskRunRequest,
   StopColumnStatisticsTaskRunResponse,
   StopColumnStatisticsTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopColumnStatisticsTaskRunRequest,
   output: StopColumnStatisticsTaskRunResponse,
@@ -26785,7 +26784,7 @@ export const stopColumnStatisticsTaskRunSchedule: API.OperationMethod<
   StopColumnStatisticsTaskRunScheduleRequest,
   StopColumnStatisticsTaskRunScheduleResponse,
   StopColumnStatisticsTaskRunScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopColumnStatisticsTaskRunScheduleRequest,
   output: StopColumnStatisticsTaskRunScheduleResponse,
@@ -26812,7 +26811,7 @@ export const stopCrawler: API.OperationMethod<
   StopCrawlerRequest,
   StopCrawlerResponse,
   StopCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCrawlerRequest,
   output: StopCrawlerResponse,
@@ -26842,7 +26841,7 @@ export const stopCrawlerSchedule: API.OperationMethod<
   StopCrawlerScheduleRequest,
   StopCrawlerScheduleResponse,
   StopCrawlerScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCrawlerScheduleRequest,
   output: StopCrawlerScheduleResponse,
@@ -26871,7 +26870,7 @@ export const stopMaterializedViewRefreshTaskRun: API.OperationMethod<
   StopMaterializedViewRefreshTaskRunRequest,
   StopMaterializedViewRefreshTaskRunResponse,
   StopMaterializedViewRefreshTaskRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMaterializedViewRefreshTaskRunRequest,
   output: StopMaterializedViewRefreshTaskRunResponse,
@@ -26902,7 +26901,7 @@ export const stopSession: API.OperationMethod<
   StopSessionRequest,
   StopSessionResponse,
   StopSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSessionRequest,
   output: StopSessionResponse,
@@ -26933,7 +26932,7 @@ export const stopTrigger: API.OperationMethod<
   StopTriggerRequest,
   StopTriggerResponse,
   StopTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTriggerRequest,
   output: StopTriggerResponse,
@@ -26963,7 +26962,7 @@ export const stopWorkflowRun: API.OperationMethod<
   StopWorkflowRunRequest,
   StopWorkflowRunResponse,
   StopWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopWorkflowRunRequest,
   output: StopWorkflowRunResponse,
@@ -26994,7 +26993,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -27031,7 +27030,7 @@ export const testConnection: API.OperationMethod<
   TestConnectionRequest,
   TestConnectionResponse,
   TestConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestConnectionRequest,
   output: TestConnectionResponse,
@@ -27064,7 +27063,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -27094,7 +27093,7 @@ export const updateAsset: API.OperationMethod<
   UpdateAssetRequest,
   UpdateAssetResponse,
   UpdateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetRequest,
   output: UpdateAssetResponse,
@@ -27126,7 +27125,7 @@ export const updateBlueprint: API.OperationMethod<
   UpdateBlueprintRequest,
   UpdateBlueprintResponse,
   UpdateBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBlueprintRequest,
   output: UpdateBlueprintResponse,
@@ -27160,7 +27159,7 @@ export const updateCatalog: API.OperationMethod<
   UpdateCatalogRequest,
   UpdateCatalogResponse,
   UpdateCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCatalogRequest,
   output: UpdateCatalogResponse,
@@ -27194,7 +27193,7 @@ export const updateClassifier: API.OperationMethod<
   UpdateClassifierRequest,
   UpdateClassifierResponse,
   UpdateClassifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClassifierRequest,
   output: UpdateClassifierResponse,
@@ -27225,7 +27224,7 @@ export const updateColumnStatisticsForPartition: API.OperationMethod<
   UpdateColumnStatisticsForPartitionRequest,
   UpdateColumnStatisticsForPartitionResponse,
   UpdateColumnStatisticsForPartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateColumnStatisticsForPartitionRequest,
   output: UpdateColumnStatisticsForPartitionResponse,
@@ -27257,7 +27256,7 @@ export const updateColumnStatisticsForTable: API.OperationMethod<
   UpdateColumnStatisticsForTableRequest,
   UpdateColumnStatisticsForTableResponse,
   UpdateColumnStatisticsForTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateColumnStatisticsForTableRequest,
   output: UpdateColumnStatisticsForTableResponse,
@@ -27287,7 +27286,7 @@ export const updateColumnStatisticsTaskSettings: API.OperationMethod<
   UpdateColumnStatisticsTaskSettingsRequest,
   UpdateColumnStatisticsTaskSettingsResponse,
   UpdateColumnStatisticsTaskSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateColumnStatisticsTaskSettingsRequest,
   output: UpdateColumnStatisticsTaskSettingsResponse,
@@ -27316,7 +27315,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   UpdateConnectionResponse,
   UpdateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: UpdateConnectionResponse,
@@ -27349,7 +27348,7 @@ export const updateCrawler: API.OperationMethod<
   UpdateCrawlerRequest,
   UpdateCrawlerResponse,
   UpdateCrawlerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCrawlerRequest,
   output: UpdateCrawlerResponse,
@@ -27381,7 +27380,7 @@ export const updateCrawlerSchedule: API.OperationMethod<
   UpdateCrawlerScheduleRequest,
   UpdateCrawlerScheduleResponse,
   UpdateCrawlerScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCrawlerScheduleRequest,
   output: UpdateCrawlerScheduleResponse,
@@ -27415,7 +27414,7 @@ export const updateDatabase: API.OperationMethod<
   UpdateDatabaseRequest,
   UpdateDatabaseResponse,
   UpdateDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatabaseRequest,
   output: UpdateDatabaseResponse,
@@ -27451,7 +27450,7 @@ export const updateDataQualityRuleset: API.OperationMethod<
   UpdateDataQualityRulesetRequest,
   UpdateDataQualityRulesetResponse,
   UpdateDataQualityRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataQualityRulesetRequest,
   output: UpdateDataQualityRulesetResponse,
@@ -27483,7 +27482,7 @@ export const updateDevEndpoint: API.OperationMethod<
   UpdateDevEndpointRequest,
   UpdateDevEndpointResponse,
   UpdateDevEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDevEndpointRequest,
   output: UpdateDevEndpointResponse,
@@ -27515,7 +27514,7 @@ export const updateGlossary: API.OperationMethod<
   UpdateGlossaryRequest,
   UpdateGlossaryResponse,
   UpdateGlossaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlossaryRequest,
   output: UpdateGlossaryResponse,
@@ -27549,7 +27548,7 @@ export const updateGlossaryTerm: API.OperationMethod<
   UpdateGlossaryTermRequest,
   UpdateGlossaryTermResponse,
   UpdateGlossaryTermError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlossaryTermRequest,
   output: UpdateGlossaryTermResponse,
@@ -27582,7 +27581,7 @@ export const updateGlueIdentityCenterConfiguration: API.OperationMethod<
   UpdateGlueIdentityCenterConfigurationRequest,
   UpdateGlueIdentityCenterConfigurationResponse,
   UpdateGlueIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlueIdentityCenterConfigurationRequest,
   output: UpdateGlueIdentityCenterConfigurationResponse,
@@ -27615,7 +27614,7 @@ export const updateIntegrationResourceProperty: API.OperationMethod<
   UpdateIntegrationResourcePropertyRequest,
   UpdateIntegrationResourcePropertyResponse,
   UpdateIntegrationResourcePropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationResourcePropertyRequest,
   output: UpdateIntegrationResourcePropertyResponse,
@@ -27651,7 +27650,7 @@ export const updateIntegrationTableProperties: API.OperationMethod<
   UpdateIntegrationTablePropertiesRequest,
   UpdateIntegrationTablePropertiesResponse,
   UpdateIntegrationTablePropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationTablePropertiesRequest,
   output: UpdateIntegrationTablePropertiesResponse,
@@ -27684,7 +27683,7 @@ export const updateJob: API.OperationMethod<
   UpdateJobRequest,
   UpdateJobResponse,
   UpdateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobRequest,
   output: UpdateJobResponse,
@@ -27719,7 +27718,7 @@ export const updateJobFromSourceControl: API.OperationMethod<
   UpdateJobFromSourceControlRequest,
   UpdateJobFromSourceControlResponse,
   UpdateJobFromSourceControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobFromSourceControlRequest,
   output: UpdateJobFromSourceControlResponse,
@@ -27755,7 +27754,7 @@ export const updateMLTransform: API.OperationMethod<
   UpdateMLTransformRequest,
   UpdateMLTransformResponse,
   UpdateMLTransformError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMLTransformRequest,
   output: UpdateMLTransformResponse,
@@ -27785,7 +27784,7 @@ export const updatePartition: API.OperationMethod<
   UpdatePartitionRequest,
   UpdatePartitionResponse,
   UpdatePartitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePartitionRequest,
   output: UpdatePartitionResponse,
@@ -27815,7 +27814,7 @@ export const updateRegistry: API.OperationMethod<
   UpdateRegistryInput,
   UpdateRegistryResponse,
   UpdateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegistryInput,
   output: UpdateRegistryResponse,
@@ -27851,7 +27850,7 @@ export const updateSchema: API.OperationMethod<
   UpdateSchemaInput,
   UpdateSchemaResponse,
   UpdateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSchemaInput,
   output: UpdateSchemaResponse,
@@ -27885,7 +27884,7 @@ export const updateSourceControlFromJob: API.OperationMethod<
   UpdateSourceControlFromJobRequest,
   UpdateSourceControlFromJobResponse,
   UpdateSourceControlFromJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSourceControlFromJobRequest,
   output: UpdateSourceControlFromJobResponse,
@@ -27923,7 +27922,7 @@ export const updateTable: API.OperationMethod<
   UpdateTableRequest,
   UpdateTableResponse,
   UpdateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableRequest,
   output: UpdateTableResponse,
@@ -27961,7 +27960,7 @@ export const updateTableOptimizer: API.OperationMethod<
   UpdateTableOptimizerRequest,
   UpdateTableOptimizerResponse,
   UpdateTableOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableOptimizerRequest,
   output: UpdateTableOptimizerResponse,
@@ -27995,7 +27994,7 @@ export const updateTrigger: API.OperationMethod<
   UpdateTriggerRequest,
   UpdateTriggerResponse,
   UpdateTriggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTriggerRequest,
   output: UpdateTriggerResponse,
@@ -28026,7 +28025,7 @@ export const updateUsageProfile: API.OperationMethod<
   UpdateUsageProfileRequest,
   UpdateUsageProfileResponse,
   UpdateUsageProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUsageProfileRequest,
   output: UpdateUsageProfileResponse,
@@ -28057,7 +28056,7 @@ export const updateUserDefinedFunction: API.OperationMethod<
   UpdateUserDefinedFunctionRequest,
   UpdateUserDefinedFunctionResponse,
   UpdateUserDefinedFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserDefinedFunctionRequest,
   output: UpdateUserDefinedFunctionResponse,
@@ -28087,7 +28086,7 @@ export const updateWorkflow: API.OperationMethod<
   UpdateWorkflowRequest,
   UpdateWorkflowResponse,
   UpdateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowRequest,
   output: UpdateWorkflowResponse,

--- a/packages/aws/src/services/grafana.ts
+++ b/packages/aws/src/services/grafana.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "grafana",
@@ -1465,7 +1464,7 @@ export const associateLicense: API.OperationMethod<
   AssociateLicenseRequest,
   AssociateLicenseResponse,
   AssociateLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLicenseRequest,
   output: AssociateLicenseResponse,
@@ -1498,7 +1497,7 @@ export const createWorkspace: API.OperationMethod<
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
   CreateWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceRequest,
   output: CreateWorkspaceResponse,
@@ -1533,7 +1532,7 @@ export const createWorkspaceApiKey: API.OperationMethod<
   CreateWorkspaceApiKeyRequest,
   CreateWorkspaceApiKeyResponse,
   CreateWorkspaceApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceApiKeyRequest,
   output: CreateWorkspaceApiKeyResponse,
@@ -1573,7 +1572,7 @@ export const createWorkspaceServiceAccount: API.OperationMethod<
   CreateWorkspaceServiceAccountRequest,
   CreateWorkspaceServiceAccountResponse,
   CreateWorkspaceServiceAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceServiceAccountRequest,
   output: CreateWorkspaceServiceAccountResponse,
@@ -1613,7 +1612,7 @@ export const createWorkspaceServiceAccountToken: API.OperationMethod<
   CreateWorkspaceServiceAccountTokenRequest,
   CreateWorkspaceServiceAccountTokenResponse,
   CreateWorkspaceServiceAccountTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceServiceAccountTokenRequest,
   output: CreateWorkspaceServiceAccountTokenResponse,
@@ -1646,7 +1645,7 @@ export const deleteWorkspace: API.OperationMethod<
   DeleteWorkspaceRequest,
   DeleteWorkspaceResponse,
   DeleteWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceRequest,
   output: DeleteWorkspaceResponse,
@@ -1680,7 +1679,7 @@ export const deleteWorkspaceApiKey: API.OperationMethod<
   DeleteWorkspaceApiKeyRequest,
   DeleteWorkspaceApiKeyResponse,
   DeleteWorkspaceApiKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceApiKeyRequest,
   output: DeleteWorkspaceApiKeyResponse,
@@ -1716,7 +1715,7 @@ export const deleteWorkspaceServiceAccount: API.OperationMethod<
   DeleteWorkspaceServiceAccountRequest,
   DeleteWorkspaceServiceAccountResponse,
   DeleteWorkspaceServiceAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceServiceAccountRequest,
   output: DeleteWorkspaceServiceAccountResponse,
@@ -1752,7 +1751,7 @@ export const deleteWorkspaceServiceAccountToken: API.OperationMethod<
   DeleteWorkspaceServiceAccountTokenRequest,
   DeleteWorkspaceServiceAccountTokenResponse,
   DeleteWorkspaceServiceAccountTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceServiceAccountTokenRequest,
   output: DeleteWorkspaceServiceAccountTokenResponse,
@@ -1783,7 +1782,7 @@ export const describeWorkspace: API.OperationMethod<
   DescribeWorkspaceRequest,
   DescribeWorkspaceResponse,
   DescribeWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceRequest,
   output: DescribeWorkspaceResponse,
@@ -1814,7 +1813,7 @@ export const describeWorkspaceAuthentication: API.OperationMethod<
   DescribeWorkspaceAuthenticationRequest,
   DescribeWorkspaceAuthenticationResponse,
   DescribeWorkspaceAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceAuthenticationRequest,
   output: DescribeWorkspaceAuthenticationResponse,
@@ -1844,7 +1843,7 @@ export const describeWorkspaceConfiguration: API.OperationMethod<
   DescribeWorkspaceConfigurationRequest,
   DescribeWorkspaceConfigurationResponse,
   DescribeWorkspaceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceConfigurationRequest,
   output: DescribeWorkspaceConfigurationResponse,
@@ -1873,7 +1872,7 @@ export const disassociateLicense: API.OperationMethod<
   DisassociateLicenseRequest,
   DisassociateLicenseResponse,
   DisassociateLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLicenseRequest,
   output: DisassociateLicenseResponse,
@@ -1903,7 +1902,7 @@ export const listPermissions: API.PaginatedOperationMethod<
   ListPermissionsRequest,
   ListPermissionsResponse,
   ListPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PermissionEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionsRequest,
@@ -1940,7 +1939,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1970,7 +1969,7 @@ export const listVersions: API.PaginatedOperationMethod<
   ListVersionsRequest,
   ListVersionsResponse,
   ListVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GrafanaVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVersionsRequest,
@@ -2005,7 +2004,7 @@ export const listWorkspaces: API.PaginatedOperationMethod<
   ListWorkspacesRequest,
   ListWorkspacesResponse,
   ListWorkspacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkspaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspacesRequest,
@@ -2039,7 +2038,7 @@ export const listWorkspaceServiceAccounts: API.PaginatedOperationMethod<
   ListWorkspaceServiceAccountsRequest,
   ListWorkspaceServiceAccountsResponse,
   ListWorkspaceServiceAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceAccountSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspaceServiceAccountsRequest,
@@ -2082,7 +2081,7 @@ export const listWorkspaceServiceAccountTokens: API.PaginatedOperationMethod<
   ListWorkspaceServiceAccountTokensRequest,
   ListWorkspaceServiceAccountTokensResponse,
   ListWorkspaceServiceAccountTokensError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceAccountTokenSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspaceServiceAccountTokensRequest,
@@ -2122,7 +2121,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2152,7 +2151,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2182,7 +2181,7 @@ export const updatePermissions: API.OperationMethod<
   UpdatePermissionsRequest,
   UpdatePermissionsResponse,
   UpdatePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePermissionsRequest,
   output: UpdatePermissionsResponse,
@@ -2217,7 +2216,7 @@ export const updateWorkspace: API.OperationMethod<
   UpdateWorkspaceRequest,
   UpdateWorkspaceResponse,
   UpdateWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceRequest,
   output: UpdateWorkspaceResponse,
@@ -2251,7 +2250,7 @@ export const updateWorkspaceAuthentication: API.OperationMethod<
   UpdateWorkspaceAuthenticationRequest,
   UpdateWorkspaceAuthenticationResponse,
   UpdateWorkspaceAuthenticationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceAuthenticationRequest,
   output: UpdateWorkspaceAuthenticationResponse,
@@ -2283,7 +2282,7 @@ export const updateWorkspaceConfiguration: API.OperationMethod<
   UpdateWorkspaceConfigurationRequest,
   UpdateWorkspaceConfigurationResponse,
   UpdateWorkspaceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceConfigurationRequest,
   output: UpdateWorkspaceConfigurationResponse,

--- a/packages/aws/src/services/greengrass.ts
+++ b/packages/aws/src/services/greengrass.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Greengrass",
   serviceShapeName: "Greengrass",
@@ -4422,7 +4421,7 @@ export const associateRoleToGroup: API.OperationMethod<
   AssociateRoleToGroupRequest,
   AssociateRoleToGroupResponse,
   AssociateRoleToGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateRoleToGroupRequest,
   output: AssociateRoleToGroupResponse,
@@ -4443,7 +4442,7 @@ export const associateServiceRoleToAccount: API.OperationMethod<
   AssociateServiceRoleToAccountRequest,
   AssociateServiceRoleToAccountResponse,
   AssociateServiceRoleToAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateServiceRoleToAccountRequest,
   output: AssociateServiceRoleToAccountResponse,
@@ -4461,7 +4460,7 @@ export const createConnectorDefinition: API.OperationMethod<
   CreateConnectorDefinitionRequest,
   CreateConnectorDefinitionResponse,
   CreateConnectorDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorDefinitionRequest,
   output: CreateConnectorDefinitionResponse,
@@ -4481,7 +4480,7 @@ export const createConnectorDefinitionVersion: API.OperationMethod<
   CreateConnectorDefinitionVersionRequest,
   CreateConnectorDefinitionVersionResponse,
   CreateConnectorDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorDefinitionVersionRequest,
   output: CreateConnectorDefinitionVersionResponse,
@@ -4499,7 +4498,7 @@ export const createCoreDefinition: API.OperationMethod<
   CreateCoreDefinitionRequest,
   CreateCoreDefinitionResponse,
   CreateCoreDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoreDefinitionRequest,
   output: CreateCoreDefinitionResponse,
@@ -4519,7 +4518,7 @@ export const createCoreDefinitionVersion: API.OperationMethod<
   CreateCoreDefinitionVersionRequest,
   CreateCoreDefinitionVersionResponse,
   CreateCoreDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoreDefinitionVersionRequest,
   output: CreateCoreDefinitionVersionResponse,
@@ -4537,7 +4536,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   CreateDeploymentResponse,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: CreateDeploymentResponse,
@@ -4555,7 +4554,7 @@ export const createDeviceDefinition: API.OperationMethod<
   CreateDeviceDefinitionRequest,
   CreateDeviceDefinitionResponse,
   CreateDeviceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeviceDefinitionRequest,
   output: CreateDeviceDefinitionResponse,
@@ -4575,7 +4574,7 @@ export const createDeviceDefinitionVersion: API.OperationMethod<
   CreateDeviceDefinitionVersionRequest,
   CreateDeviceDefinitionVersionResponse,
   CreateDeviceDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeviceDefinitionVersionRequest,
   output: CreateDeviceDefinitionVersionResponse,
@@ -4593,7 +4592,7 @@ export const createFunctionDefinition: API.OperationMethod<
   CreateFunctionDefinitionRequest,
   CreateFunctionDefinitionResponse,
   CreateFunctionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionDefinitionRequest,
   output: CreateFunctionDefinitionResponse,
@@ -4613,7 +4612,7 @@ export const createFunctionDefinitionVersion: API.OperationMethod<
   CreateFunctionDefinitionVersionRequest,
   CreateFunctionDefinitionVersionResponse,
   CreateFunctionDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionDefinitionVersionRequest,
   output: CreateFunctionDefinitionVersionResponse,
@@ -4631,7 +4630,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -4652,7 +4651,7 @@ export const createGroupCertificateAuthority: API.OperationMethod<
   CreateGroupCertificateAuthorityRequest,
   CreateGroupCertificateAuthorityResponse,
   CreateGroupCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupCertificateAuthorityRequest,
   output: CreateGroupCertificateAuthorityResponse,
@@ -4670,7 +4669,7 @@ export const createGroupVersion: API.OperationMethod<
   CreateGroupVersionRequest,
   CreateGroupVersionResponse,
   CreateGroupVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupVersionRequest,
   output: CreateGroupVersionResponse,
@@ -4688,7 +4687,7 @@ export const createLoggerDefinition: API.OperationMethod<
   CreateLoggerDefinitionRequest,
   CreateLoggerDefinitionResponse,
   CreateLoggerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoggerDefinitionRequest,
   output: CreateLoggerDefinitionResponse,
@@ -4708,7 +4707,7 @@ export const createLoggerDefinitionVersion: API.OperationMethod<
   CreateLoggerDefinitionVersionRequest,
   CreateLoggerDefinitionVersionResponse,
   CreateLoggerDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoggerDefinitionVersionRequest,
   output: CreateLoggerDefinitionVersionResponse,
@@ -4726,7 +4725,7 @@ export const createResourceDefinition: API.OperationMethod<
   CreateResourceDefinitionRequest,
   CreateResourceDefinitionResponse,
   CreateResourceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceDefinitionRequest,
   output: CreateResourceDefinitionResponse,
@@ -4746,7 +4745,7 @@ export const createResourceDefinitionVersion: API.OperationMethod<
   CreateResourceDefinitionVersionRequest,
   CreateResourceDefinitionVersionResponse,
   CreateResourceDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceDefinitionVersionRequest,
   output: CreateResourceDefinitionVersionResponse,
@@ -4767,7 +4766,7 @@ export const createSoftwareUpdateJob: API.OperationMethod<
   CreateSoftwareUpdateJobRequest,
   CreateSoftwareUpdateJobResponse,
   CreateSoftwareUpdateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSoftwareUpdateJobRequest,
   output: CreateSoftwareUpdateJobResponse,
@@ -4787,7 +4786,7 @@ export const createSubscriptionDefinition: API.OperationMethod<
   CreateSubscriptionDefinitionRequest,
   CreateSubscriptionDefinitionResponse,
   CreateSubscriptionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionDefinitionRequest,
   output: CreateSubscriptionDefinitionResponse,
@@ -4807,7 +4806,7 @@ export const createSubscriptionDefinitionVersion: API.OperationMethod<
   CreateSubscriptionDefinitionVersionRequest,
   CreateSubscriptionDefinitionVersionResponse,
   CreateSubscriptionDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionDefinitionVersionRequest,
   output: CreateSubscriptionDefinitionVersionResponse,
@@ -4825,7 +4824,7 @@ export const deleteConnectorDefinition: API.OperationMethod<
   DeleteConnectorDefinitionRequest,
   DeleteConnectorDefinitionResponse,
   DeleteConnectorDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorDefinitionRequest,
   output: DeleteConnectorDefinitionResponse,
@@ -4843,7 +4842,7 @@ export const deleteCoreDefinition: API.OperationMethod<
   DeleteCoreDefinitionRequest,
   DeleteCoreDefinitionResponse,
   DeleteCoreDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoreDefinitionRequest,
   output: DeleteCoreDefinitionResponse,
@@ -4861,7 +4860,7 @@ export const deleteDeviceDefinition: API.OperationMethod<
   DeleteDeviceDefinitionRequest,
   DeleteDeviceDefinitionResponse,
   DeleteDeviceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceDefinitionRequest,
   output: DeleteDeviceDefinitionResponse,
@@ -4879,7 +4878,7 @@ export const deleteFunctionDefinition: API.OperationMethod<
   DeleteFunctionDefinitionRequest,
   DeleteFunctionDefinitionResponse,
   DeleteFunctionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionDefinitionRequest,
   output: DeleteFunctionDefinitionResponse,
@@ -4897,7 +4896,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -4915,7 +4914,7 @@ export const deleteLoggerDefinition: API.OperationMethod<
   DeleteLoggerDefinitionRequest,
   DeleteLoggerDefinitionResponse,
   DeleteLoggerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggerDefinitionRequest,
   output: DeleteLoggerDefinitionResponse,
@@ -4933,7 +4932,7 @@ export const deleteResourceDefinition: API.OperationMethod<
   DeleteResourceDefinitionRequest,
   DeleteResourceDefinitionResponse,
   DeleteResourceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceDefinitionRequest,
   output: DeleteResourceDefinitionResponse,
@@ -4953,7 +4952,7 @@ export const deleteSubscriptionDefinition: API.OperationMethod<
   DeleteSubscriptionDefinitionRequest,
   DeleteSubscriptionDefinitionResponse,
   DeleteSubscriptionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionDefinitionRequest,
   output: DeleteSubscriptionDefinitionResponse,
@@ -4974,7 +4973,7 @@ export const disassociateRoleFromGroup: API.OperationMethod<
   DisassociateRoleFromGroupRequest,
   DisassociateRoleFromGroupResponse,
   DisassociateRoleFromGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateRoleFromGroupRequest,
   output: DisassociateRoleFromGroupResponse,
@@ -4994,7 +4993,7 @@ export const disassociateServiceRoleFromAccount: API.OperationMethod<
   DisassociateServiceRoleFromAccountRequest,
   DisassociateServiceRoleFromAccountResponse,
   DisassociateServiceRoleFromAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateServiceRoleFromAccountRequest,
   output: DisassociateServiceRoleFromAccountResponse,
@@ -5015,7 +5014,7 @@ export const getAssociatedRole: API.OperationMethod<
   GetAssociatedRoleRequest,
   GetAssociatedRoleResponse,
   GetAssociatedRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociatedRoleRequest,
   output: GetAssociatedRoleResponse,
@@ -5033,7 +5032,7 @@ export const getBulkDeploymentStatus: API.OperationMethod<
   GetBulkDeploymentStatusRequest,
   GetBulkDeploymentStatusResponse,
   GetBulkDeploymentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBulkDeploymentStatusRequest,
   output: GetBulkDeploymentStatusResponse,
@@ -5054,7 +5053,7 @@ export const getConnectivityInfo: API.OperationMethod<
   GetConnectivityInfoRequest,
   GetConnectivityInfoResponse,
   GetConnectivityInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectivityInfoRequest,
   output: GetConnectivityInfoResponse,
@@ -5072,7 +5071,7 @@ export const getConnectorDefinition: API.OperationMethod<
   GetConnectorDefinitionRequest,
   GetConnectorDefinitionResponse,
   GetConnectorDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorDefinitionRequest,
   output: GetConnectorDefinitionResponse,
@@ -5092,7 +5091,7 @@ export const getConnectorDefinitionVersion: API.OperationMethod<
   GetConnectorDefinitionVersionRequest,
   GetConnectorDefinitionVersionResponse,
   GetConnectorDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorDefinitionVersionRequest,
   output: GetConnectorDefinitionVersionResponse,
@@ -5110,7 +5109,7 @@ export const getCoreDefinition: API.OperationMethod<
   GetCoreDefinitionRequest,
   GetCoreDefinitionResponse,
   GetCoreDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoreDefinitionRequest,
   output: GetCoreDefinitionResponse,
@@ -5128,7 +5127,7 @@ export const getCoreDefinitionVersion: API.OperationMethod<
   GetCoreDefinitionVersionRequest,
   GetCoreDefinitionVersionResponse,
   GetCoreDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoreDefinitionVersionRequest,
   output: GetCoreDefinitionVersionResponse,
@@ -5146,7 +5145,7 @@ export const getDeploymentStatus: API.OperationMethod<
   GetDeploymentStatusRequest,
   GetDeploymentStatusResponse,
   GetDeploymentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentStatusRequest,
   output: GetDeploymentStatusResponse,
@@ -5164,7 +5163,7 @@ export const getDeviceDefinition: API.OperationMethod<
   GetDeviceDefinitionRequest,
   GetDeviceDefinitionResponse,
   GetDeviceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceDefinitionRequest,
   output: GetDeviceDefinitionResponse,
@@ -5184,7 +5183,7 @@ export const getDeviceDefinitionVersion: API.OperationMethod<
   GetDeviceDefinitionVersionRequest,
   GetDeviceDefinitionVersionResponse,
   GetDeviceDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceDefinitionVersionRequest,
   output: GetDeviceDefinitionVersionResponse,
@@ -5202,7 +5201,7 @@ export const getFunctionDefinition: API.OperationMethod<
   GetFunctionDefinitionRequest,
   GetFunctionDefinitionResponse,
   GetFunctionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionDefinitionRequest,
   output: GetFunctionDefinitionResponse,
@@ -5222,7 +5221,7 @@ export const getFunctionDefinitionVersion: API.OperationMethod<
   GetFunctionDefinitionVersionRequest,
   GetFunctionDefinitionVersionResponse,
   GetFunctionDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionDefinitionVersionRequest,
   output: GetFunctionDefinitionVersionResponse,
@@ -5240,7 +5239,7 @@ export const getGroup: API.OperationMethod<
   GetGroupRequest,
   GetGroupResponse,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupRequest,
   output: GetGroupResponse,
@@ -5261,7 +5260,7 @@ export const getGroupCertificateAuthority: API.OperationMethod<
   GetGroupCertificateAuthorityRequest,
   GetGroupCertificateAuthorityResponse,
   GetGroupCertificateAuthorityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupCertificateAuthorityRequest,
   output: GetGroupCertificateAuthorityResponse,
@@ -5282,7 +5281,7 @@ export const getGroupCertificateConfiguration: API.OperationMethod<
   GetGroupCertificateConfigurationRequest,
   GetGroupCertificateConfigurationResponse,
   GetGroupCertificateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupCertificateConfigurationRequest,
   output: GetGroupCertificateConfigurationResponse,
@@ -5300,7 +5299,7 @@ export const getGroupVersion: API.OperationMethod<
   GetGroupVersionRequest,
   GetGroupVersionResponse,
   GetGroupVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupVersionRequest,
   output: GetGroupVersionResponse,
@@ -5318,7 +5317,7 @@ export const getLoggerDefinition: API.OperationMethod<
   GetLoggerDefinitionRequest,
   GetLoggerDefinitionResponse,
   GetLoggerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggerDefinitionRequest,
   output: GetLoggerDefinitionResponse,
@@ -5338,7 +5337,7 @@ export const getLoggerDefinitionVersion: API.OperationMethod<
   GetLoggerDefinitionVersionRequest,
   GetLoggerDefinitionVersionResponse,
   GetLoggerDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggerDefinitionVersionRequest,
   output: GetLoggerDefinitionVersionResponse,
@@ -5356,7 +5355,7 @@ export const getResourceDefinition: API.OperationMethod<
   GetResourceDefinitionRequest,
   GetResourceDefinitionResponse,
   GetResourceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceDefinitionRequest,
   output: GetResourceDefinitionResponse,
@@ -5376,7 +5375,7 @@ export const getResourceDefinitionVersion: API.OperationMethod<
   GetResourceDefinitionVersionRequest,
   GetResourceDefinitionVersionResponse,
   GetResourceDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceDefinitionVersionRequest,
   output: GetResourceDefinitionVersionResponse,
@@ -5396,7 +5395,7 @@ export const getServiceRoleForAccount: API.OperationMethod<
   GetServiceRoleForAccountRequest,
   GetServiceRoleForAccountResponse,
   GetServiceRoleForAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRoleForAccountRequest,
   output: GetServiceRoleForAccountResponse,
@@ -5414,7 +5413,7 @@ export const getSubscriptionDefinition: API.OperationMethod<
   GetSubscriptionDefinitionRequest,
   GetSubscriptionDefinitionResponse,
   GetSubscriptionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionDefinitionRequest,
   output: GetSubscriptionDefinitionResponse,
@@ -5434,7 +5433,7 @@ export const getSubscriptionDefinitionVersion: API.OperationMethod<
   GetSubscriptionDefinitionVersionRequest,
   GetSubscriptionDefinitionVersionResponse,
   GetSubscriptionDefinitionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionDefinitionVersionRequest,
   output: GetSubscriptionDefinitionVersionResponse,
@@ -5455,7 +5454,7 @@ export const getThingRuntimeConfiguration: API.OperationMethod<
   GetThingRuntimeConfigurationRequest,
   GetThingRuntimeConfigurationResponse,
   GetThingRuntimeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThingRuntimeConfigurationRequest,
   output: GetThingRuntimeConfigurationResponse,
@@ -5475,7 +5474,7 @@ export const listBulkDeploymentDetailedReports: API.OperationMethod<
   ListBulkDeploymentDetailedReportsRequest,
   ListBulkDeploymentDetailedReportsResponse,
   ListBulkDeploymentDetailedReportsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBulkDeploymentDetailedReportsRequest,
   output: ListBulkDeploymentDetailedReportsResponse,
@@ -5493,7 +5492,7 @@ export const listBulkDeployments: API.OperationMethod<
   ListBulkDeploymentsRequest,
   ListBulkDeploymentsResponse,
   ListBulkDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBulkDeploymentsRequest,
   output: ListBulkDeploymentsResponse,
@@ -5511,7 +5510,7 @@ export const listConnectorDefinitions: API.OperationMethod<
   ListConnectorDefinitionsRequest,
   ListConnectorDefinitionsResponse,
   ListConnectorDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectorDefinitionsRequest,
   output: ListConnectorDefinitionsResponse,
@@ -5531,7 +5530,7 @@ export const listConnectorDefinitionVersions: API.OperationMethod<
   ListConnectorDefinitionVersionsRequest,
   ListConnectorDefinitionVersionsResponse,
   ListConnectorDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectorDefinitionVersionsRequest,
   output: ListConnectorDefinitionVersionsResponse,
@@ -5549,7 +5548,7 @@ export const listCoreDefinitions: API.OperationMethod<
   ListCoreDefinitionsRequest,
   ListCoreDefinitionsResponse,
   ListCoreDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCoreDefinitionsRequest,
   output: ListCoreDefinitionsResponse,
@@ -5569,7 +5568,7 @@ export const listCoreDefinitionVersions: API.OperationMethod<
   ListCoreDefinitionVersionsRequest,
   ListCoreDefinitionVersionsResponse,
   ListCoreDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCoreDefinitionVersionsRequest,
   output: ListCoreDefinitionVersionsResponse,
@@ -5587,7 +5586,7 @@ export const listDeployments: API.OperationMethod<
   ListDeploymentsRequest,
   ListDeploymentsResponse,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeploymentsRequest,
   output: ListDeploymentsResponse,
@@ -5605,7 +5604,7 @@ export const listDeviceDefinitions: API.OperationMethod<
   ListDeviceDefinitionsRequest,
   ListDeviceDefinitionsResponse,
   ListDeviceDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeviceDefinitionsRequest,
   output: ListDeviceDefinitionsResponse,
@@ -5625,7 +5624,7 @@ export const listDeviceDefinitionVersions: API.OperationMethod<
   ListDeviceDefinitionVersionsRequest,
   ListDeviceDefinitionVersionsResponse,
   ListDeviceDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDeviceDefinitionVersionsRequest,
   output: ListDeviceDefinitionVersionsResponse,
@@ -5643,7 +5642,7 @@ export const listFunctionDefinitions: API.OperationMethod<
   ListFunctionDefinitionsRequest,
   ListFunctionDefinitionsResponse,
   ListFunctionDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFunctionDefinitionsRequest,
   output: ListFunctionDefinitionsResponse,
@@ -5663,7 +5662,7 @@ export const listFunctionDefinitionVersions: API.OperationMethod<
   ListFunctionDefinitionVersionsRequest,
   ListFunctionDefinitionVersionsResponse,
   ListFunctionDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFunctionDefinitionVersionsRequest,
   output: ListFunctionDefinitionVersionsResponse,
@@ -5684,7 +5683,7 @@ export const listGroupCertificateAuthorities: API.OperationMethod<
   ListGroupCertificateAuthoritiesRequest,
   ListGroupCertificateAuthoritiesResponse,
   ListGroupCertificateAuthoritiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGroupCertificateAuthoritiesRequest,
   output: ListGroupCertificateAuthoritiesResponse,
@@ -5702,7 +5701,7 @@ export const listGroups: API.OperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGroupsRequest,
   output: ListGroupsResponse,
@@ -5720,7 +5719,7 @@ export const listGroupVersions: API.OperationMethod<
   ListGroupVersionsRequest,
   ListGroupVersionsResponse,
   ListGroupVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGroupVersionsRequest,
   output: ListGroupVersionsResponse,
@@ -5738,7 +5737,7 @@ export const listLoggerDefinitions: API.OperationMethod<
   ListLoggerDefinitionsRequest,
   ListLoggerDefinitionsResponse,
   ListLoggerDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoggerDefinitionsRequest,
   output: ListLoggerDefinitionsResponse,
@@ -5758,7 +5757,7 @@ export const listLoggerDefinitionVersions: API.OperationMethod<
   ListLoggerDefinitionVersionsRequest,
   ListLoggerDefinitionVersionsResponse,
   ListLoggerDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoggerDefinitionVersionsRequest,
   output: ListLoggerDefinitionVersionsResponse,
@@ -5776,7 +5775,7 @@ export const listResourceDefinitions: API.OperationMethod<
   ListResourceDefinitionsRequest,
   ListResourceDefinitionsResponse,
   ListResourceDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceDefinitionsRequest,
   output: ListResourceDefinitionsResponse,
@@ -5796,7 +5795,7 @@ export const listResourceDefinitionVersions: API.OperationMethod<
   ListResourceDefinitionVersionsRequest,
   ListResourceDefinitionVersionsResponse,
   ListResourceDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceDefinitionVersionsRequest,
   output: ListResourceDefinitionVersionsResponse,
@@ -5814,7 +5813,7 @@ export const listSubscriptionDefinitions: API.OperationMethod<
   ListSubscriptionDefinitionsRequest,
   ListSubscriptionDefinitionsResponse,
   ListSubscriptionDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSubscriptionDefinitionsRequest,
   output: ListSubscriptionDefinitionsResponse,
@@ -5834,7 +5833,7 @@ export const listSubscriptionDefinitionVersions: API.OperationMethod<
   ListSubscriptionDefinitionVersionsRequest,
   ListSubscriptionDefinitionVersionsResponse,
   ListSubscriptionDefinitionVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSubscriptionDefinitionVersionsRequest,
   output: ListSubscriptionDefinitionVersionsResponse,
@@ -5852,7 +5851,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5870,7 +5869,7 @@ export const resetDeployments: API.OperationMethod<
   ResetDeploymentsRequest,
   ResetDeploymentsResponse,
   ResetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDeploymentsRequest,
   output: ResetDeploymentsResponse,
@@ -5888,7 +5887,7 @@ export const startBulkDeployment: API.OperationMethod<
   StartBulkDeploymentRequest,
   StartBulkDeploymentResponse,
   StartBulkDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBulkDeploymentRequest,
   output: StartBulkDeploymentResponse,
@@ -5906,7 +5905,7 @@ export const stopBulkDeployment: API.OperationMethod<
   StopBulkDeploymentRequest,
   StopBulkDeploymentResponse,
   StopBulkDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBulkDeploymentRequest,
   output: StopBulkDeploymentResponse,
@@ -5924,7 +5923,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5942,7 +5941,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5963,7 +5962,7 @@ export const updateConnectivityInfo: API.OperationMethod<
   UpdateConnectivityInfoRequest,
   UpdateConnectivityInfoResponse,
   UpdateConnectivityInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectivityInfoRequest,
   output: UpdateConnectivityInfoResponse,
@@ -5981,7 +5980,7 @@ export const updateConnectorDefinition: API.OperationMethod<
   UpdateConnectorDefinitionRequest,
   UpdateConnectorDefinitionResponse,
   UpdateConnectorDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorDefinitionRequest,
   output: UpdateConnectorDefinitionResponse,
@@ -5999,7 +5998,7 @@ export const updateCoreDefinition: API.OperationMethod<
   UpdateCoreDefinitionRequest,
   UpdateCoreDefinitionResponse,
   UpdateCoreDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCoreDefinitionRequest,
   output: UpdateCoreDefinitionResponse,
@@ -6017,7 +6016,7 @@ export const updateDeviceDefinition: API.OperationMethod<
   UpdateDeviceDefinitionRequest,
   UpdateDeviceDefinitionResponse,
   UpdateDeviceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceDefinitionRequest,
   output: UpdateDeviceDefinitionResponse,
@@ -6035,7 +6034,7 @@ export const updateFunctionDefinition: API.OperationMethod<
   UpdateFunctionDefinitionRequest,
   UpdateFunctionDefinitionResponse,
   UpdateFunctionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionDefinitionRequest,
   output: UpdateFunctionDefinitionResponse,
@@ -6053,7 +6052,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -6074,7 +6073,7 @@ export const updateGroupCertificateConfiguration: API.OperationMethod<
   UpdateGroupCertificateConfigurationRequest,
   UpdateGroupCertificateConfigurationResponse,
   UpdateGroupCertificateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupCertificateConfigurationRequest,
   output: UpdateGroupCertificateConfigurationResponse,
@@ -6092,7 +6091,7 @@ export const updateLoggerDefinition: API.OperationMethod<
   UpdateLoggerDefinitionRequest,
   UpdateLoggerDefinitionResponse,
   UpdateLoggerDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoggerDefinitionRequest,
   output: UpdateLoggerDefinitionResponse,
@@ -6110,7 +6109,7 @@ export const updateResourceDefinition: API.OperationMethod<
   UpdateResourceDefinitionRequest,
   UpdateResourceDefinitionResponse,
   UpdateResourceDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceDefinitionRequest,
   output: UpdateResourceDefinitionResponse,
@@ -6130,7 +6129,7 @@ export const updateSubscriptionDefinition: API.OperationMethod<
   UpdateSubscriptionDefinitionRequest,
   UpdateSubscriptionDefinitionResponse,
   UpdateSubscriptionDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionDefinitionRequest,
   output: UpdateSubscriptionDefinitionResponse,
@@ -6151,7 +6150,7 @@ export const updateThingRuntimeConfiguration: API.OperationMethod<
   UpdateThingRuntimeConfigurationRequest,
   UpdateThingRuntimeConfigurationResponse,
   UpdateThingRuntimeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingRuntimeConfigurationRequest,
   output: UpdateThingRuntimeConfigurationResponse,

--- a/packages/aws/src/services/greengrassv2.ts
+++ b/packages/aws/src/services/greengrassv2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "GreengrassV2",
   serviceShapeName: "GreengrassV2",
@@ -2168,7 +2167,7 @@ export const associateServiceRoleToAccount: API.OperationMethod<
   AssociateServiceRoleToAccountRequest,
   AssociateServiceRoleToAccountResponse,
   AssociateServiceRoleToAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateServiceRoleToAccountRequest,
   output: AssociateServiceRoleToAccountResponse,
@@ -2202,7 +2201,7 @@ export const batchAssociateClientDeviceWithCoreDevice: API.OperationMethod<
   BatchAssociateClientDeviceWithCoreDeviceRequest,
   BatchAssociateClientDeviceWithCoreDeviceResponse,
   BatchAssociateClientDeviceWithCoreDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateClientDeviceWithCoreDeviceRequest,
   output: BatchAssociateClientDeviceWithCoreDeviceResponse,
@@ -2234,7 +2233,7 @@ export const batchDisassociateClientDeviceFromCoreDevice: API.OperationMethod<
   BatchDisassociateClientDeviceFromCoreDeviceRequest,
   BatchDisassociateClientDeviceFromCoreDeviceResponse,
   BatchDisassociateClientDeviceFromCoreDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateClientDeviceFromCoreDeviceRequest,
   output: BatchDisassociateClientDeviceFromCoreDeviceResponse,
@@ -2267,7 +2266,7 @@ export const cancelDeployment: API.OperationMethod<
   CancelDeploymentRequest,
   CancelDeploymentResponse,
   CancelDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDeploymentRequest,
   output: CancelDeploymentResponse,
@@ -2329,7 +2328,7 @@ export const createComponentVersion: API.OperationMethod<
   CreateComponentVersionRequest,
   CreateComponentVersionResponse,
   CreateComponentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentVersionRequest,
   output: CreateComponentVersionResponse,
@@ -2376,7 +2375,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   CreateDeploymentResponse,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: CreateDeploymentResponse,
@@ -2414,7 +2413,7 @@ export const deleteComponent: API.OperationMethod<
   DeleteComponentRequest,
   DeleteComponentResponse,
   DeleteComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentRequest,
   output: DeleteComponentResponse,
@@ -2449,7 +2448,7 @@ export const deleteCoreDevice: API.OperationMethod<
   DeleteCoreDeviceRequest,
   DeleteCoreDeviceResponse,
   DeleteCoreDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoreDeviceRequest,
   output: DeleteCoreDeviceResponse,
@@ -2486,7 +2485,7 @@ export const deleteDeployment: API.OperationMethod<
   DeleteDeploymentRequest,
   DeleteDeploymentResponse,
   DeleteDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentRequest,
   output: DeleteDeploymentResponse,
@@ -2517,7 +2516,7 @@ export const describeComponent: API.OperationMethod<
   DescribeComponentRequest,
   DescribeComponentResponse,
   DescribeComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComponentRequest,
   output: DescribeComponentResponse,
@@ -2546,7 +2545,7 @@ export const disassociateServiceRoleFromAccount: API.OperationMethod<
   DisassociateServiceRoleFromAccountRequest,
   DisassociateServiceRoleFromAccountResponse,
   DisassociateServiceRoleFromAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateServiceRoleFromAccountRequest,
   output: DisassociateServiceRoleFromAccountResponse,
@@ -2570,7 +2569,7 @@ export const getComponent: API.OperationMethod<
   GetComponentRequest,
   GetComponentResponse,
   GetComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentRequest,
   output: GetComponentResponse,
@@ -2602,7 +2601,7 @@ export const getComponentVersionArtifact: API.OperationMethod<
   GetComponentVersionArtifactRequest,
   GetComponentVersionArtifactResponse,
   GetComponentVersionArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentVersionArtifactRequest,
   output: GetComponentVersionArtifactResponse,
@@ -2636,7 +2635,7 @@ export const getConnectivityInfo: API.OperationMethod<
   GetConnectivityInfoRequest,
   GetConnectivityInfoResponse,
   GetConnectivityInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectivityInfoRequest,
   output: GetConnectivityInfoResponse,
@@ -2679,7 +2678,7 @@ export const getCoreDevice: API.OperationMethod<
   GetCoreDeviceRequest,
   GetCoreDeviceResponse,
   GetCoreDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoreDeviceRequest,
   output: GetCoreDeviceResponse,
@@ -2709,7 +2708,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentRequest,
   GetDeploymentResponse,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentRequest,
   output: GetDeploymentResponse,
@@ -2738,7 +2737,7 @@ export const getServiceRoleForAccount: API.OperationMethod<
   GetServiceRoleForAccountRequest,
   GetServiceRoleForAccountResponse,
   GetServiceRoleForAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRoleForAccountRequest,
   output: GetServiceRoleForAccountResponse,
@@ -2763,7 +2762,7 @@ export const listClientDevicesAssociatedWithCoreDevice: API.PaginatedOperationMe
   ListClientDevicesAssociatedWithCoreDeviceRequest,
   ListClientDevicesAssociatedWithCoreDeviceResponse,
   ListClientDevicesAssociatedWithCoreDeviceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedClientDevice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClientDevicesAssociatedWithCoreDeviceRequest,
@@ -2801,7 +2800,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsRequest,
   ListComponentsResponse,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Component
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsRequest,
@@ -2839,7 +2838,7 @@ export const listComponentVersions: API.PaginatedOperationMethod<
   ListComponentVersionsRequest,
   ListComponentVersionsResponse,
   ListComponentVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentVersionListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentVersionsRequest,
@@ -2899,7 +2898,7 @@ export const listCoreDevices: API.PaginatedOperationMethod<
   ListCoreDevicesRequest,
   ListCoreDevicesResponse,
   ListCoreDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreDevice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoreDevicesRequest,
@@ -2934,7 +2933,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsRequest,
   ListDeploymentsResponse,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Deployment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsRequest,
@@ -2970,7 +2969,7 @@ export const listEffectiveDeployments: API.PaginatedOperationMethod<
   ListEffectiveDeploymentsRequest,
   ListEffectiveDeploymentsResponse,
   ListEffectiveDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EffectiveDeployment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEffectiveDeploymentsRequest,
@@ -3029,7 +3028,7 @@ export const listInstalledComponents: API.PaginatedOperationMethod<
   ListInstalledComponentsRequest,
   ListInstalledComponentsResponse,
   ListInstalledComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstalledComponent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstalledComponentsRequest,
@@ -3064,7 +3063,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3108,7 +3107,7 @@ export const resolveComponentCandidates: API.OperationMethod<
   ResolveComponentCandidatesRequest,
   ResolveComponentCandidatesResponse,
   ResolveComponentCandidatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResolveComponentCandidatesRequest,
   output: ResolveComponentCandidatesResponse,
@@ -3138,7 +3137,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3164,7 +3163,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3196,7 +3195,7 @@ export const updateConnectivityInfo: API.OperationMethod<
   UpdateConnectivityInfoRequest,
   UpdateConnectivityInfoResponse,
   UpdateConnectivityInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectivityInfoRequest,
   output: UpdateConnectivityInfoResponse,

--- a/packages/aws/src/services/groundstation.ts
+++ b/packages/aws/src/services/groundstation.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "GroundStation",
   serviceShapeName: "GroundStation",
@@ -3003,7 +3002,7 @@ export const cancelContact: API.OperationMethod<
   CancelContactRequest,
   ContactIdResponse,
   CancelContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelContactRequest,
   output: ContactIdResponse,
@@ -3032,7 +3031,7 @@ export const createConfig: API.OperationMethod<
   CreateConfigRequest,
   ConfigIdResponse,
   CreateConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigRequest,
   output: ConfigIdResponse,
@@ -3063,7 +3062,7 @@ export const createDataflowEndpointGroup: API.OperationMethod<
   CreateDataflowEndpointGroupRequest,
   DataflowEndpointGroupIdResponse,
   CreateDataflowEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataflowEndpointGroupRequest,
   output: DataflowEndpointGroupIdResponse,
@@ -3094,7 +3093,7 @@ export const createDataflowEndpointGroupV2: API.OperationMethod<
   CreateDataflowEndpointGroupV2Request,
   CreateDataflowEndpointGroupV2Response,
   CreateDataflowEndpointGroupV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataflowEndpointGroupV2Request,
   output: CreateDataflowEndpointGroupV2Response,
@@ -3121,7 +3120,7 @@ export const createEphemeris: API.OperationMethod<
   CreateEphemerisRequest,
   EphemerisIdResponse,
   CreateEphemerisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEphemerisRequest,
   output: EphemerisIdResponse,
@@ -3149,7 +3148,7 @@ export const createMissionProfile: API.OperationMethod<
   CreateMissionProfileRequest,
   MissionProfileIdResponse,
   CreateMissionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMissionProfileRequest,
   output: MissionProfileIdResponse,
@@ -3175,7 +3174,7 @@ export const deleteConfig: API.OperationMethod<
   DeleteConfigRequest,
   ConfigIdResponse,
   DeleteConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigRequest,
   output: ConfigIdResponse,
@@ -3201,7 +3200,7 @@ export const deleteDataflowEndpointGroup: API.OperationMethod<
   DeleteDataflowEndpointGroupRequest,
   DataflowEndpointGroupIdResponse,
   DeleteDataflowEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataflowEndpointGroupRequest,
   output: DataflowEndpointGroupIdResponse,
@@ -3228,7 +3227,7 @@ export const deleteEphemeris: API.OperationMethod<
   DeleteEphemerisRequest,
   EphemerisIdResponse,
   DeleteEphemerisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEphemerisRequest,
   output: EphemerisIdResponse,
@@ -3255,7 +3254,7 @@ export const deleteMissionProfile: API.OperationMethod<
   DeleteMissionProfileRequest,
   MissionProfileIdResponse,
   DeleteMissionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMissionProfileRequest,
   output: MissionProfileIdResponse,
@@ -3281,7 +3280,7 @@ export const describeContact: API.OperationMethod<
   DescribeContactRequest,
   DescribeContactResponse,
   DescribeContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactRequest,
   output: DescribeContactResponse,
@@ -3307,7 +3306,7 @@ export const describeContactVersion: API.OperationMethod<
   DescribeContactVersionRequest,
   DescribeContactVersionResponse,
   DescribeContactVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContactVersionRequest,
   output: DescribeContactVersionResponse,
@@ -3333,7 +3332,7 @@ export const describeEphemeris: API.OperationMethod<
   DescribeEphemerisRequest,
   DescribeEphemerisResponse,
   DescribeEphemerisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEphemerisRequest,
   output: DescribeEphemerisResponse,
@@ -3361,7 +3360,7 @@ export const getAgentConfiguration: API.OperationMethod<
   GetAgentConfigurationRequest,
   GetAgentConfigurationResponse,
   GetAgentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentConfigurationRequest,
   output: GetAgentConfigurationResponse,
@@ -3389,7 +3388,7 @@ export const getAgentTaskResponseUrl: API.OperationMethod<
   GetAgentTaskResponseUrlRequest,
   GetAgentTaskResponseUrlResponse,
   GetAgentTaskResponseUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgentTaskResponseUrlRequest,
   output: GetAgentTaskResponseUrlResponse,
@@ -3417,7 +3416,7 @@ export const getConfig: API.OperationMethod<
   GetConfigRequest,
   GetConfigResponse,
   GetConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigRequest,
   output: GetConfigResponse,
@@ -3443,7 +3442,7 @@ export const getDataflowEndpointGroup: API.OperationMethod<
   GetDataflowEndpointGroupRequest,
   GetDataflowEndpointGroupResponse,
   GetDataflowEndpointGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataflowEndpointGroupRequest,
   output: GetDataflowEndpointGroupResponse,
@@ -3469,7 +3468,7 @@ export const getMinuteUsage: API.OperationMethod<
   GetMinuteUsageRequest,
   GetMinuteUsageResponse,
   GetMinuteUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMinuteUsageRequest,
   output: GetMinuteUsageResponse,
@@ -3495,7 +3494,7 @@ export const getMissionProfile: API.OperationMethod<
   GetMissionProfileRequest,
   GetMissionProfileResponse,
   GetMissionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMissionProfileRequest,
   output: GetMissionProfileResponse,
@@ -3521,7 +3520,7 @@ export const getSatellite: API.OperationMethod<
   GetSatelliteRequest,
   GetSatelliteResponse,
   GetSatelliteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSatelliteRequest,
   output: GetSatelliteResponse,
@@ -3546,7 +3545,7 @@ export const listAntennas: API.PaginatedOperationMethod<
   ListAntennasRequest,
   ListAntennasResponse,
   ListAntennasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AntennaListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAntennasRequest,
@@ -3575,7 +3574,7 @@ export const listConfigs: API.PaginatedOperationMethod<
   ListConfigsRequest,
   ListConfigsResponse,
   ListConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigsRequest,
@@ -3610,7 +3609,7 @@ export const listContacts: API.PaginatedOperationMethod<
   ListContactsRequest,
   ListContactsResponse,
   ListContactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContactData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactsRequest,
@@ -3643,7 +3642,7 @@ export const listContactVersions: API.PaginatedOperationMethod<
   ListContactVersionsRequest,
   ListContactVersionsResponse,
   ListContactVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContactVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactVersionsRequest,
@@ -3676,7 +3675,7 @@ export const listDataflowEndpointGroups: API.PaginatedOperationMethod<
   ListDataflowEndpointGroupsRequest,
   ListDataflowEndpointGroupsResponse,
   ListDataflowEndpointGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataflowEndpointListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataflowEndpointGroupsRequest,
@@ -3709,7 +3708,7 @@ export const listEphemerides: API.PaginatedOperationMethod<
   ListEphemeridesRequest,
   ListEphemeridesResponse,
   ListEphemeridesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EphemerisItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEphemeridesRequest,
@@ -3741,7 +3740,7 @@ export const listGroundStationReservations: API.PaginatedOperationMethod<
   ListGroundStationReservationsRequest,
   ListGroundStationReservationsResponse,
   ListGroundStationReservationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroundStationReservationListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroundStationReservationsRequest,
@@ -3770,7 +3769,7 @@ export const listGroundStations: API.PaginatedOperationMethod<
   ListGroundStationsRequest,
   ListGroundStationsResponse,
   ListGroundStationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroundStationData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroundStationsRequest,
@@ -3803,7 +3802,7 @@ export const listMissionProfiles: API.PaginatedOperationMethod<
   ListMissionProfilesRequest,
   ListMissionProfilesResponse,
   ListMissionProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MissionProfileListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMissionProfilesRequest,
@@ -3836,7 +3835,7 @@ export const listSatellites: API.PaginatedOperationMethod<
   ListSatellitesRequest,
   ListSatellitesResponse,
   ListSatellitesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SatelliteListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSatellitesRequest,
@@ -3869,7 +3868,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3897,7 +3896,7 @@ export const registerAgent: API.OperationMethod<
   RegisterAgentRequest,
   RegisterAgentResponse,
   RegisterAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAgentRequest,
   output: RegisterAgentResponse,
@@ -3924,7 +3923,7 @@ export const reserveContact: API.OperationMethod<
   ReserveContactRequest,
   ContactIdResponse,
   ReserveContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReserveContactRequest,
   output: ContactIdResponse,
@@ -3951,7 +3950,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3977,7 +3976,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4005,7 +4004,7 @@ export const updateAgentStatus: API.OperationMethod<
   UpdateAgentStatusRequest,
   UpdateAgentStatusResponse,
   UpdateAgentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentStatusRequest,
   output: UpdateAgentStatusResponse,
@@ -4033,7 +4032,7 @@ export const updateConfig: API.OperationMethod<
   UpdateConfigRequest,
   ConfigIdResponse,
   UpdateConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigRequest,
   output: ConfigIdResponse,
@@ -4060,7 +4059,7 @@ export const updateContact: API.OperationMethod<
   UpdateContactRequest,
   UpdateContactResponse,
   UpdateContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactRequest,
   output: UpdateContactResponse,
@@ -4087,7 +4086,7 @@ export const updateEphemeris: API.OperationMethod<
   UpdateEphemerisRequest,
   EphemerisIdResponse,
   UpdateEphemerisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEphemerisRequest,
   output: EphemerisIdResponse,
@@ -4115,7 +4114,7 @@ export const updateMissionProfile: API.OperationMethod<
   UpdateMissionProfileRequest,
   MissionProfileIdResponse,
   UpdateMissionProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMissionProfileRequest,
   output: MissionProfileIdResponse,

--- a/packages/aws/src/services/guardduty.ts
+++ b/packages/aws/src/services/guardduty.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "GuardDuty",
@@ -9928,7 +9927,7 @@ export const acceptAdministratorInvitation: API.OperationMethod<
   AcceptAdministratorInvitationRequest,
   AcceptAdministratorInvitationResponse,
   AcceptAdministratorInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAdministratorInvitationRequest,
   output: AcceptAdministratorInvitationResponse,
@@ -9949,7 +9948,7 @@ export const acceptInvitation: API.OperationMethod<
   AcceptInvitationRequest,
   AcceptInvitationResponse,
   AcceptInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInvitationRequest,
   output: AcceptInvitationResponse,
@@ -9972,7 +9971,7 @@ export const archiveFindings: API.OperationMethod<
   ArchiveFindingsRequest,
   ArchiveFindingsResponse,
   ArchiveFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ArchiveFindingsRequest,
   output: ArchiveFindingsResponse,
@@ -10001,7 +10000,7 @@ export const createDetector: API.OperationMethod<
   CreateDetectorRequest,
   CreateDetectorResponse,
   CreateDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDetectorRequest,
   output: CreateDetectorResponse,
@@ -10022,7 +10021,7 @@ export const createFilter: API.OperationMethod<
   CreateFilterRequest,
   CreateFilterResponse,
   CreateFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFilterRequest,
   output: CreateFilterResponse,
@@ -10052,7 +10051,7 @@ export const createInvestigation: API.OperationMethod<
   CreateInvestigationRequest,
   CreateInvestigationResponse,
   CreateInvestigationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvestigationRequest,
   output: CreateInvestigationResponse,
@@ -10078,7 +10077,7 @@ export const createIPSet: API.OperationMethod<
   CreateIPSetRequest,
   CreateIPSetResponse,
   CreateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIPSetRequest,
   output: CreateIPSetResponse,
@@ -10107,7 +10106,7 @@ export const createMalwareProtectionPlan: API.OperationMethod<
   CreateMalwareProtectionPlanRequest,
   CreateMalwareProtectionPlanResponse,
   CreateMalwareProtectionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMalwareProtectionPlanRequest,
   output: CreateMalwareProtectionPlanResponse,
@@ -10141,7 +10140,7 @@ export const createMembers: API.OperationMethod<
   CreateMembersRequest,
   CreateMembersResponse,
   CreateMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembersRequest,
   output: CreateMembersResponse,
@@ -10162,7 +10161,7 @@ export const createPublishingDestination: API.OperationMethod<
   CreatePublishingDestinationRequest,
   CreatePublishingDestinationResponse,
   CreatePublishingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePublishingDestinationRequest,
   output: CreatePublishingDestinationResponse,
@@ -10183,7 +10182,7 @@ export const createSampleFindings: API.OperationMethod<
   CreateSampleFindingsRequest,
   CreateSampleFindingsResponse,
   CreateSampleFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSampleFindingsRequest,
   output: CreateSampleFindingsResponse,
@@ -10204,7 +10203,7 @@ export const createThreatEntitySet: API.OperationMethod<
   CreateThreatEntitySetRequest,
   CreateThreatEntitySetResponse,
   CreateThreatEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThreatEntitySetRequest,
   output: CreateThreatEntitySetResponse,
@@ -10226,7 +10225,7 @@ export const createThreatIntelSet: API.OperationMethod<
   CreateThreatIntelSetRequest,
   CreateThreatIntelSetResponse,
   CreateThreatIntelSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThreatIntelSetRequest,
   output: CreateThreatIntelSetResponse,
@@ -10253,7 +10252,7 @@ export const createTrustedEntitySet: API.OperationMethod<
   CreateTrustedEntitySetRequest,
   CreateTrustedEntitySetResponse,
   CreateTrustedEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustedEntitySetRequest,
   output: CreateTrustedEntitySetResponse,
@@ -10274,7 +10273,7 @@ export const declineInvitations: API.OperationMethod<
   DeclineInvitationsRequest,
   DeclineInvitationsResponse,
   DeclineInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeclineInvitationsRequest,
   output: DeclineInvitationsResponse,
@@ -10295,7 +10294,7 @@ export const deleteDetector: API.OperationMethod<
   DeleteDetectorRequest,
   DeleteDetectorResponse,
   DeleteDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDetectorRequest,
   output: DeleteDetectorResponse,
@@ -10316,7 +10315,7 @@ export const deleteFilter: API.OperationMethod<
   DeleteFilterRequest,
   DeleteFilterResponse,
   DeleteFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFilterRequest,
   output: DeleteFilterResponse,
@@ -10337,7 +10336,7 @@ export const deleteInvitations: API.OperationMethod<
   DeleteInvitationsRequest,
   DeleteInvitationsResponse,
   DeleteInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvitationsRequest,
   output: DeleteInvitationsResponse,
@@ -10358,7 +10357,7 @@ export const deleteIPSet: API.OperationMethod<
   DeleteIPSetRequest,
   DeleteIPSetResponse,
   DeleteIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIPSetRequest,
   output: DeleteIPSetResponse,
@@ -10381,7 +10380,7 @@ export const deleteMalwareProtectionPlan: API.OperationMethod<
   DeleteMalwareProtectionPlanRequest,
   DeleteMalwareProtectionPlanResponse,
   DeleteMalwareProtectionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMalwareProtectionPlanRequest,
   output: DeleteMalwareProtectionPlanResponse,
@@ -10409,7 +10408,7 @@ export const deleteMembers: API.OperationMethod<
   DeleteMembersRequest,
   DeleteMembersResponse,
   DeleteMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMembersRequest,
   output: DeleteMembersResponse,
@@ -10430,7 +10429,7 @@ export const deletePublishingDestination: API.OperationMethod<
   DeletePublishingDestinationRequest,
   DeletePublishingDestinationResponse,
   DeletePublishingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublishingDestinationRequest,
   output: DeletePublishingDestinationResponse,
@@ -10451,7 +10450,7 @@ export const deleteThreatEntitySet: API.OperationMethod<
   DeleteThreatEntitySetRequest,
   DeleteThreatEntitySetResponse,
   DeleteThreatEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThreatEntitySetRequest,
   output: DeleteThreatEntitySetResponse,
@@ -10472,7 +10471,7 @@ export const deleteThreatIntelSet: API.OperationMethod<
   DeleteThreatIntelSetRequest,
   DeleteThreatIntelSetResponse,
   DeleteThreatIntelSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThreatIntelSetRequest,
   output: DeleteThreatIntelSetResponse,
@@ -10493,7 +10492,7 @@ export const deleteTrustedEntitySet: API.OperationMethod<
   DeleteTrustedEntitySetRequest,
   DeleteTrustedEntitySetResponse,
   DeleteTrustedEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustedEntitySetRequest,
   output: DeleteTrustedEntitySetResponse,
@@ -10516,7 +10515,7 @@ export const describeMalwareScans: API.PaginatedOperationMethod<
   DescribeMalwareScansRequest,
   DescribeMalwareScansResponse,
   DescribeMalwareScansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Scan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMalwareScansRequest,
@@ -10546,7 +10545,7 @@ export const describeOrganizationConfiguration: API.PaginatedOperationMethod<
   DescribeOrganizationConfigurationRequest,
   DescribeOrganizationConfigurationResponse,
   DescribeOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrganizationConfigurationRequest,
@@ -10573,7 +10572,7 @@ export const describePublishingDestination: API.OperationMethod<
   DescribePublishingDestinationRequest,
   DescribePublishingDestinationResponse,
   DescribePublishingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePublishingDestinationRequest,
   output: DescribePublishingDestinationResponse,
@@ -10594,7 +10593,7 @@ export const disableOrganizationAdminAccount: API.OperationMethod<
   DisableOrganizationAdminAccountRequest,
   DisableOrganizationAdminAccountResponse,
   DisableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationAdminAccountRequest,
   output: DisableOrganizationAdminAccountResponse,
@@ -10619,7 +10618,7 @@ export const disassociateFromAdministratorAccount: API.OperationMethod<
   DisassociateFromAdministratorAccountRequest,
   DisassociateFromAdministratorAccountResponse,
   DisassociateFromAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromAdministratorAccountRequest,
   output: DisassociateFromAdministratorAccountResponse,
@@ -10642,7 +10641,7 @@ export const disassociateFromMasterAccount: API.OperationMethod<
   DisassociateFromMasterAccountRequest,
   DisassociateFromMasterAccountResponse,
   DisassociateFromMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromMasterAccountRequest,
   output: DisassociateFromMasterAccountResponse,
@@ -10671,7 +10670,7 @@ export const disassociateMembers: API.OperationMethod<
   DisassociateMembersRequest,
   DisassociateMembersResponse,
   DisassociateMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMembersRequest,
   output: DisassociateMembersResponse,
@@ -10692,7 +10691,7 @@ export const enableOrganizationAdminAccount: API.OperationMethod<
   EnableOrganizationAdminAccountRequest,
   EnableOrganizationAdminAccountResponse,
   EnableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationAdminAccountRequest,
   output: EnableOrganizationAdminAccountResponse,
@@ -10721,7 +10720,7 @@ export const getAdministratorAccount: API.OperationMethod<
   GetAdministratorAccountRequest,
   GetAdministratorAccountResponse,
   GetAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdministratorAccountRequest,
   output: GetAdministratorAccountResponse,
@@ -10742,7 +10741,7 @@ export const getCoverageStatistics: API.OperationMethod<
   GetCoverageStatisticsRequest,
   GetCoverageStatisticsResponse,
   GetCoverageStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoverageStatisticsRequest,
   output: GetCoverageStatisticsResponse,
@@ -10765,7 +10764,7 @@ export const getDetector: API.OperationMethod<
   GetDetectorRequest,
   GetDetectorResponse,
   GetDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDetectorRequest,
   output: GetDetectorResponse,
@@ -10786,7 +10785,7 @@ export const getFilter: API.OperationMethod<
   GetFilterRequest,
   GetFilterResponse,
   GetFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFilterRequest,
   output: GetFilterResponse,
@@ -10807,7 +10806,7 @@ export const getFindings: API.OperationMethod<
   GetFindingsRequest,
   GetFindingsResponse,
   GetFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsRequest,
   output: GetFindingsResponse,
@@ -10832,7 +10831,7 @@ export const getFindingsStatistics: API.OperationMethod<
   GetFindingsStatisticsRequest,
   GetFindingsStatisticsResponse,
   GetFindingsStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsStatisticsRequest,
   output: GetFindingsStatisticsResponse,
@@ -10859,7 +10858,7 @@ export const getInvestigation: API.OperationMethod<
   GetInvestigationRequest,
   GetInvestigationResponse,
   GetInvestigationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvestigationRequest,
   output: GetInvestigationResponse,
@@ -10885,7 +10884,7 @@ export const getInvitationsCount: API.OperationMethod<
   GetInvitationsCountRequest,
   GetInvitationsCountResponse,
   GetInvitationsCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvitationsCountRequest,
   output: GetInvitationsCountResponse,
@@ -10906,7 +10905,7 @@ export const getIPSet: API.OperationMethod<
   GetIPSetRequest,
   GetIPSetResponse,
   GetIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIPSetRequest,
   output: GetIPSetResponse,
@@ -10929,7 +10928,7 @@ export const getMalwareProtectionPlan: API.OperationMethod<
   GetMalwareProtectionPlanRequest,
   GetMalwareProtectionPlanResponse,
   GetMalwareProtectionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMalwareProtectionPlanRequest,
   output: GetMalwareProtectionPlanResponse,
@@ -10958,7 +10957,7 @@ export const getMalwareScan: API.OperationMethod<
   GetMalwareScanRequest,
   GetMalwareScanResponse,
   GetMalwareScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMalwareScanRequest,
   output: GetMalwareScanResponse,
@@ -10985,7 +10984,7 @@ export const getMalwareScanSettings: API.OperationMethod<
   GetMalwareScanSettingsRequest,
   GetMalwareScanSettingsResponse,
   GetMalwareScanSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMalwareScanSettingsRequest,
   output: GetMalwareScanSettingsResponse,
@@ -11006,7 +11005,7 @@ export const getMasterAccount: API.OperationMethod<
   GetMasterAccountRequest,
   GetMasterAccountResponse,
   GetMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMasterAccountRequest,
   output: GetMasterAccountResponse,
@@ -11029,7 +11028,7 @@ export const getMemberDetectors: API.OperationMethod<
   GetMemberDetectorsRequest,
   GetMemberDetectorsResponse,
   GetMemberDetectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemberDetectorsRequest,
   output: GetMemberDetectorsResponse,
@@ -11050,7 +11049,7 @@ export const getMembers: API.OperationMethod<
   GetMembersRequest,
   GetMembersResponse,
   GetMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMembersRequest,
   output: GetMembersResponse,
@@ -11073,7 +11072,7 @@ export const getOrganizationStatistics: API.OperationMethod<
   GetOrganizationStatisticsRequest,
   GetOrganizationStatisticsResponse,
   GetOrganizationStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrganizationStatisticsRequest,
   output: GetOrganizationStatisticsResponse,
@@ -11094,7 +11093,7 @@ export const getRemainingFreeTrialDays: API.OperationMethod<
   GetRemainingFreeTrialDaysRequest,
   GetRemainingFreeTrialDaysResponse,
   GetRemainingFreeTrialDaysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRemainingFreeTrialDaysRequest,
   output: GetRemainingFreeTrialDaysResponse,
@@ -11115,7 +11114,7 @@ export const getThreatEntitySet: API.OperationMethod<
   GetThreatEntitySetRequest,
   GetThreatEntitySetResponse,
   GetThreatEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThreatEntitySetRequest,
   output: GetThreatEntitySetResponse,
@@ -11136,7 +11135,7 @@ export const getThreatIntelSet: API.OperationMethod<
   GetThreatIntelSetRequest,
   GetThreatIntelSetResponse,
   GetThreatIntelSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThreatIntelSetRequest,
   output: GetThreatIntelSetResponse,
@@ -11157,7 +11156,7 @@ export const getTrustedEntitySet: API.OperationMethod<
   GetTrustedEntitySetRequest,
   GetTrustedEntitySetResponse,
   GetTrustedEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustedEntitySetRequest,
   output: GetTrustedEntitySetResponse,
@@ -11178,7 +11177,7 @@ export const getUsageStatistics: API.PaginatedOperationMethod<
   GetUsageStatisticsRequest,
   GetUsageStatisticsResponse,
   GetUsageStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUsageStatisticsRequest,
@@ -11213,7 +11212,7 @@ export const inviteMembers: API.OperationMethod<
   InviteMembersRequest,
   InviteMembersResponse,
   InviteMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InviteMembersRequest,
   output: InviteMembersResponse,
@@ -11236,7 +11235,7 @@ export const listCoverage: API.PaginatedOperationMethod<
   ListCoverageRequest,
   ListCoverageResponse,
   ListCoverageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoverageResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoverageRequest,
@@ -11264,7 +11263,7 @@ export const listDetectors: API.PaginatedOperationMethod<
   ListDetectorsRequest,
   ListDetectorsResponse,
   ListDetectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DetectorId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDetectorsRequest,
@@ -11292,7 +11291,7 @@ export const listFilters: API.PaginatedOperationMethod<
   ListFiltersRequest,
   ListFiltersResponse,
   ListFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FilterName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFiltersRequest,
@@ -11322,7 +11321,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsRequest,
   ListFindingsResponse,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsRequest,
@@ -11355,7 +11354,7 @@ export const listInvestigations: API.PaginatedOperationMethod<
   ListInvestigationsRequest,
   ListInvestigationsResponse,
   ListInvestigationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvestigationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvestigationsRequest,
@@ -11387,7 +11386,7 @@ export const listInvitations: API.PaginatedOperationMethod<
   ListInvitationsRequest,
   ListInvitationsResponse,
   ListInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Invitation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvitationsRequest,
@@ -11415,7 +11414,7 @@ export const listIPSets: API.PaginatedOperationMethod<
   ListIPSetsRequest,
   ListIPSetsResponse,
   ListIPSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIPSetsRequest,
@@ -11444,7 +11443,7 @@ export const listMalwareProtectionPlans: API.OperationMethod<
   ListMalwareProtectionPlansRequest,
   ListMalwareProtectionPlansResponse,
   ListMalwareProtectionPlansError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMalwareProtectionPlansRequest,
   output: ListMalwareProtectionPlansResponse,
@@ -11469,7 +11468,7 @@ export const listMalwareScans: API.PaginatedOperationMethod<
   ListMalwareScansRequest,
   ListMalwareScansResponse,
   ListMalwareScansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MalwareScan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMalwareScansRequest,
@@ -11497,7 +11496,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersRequest,
   ListMembersResponse,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Member
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersRequest,
@@ -11525,7 +11524,7 @@ export const listOrganizationAdminAccounts: API.PaginatedOperationMethod<
   ListOrganizationAdminAccountsRequest,
   ListOrganizationAdminAccountsResponse,
   ListOrganizationAdminAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdminAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationAdminAccountsRequest,
@@ -11553,7 +11552,7 @@ export const listPublishingDestinations: API.PaginatedOperationMethod<
   ListPublishingDestinationsRequest,
   ListPublishingDestinationsResponse,
   ListPublishingDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPublishingDestinationsRequest,
@@ -11581,7 +11580,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -11606,7 +11605,7 @@ export const listThreatEntitySets: API.PaginatedOperationMethod<
   ListThreatEntitySetsRequest,
   ListThreatEntitySetsResponse,
   ListThreatEntitySetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatEntitySetsRequest,
@@ -11634,7 +11633,7 @@ export const listThreatIntelSets: API.PaginatedOperationMethod<
   ListThreatIntelSetsRequest,
   ListThreatIntelSetsResponse,
   ListThreatIntelSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatIntelSetsRequest,
@@ -11662,7 +11661,7 @@ export const listTrustedEntitySets: API.PaginatedOperationMethod<
   ListTrustedEntitySetsRequest,
   ListTrustedEntitySetsResponse,
   ListTrustedEntitySetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustedEntitySetsRequest,
@@ -11693,7 +11692,7 @@ export const sendObjectMalwareScan: API.OperationMethod<
   SendObjectMalwareScanRequest,
   SendObjectMalwareScanResponse,
   SendObjectMalwareScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendObjectMalwareScanRequest,
   output: SendObjectMalwareScanResponse,
@@ -11723,7 +11722,7 @@ export const startMalwareScan: API.OperationMethod<
   StartMalwareScanRequest,
   StartMalwareScanResponse,
   StartMalwareScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMalwareScanRequest,
   output: StartMalwareScanResponse,
@@ -11748,7 +11747,7 @@ export const startMonitoringMembers: API.OperationMethod<
   StartMonitoringMembersRequest,
   StartMonitoringMembersResponse,
   StartMonitoringMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMonitoringMembersRequest,
   output: StartMonitoringMembersResponse,
@@ -11771,7 +11770,7 @@ export const stopMonitoringMembers: API.OperationMethod<
   StopMonitoringMembersRequest,
   StopMonitoringMembersResponse,
   StopMonitoringMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMonitoringMembersRequest,
   output: StopMonitoringMembersResponse,
@@ -11793,7 +11792,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -11818,7 +11817,7 @@ export const unarchiveFindings: API.OperationMethod<
   UnarchiveFindingsRequest,
   UnarchiveFindingsResponse,
   UnarchiveFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnarchiveFindingsRequest,
   output: UnarchiveFindingsResponse,
@@ -11840,7 +11839,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -11869,7 +11868,7 @@ export const updateDetector: API.OperationMethod<
   UpdateDetectorRequest,
   UpdateDetectorResponse,
   UpdateDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDetectorRequest,
   output: UpdateDetectorResponse,
@@ -11890,7 +11889,7 @@ export const updateFilter: API.OperationMethod<
   UpdateFilterRequest,
   UpdateFilterResponse,
   UpdateFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFilterRequest,
   output: UpdateFilterResponse,
@@ -11911,7 +11910,7 @@ export const updateFindingsFeedback: API.OperationMethod<
   UpdateFindingsFeedbackRequest,
   UpdateFindingsFeedbackResponse,
   UpdateFindingsFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingsFeedbackRequest,
   output: UpdateFindingsFeedbackResponse,
@@ -11933,7 +11932,7 @@ export const updateIPSet: API.OperationMethod<
   UpdateIPSetRequest,
   UpdateIPSetResponse,
   UpdateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIPSetRequest,
   output: UpdateIPSetResponse,
@@ -11960,7 +11959,7 @@ export const updateMalwareProtectionPlan: API.OperationMethod<
   UpdateMalwareProtectionPlanRequest,
   UpdateMalwareProtectionPlanResponse,
   UpdateMalwareProtectionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMalwareProtectionPlanRequest,
   output: UpdateMalwareProtectionPlanResponse,
@@ -11988,7 +11987,7 @@ export const updateMalwareScanSettings: API.OperationMethod<
   UpdateMalwareScanSettingsRequest,
   UpdateMalwareScanSettingsResponse,
   UpdateMalwareScanSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMalwareScanSettingsRequest,
   output: UpdateMalwareScanSettingsResponse,
@@ -12013,7 +12012,7 @@ export const updateMemberDetectors: API.OperationMethod<
   UpdateMemberDetectorsRequest,
   UpdateMemberDetectorsResponse,
   UpdateMemberDetectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMemberDetectorsRequest,
   output: UpdateMemberDetectorsResponse,
@@ -12038,7 +12037,7 @@ export const updateOrganizationConfiguration: API.OperationMethod<
   UpdateOrganizationConfigurationRequest,
   UpdateOrganizationConfigurationResponse,
   UpdateOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationConfigurationRequest,
   output: UpdateOrganizationConfigurationResponse,
@@ -12059,7 +12058,7 @@ export const updatePublishingDestination: API.OperationMethod<
   UpdatePublishingDestinationRequest,
   UpdatePublishingDestinationResponse,
   UpdatePublishingDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePublishingDestinationRequest,
   output: UpdatePublishingDestinationResponse,
@@ -12080,7 +12079,7 @@ export const updateThreatEntitySet: API.OperationMethod<
   UpdateThreatEntitySetRequest,
   UpdateThreatEntitySetResponse,
   UpdateThreatEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThreatEntitySetRequest,
   output: UpdateThreatEntitySetResponse,
@@ -12102,7 +12101,7 @@ export const updateThreatIntelSet: API.OperationMethod<
   UpdateThreatIntelSetRequest,
   UpdateThreatIntelSetResponse,
   UpdateThreatIntelSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThreatIntelSetRequest,
   output: UpdateThreatIntelSetResponse,
@@ -12127,7 +12126,7 @@ export const updateTrustedEntitySet: API.OperationMethod<
   UpdateTrustedEntitySetRequest,
   UpdateTrustedEntitySetResponse,
   UpdateTrustedEntitySetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustedEntitySetRequest,
   output: UpdateTrustedEntitySetResponse,

--- a/packages/aws/src/services/health.ts
+++ b/packages/aws/src/services/health.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Health",
   serviceShapeName: "AWSHealth_20160804",
@@ -1122,7 +1121,7 @@ export const describeAffectedAccountsForOrganization: API.PaginatedOperationMeth
   DescribeAffectedAccountsForOrganizationRequest,
   DescribeAffectedAccountsForOrganizationResponse,
   DescribeAffectedAccountsForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAffectedAccountsForOrganizationRequest,
@@ -1161,7 +1160,7 @@ export const describeAffectedEntities: API.PaginatedOperationMethod<
   DescribeAffectedEntitiesRequest,
   DescribeAffectedEntitiesResponse,
   DescribeAffectedEntitiesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AffectedEntity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAffectedEntitiesRequest,
@@ -1203,7 +1202,7 @@ export const describeAffectedEntitiesForOrganization: API.PaginatedOperationMeth
   DescribeAffectedEntitiesForOrganizationRequest,
   DescribeAffectedEntitiesForOrganizationResponse,
   DescribeAffectedEntitiesForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AffectedEntity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAffectedEntitiesForOrganizationRequest,
@@ -1228,7 +1227,7 @@ export const describeEntityAggregates: API.OperationMethod<
   DescribeEntityAggregatesRequest,
   DescribeEntityAggregatesResponse,
   DescribeEntityAggregatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntityAggregatesRequest,
   output: DescribeEntityAggregatesResponse,
@@ -1246,7 +1245,7 @@ export const describeEntityAggregatesForOrganization: API.OperationMethod<
   DescribeEntityAggregatesForOrganizationRequest,
   DescribeEntityAggregatesForOrganizationResponse,
   DescribeEntityAggregatesForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntityAggregatesForOrganizationRequest,
   output: DescribeEntityAggregatesForOrganizationResponse,
@@ -1270,7 +1269,7 @@ export const describeEventAggregates: API.PaginatedOperationMethod<
   DescribeEventAggregatesRequest,
   DescribeEventAggregatesResponse,
   DescribeEventAggregatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventAggregate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventAggregatesRequest,
@@ -1304,7 +1303,7 @@ export const describeEventDetails: API.OperationMethod<
   DescribeEventDetailsRequest,
   DescribeEventDetailsResponse,
   DescribeEventDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventDetailsRequest,
   output: DescribeEventDetailsResponse,
@@ -1351,7 +1350,7 @@ export const describeEventDetailsForOrganization: API.OperationMethod<
   DescribeEventDetailsForOrganizationRequest,
   DescribeEventDetailsForOrganizationResponse,
   DescribeEventDetailsForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventDetailsForOrganizationRequest,
   output: DescribeEventDetailsForOrganizationResponse,
@@ -1389,7 +1388,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsRequest,
   DescribeEventsResponse,
   DescribeEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsRequest,
@@ -1439,7 +1438,7 @@ export const describeEventsForOrganization: API.PaginatedOperationMethod<
   DescribeEventsForOrganizationRequest,
   DescribeEventsForOrganizationResponse,
   DescribeEventsForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsForOrganizationRequest,
@@ -1473,7 +1472,7 @@ export const describeEventTypes: API.PaginatedOperationMethod<
   DescribeEventTypesRequest,
   DescribeEventTypesResponse,
   DescribeEventTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventTypesRequest,
@@ -1500,7 +1499,7 @@ export const describeHealthServiceStatusForOrganization: API.OperationMethod<
   DescribeHealthServiceStatusForOrganizationRequest,
   DescribeHealthServiceStatusForOrganizationResponse,
   DescribeHealthServiceStatusForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHealthServiceStatusForOrganizationRequest,
   output: DescribeHealthServiceStatusForOrganizationResponse,
@@ -1533,7 +1532,7 @@ export const disableHealthServiceAccessForOrganization: API.OperationMethod<
   DisableHealthServiceAccessForOrganizationRequest,
   DisableHealthServiceAccessForOrganizationResponse,
   DisableHealthServiceAccessForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableHealthServiceAccessForOrganizationRequest,
   output: DisableHealthServiceAccessForOrganizationResponse,
@@ -1572,7 +1571,7 @@ export const enableHealthServiceAccessForOrganization: API.OperationMethod<
   EnableHealthServiceAccessForOrganizationRequest,
   EnableHealthServiceAccessForOrganizationResponse,
   EnableHealthServiceAccessForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableHealthServiceAccessForOrganizationRequest,
   output: EnableHealthServiceAccessForOrganizationResponse,

--- a/packages/aws/src/services/healthlake.ts
+++ b/packages/aws/src/services/healthlake.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "HealthLake",
   serviceShapeName: "HealthLake",
@@ -861,7 +860,7 @@ export const createFHIRDatastore: API.OperationMethod<
   CreateFHIRDatastoreRequest,
   CreateFHIRDatastoreResponse,
   CreateFHIRDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFHIRDatastoreRequest,
   output: CreateFHIRDatastoreResponse,
@@ -891,7 +890,7 @@ export const deleteFHIRDatastore: API.OperationMethod<
   DeleteFHIRDatastoreRequest,
   DeleteFHIRDatastoreResponse,
   DeleteFHIRDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFHIRDatastoreRequest,
   output: DeleteFHIRDatastoreResponse,
@@ -921,7 +920,7 @@ export const describeFHIRDatastore: API.OperationMethod<
   DescribeFHIRDatastoreRequest,
   DescribeFHIRDatastoreResponse,
   DescribeFHIRDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFHIRDatastoreRequest,
   output: DescribeFHIRDatastoreResponse,
@@ -949,7 +948,7 @@ export const describeFHIRExportJob: API.OperationMethod<
   DescribeFHIRExportJobRequest,
   DescribeFHIRExportJobResponse,
   DescribeFHIRExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFHIRExportJobRequest,
   output: DescribeFHIRExportJobResponse,
@@ -977,7 +976,7 @@ export const describeFHIRImportJob: API.OperationMethod<
   DescribeFHIRImportJobRequest,
   DescribeFHIRImportJobResponse,
   DescribeFHIRImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFHIRImportJobRequest,
   output: DescribeFHIRImportJobResponse,
@@ -1005,7 +1004,7 @@ export const listFHIRDatastores: API.PaginatedOperationMethod<
   ListFHIRDatastoresRequest,
   ListFHIRDatastoresResponse,
   ListFHIRDatastoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFHIRDatastoresRequest,
@@ -1035,7 +1034,7 @@ export const listFHIRExportJobs: API.PaginatedOperationMethod<
   ListFHIRExportJobsRequest,
   ListFHIRExportJobsResponse,
   ListFHIRExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFHIRExportJobsRequest,
@@ -1071,7 +1070,7 @@ export const listFHIRImportJobs: API.PaginatedOperationMethod<
   ListFHIRImportJobsRequest,
   ListFHIRImportJobsResponse,
   ListFHIRImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFHIRImportJobsRequest,
@@ -1104,7 +1103,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1128,7 +1127,7 @@ export const startFHIRExportJob: API.OperationMethod<
   StartFHIRExportJobRequest,
   StartFHIRExportJobResponse,
   StartFHIRExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFHIRExportJobRequest,
   output: StartFHIRExportJobResponse,
@@ -1160,7 +1159,7 @@ export const startFHIRImportJob: API.OperationMethod<
   StartFHIRImportJobRequest,
   StartFHIRImportJobResponse,
   StartFHIRImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFHIRImportJobRequest,
   output: StartFHIRImportJobResponse,
@@ -1187,7 +1186,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1208,7 +1207,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1233,7 +1232,7 @@ export const updateFHIRDatastore: API.OperationMethod<
   UpdateFHIRDatastoreRequest,
   UpdateFHIRDatastoreResponse,
   UpdateFHIRDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFHIRDatastoreRequest,
   output: UpdateFHIRDatastoreResponse,

--- a/packages/aws/src/services/iam.ts
+++ b/packages/aws/src/services/iam.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const ns = T.XmlNamespace("https://iam.amazonaws.com/doc/2010-05-08/");
 const svc = T.AwsApiService({
@@ -7511,7 +7510,7 @@ export const acceptDelegationRequest: API.OperationMethod<
   AcceptDelegationRequestRequest,
   AcceptDelegationRequestResponse,
   AcceptDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptDelegationRequestRequest,
   output: AcceptDelegationRequestResponse,
@@ -7543,7 +7542,7 @@ export const addClientIDToOpenIDConnectProvider: API.OperationMethod<
   AddClientIDToOpenIDConnectProviderRequest,
   AddClientIDToOpenIDConnectProviderResponse,
   AddClientIDToOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddClientIDToOpenIDConnectProviderRequest,
   output: AddClientIDToOpenIDConnectProviderResponse,
@@ -7592,7 +7591,7 @@ export const addRoleToInstanceProfile: API.OperationMethod<
   AddRoleToInstanceProfileRequest,
   AddRoleToInstanceProfileResponse,
   AddRoleToInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRoleToInstanceProfileRequest,
   output: AddRoleToInstanceProfileResponse,
@@ -7620,7 +7619,7 @@ export const addUserToGroup: API.OperationMethod<
   AddUserToGroupRequest,
   AddUserToGroupResponse,
   AddUserToGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddUserToGroupRequest,
   output: AddUserToGroupResponse,
@@ -7666,7 +7665,7 @@ export const associateDelegationRequest: API.OperationMethod<
   AssociateDelegationRequestRequest,
   AssociateDelegationRequestResponse,
   AssociateDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDelegationRequestRequest,
   output: AssociateDelegationRequestResponse,
@@ -7707,7 +7706,7 @@ export const attachGroupPolicy: API.OperationMethod<
   AttachGroupPolicyRequest,
   AttachGroupPolicyResponse,
   AttachGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachGroupPolicyRequest,
   output: AttachGroupPolicyResponse,
@@ -7759,7 +7758,7 @@ export const attachRolePolicy: API.OperationMethod<
   AttachRolePolicyRequest,
   AttachRolePolicyResponse,
   AttachRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachRolePolicyRequest,
   output: AttachRolePolicyResponse,
@@ -7802,7 +7801,7 @@ export const attachUserPolicy: API.OperationMethod<
   AttachUserPolicyRequest,
   AttachUserPolicyResponse,
   AttachUserPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachUserPolicyRequest,
   output: AttachUserPolicyResponse,
@@ -7842,7 +7841,7 @@ export const changePassword: API.OperationMethod<
   ChangePasswordRequest,
   ChangePasswordResponse,
   ChangePasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangePasswordRequest,
   output: ChangePasswordResponse,
@@ -7885,7 +7884,7 @@ export const createAccessKey: API.OperationMethod<
   CreateAccessKeyRequest,
   CreateAccessKeyResponse,
   CreateAccessKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessKeyRequest,
   output: CreateAccessKeyResponse,
@@ -7915,7 +7914,7 @@ export const createAccountAlias: API.OperationMethod<
   CreateAccountAliasRequest,
   CreateAccountAliasResponse,
   CreateAccountAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountAliasRequest,
   output: CreateAccountAliasResponse,
@@ -7948,7 +7947,7 @@ export const createDelegationRequest: API.OperationMethod<
   CreateDelegationRequestRequest,
   CreateDelegationRequestResponse,
   CreateDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDelegationRequestRequest,
   output: CreateDelegationRequestResponse,
@@ -7980,7 +7979,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -8014,7 +8013,7 @@ export const createInstanceProfile: API.OperationMethod<
   CreateInstanceProfileRequest,
   CreateInstanceProfileResponse,
   CreateInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceProfileRequest,
   output: CreateInstanceProfileResponse,
@@ -8051,7 +8050,7 @@ export const createLoginProfile: API.OperationMethod<
   CreateLoginProfileRequest,
   CreateLoginProfileResponse,
   CreateLoginProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoginProfileRequest,
   output: CreateLoginProfileResponse,
@@ -8118,7 +8117,7 @@ export const createOpenIDConnectProvider: API.OperationMethod<
   CreateOpenIDConnectProviderRequest,
   CreateOpenIDConnectProviderResponse,
   CreateOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOpenIDConnectProviderRequest,
   output: CreateOpenIDConnectProviderResponse,
@@ -8163,7 +8162,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyRequest,
   CreatePolicyResponse,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyRequest,
   output: CreatePolicyResponse,
@@ -8203,7 +8202,7 @@ export const createPolicyVersion: API.OperationMethod<
   CreatePolicyVersionRequest,
   CreatePolicyVersionResponse,
   CreatePolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyVersionRequest,
   output: CreatePolicyVersionResponse,
@@ -8239,7 +8238,7 @@ export const createRole: API.OperationMethod<
   CreateRoleRequest,
   CreateRoleResponse,
   CreateRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoleRequest,
   output: CreateRoleResponse,
@@ -8289,7 +8288,7 @@ export const createSAMLProvider: API.OperationMethod<
   CreateSAMLProviderRequest,
   CreateSAMLProviderResponse,
   CreateSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSAMLProviderRequest,
   output: CreateSAMLProviderResponse,
@@ -8327,7 +8326,7 @@ export const createServiceLinkedRole: API.OperationMethod<
   CreateServiceLinkedRoleRequest,
   CreateServiceLinkedRoleResponse,
   CreateServiceLinkedRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceLinkedRoleRequest,
   output: CreateServiceLinkedRoleResponse,
@@ -8375,7 +8374,7 @@ export const createServiceSpecificCredential: API.OperationMethod<
   CreateServiceSpecificCredentialRequest,
   CreateServiceSpecificCredentialResponse,
   CreateServiceSpecificCredentialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceSpecificCredentialRequest,
   output: CreateServiceSpecificCredentialResponse,
@@ -8407,7 +8406,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -8451,7 +8450,7 @@ export const createVirtualMFADevice: API.OperationMethod<
   CreateVirtualMFADeviceRequest,
   CreateVirtualMFADeviceResponse,
   CreateVirtualMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVirtualMFADeviceRequest,
   output: CreateVirtualMFADeviceResponse,
@@ -8486,7 +8485,7 @@ export const deactivateMFADevice: API.OperationMethod<
   DeactivateMFADeviceRequest,
   DeactivateMFADeviceResponse,
   DeactivateMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateMFADeviceRequest,
   output: DeactivateMFADeviceResponse,
@@ -8519,7 +8518,7 @@ export const deleteAccessKey: API.OperationMethod<
   DeleteAccessKeyRequest,
   DeleteAccessKeyResponse,
   DeleteAccessKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessKeyRequest,
   output: DeleteAccessKeyResponse,
@@ -8549,7 +8548,7 @@ export const deleteAccountAlias: API.OperationMethod<
   DeleteAccountAliasRequest,
   DeleteAccountAliasResponse,
   DeleteAccountAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountAliasRequest,
   output: DeleteAccountAliasResponse,
@@ -8576,7 +8575,7 @@ export const deleteAccountPasswordPolicy: API.OperationMethod<
   DeleteAccountPasswordPolicyRequest,
   DeleteAccountPasswordPolicyResponse,
   DeleteAccountPasswordPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountPasswordPolicyRequest,
   output: DeleteAccountPasswordPolicyResponse,
@@ -8604,7 +8603,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -8637,7 +8636,7 @@ export const deleteGroupPolicy: API.OperationMethod<
   DeleteGroupPolicyRequest,
   DeleteGroupPolicyResponse,
   DeleteGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupPolicyRequest,
   output: DeleteGroupPolicyResponse,
@@ -8673,7 +8672,7 @@ export const deleteInstanceProfile: API.OperationMethod<
   DeleteInstanceProfileRequest,
   DeleteInstanceProfileResponse,
   DeleteInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceProfileRequest,
   output: DeleteInstanceProfileResponse,
@@ -8714,7 +8713,7 @@ export const deleteLoginProfile: API.OperationMethod<
   DeleteLoginProfileRequest,
   DeleteLoginProfileResponse,
   DeleteLoginProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoginProfileRequest,
   output: DeleteLoginProfileResponse,
@@ -8748,7 +8747,7 @@ export const deleteOpenIDConnectProvider: API.OperationMethod<
   DeleteOpenIDConnectProviderRequest,
   DeleteOpenIDConnectProviderResponse,
   DeleteOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOpenIDConnectProviderRequest,
   output: DeleteOpenIDConnectProviderResponse,
@@ -8795,7 +8794,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -8832,7 +8831,7 @@ export const deletePolicyVersion: API.OperationMethod<
   DeletePolicyVersionRequest,
   DeletePolicyVersionResponse,
   DeletePolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyVersionRequest,
   output: DeletePolicyVersionResponse,
@@ -8879,7 +8878,7 @@ export const deleteRole: API.OperationMethod<
   DeleteRoleRequest,
   DeleteRoleResponse,
   DeleteRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoleRequest,
   output: DeleteRoleResponse,
@@ -8914,7 +8913,7 @@ export const deleteRolePermissionsBoundary: API.OperationMethod<
   DeleteRolePermissionsBoundaryRequest,
   DeleteRolePermissionsBoundaryResponse,
   DeleteRolePermissionsBoundaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRolePermissionsBoundaryRequest,
   output: DeleteRolePermissionsBoundaryResponse,
@@ -8947,7 +8946,7 @@ export const deleteRolePolicy: API.OperationMethod<
   DeleteRolePolicyRequest,
   DeleteRolePolicyResponse,
   DeleteRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRolePolicyRequest,
   output: DeleteRolePolicyResponse,
@@ -8981,7 +8980,7 @@ export const deleteSAMLProvider: API.OperationMethod<
   DeleteSAMLProviderRequest,
   DeleteSAMLProviderResponse,
   DeleteSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSAMLProviderRequest,
   output: DeleteSAMLProviderResponse,
@@ -9023,7 +9022,7 @@ export const deleteServerCertificate: API.OperationMethod<
   DeleteServerCertificateRequest,
   DeleteServerCertificateResponse,
   DeleteServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServerCertificateRequest,
   output: DeleteServerCertificateResponse,
@@ -9068,7 +9067,7 @@ export const deleteServiceLinkedRole: API.OperationMethod<
   DeleteServiceLinkedRoleRequest,
   DeleteServiceLinkedRoleResponse,
   DeleteServiceLinkedRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceLinkedRoleRequest,
   output: DeleteServiceLinkedRoleResponse,
@@ -9092,7 +9091,7 @@ export const deleteServiceSpecificCredential: API.OperationMethod<
   DeleteServiceSpecificCredentialRequest,
   DeleteServiceSpecificCredentialResponse,
   DeleteServiceSpecificCredentialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceSpecificCredentialRequest,
   output: DeleteServiceSpecificCredentialResponse,
@@ -9120,7 +9119,7 @@ export const deleteSigningCertificate: API.OperationMethod<
   DeleteSigningCertificateRequest,
   DeleteSigningCertificateResponse,
   DeleteSigningCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSigningCertificateRequest,
   output: DeleteSigningCertificateResponse,
@@ -9148,7 +9147,7 @@ export const deleteSSHPublicKey: API.OperationMethod<
   DeleteSSHPublicKeyRequest,
   DeleteSSHPublicKeyResponse,
   DeleteSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSSHPublicKeyRequest,
   output: DeleteSSHPublicKeyResponse,
@@ -9193,7 +9192,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -9223,7 +9222,7 @@ export const deleteUserPermissionsBoundary: API.OperationMethod<
   DeleteUserPermissionsBoundaryRequest,
   DeleteUserPermissionsBoundaryResponse,
   DeleteUserPermissionsBoundaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPermissionsBoundaryRequest,
   output: DeleteUserPermissionsBoundaryResponse,
@@ -9251,7 +9250,7 @@ export const deleteUserPolicy: API.OperationMethod<
   DeleteUserPolicyRequest,
   DeleteUserPolicyResponse,
   DeleteUserPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserPolicyRequest,
   output: DeleteUserPolicyResponse,
@@ -9282,7 +9281,7 @@ export const deleteVirtualMFADevice: API.OperationMethod<
   DeleteVirtualMFADeviceRequest,
   DeleteVirtualMFADeviceResponse,
   DeleteVirtualMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVirtualMFADeviceRequest,
   output: DeleteVirtualMFADeviceResponse,
@@ -9316,7 +9315,7 @@ export const detachGroupPolicy: API.OperationMethod<
   DetachGroupPolicyRequest,
   DetachGroupPolicyResponse,
   DetachGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachGroupPolicyRequest,
   output: DetachGroupPolicyResponse,
@@ -9350,7 +9349,7 @@ export const detachRolePolicy: API.OperationMethod<
   DetachRolePolicyRequest,
   DetachRolePolicyResponse,
   DetachRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachRolePolicyRequest,
   output: DetachRolePolicyResponse,
@@ -9384,7 +9383,7 @@ export const detachUserPolicy: API.OperationMethod<
   DetachUserPolicyRequest,
   DetachUserPolicyResponse,
   DetachUserPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachUserPolicyRequest,
   output: DetachUserPolicyResponse,
@@ -9415,7 +9414,7 @@ export const disableOrganizationsRootCredentialsManagement: API.OperationMethod<
   DisableOrganizationsRootCredentialsManagementRequest,
   DisableOrganizationsRootCredentialsManagementResponse,
   DisableOrganizationsRootCredentialsManagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationsRootCredentialsManagementRequest,
   output: DisableOrganizationsRootCredentialsManagementResponse,
@@ -9446,7 +9445,7 @@ export const disableOrganizationsRootSessions: API.OperationMethod<
   DisableOrganizationsRootSessionsRequest,
   DisableOrganizationsRootSessionsResponse,
   DisableOrganizationsRootSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationsRootSessionsRequest,
   output: DisableOrganizationsRootSessionsResponse,
@@ -9473,7 +9472,7 @@ export const disableOutboundWebIdentityFederation: API.OperationMethod<
   DisableOutboundWebIdentityFederationRequest,
   DisableOutboundWebIdentityFederationResponse,
   DisableOutboundWebIdentityFederationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOutboundWebIdentityFederationRequest,
   output: DisableOutboundWebIdentityFederationResponse,
@@ -9501,7 +9500,7 @@ export const enableMFADevice: API.OperationMethod<
   EnableMFADeviceRequest,
   EnableMFADeviceResponse,
   EnableMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableMFADeviceRequest,
   output: EnableMFADeviceResponse,
@@ -9545,7 +9544,7 @@ export const enableOrganizationsRootCredentialsManagement: API.OperationMethod<
   EnableOrganizationsRootCredentialsManagementRequest,
   EnableOrganizationsRootCredentialsManagementResponse,
   EnableOrganizationsRootCredentialsManagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationsRootCredentialsManagementRequest,
   output: EnableOrganizationsRootCredentialsManagementResponse,
@@ -9586,7 +9585,7 @@ export const enableOrganizationsRootSessions: API.OperationMethod<
   EnableOrganizationsRootSessionsRequest,
   EnableOrganizationsRootSessionsResponse,
   EnableOrganizationsRootSessionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationsRootSessionsRequest,
   output: EnableOrganizationsRootSessionsResponse,
@@ -9614,7 +9613,7 @@ export const enableOutboundWebIdentityFederation: API.OperationMethod<
   EnableOutboundWebIdentityFederationRequest,
   EnableOutboundWebIdentityFederationResponse,
   EnableOutboundWebIdentityFederationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOutboundWebIdentityFederationRequest,
   output: EnableOutboundWebIdentityFederationResponse,
@@ -9637,7 +9636,7 @@ export const generateCredentialReport: API.OperationMethod<
   GenerateCredentialReportRequest,
   GenerateCredentialReportResponse,
   GenerateCredentialReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateCredentialReportRequest,
   output: GenerateCredentialReportResponse,
@@ -9773,7 +9772,7 @@ export const generateOrganizationsAccessReport: API.OperationMethod<
   GenerateOrganizationsAccessReportRequest,
   GenerateOrganizationsAccessReportResponse,
   GenerateOrganizationsAccessReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateOrganizationsAccessReportRequest,
   output: GenerateOrganizationsAccessReportResponse,
@@ -9845,7 +9844,7 @@ export const generateServiceLastAccessedDetails: API.OperationMethod<
   GenerateServiceLastAccessedDetailsRequest,
   GenerateServiceLastAccessedDetailsResponse,
   GenerateServiceLastAccessedDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateServiceLastAccessedDetailsRequest,
   output: GenerateServiceLastAccessedDetailsResponse,
@@ -9865,7 +9864,7 @@ export const getAccessKeyLastUsed: API.OperationMethod<
   GetAccessKeyLastUsedRequest,
   GetAccessKeyLastUsedResponse,
   GetAccessKeyLastUsedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessKeyLastUsedRequest,
   output: GetAccessKeyLastUsedResponse,
@@ -9899,7 +9898,7 @@ export const getAccountAuthorizationDetails: API.PaginatedOperationMethod<
   GetAccountAuthorizationDetailsRequest,
   GetAccountAuthorizationDetailsResponse,
   GetAccountAuthorizationDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAccountAuthorizationDetailsRequest,
@@ -9929,7 +9928,7 @@ export const getAccountPasswordPolicy: API.OperationMethod<
   GetAccountPasswordPolicyRequest,
   GetAccountPasswordPolicyResponse,
   GetAccountPasswordPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountPasswordPolicyRequest,
   output: GetAccountPasswordPolicyResponse,
@@ -9951,7 +9950,7 @@ export const getAccountSummary: API.OperationMethod<
   GetAccountSummaryRequest,
   GetAccountSummaryResponse,
   GetAccountSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSummaryRequest,
   output: GetAccountSummaryResponse,
@@ -9981,7 +9980,7 @@ export const getContextKeysForCustomPolicy: API.OperationMethod<
   GetContextKeysForCustomPolicyRequest,
   GetContextKeysForPolicyResponse,
   GetContextKeysForCustomPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContextKeysForCustomPolicyRequest,
   output: GetContextKeysForPolicyResponse,
@@ -10018,7 +10017,7 @@ export const getContextKeysForPrincipalPolicy: API.OperationMethod<
   GetContextKeysForPrincipalPolicyRequest,
   GetContextKeysForPolicyResponse,
   GetContextKeysForPrincipalPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContextKeysForPrincipalPolicyRequest,
   output: GetContextKeysForPolicyResponse,
@@ -10043,7 +10042,7 @@ export const getCredentialReport: API.OperationMethod<
   GetCredentialReportRequest,
   GetCredentialReportResponse,
   GetCredentialReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCredentialReportRequest,
   output: GetCredentialReportResponse,
@@ -10077,7 +10076,7 @@ export const getDelegationRequest: API.OperationMethod<
   GetDelegationRequestRequest,
   GetDelegationRequestResponse,
   GetDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDelegationRequestRequest,
   output: GetDelegationRequestResponse,
@@ -10099,7 +10098,7 @@ export const getGroup: API.PaginatedOperationMethod<
   GetGroupRequest,
   GetGroupResponse,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetGroupRequest,
@@ -10143,7 +10142,7 @@ export const getGroupPolicy: API.OperationMethod<
   GetGroupPolicyRequest,
   GetGroupPolicyResponse,
   GetGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupPolicyRequest,
   output: GetGroupPolicyResponse,
@@ -10180,7 +10179,7 @@ export const getHumanReadableSummary: API.OperationMethod<
   GetHumanReadableSummaryRequest,
   GetHumanReadableSummaryResponse,
   GetHumanReadableSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHumanReadableSummaryRequest,
   output: GetHumanReadableSummaryResponse,
@@ -10208,7 +10207,7 @@ export const getInstanceProfile: API.OperationMethod<
   GetInstanceProfileRequest,
   GetInstanceProfileResponse,
   GetInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceProfileRequest,
   output: GetInstanceProfileResponse,
@@ -10240,7 +10239,7 @@ export const getLoginProfile: API.OperationMethod<
   GetLoginProfileRequest,
   GetLoginProfileResponse,
   GetLoginProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoginProfileRequest,
   output: GetLoginProfileResponse,
@@ -10261,7 +10260,7 @@ export const getMFADevice: API.OperationMethod<
   GetMFADeviceRequest,
   GetMFADeviceResponse,
   GetMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMFADeviceRequest,
   output: GetMFADeviceResponse,
@@ -10284,7 +10283,7 @@ export const getOpenIDConnectProvider: API.OperationMethod<
   GetOpenIDConnectProviderRequest,
   GetOpenIDConnectProviderResponse,
   GetOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpenIDConnectProviderRequest,
   output: GetOpenIDConnectProviderResponse,
@@ -10329,7 +10328,7 @@ export const getOrganizationsAccessReport: API.OperationMethod<
   GetOrganizationsAccessReportRequest,
   GetOrganizationsAccessReportResponse,
   GetOrganizationsAccessReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrganizationsAccessReportRequest,
   output: GetOrganizationsAccessReportResponse,
@@ -10350,7 +10349,7 @@ export const getOutboundWebIdentityFederationInfo: API.OperationMethod<
   GetOutboundWebIdentityFederationInfoRequest,
   GetOutboundWebIdentityFederationInfoResponse,
   GetOutboundWebIdentityFederationInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOutboundWebIdentityFederationInfoRequest,
   output: GetOutboundWebIdentityFederationInfoResponse,
@@ -10383,7 +10382,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -10429,7 +10428,7 @@ export const getPolicyVersion: API.OperationMethod<
   GetPolicyVersionRequest,
   GetPolicyVersionResponse,
   GetPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyVersionRequest,
   output: GetPolicyVersionResponse,
@@ -10464,7 +10463,7 @@ export const getRole: API.OperationMethod<
   GetRoleRequest,
   GetRoleResponse,
   GetRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoleRequest,
   output: GetRoleResponse,
@@ -10504,7 +10503,7 @@ export const getRolePolicy: API.OperationMethod<
   GetRolePolicyRequest,
   GetRolePolicyResponse,
   GetRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRolePolicyRequest,
   output: GetRolePolicyResponse,
@@ -10529,7 +10528,7 @@ export const getSAMLProvider: API.OperationMethod<
   GetSAMLProviderRequest,
   GetSAMLProviderResponse,
   GetSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSAMLProviderRequest,
   output: GetSAMLProviderResponse,
@@ -10559,7 +10558,7 @@ export const getServerCertificate: API.OperationMethod<
   GetServerCertificateRequest,
   GetServerCertificateResponse,
   GetServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServerCertificateRequest,
   output: GetServerCertificateResponse,
@@ -10625,7 +10624,7 @@ export const getServiceLastAccessedDetails: API.OperationMethod<
   GetServiceLastAccessedDetailsRequest,
   GetServiceLastAccessedDetailsResponse,
   GetServiceLastAccessedDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceLastAccessedDetailsRequest,
   output: GetServiceLastAccessedDetailsResponse,
@@ -10668,7 +10667,7 @@ export const getServiceLastAccessedDetailsWithEntities: API.OperationMethod<
   GetServiceLastAccessedDetailsWithEntitiesRequest,
   GetServiceLastAccessedDetailsWithEntitiesResponse,
   GetServiceLastAccessedDetailsWithEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceLastAccessedDetailsWithEntitiesRequest,
   output: GetServiceLastAccessedDetailsWithEntitiesResponse,
@@ -10694,7 +10693,7 @@ export const getServiceLinkedRoleDeletionStatus: API.OperationMethod<
   GetServiceLinkedRoleDeletionStatusRequest,
   GetServiceLinkedRoleDeletionStatusResponse,
   GetServiceLinkedRoleDeletionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceLinkedRoleDeletionStatusRequest,
   output: GetServiceLinkedRoleDeletionStatusResponse,
@@ -10724,7 +10723,7 @@ export const getSSHPublicKey: API.OperationMethod<
   GetSSHPublicKeyRequest,
   GetSSHPublicKeyResponse,
   GetSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSSHPublicKeyRequest,
   output: GetSSHPublicKeyResponse,
@@ -10749,7 +10748,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -10786,7 +10785,7 @@ export const getUserPolicy: API.OperationMethod<
   GetUserPolicyRequest,
   GetUserPolicyResponse,
   GetUserPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserPolicyRequest,
   output: GetUserPolicyResponse,
@@ -10823,7 +10822,7 @@ export const listAccessKeys: API.PaginatedOperationMethod<
   ListAccessKeysRequest,
   ListAccessKeysResponse,
   ListAccessKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessKeyMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessKeysRequest,
@@ -10851,7 +10850,7 @@ export const listAccountAliases: API.PaginatedOperationMethod<
   ListAccountAliasesRequest,
   ListAccountAliasesResponse,
   ListAccountAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAliasType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAliasesRequest,
@@ -10891,7 +10890,7 @@ export const listAttachedGroupPolicies: API.PaginatedOperationMethod<
   ListAttachedGroupPoliciesRequest,
   ListAttachedGroupPoliciesResponse,
   ListAttachedGroupPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachedPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedGroupPoliciesRequest,
@@ -10935,7 +10934,7 @@ export const listAttachedRolePolicies: API.PaginatedOperationMethod<
   ListAttachedRolePoliciesRequest,
   ListAttachedRolePoliciesResponse,
   ListAttachedRolePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachedPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedRolePoliciesRequest,
@@ -10979,7 +10978,7 @@ export const listAttachedUserPolicies: API.PaginatedOperationMethod<
   ListAttachedUserPoliciesRequest,
   ListAttachedUserPoliciesResponse,
   ListAttachedUserPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachedPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedUserPoliciesRequest,
@@ -11019,7 +11018,7 @@ export const listDelegationRequests: API.OperationMethod<
   ListDelegationRequestsRequest,
   ListDelegationRequestsResponse,
   ListDelegationRequestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDelegationRequestsRequest,
   output: ListDelegationRequestsResponse,
@@ -11054,7 +11053,7 @@ export const listEntitiesForPolicy: API.PaginatedOperationMethod<
   ListEntitiesForPolicyRequest,
   ListEntitiesForPolicyResponse,
   ListEntitiesForPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitiesForPolicyRequest,
@@ -11095,7 +11094,7 @@ export const listGroupPolicies: API.PaginatedOperationMethod<
   ListGroupPoliciesRequest,
   ListGroupPoliciesResponse,
   ListGroupPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyNameType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupPoliciesRequest,
@@ -11123,7 +11122,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -11154,7 +11153,7 @@ export const listGroupsForUser: API.PaginatedOperationMethod<
   ListGroupsForUserRequest,
   ListGroupsForUserResponse,
   ListGroupsForUserError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsForUserRequest,
@@ -11189,7 +11188,7 @@ export const listInstanceProfiles: API.PaginatedOperationMethod<
   ListInstanceProfilesRequest,
   ListInstanceProfilesResponse,
   ListInstanceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceProfile
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceProfilesRequest,
@@ -11223,7 +11222,7 @@ export const listInstanceProfilesForRole: API.PaginatedOperationMethod<
   ListInstanceProfilesForRoleRequest,
   ListInstanceProfilesForRoleResponse,
   ListInstanceProfilesForRoleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceProfile
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceProfilesForRoleRequest,
@@ -11253,7 +11252,7 @@ export const listInstanceProfileTags: API.PaginatedOperationMethod<
   ListInstanceProfileTagsRequest,
   ListInstanceProfileTagsResponse,
   ListInstanceProfileTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceProfileTagsRequest,
@@ -11287,7 +11286,7 @@ export const listMFADevices: API.PaginatedOperationMethod<
   ListMFADevicesRequest,
   ListMFADevicesResponse,
   ListMFADevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MFADevice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMFADevicesRequest,
@@ -11318,7 +11317,7 @@ export const listMFADeviceTags: API.PaginatedOperationMethod<
   ListMFADeviceTagsRequest,
   ListMFADeviceTagsResponse,
   ListMFADeviceTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMFADeviceTagsRequest,
@@ -11353,7 +11352,7 @@ export const listOpenIDConnectProviders: API.OperationMethod<
   ListOpenIDConnectProvidersRequest,
   ListOpenIDConnectProvidersResponse,
   ListOpenIDConnectProvidersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOpenIDConnectProvidersRequest,
   output: ListOpenIDConnectProvidersResponse,
@@ -11380,7 +11379,7 @@ export const listOpenIDConnectProviderTags: API.PaginatedOperationMethod<
   ListOpenIDConnectProviderTagsRequest,
   ListOpenIDConnectProviderTagsResponse,
   ListOpenIDConnectProviderTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpenIDConnectProviderTagsRequest,
@@ -11415,7 +11414,7 @@ export const listOrganizationsFeatures: API.OperationMethod<
   ListOrganizationsFeaturesRequest,
   ListOrganizationsFeaturesResponse,
   ListOrganizationsFeaturesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOrganizationsFeaturesRequest,
   output: ListOrganizationsFeaturesResponse,
@@ -11455,7 +11454,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -11516,7 +11515,7 @@ export const listPoliciesGrantingServiceAccess: API.OperationMethod<
   ListPoliciesGrantingServiceAccessRequest,
   ListPoliciesGrantingServiceAccessResponse,
   ListPoliciesGrantingServiceAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPoliciesGrantingServiceAccessRequest,
   output: ListPoliciesGrantingServiceAccessResponse,
@@ -11540,7 +11539,7 @@ export const listPolicyTags: API.PaginatedOperationMethod<
   ListPolicyTagsRequest,
   ListPolicyTagsResponse,
   ListPolicyTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyTagsRequest,
@@ -11577,7 +11576,7 @@ export const listPolicyVersions: API.PaginatedOperationMethod<
   ListPolicyVersionsRequest,
   ListPolicyVersionsResponse,
   ListPolicyVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyVersionsRequest,
@@ -11619,7 +11618,7 @@ export const listRolePolicies: API.PaginatedOperationMethod<
   ListRolePoliciesRequest,
   ListRolePoliciesResponse,
   ListRolePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyNameType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRolePoliciesRequest,
@@ -11660,7 +11659,7 @@ export const listRoles: API.PaginatedOperationMethod<
   ListRolesRequest,
   ListRolesResponse,
   ListRolesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Role
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRolesRequest,
@@ -11690,7 +11689,7 @@ export const listRoleTags: API.PaginatedOperationMethod<
   ListRoleTagsRequest,
   ListRoleTagsResponse,
   ListRoleTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoleTagsRequest,
@@ -11719,7 +11718,7 @@ export const listSAMLProviders: API.OperationMethod<
   ListSAMLProvidersRequest,
   ListSAMLProvidersResponse,
   ListSAMLProvidersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSAMLProvidersRequest,
   output: ListSAMLProvidersResponse,
@@ -11746,7 +11745,7 @@ export const listSAMLProviderTags: API.PaginatedOperationMethod<
   ListSAMLProviderTagsRequest,
   ListSAMLProviderTagsResponse,
   ListSAMLProviderTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSAMLProviderTagsRequest,
@@ -11790,7 +11789,7 @@ export const listServerCertificates: API.PaginatedOperationMethod<
   ListServerCertificatesRequest,
   ListServerCertificatesResponse,
   ListServerCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerCertificateMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServerCertificatesRequest,
@@ -11826,7 +11825,7 @@ export const listServerCertificateTags: API.PaginatedOperationMethod<
   ListServerCertificateTagsRequest,
   ListServerCertificateTagsResponse,
   ListServerCertificateTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServerCertificateTagsRequest,
@@ -11871,7 +11870,7 @@ export const listServiceSpecificCredentials: API.OperationMethod<
   ListServiceSpecificCredentialsRequest,
   ListServiceSpecificCredentialsResponse,
   ListServiceSpecificCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListServiceSpecificCredentialsRequest,
   output: ListServiceSpecificCredentialsResponse,
@@ -11908,7 +11907,7 @@ export const listSigningCertificates: API.PaginatedOperationMethod<
   ListSigningCertificatesRequest,
   ListSigningCertificatesResponse,
   ListSigningCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SigningCertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSigningCertificatesRequest,
@@ -11942,7 +11941,7 @@ export const listSSHPublicKeys: API.PaginatedOperationMethod<
   ListSSHPublicKeysRequest,
   ListSSHPublicKeysResponse,
   ListSSHPublicKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SSHPublicKeyMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSSHPublicKeysRequest,
@@ -11979,7 +11978,7 @@ export const listUserPolicies: API.PaginatedOperationMethod<
   ListUserPoliciesRequest,
   ListUserPoliciesResponse,
   ListUserPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyNameType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserPoliciesRequest,
@@ -12018,7 +12017,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -12047,7 +12046,7 @@ export const listUserTags: API.PaginatedOperationMethod<
   ListUserTagsRequest,
   ListUserTagsResponse,
   ListUserTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserTagsRequest,
@@ -12081,7 +12080,7 @@ export const listVirtualMFADevices: API.PaginatedOperationMethod<
   ListVirtualMFADevicesRequest,
   ListVirtualMFADevicesResponse,
   ListVirtualMFADevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VirtualMFADevice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVirtualMFADevicesRequest,
@@ -12130,7 +12129,7 @@ export const putGroupPolicy: API.OperationMethod<
   PutGroupPolicyRequest,
   PutGroupPolicyResponse,
   PutGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGroupPolicyRequest,
   output: PutGroupPolicyResponse,
@@ -12170,7 +12169,7 @@ export const putRolePermissionsBoundary: API.OperationMethod<
   PutRolePermissionsBoundaryRequest,
   PutRolePermissionsBoundaryResponse,
   PutRolePermissionsBoundaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRolePermissionsBoundaryRequest,
   output: PutRolePermissionsBoundaryResponse,
@@ -12230,7 +12229,7 @@ export const putRolePolicy: API.OperationMethod<
   PutRolePolicyRequest,
   PutRolePolicyResponse,
   PutRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRolePolicyRequest,
   output: PutRolePolicyResponse,
@@ -12268,7 +12267,7 @@ export const putUserPermissionsBoundary: API.OperationMethod<
   PutUserPermissionsBoundaryRequest,
   PutUserPermissionsBoundaryResponse,
   PutUserPermissionsBoundaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutUserPermissionsBoundaryRequest,
   output: PutUserPermissionsBoundaryResponse,
@@ -12315,7 +12314,7 @@ export const putUserPolicy: API.OperationMethod<
   PutUserPolicyRequest,
   PutUserPolicyResponse,
   PutUserPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutUserPolicyRequest,
   output: PutUserPolicyResponse,
@@ -12351,7 +12350,7 @@ export const rejectDelegationRequest: API.OperationMethod<
   RejectDelegationRequestRequest,
   RejectDelegationRequestResponse,
   RejectDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectDelegationRequestRequest,
   output: RejectDelegationRequestResponse,
@@ -12384,7 +12383,7 @@ export const removeClientIDFromOpenIDConnectProvider: API.OperationMethod<
   RemoveClientIDFromOpenIDConnectProviderRequest,
   RemoveClientIDFromOpenIDConnectProviderResponse,
   RemoveClientIDFromOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveClientIDFromOpenIDConnectProviderRequest,
   output: RemoveClientIDFromOpenIDConnectProviderResponse,
@@ -12422,7 +12421,7 @@ export const removeRoleFromInstanceProfile: API.OperationMethod<
   RemoveRoleFromInstanceProfileRequest,
   RemoveRoleFromInstanceProfileResponse,
   RemoveRoleFromInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRoleFromInstanceProfileRequest,
   output: RemoveRoleFromInstanceProfileResponse,
@@ -12449,7 +12448,7 @@ export const removeUserFromGroup: API.OperationMethod<
   RemoveUserFromGroupRequest,
   RemoveUserFromGroupResponse,
   RemoveUserFromGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveUserFromGroupRequest,
   output: RemoveUserFromGroupResponse,
@@ -12476,7 +12475,7 @@ export const resetServiceSpecificCredential: API.OperationMethod<
   ResetServiceSpecificCredentialRequest,
   ResetServiceSpecificCredentialResponse,
   ResetServiceSpecificCredentialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetServiceSpecificCredentialRequest,
   output: ResetServiceSpecificCredentialResponse,
@@ -12504,7 +12503,7 @@ export const resyncMFADevice: API.OperationMethod<
   ResyncMFADeviceRequest,
   ResyncMFADeviceResponse,
   ResyncMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResyncMFADeviceRequest,
   output: ResyncMFADeviceResponse,
@@ -12544,7 +12543,7 @@ export const sendDelegationToken: API.OperationMethod<
   SendDelegationTokenRequest,
   SendDelegationTokenResponse,
   SendDelegationTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDelegationTokenRequest,
   output: SendDelegationTokenResponse,
@@ -12579,7 +12578,7 @@ export const setDefaultPolicyVersion: API.OperationMethod<
   SetDefaultPolicyVersionRequest,
   SetDefaultPolicyVersionResponse,
   SetDefaultPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultPolicyVersionRequest,
   output: SetDefaultPolicyVersionResponse,
@@ -12625,7 +12624,7 @@ export const setSecurityTokenServicePreferences: API.OperationMethod<
   SetSecurityTokenServicePreferencesRequest,
   SetSecurityTokenServicePreferencesResponse,
   SetSecurityTokenServicePreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSecurityTokenServicePreferencesRequest,
   output: SetSecurityTokenServicePreferencesResponse,
@@ -12672,7 +12671,7 @@ export const simulateCustomPolicy: API.PaginatedOperationMethod<
   SimulateCustomPolicyRequest,
   SimulatePolicyResponse,
   SimulateCustomPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SimulateCustomPolicyRequest,
@@ -12736,7 +12735,7 @@ export const simulatePrincipalPolicy: API.PaginatedOperationMethod<
   SimulatePrincipalPolicyRequest,
   SimulatePolicyResponse,
   SimulatePrincipalPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EvaluationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SimulatePrincipalPolicyRequest,
@@ -12795,7 +12794,7 @@ export const tagInstanceProfile: API.OperationMethod<
   TagInstanceProfileRequest,
   TagInstanceProfileResponse,
   TagInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagInstanceProfileRequest,
   output: TagInstanceProfileResponse,
@@ -12850,7 +12849,7 @@ export const tagMFADevice: API.OperationMethod<
   TagMFADeviceRequest,
   TagMFADeviceResponse,
   TagMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagMFADeviceRequest,
   output: TagMFADeviceResponse,
@@ -12906,7 +12905,7 @@ export const tagOpenIDConnectProvider: API.OperationMethod<
   TagOpenIDConnectProviderRequest,
   TagOpenIDConnectProviderResponse,
   TagOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagOpenIDConnectProviderRequest,
   output: TagOpenIDConnectProviderResponse,
@@ -12960,7 +12959,7 @@ export const tagPolicy: API.OperationMethod<
   TagPolicyRequest,
   TagPolicyResponse,
   TagPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagPolicyRequest,
   output: TagPolicyResponse,
@@ -13022,7 +13021,7 @@ export const tagRole: API.OperationMethod<
   TagRoleRequest,
   TagRoleResponse,
   TagRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagRoleRequest,
   output: TagRoleResponse,
@@ -13078,7 +13077,7 @@ export const tagSAMLProvider: API.OperationMethod<
   TagSAMLProviderRequest,
   TagSAMLProviderResponse,
   TagSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagSAMLProviderRequest,
   output: TagSAMLProviderResponse,
@@ -13141,7 +13140,7 @@ export const tagServerCertificate: API.OperationMethod<
   TagServerCertificateRequest,
   TagServerCertificateResponse,
   TagServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagServerCertificateRequest,
   output: TagServerCertificateResponse,
@@ -13202,7 +13201,7 @@ export const tagUser: API.OperationMethod<
   TagUserRequest,
   TagUserResponse,
   TagUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagUserRequest,
   output: TagUserResponse,
@@ -13232,7 +13231,7 @@ export const untagInstanceProfile: API.OperationMethod<
   UntagInstanceProfileRequest,
   UntagInstanceProfileResponse,
   UntagInstanceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagInstanceProfileRequest,
   output: UntagInstanceProfileResponse,
@@ -13262,7 +13261,7 @@ export const untagMFADevice: API.OperationMethod<
   UntagMFADeviceRequest,
   UntagMFADeviceResponse,
   UntagMFADeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagMFADeviceRequest,
   output: UntagMFADeviceResponse,
@@ -13293,7 +13292,7 @@ export const untagOpenIDConnectProvider: API.OperationMethod<
   UntagOpenIDConnectProviderRequest,
   UntagOpenIDConnectProviderResponse,
   UntagOpenIDConnectProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagOpenIDConnectProviderRequest,
   output: UntagOpenIDConnectProviderResponse,
@@ -13322,7 +13321,7 @@ export const untagPolicy: API.OperationMethod<
   UntagPolicyRequest,
   UntagPolicyResponse,
   UntagPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagPolicyRequest,
   output: UntagPolicyResponse,
@@ -13350,7 +13349,7 @@ export const untagRole: API.OperationMethod<
   UntagRoleRequest,
   UntagRoleResponse,
   UntagRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagRoleRequest,
   output: UntagRoleResponse,
@@ -13380,7 +13379,7 @@ export const untagSAMLProvider: API.OperationMethod<
   UntagSAMLProviderRequest,
   UntagSAMLProviderResponse,
   UntagSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagSAMLProviderRequest,
   output: UntagSAMLProviderResponse,
@@ -13416,7 +13415,7 @@ export const untagServerCertificate: API.OperationMethod<
   UntagServerCertificateRequest,
   UntagServerCertificateResponse,
   UntagServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagServerCertificateRequest,
   output: UntagServerCertificateResponse,
@@ -13444,7 +13443,7 @@ export const untagUser: API.OperationMethod<
   UntagUserRequest,
   UntagUserResponse,
   UntagUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagUserRequest,
   output: UntagUserResponse,
@@ -13483,7 +13482,7 @@ export const updateAccessKey: API.OperationMethod<
   UpdateAccessKeyRequest,
   UpdateAccessKeyResponse,
   UpdateAccessKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessKeyRequest,
   output: UpdateAccessKeyResponse,
@@ -13521,7 +13520,7 @@ export const updateAccountPasswordPolicy: API.OperationMethod<
   UpdateAccountPasswordPolicyRequest,
   UpdateAccountPasswordPolicyResponse,
   UpdateAccountPasswordPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountPasswordPolicyRequest,
   output: UpdateAccountPasswordPolicyResponse,
@@ -13553,7 +13552,7 @@ export const updateAssumeRolePolicy: API.OperationMethod<
   UpdateAssumeRolePolicyRequest,
   UpdateAssumeRolePolicyResponse,
   UpdateAssumeRolePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssumeRolePolicyRequest,
   output: UpdateAssumeRolePolicyResponse,
@@ -13588,7 +13587,7 @@ export const updateDelegationRequest: API.OperationMethod<
   UpdateDelegationRequestRequest,
   UpdateDelegationRequestResponse,
   UpdateDelegationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDelegationRequestRequest,
   output: UpdateDelegationRequestResponse,
@@ -13627,7 +13626,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -13663,7 +13662,7 @@ export const updateLoginProfile: API.OperationMethod<
   UpdateLoginProfileRequest,
   UpdateLoginProfileResponse,
   UpdateLoginProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoginProfileRequest,
   output: UpdateLoginProfileResponse,
@@ -13713,7 +13712,7 @@ export const updateOpenIDConnectProviderThumbprint: API.OperationMethod<
   UpdateOpenIDConnectProviderThumbprintRequest,
   UpdateOpenIDConnectProviderThumbprintResponse,
   UpdateOpenIDConnectProviderThumbprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOpenIDConnectProviderThumbprintRequest,
   output: UpdateOpenIDConnectProviderThumbprintResponse,
@@ -13740,7 +13739,7 @@ export const updateRole: API.OperationMethod<
   UpdateRoleRequest,
   UpdateRoleResponse,
   UpdateRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoleRequest,
   output: UpdateRoleResponse,
@@ -13769,7 +13768,7 @@ export const updateRoleDescription: API.OperationMethod<
   UpdateRoleDescriptionRequest,
   UpdateRoleDescriptionResponse,
   UpdateRoleDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoleDescriptionRequest,
   output: UpdateRoleDescriptionResponse,
@@ -13799,7 +13798,7 @@ export const updateSAMLProvider: API.OperationMethod<
   UpdateSAMLProviderRequest,
   UpdateSAMLProviderResponse,
   UpdateSAMLProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSAMLProviderRequest,
   output: UpdateSAMLProviderResponse,
@@ -13846,7 +13845,7 @@ export const updateServerCertificate: API.OperationMethod<
   UpdateServerCertificateRequest,
   UpdateServerCertificateResponse,
   UpdateServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServerCertificateRequest,
   output: UpdateServerCertificateResponse,
@@ -13874,7 +13873,7 @@ export const updateServiceSpecificCredential: API.OperationMethod<
   UpdateServiceSpecificCredentialRequest,
   UpdateServiceSpecificCredentialResponse,
   UpdateServiceSpecificCredentialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSpecificCredentialRequest,
   output: UpdateServiceSpecificCredentialResponse,
@@ -13905,7 +13904,7 @@ export const updateSigningCertificate: API.OperationMethod<
   UpdateSigningCertificateRequest,
   UpdateSigningCertificateResponse,
   UpdateSigningCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSigningCertificateRequest,
   output: UpdateSigningCertificateResponse,
@@ -13938,7 +13937,7 @@ export const updateSSHPublicKey: API.OperationMethod<
   UpdateSSHPublicKeyRequest,
   UpdateSSHPublicKeyResponse,
   UpdateSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSSHPublicKeyRequest,
   output: UpdateSSHPublicKeyResponse,
@@ -13973,7 +13972,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,
@@ -14031,7 +14030,7 @@ export const uploadServerCertificate: API.OperationMethod<
   UploadServerCertificateRequest,
   UploadServerCertificateResponse,
   UploadServerCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadServerCertificateRequest,
   output: UploadServerCertificateResponse,
@@ -14086,7 +14085,7 @@ export const uploadSigningCertificate: API.OperationMethod<
   UploadSigningCertificateRequest,
   UploadSigningCertificateResponse,
   UploadSigningCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadSigningCertificateRequest,
   output: UploadSigningCertificateResponse,
@@ -14124,7 +14123,7 @@ export const uploadSSHPublicKey: API.OperationMethod<
   UploadSSHPublicKeyRequest,
   UploadSSHPublicKeyResponse,
   UploadSSHPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadSSHPublicKeyRequest,
   output: UploadSSHPublicKeyResponse,

--- a/packages/aws/src/services/identitystore.ts
+++ b/packages/aws/src/services/identitystore.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "identitystore",
@@ -1052,7 +1051,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -1080,7 +1079,7 @@ export const createGroupMembership: API.OperationMethod<
   CreateGroupMembershipRequest,
   CreateGroupMembershipResponse,
   CreateGroupMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupMembershipRequest,
   output: CreateGroupMembershipResponse,
@@ -1108,7 +1107,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -1135,7 +1134,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -1157,7 +1156,7 @@ export const deleteGroupMembership: API.OperationMethod<
   DeleteGroupMembershipRequest,
   DeleteGroupMembershipResponse,
   DeleteGroupMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupMembershipRequest,
   output: DeleteGroupMembershipResponse,
@@ -1179,7 +1178,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -1202,7 +1201,7 @@ export const describeGroup: API.OperationMethod<
   DescribeGroupRequest,
   DescribeGroupResponse,
   DescribeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupRequest,
   output: DescribeGroupResponse,
@@ -1225,7 +1224,7 @@ export const describeGroupMembership: API.OperationMethod<
   DescribeGroupMembershipRequest,
   DescribeGroupMembershipResponse,
   DescribeGroupMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupMembershipRequest,
   output: DescribeGroupMembershipResponse,
@@ -1248,7 +1247,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -1271,7 +1270,7 @@ export const getGroupId: API.OperationMethod<
   GetGroupIdRequest,
   GetGroupIdResponse,
   GetGroupIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupIdRequest,
   output: GetGroupIdResponse,
@@ -1294,7 +1293,7 @@ export const getGroupMembershipId: API.OperationMethod<
   GetGroupMembershipIdRequest,
   GetGroupMembershipIdResponse,
   GetGroupMembershipIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupMembershipIdRequest,
   output: GetGroupMembershipIdResponse,
@@ -1317,7 +1316,7 @@ export const getUserId: API.OperationMethod<
   GetUserIdRequest,
   GetUserIdResponse,
   GetUserIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserIdRequest,
   output: GetUserIdResponse,
@@ -1340,7 +1339,7 @@ export const isMemberInGroups: API.OperationMethod<
   IsMemberInGroupsRequest,
   IsMemberInGroupsResponse,
   IsMemberInGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IsMemberInGroupsRequest,
   output: IsMemberInGroupsResponse,
@@ -1363,7 +1362,7 @@ export const listGroupMemberships: API.PaginatedOperationMethod<
   ListGroupMembershipsRequest,
   ListGroupMembershipsResponse,
   ListGroupMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupMembership
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupMembershipsRequest,
@@ -1393,7 +1392,7 @@ export const listGroupMembershipsForMember: API.PaginatedOperationMethod<
   ListGroupMembershipsForMemberRequest,
   ListGroupMembershipsForMemberResponse,
   ListGroupMembershipsForMemberError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupMembership
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupMembershipsForMemberRequest,
@@ -1423,7 +1422,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -1453,7 +1452,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -1483,7 +1482,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -1511,7 +1510,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/imagebuilder.ts
+++ b/packages/aws/src/services/imagebuilder.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "imagebuilder",
   serviceShapeName: "imagebuilder",
@@ -5581,7 +5580,7 @@ export const cancelImageCreation: API.OperationMethod<
   CancelImageCreationRequest,
   CancelImageCreationResponse,
   CancelImageCreationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelImageCreationRequest,
   output: CancelImageCreationResponse,
@@ -5618,7 +5617,7 @@ export const cancelLifecycleExecution: API.OperationMethod<
   CancelLifecycleExecutionRequest,
   CancelLifecycleExecutionResponse,
   CancelLifecycleExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelLifecycleExecutionRequest,
   output: CancelLifecycleExecutionResponse,
@@ -5665,7 +5664,7 @@ export const createComponent: API.OperationMethod<
   CreateComponentRequest,
   CreateComponentResponse,
   CreateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentRequest,
   output: CreateComponentResponse,
@@ -5709,7 +5708,7 @@ export const createContainerRecipe: API.OperationMethod<
   CreateContainerRecipeRequest,
   CreateContainerRecipeResponse,
   CreateContainerRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerRecipeRequest,
   output: CreateContainerRecipeResponse,
@@ -5752,7 +5751,7 @@ export const createDistributionConfiguration: API.OperationMethod<
   CreateDistributionConfigurationRequest,
   CreateDistributionConfigurationResponse,
   CreateDistributionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDistributionConfigurationRequest,
   output: CreateDistributionConfigurationResponse,
@@ -5795,7 +5794,7 @@ export const createImage: API.OperationMethod<
   CreateImageRequest,
   CreateImageResponse,
   CreateImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageRequest,
   output: CreateImageResponse,
@@ -5835,7 +5834,7 @@ export const createImagePipeline: API.OperationMethod<
   CreateImagePipelineRequest,
   CreateImagePipelineResponse,
   CreateImagePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImagePipelineRequest,
   output: CreateImagePipelineResponse,
@@ -5877,7 +5876,7 @@ export const createImageRecipe: API.OperationMethod<
   CreateImageRecipeRequest,
   CreateImageRecipeResponse,
   CreateImageRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageRecipeRequest,
   output: CreateImageRecipeResponse,
@@ -5920,7 +5919,7 @@ export const createInfrastructureConfiguration: API.OperationMethod<
   CreateInfrastructureConfigurationRequest,
   CreateInfrastructureConfigurationResponse,
   CreateInfrastructureConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInfrastructureConfigurationRequest,
   output: CreateInfrastructureConfigurationResponse,
@@ -5961,7 +5960,7 @@ export const createLifecyclePolicy: API.OperationMethod<
   CreateLifecyclePolicyRequest,
   CreateLifecyclePolicyResponse,
   CreateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLifecyclePolicyRequest,
   output: CreateLifecyclePolicyResponse,
@@ -6003,7 +6002,7 @@ export const createWorkflow: API.OperationMethod<
   CreateWorkflowRequest,
   CreateWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRequest,
   output: CreateWorkflowResponse,
@@ -6043,7 +6042,7 @@ export const deleteComponent: API.OperationMethod<
   DeleteComponentRequest,
   DeleteComponentResponse,
   DeleteComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentRequest,
   output: DeleteComponentResponse,
@@ -6078,7 +6077,7 @@ export const deleteContainerRecipe: API.OperationMethod<
   DeleteContainerRecipeRequest,
   DeleteContainerRecipeResponse,
   DeleteContainerRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerRecipeRequest,
   output: DeleteContainerRecipeResponse,
@@ -6113,7 +6112,7 @@ export const deleteDistributionConfiguration: API.OperationMethod<
   DeleteDistributionConfigurationRequest,
   DeleteDistributionConfigurationResponse,
   DeleteDistributionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDistributionConfigurationRequest,
   output: DeleteDistributionConfigurationResponse,
@@ -6165,7 +6164,7 @@ export const deleteImage: API.OperationMethod<
   DeleteImageRequest,
   DeleteImageResponse,
   DeleteImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageRequest,
   output: DeleteImageResponse,
@@ -6201,7 +6200,7 @@ export const deleteImagePipeline: API.OperationMethod<
   DeleteImagePipelineRequest,
   DeleteImagePipelineResponse,
   DeleteImagePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImagePipelineRequest,
   output: DeleteImagePipelineResponse,
@@ -6237,7 +6236,7 @@ export const deleteImageRecipe: API.OperationMethod<
   DeleteImageRecipeRequest,
   DeleteImageRecipeResponse,
   DeleteImageRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageRecipeRequest,
   output: DeleteImageRecipeResponse,
@@ -6273,7 +6272,7 @@ export const deleteInfrastructureConfiguration: API.OperationMethod<
   DeleteInfrastructureConfigurationRequest,
   DeleteInfrastructureConfigurationResponse,
   DeleteInfrastructureConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInfrastructureConfigurationRequest,
   output: DeleteInfrastructureConfigurationResponse,
@@ -6308,7 +6307,7 @@ export const deleteLifecyclePolicy: API.OperationMethod<
   DeleteLifecyclePolicyRequest,
   DeleteLifecyclePolicyResponse,
   DeleteLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecyclePolicyRequest,
   output: DeleteLifecyclePolicyResponse,
@@ -6342,7 +6341,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -6383,7 +6382,7 @@ export const distributeImage: API.OperationMethod<
   DistributeImageRequest,
   DistributeImageResponse,
   DistributeImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DistributeImageRequest,
   output: DistributeImageResponse,
@@ -6422,7 +6421,7 @@ export const getComponent: API.OperationMethod<
   GetComponentRequest,
   GetComponentResponse,
   GetComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentRequest,
   output: GetComponentResponse,
@@ -6455,7 +6454,7 @@ export const getComponentPolicy: API.OperationMethod<
   GetComponentPolicyRequest,
   GetComponentPolicyResponse,
   GetComponentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentPolicyRequest,
   output: GetComponentPolicyResponse,
@@ -6487,7 +6486,7 @@ export const getContainerRecipe: API.OperationMethod<
   GetContainerRecipeRequest,
   GetContainerRecipeResponse,
   GetContainerRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerRecipeRequest,
   output: GetContainerRecipeResponse,
@@ -6519,7 +6518,7 @@ export const getContainerRecipePolicy: API.OperationMethod<
   GetContainerRecipePolicyRequest,
   GetContainerRecipePolicyResponse,
   GetContainerRecipePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerRecipePolicyRequest,
   output: GetContainerRecipePolicyResponse,
@@ -6552,7 +6551,7 @@ export const getDistributionConfiguration: API.OperationMethod<
   GetDistributionConfigurationRequest,
   GetDistributionConfigurationResponse,
   GetDistributionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionConfigurationRequest,
   output: GetDistributionConfigurationResponse,
@@ -6586,7 +6585,7 @@ export const getImage: API.OperationMethod<
   GetImageRequest,
   GetImageResponse,
   GetImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageRequest,
   output: GetImageResponse,
@@ -6620,7 +6619,7 @@ export const getImagePipeline: API.OperationMethod<
   GetImagePipelineRequest,
   GetImagePipelineResponse,
   GetImagePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImagePipelineRequest,
   output: GetImagePipelineResponse,
@@ -6653,7 +6652,7 @@ export const getImagePolicy: API.OperationMethod<
   GetImagePolicyRequest,
   GetImagePolicyResponse,
   GetImagePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImagePolicyRequest,
   output: GetImagePolicyResponse,
@@ -6686,7 +6685,7 @@ export const getImageRecipe: API.OperationMethod<
   GetImageRecipeRequest,
   GetImageRecipeResponse,
   GetImageRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageRecipeRequest,
   output: GetImageRecipeResponse,
@@ -6719,7 +6718,7 @@ export const getImageRecipePolicy: API.OperationMethod<
   GetImageRecipePolicyRequest,
   GetImageRecipePolicyResponse,
   GetImageRecipePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageRecipePolicyRequest,
   output: GetImageRecipePolicyResponse,
@@ -6752,7 +6751,7 @@ export const getInfrastructureConfiguration: API.OperationMethod<
   GetInfrastructureConfigurationRequest,
   GetInfrastructureConfigurationResponse,
   GetInfrastructureConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInfrastructureConfigurationRequest,
   output: GetInfrastructureConfigurationResponse,
@@ -6785,7 +6784,7 @@ export const getLifecycleExecution: API.OperationMethod<
   GetLifecycleExecutionRequest,
   GetLifecycleExecutionResponse,
   GetLifecycleExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecycleExecutionRequest,
   output: GetLifecycleExecutionResponse,
@@ -6817,7 +6816,7 @@ export const getLifecyclePolicy: API.OperationMethod<
   GetLifecyclePolicyRequest,
   GetLifecyclePolicyResponse,
   GetLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecyclePolicyRequest,
   output: GetLifecyclePolicyResponse,
@@ -6851,7 +6850,7 @@ export const getMarketplaceResource: API.OperationMethod<
   GetMarketplaceResourceRequest,
   GetMarketplaceResourceResponse,
   GetMarketplaceResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMarketplaceResourceRequest,
   output: GetMarketplaceResourceResponse,
@@ -6883,7 +6882,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -6916,7 +6915,7 @@ export const getWorkflowExecution: API.OperationMethod<
   GetWorkflowExecutionRequest,
   GetWorkflowExecutionResponse,
   GetWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowExecutionRequest,
   output: GetWorkflowExecutionResponse,
@@ -6949,7 +6948,7 @@ export const getWorkflowStepExecution: API.OperationMethod<
   GetWorkflowStepExecutionRequest,
   GetWorkflowStepExecutionResponse,
   GetWorkflowStepExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowStepExecutionRequest,
   output: GetWorkflowStepExecutionResponse,
@@ -6985,7 +6984,7 @@ export const importComponent: API.OperationMethod<
   ImportComponentRequest,
   ImportComponentResponse,
   ImportComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportComponentRequest,
   output: ImportComponentResponse,
@@ -7023,7 +7022,7 @@ export const importDiskImage: API.OperationMethod<
   ImportDiskImageRequest,
   ImportDiskImageResponse,
   ImportDiskImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportDiskImageRequest,
   output: ImportDiskImageResponse,
@@ -7058,7 +7057,7 @@ export const importVmImage: API.OperationMethod<
   ImportVmImageRequest,
   ImportVmImageResponse,
   ImportVmImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportVmImageRequest,
   output: ImportVmImageResponse,
@@ -7086,7 +7085,7 @@ export const listComponentBuildVersions: API.PaginatedOperationMethod<
   ListComponentBuildVersionsRequest,
   ListComponentBuildVersionsResponse,
   ListComponentBuildVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentBuildVersionsRequest,
@@ -7138,7 +7137,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsRequest,
   ListComponentsResponse,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsRequest,
@@ -7179,7 +7178,7 @@ export const listContainerRecipes: API.PaginatedOperationMethod<
   ListContainerRecipesRequest,
   ListContainerRecipesResponse,
   ListContainerRecipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContainerRecipeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainerRecipesRequest,
@@ -7220,7 +7219,7 @@ export const listDistributionConfigurations: API.PaginatedOperationMethod<
   ListDistributionConfigurationsRequest,
   ListDistributionConfigurationsResponse,
   ListDistributionConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DistributionConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDistributionConfigurationsRequest,
@@ -7261,7 +7260,7 @@ export const listImageBuildVersions: API.PaginatedOperationMethod<
   ListImageBuildVersionsRequest,
   ListImageBuildVersionsResponse,
   ListImageBuildVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageBuildVersionsRequest,
@@ -7304,7 +7303,7 @@ export const listImagePackages: API.PaginatedOperationMethod<
   ListImagePackagesRequest,
   ListImagePackagesResponse,
   ListImagePackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImagePackage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagePackagesRequest,
@@ -7347,7 +7346,7 @@ export const listImagePipelineImages: API.PaginatedOperationMethod<
   ListImagePipelineImagesRequest,
   ListImagePipelineImagesResponse,
   ListImagePipelineImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagePipelineImagesRequest,
@@ -7389,7 +7388,7 @@ export const listImagePipelines: API.PaginatedOperationMethod<
   ListImagePipelinesRequest,
   ListImagePipelinesResponse,
   ListImagePipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImagePipeline
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagePipelinesRequest,
@@ -7430,7 +7429,7 @@ export const listImageRecipes: API.PaginatedOperationMethod<
   ListImageRecipesRequest,
   ListImageRecipesResponse,
   ListImageRecipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageRecipeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageRecipesRequest,
@@ -7472,7 +7471,7 @@ export const listImages: API.PaginatedOperationMethod<
   ListImagesRequest,
   ListImagesResponse,
   ListImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagesRequest,
@@ -7527,7 +7526,7 @@ export const listImageScanFindingAggregations: API.PaginatedOperationMethod<
   ListImageScanFindingAggregationsRequest,
   ListImageScanFindingAggregationsResponse,
   ListImageScanFindingAggregationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageScanFindingAggregation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageScanFindingAggregationsRequest,
@@ -7567,7 +7566,7 @@ export const listImageScanFindings: API.PaginatedOperationMethod<
   ListImageScanFindingsRequest,
   ListImageScanFindingsResponse,
   ListImageScanFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageScanFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageScanFindingsRequest,
@@ -7608,7 +7607,7 @@ export const listInfrastructureConfigurations: API.PaginatedOperationMethod<
   ListInfrastructureConfigurationsRequest,
   ListInfrastructureConfigurationsResponse,
   ListInfrastructureConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InfrastructureConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInfrastructureConfigurationsRequest,
@@ -7649,7 +7648,7 @@ export const listLifecycleExecutionResources: API.PaginatedOperationMethod<
   ListLifecycleExecutionResourcesRequest,
   ListLifecycleExecutionResourcesResponse,
   ListLifecycleExecutionResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LifecycleExecutionResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLifecycleExecutionResourcesRequest,
@@ -7690,7 +7689,7 @@ export const listLifecycleExecutions: API.PaginatedOperationMethod<
   ListLifecycleExecutionsRequest,
   ListLifecycleExecutionsResponse,
   ListLifecycleExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LifecycleExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLifecycleExecutionsRequest,
@@ -7731,7 +7730,7 @@ export const listLifecyclePolicies: API.PaginatedOperationMethod<
   ListLifecyclePoliciesRequest,
   ListLifecyclePoliciesResponse,
   ListLifecyclePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LifecyclePolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLifecyclePoliciesRequest,
@@ -7768,7 +7767,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -7799,7 +7798,7 @@ export const listWaitingWorkflowSteps: API.PaginatedOperationMethod<
   ListWaitingWorkflowStepsRequest,
   ListWaitingWorkflowStepsResponse,
   ListWaitingWorkflowStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowStepExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWaitingWorkflowStepsRequest,
@@ -7840,7 +7839,7 @@ export const listWorkflowBuildVersions: API.PaginatedOperationMethod<
   ListWorkflowBuildVersionsRequest,
   ListWorkflowBuildVersionsResponse,
   ListWorkflowBuildVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowBuildVersionsRequest,
@@ -7882,7 +7881,7 @@ export const listWorkflowExecutions: API.PaginatedOperationMethod<
   ListWorkflowExecutionsRequest,
   ListWorkflowExecutionsResponse,
   ListWorkflowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowExecutionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowExecutionsRequest,
@@ -7923,7 +7922,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -7965,7 +7964,7 @@ export const listWorkflowStepExecutions: API.PaginatedOperationMethod<
   ListWorkflowStepExecutionsRequest,
   ListWorkflowStepExecutionsResponse,
   ListWorkflowStepExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowStepMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowStepExecutionsRequest,
@@ -8009,7 +8008,7 @@ export const putComponentPolicy: API.OperationMethod<
   PutComponentPolicyRequest,
   PutComponentPolicyResponse,
   PutComponentPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutComponentPolicyRequest,
   output: PutComponentPolicyResponse,
@@ -8052,7 +8051,7 @@ export const putContainerRecipePolicy: API.OperationMethod<
   PutContainerRecipePolicyRequest,
   PutContainerRecipePolicyResponse,
   PutContainerRecipePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutContainerRecipePolicyRequest,
   output: PutContainerRecipePolicyResponse,
@@ -8090,7 +8089,7 @@ export const putImagePolicy: API.OperationMethod<
   PutImagePolicyRequest,
   PutImagePolicyResponse,
   PutImagePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImagePolicyRequest,
   output: PutImagePolicyResponse,
@@ -8128,7 +8127,7 @@ export const putImageRecipePolicy: API.OperationMethod<
   PutImageRecipePolicyRequest,
   PutImageRecipePolicyResponse,
   PutImageRecipePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutImageRecipePolicyRequest,
   output: PutImageRecipePolicyResponse,
@@ -8164,7 +8163,7 @@ export const retryImage: API.OperationMethod<
   RetryImageRequest,
   RetryImageResponse,
   RetryImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryImageRequest,
   output: RetryImageResponse,
@@ -8203,7 +8202,7 @@ export const sendWorkflowStepAction: API.OperationMethod<
   SendWorkflowStepActionRequest,
   SendWorkflowStepActionResponse,
   SendWorkflowStepActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendWorkflowStepActionRequest,
   output: SendWorkflowStepActionResponse,
@@ -8242,7 +8241,7 @@ export const startImagePipelineExecution: API.OperationMethod<
   StartImagePipelineExecutionRequest,
   StartImagePipelineExecutionResponse,
   StartImagePipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImagePipelineExecutionRequest,
   output: StartImagePipelineExecutionResponse,
@@ -8281,7 +8280,7 @@ export const startResourceStateUpdate: API.OperationMethod<
   StartResourceStateUpdateRequest,
   StartResourceStateUpdateResponse,
   StartResourceStateUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceStateUpdateRequest,
   output: StartResourceStateUpdateResponse,
@@ -8313,7 +8312,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8339,7 +8338,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8373,7 +8372,7 @@ export const updateDistributionConfiguration: API.OperationMethod<
   UpdateDistributionConfigurationRequest,
   UpdateDistributionConfigurationResponse,
   UpdateDistributionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionConfigurationRequest,
   output: UpdateDistributionConfigurationResponse,
@@ -8418,7 +8417,7 @@ export const updateImagePipeline: API.OperationMethod<
   UpdateImagePipelineRequest,
   UpdateImagePipelineResponse,
   UpdateImagePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImagePipelineRequest,
   output: UpdateImagePipelineResponse,
@@ -8458,7 +8457,7 @@ export const updateInfrastructureConfiguration: API.OperationMethod<
   UpdateInfrastructureConfigurationRequest,
   UpdateInfrastructureConfigurationResponse,
   UpdateInfrastructureConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInfrastructureConfigurationRequest,
   output: UpdateInfrastructureConfigurationResponse,
@@ -8497,7 +8496,7 @@ export const updateLifecyclePolicy: API.OperationMethod<
   UpdateLifecyclePolicyRequest,
   UpdateLifecyclePolicyResponse,
   UpdateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLifecyclePolicyRequest,
   output: UpdateLifecyclePolicyResponse,

--- a/packages/aws/src/services/inspector-scan.ts
+++ b/packages/aws/src/services/inspector-scan.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Inspector Scan",
   serviceShapeName: "InspectorScan",
@@ -204,7 +203,7 @@ export const scanSbom: API.OperationMethod<
   ScanSbomRequest,
   ScanSbomResponse,
   ScanSbomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScanSbomRequest,
   output: ScanSbomResponse,

--- a/packages/aws/src/services/inspector.ts
+++ b/packages/aws/src/services/inspector.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Inspector",
   serviceShapeName: "InspectorService",
@@ -1917,7 +1916,7 @@ export const addAttributesToFindings: API.OperationMethod<
   AddAttributesToFindingsRequest,
   AddAttributesToFindingsResponse,
   AddAttributesToFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddAttributesToFindingsRequest,
   output: AddAttributesToFindingsResponse,
@@ -1956,7 +1955,7 @@ export const createAssessmentTarget: API.OperationMethod<
   CreateAssessmentTargetRequest,
   CreateAssessmentTargetResponse,
   CreateAssessmentTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssessmentTargetRequest,
   output: CreateAssessmentTargetResponse,
@@ -1992,7 +1991,7 @@ export const createAssessmentTemplate: API.OperationMethod<
   CreateAssessmentTemplateRequest,
   CreateAssessmentTemplateResponse,
   CreateAssessmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssessmentTemplateRequest,
   output: CreateAssessmentTemplateResponse,
@@ -2026,7 +2025,7 @@ export const createExclusionsPreview: API.OperationMethod<
   CreateExclusionsPreviewRequest,
   CreateExclusionsPreviewResponse,
   CreateExclusionsPreviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExclusionsPreviewRequest,
   output: CreateExclusionsPreviewResponse,
@@ -2060,7 +2059,7 @@ export const createResourceGroup: API.OperationMethod<
   CreateResourceGroupRequest,
   CreateResourceGroupResponse,
   CreateResourceGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceGroupRequest,
   output: CreateResourceGroupResponse,
@@ -2092,7 +2091,7 @@ export const deleteAssessmentRun: API.OperationMethod<
   DeleteAssessmentRunRequest,
   DeleteAssessmentRunResponse,
   DeleteAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentRunRequest,
   output: DeleteAssessmentRunResponse,
@@ -2125,7 +2124,7 @@ export const deleteAssessmentTarget: API.OperationMethod<
   DeleteAssessmentTargetRequest,
   DeleteAssessmentTargetResponse,
   DeleteAssessmentTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentTargetRequest,
   output: DeleteAssessmentTargetResponse,
@@ -2158,7 +2157,7 @@ export const deleteAssessmentTemplate: API.OperationMethod<
   DeleteAssessmentTemplateRequest,
   DeleteAssessmentTemplateResponse,
   DeleteAssessmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssessmentTemplateRequest,
   output: DeleteAssessmentTemplateResponse,
@@ -2187,7 +2186,7 @@ export const describeAssessmentRuns: API.OperationMethod<
   DescribeAssessmentRunsRequest,
   DescribeAssessmentRunsResponse,
   DescribeAssessmentRunsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssessmentRunsRequest,
   output: DescribeAssessmentRunsResponse,
@@ -2209,7 +2208,7 @@ export const describeAssessmentTargets: API.OperationMethod<
   DescribeAssessmentTargetsRequest,
   DescribeAssessmentTargetsResponse,
   DescribeAssessmentTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssessmentTargetsRequest,
   output: DescribeAssessmentTargetsResponse,
@@ -2231,7 +2230,7 @@ export const describeAssessmentTemplates: API.OperationMethod<
   DescribeAssessmentTemplatesRequest,
   DescribeAssessmentTemplatesResponse,
   DescribeAssessmentTemplatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssessmentTemplatesRequest,
   output: DescribeAssessmentTemplatesResponse,
@@ -2252,7 +2251,7 @@ export const describeCrossAccountAccessRole: API.OperationMethod<
   DescribeCrossAccountAccessRoleRequest,
   DescribeCrossAccountAccessRoleResponse,
   DescribeCrossAccountAccessRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCrossAccountAccessRoleRequest,
   output: DescribeCrossAccountAccessRoleResponse,
@@ -2273,7 +2272,7 @@ export const describeExclusions: API.OperationMethod<
   DescribeExclusionsRequest,
   DescribeExclusionsResponse,
   DescribeExclusionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExclusionsRequest,
   output: DescribeExclusionsResponse,
@@ -2294,7 +2293,7 @@ export const describeFindings: API.OperationMethod<
   DescribeFindingsRequest,
   DescribeFindingsResponse,
   DescribeFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFindingsRequest,
   output: DescribeFindingsResponse,
@@ -2316,7 +2315,7 @@ export const describeResourceGroups: API.OperationMethod<
   DescribeResourceGroupsRequest,
   DescribeResourceGroupsResponse,
   DescribeResourceGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceGroupsRequest,
   output: DescribeResourceGroupsResponse,
@@ -2338,7 +2337,7 @@ export const describeRulesPackages: API.OperationMethod<
   DescribeRulesPackagesRequest,
   DescribeRulesPackagesResponse,
   DescribeRulesPackagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRulesPackagesRequest,
   output: DescribeRulesPackagesResponse,
@@ -2365,7 +2364,7 @@ export const getAssessmentReport: API.OperationMethod<
   GetAssessmentReportRequest,
   GetAssessmentReportResponse,
   GetAssessmentReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssessmentReportRequest,
   output: GetAssessmentReportResponse,
@@ -2398,7 +2397,7 @@ export const getExclusionsPreview: API.PaginatedOperationMethod<
   GetExclusionsPreviewRequest,
   GetExclusionsPreviewResponse,
   GetExclusionsPreviewError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetExclusionsPreviewRequest,
@@ -2433,7 +2432,7 @@ export const getTelemetryMetadata: API.OperationMethod<
   GetTelemetryMetadataRequest,
   GetTelemetryMetadataResponse,
   GetTelemetryMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryMetadataRequest,
   output: GetTelemetryMetadataResponse,
@@ -2462,7 +2461,7 @@ export const listAssessmentRunAgents: API.PaginatedOperationMethod<
   ListAssessmentRunAgentsRequest,
   ListAssessmentRunAgentsResponse,
   ListAssessmentRunAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentRunAgentsRequest,
@@ -2497,7 +2496,7 @@ export const listAssessmentRuns: API.PaginatedOperationMethod<
   ListAssessmentRunsRequest,
   ListAssessmentRunsResponse,
   ListAssessmentRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentRunsRequest,
@@ -2532,7 +2531,7 @@ export const listAssessmentTargets: API.PaginatedOperationMethod<
   ListAssessmentTargetsRequest,
   ListAssessmentTargetsResponse,
   ListAssessmentTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentTargetsRequest,
@@ -2562,7 +2561,7 @@ export const listAssessmentTemplates: API.PaginatedOperationMethod<
   ListAssessmentTemplatesRequest,
   ListAssessmentTemplatesResponse,
   ListAssessmentTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssessmentTemplatesRequest,
@@ -2597,7 +2596,7 @@ export const listEventSubscriptions: API.PaginatedOperationMethod<
   ListEventSubscriptionsRequest,
   ListEventSubscriptionsResponse,
   ListEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventSubscriptionsRequest,
@@ -2631,7 +2630,7 @@ export const listExclusions: API.PaginatedOperationMethod<
   ListExclusionsRequest,
   ListExclusionsResponse,
   ListExclusionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExclusionsRequest,
@@ -2666,7 +2665,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsRequest,
   ListFindingsResponse,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsRequest,
@@ -2699,7 +2698,7 @@ export const listRulesPackages: API.PaginatedOperationMethod<
   ListRulesPackagesRequest,
   ListRulesPackagesResponse,
   ListRulesPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesPackagesRequest,
@@ -2728,7 +2727,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2758,7 +2757,7 @@ export const previewAgents: API.PaginatedOperationMethod<
   PreviewAgentsRequest,
   PreviewAgentsResponse,
   PreviewAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: PreviewAgentsRequest,
@@ -2795,7 +2794,7 @@ export const registerCrossAccountAccessRole: API.OperationMethod<
   RegisterCrossAccountAccessRoleRequest,
   RegisterCrossAccountAccessRoleResponse,
   RegisterCrossAccountAccessRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCrossAccountAccessRoleRequest,
   output: RegisterCrossAccountAccessRoleResponse,
@@ -2826,7 +2825,7 @@ export const removeAttributesFromFindings: API.OperationMethod<
   RemoveAttributesFromFindingsRequest,
   RemoveAttributesFromFindingsResponse,
   RemoveAttributesFromFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAttributesFromFindingsRequest,
   output: RemoveAttributesFromFindingsResponse,
@@ -2857,7 +2856,7 @@ export const setTagsForResource: API.OperationMethod<
   SetTagsForResourceRequest,
   SetTagsForResourceResponse,
   SetTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTagsForResourceRequest,
   output: SetTagsForResourceResponse,
@@ -2892,7 +2891,7 @@ export const startAssessmentRun: API.OperationMethod<
   StartAssessmentRunRequest,
   StartAssessmentRunResponse,
   StartAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssessmentRunRequest,
   output: StartAssessmentRunResponse,
@@ -2926,7 +2925,7 @@ export const stopAssessmentRun: API.OperationMethod<
   StopAssessmentRunRequest,
   StopAssessmentRunResponse,
   StopAssessmentRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAssessmentRunRequest,
   output: StopAssessmentRunResponse,
@@ -2958,7 +2957,7 @@ export const subscribeToEvent: API.OperationMethod<
   SubscribeToEventRequest,
   SubscribeToEventResponse,
   SubscribeToEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubscribeToEventRequest,
   output: SubscribeToEventResponse,
@@ -2990,7 +2989,7 @@ export const unsubscribeFromEvent: API.OperationMethod<
   UnsubscribeFromEventRequest,
   UnsubscribeFromEventResponse,
   UnsubscribeFromEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnsubscribeFromEventRequest,
   output: UnsubscribeFromEventResponse,
@@ -3024,7 +3023,7 @@ export const updateAssessmentTarget: API.OperationMethod<
   UpdateAssessmentTargetRequest,
   UpdateAssessmentTargetResponse,
   UpdateAssessmentTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssessmentTargetRequest,
   output: UpdateAssessmentTargetResponse,

--- a/packages/aws/src/services/inspector2.ts
+++ b/packages/aws/src/services/inspector2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Inspector2",
@@ -6439,7 +6438,7 @@ export const associateMember: API.OperationMethod<
   AssociateMemberRequest,
   AssociateMemberResponse,
   AssociateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberRequest,
   output: AssociateMemberResponse,
@@ -6471,7 +6470,7 @@ export const batchAssociateCodeSecurityScanConfiguration: API.OperationMethod<
   BatchAssociateCodeSecurityScanConfigurationRequest,
   BatchAssociateCodeSecurityScanConfigurationResponse,
   BatchAssociateCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateCodeSecurityScanConfigurationRequest,
   output: BatchAssociateCodeSecurityScanConfigurationResponse,
@@ -6504,7 +6503,7 @@ export const batchDisassociateCodeSecurityScanConfiguration: API.OperationMethod
   BatchDisassociateCodeSecurityScanConfigurationRequest,
   BatchDisassociateCodeSecurityScanConfigurationResponse,
   BatchDisassociateCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateCodeSecurityScanConfigurationRequest,
   output: BatchDisassociateCodeSecurityScanConfigurationResponse,
@@ -6535,7 +6534,7 @@ export const batchGetAccountStatus: API.OperationMethod<
   BatchGetAccountStatusRequest,
   BatchGetAccountStatusResponse,
   BatchGetAccountStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAccountStatusRequest,
   output: BatchGetAccountStatusResponse,
@@ -6565,7 +6564,7 @@ export const batchGetCodeSnippet: API.OperationMethod<
   BatchGetCodeSnippetRequest,
   BatchGetCodeSnippetResponse,
   BatchGetCodeSnippetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCodeSnippetRequest,
   output: BatchGetCodeSnippetResponse,
@@ -6593,7 +6592,7 @@ export const batchGetFindingDetails: API.OperationMethod<
   BatchGetFindingDetailsRequest,
   BatchGetFindingDetailsResponse,
   BatchGetFindingDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFindingDetailsRequest,
   output: BatchGetFindingDetailsResponse,
@@ -6621,7 +6620,7 @@ export const batchGetFreeTrialInfo: API.OperationMethod<
   BatchGetFreeTrialInfoRequest,
   BatchGetFreeTrialInfoResponse,
   BatchGetFreeTrialInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFreeTrialInfoRequest,
   output: BatchGetFreeTrialInfoResponse,
@@ -6651,7 +6650,7 @@ export const batchGetMemberEc2DeepInspectionStatus: API.OperationMethod<
   BatchGetMemberEc2DeepInspectionStatusRequest,
   BatchGetMemberEc2DeepInspectionStatusResponse,
   BatchGetMemberEc2DeepInspectionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetMemberEc2DeepInspectionStatusRequest,
   output: BatchGetMemberEc2DeepInspectionStatusResponse,
@@ -6681,7 +6680,7 @@ export const batchUpdateMemberEc2DeepInspectionStatus: API.OperationMethod<
   BatchUpdateMemberEc2DeepInspectionStatusRequest,
   BatchUpdateMemberEc2DeepInspectionStatusResponse,
   BatchUpdateMemberEc2DeepInspectionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateMemberEc2DeepInspectionStatusRequest,
   output: BatchUpdateMemberEc2DeepInspectionStatusResponse,
@@ -6710,7 +6709,7 @@ export const cancelFindingsReport: API.OperationMethod<
   CancelFindingsReportRequest,
   CancelFindingsReportResponse,
   CancelFindingsReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelFindingsReportRequest,
   output: CancelFindingsReportResponse,
@@ -6740,7 +6739,7 @@ export const cancelSbomExport: API.OperationMethod<
   CancelSbomExportRequest,
   CancelSbomExportResponse,
   CancelSbomExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSbomExportRequest,
   output: CancelSbomExportResponse,
@@ -6769,7 +6768,7 @@ export const createCisScanConfiguration: API.OperationMethod<
   CreateCisScanConfigurationRequest,
   CreateCisScanConfigurationResponse,
   CreateCisScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCisScanConfigurationRequest,
   output: CreateCisScanConfigurationResponse,
@@ -6804,7 +6803,7 @@ export const createCodeSecurityIntegration: API.OperationMethod<
   CreateCodeSecurityIntegrationRequest,
   CreateCodeSecurityIntegrationResponse,
   CreateCodeSecurityIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeSecurityIntegrationRequest,
   output: CreateCodeSecurityIntegrationResponse,
@@ -6836,7 +6835,7 @@ export const createCodeSecurityScanConfiguration: API.OperationMethod<
   CreateCodeSecurityScanConfigurationRequest,
   CreateCodeSecurityScanConfigurationResponse,
   CreateCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeSecurityScanConfigurationRequest,
   output: CreateCodeSecurityScanConfigurationResponse,
@@ -6869,7 +6868,7 @@ export const createFilter: API.OperationMethod<
   CreateFilterRequest,
   CreateFilterResponse,
   CreateFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFilterRequest,
   output: CreateFilterResponse,
@@ -6902,7 +6901,7 @@ export const createFindingsReport: API.OperationMethod<
   CreateFindingsReportRequest,
   CreateFindingsReportResponse,
   CreateFindingsReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFindingsReportRequest,
   output: CreateFindingsReportResponse,
@@ -6932,7 +6931,7 @@ export const createSbomExport: API.OperationMethod<
   CreateSbomExportRequest,
   CreateSbomExportResponse,
   CreateSbomExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSbomExportRequest,
   output: CreateSbomExportResponse,
@@ -6962,7 +6961,7 @@ export const deleteCisScanConfiguration: API.OperationMethod<
   DeleteCisScanConfigurationRequest,
   DeleteCisScanConfigurationResponse,
   DeleteCisScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCisScanConfigurationRequest,
   output: DeleteCisScanConfigurationResponse,
@@ -6992,7 +6991,7 @@ export const deleteCodeSecurityIntegration: API.OperationMethod<
   DeleteCodeSecurityIntegrationRequest,
   DeleteCodeSecurityIntegrationResponse,
   DeleteCodeSecurityIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCodeSecurityIntegrationRequest,
   output: DeleteCodeSecurityIntegrationResponse,
@@ -7022,7 +7021,7 @@ export const deleteCodeSecurityScanConfiguration: API.OperationMethod<
   DeleteCodeSecurityScanConfigurationRequest,
   DeleteCodeSecurityScanConfigurationResponse,
   DeleteCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCodeSecurityScanConfigurationRequest,
   output: DeleteCodeSecurityScanConfigurationResponse,
@@ -7052,7 +7051,7 @@ export const deleteFilter: API.OperationMethod<
   DeleteFilterRequest,
   DeleteFilterResponse,
   DeleteFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFilterRequest,
   output: DeleteFilterResponse,
@@ -7081,7 +7080,7 @@ export const describeOrganizationConfiguration: API.OperationMethod<
   DescribeOrganizationConfigurationRequest,
   DescribeOrganizationConfigurationResponse,
   DescribeOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationConfigurationRequest,
   output: DescribeOrganizationConfigurationResponse,
@@ -7111,7 +7110,7 @@ export const disable: API.OperationMethod<
   DisableRequest,
   DisableResponse,
   DisableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableRequest,
   output: DisableResponse,
@@ -7142,7 +7141,7 @@ export const disableDelegatedAdminAccount: API.OperationMethod<
   DisableDelegatedAdminAccountRequest,
   DisableDelegatedAdminAccountResponse,
   DisableDelegatedAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDelegatedAdminAccountRequest,
   output: DisableDelegatedAdminAccountResponse,
@@ -7172,7 +7171,7 @@ export const disassociateMember: API.OperationMethod<
   DisassociateMemberRequest,
   DisassociateMemberResponse,
   DisassociateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberRequest,
   output: DisassociateMemberResponse,
@@ -7201,7 +7200,7 @@ export const enable: API.OperationMethod<
   EnableRequest,
   EnableResponse,
   EnableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableRequest,
   output: EnableResponse,
@@ -7232,7 +7231,7 @@ export const enableDelegatedAdminAccount: API.OperationMethod<
   EnableDelegatedAdminAccountRequest,
   EnableDelegatedAdminAccountResponse,
   EnableDelegatedAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDelegatedAdminAccountRequest,
   output: EnableDelegatedAdminAccountResponse,
@@ -7263,7 +7262,7 @@ export const getCisScanReport: API.OperationMethod<
   GetCisScanReportRequest,
   GetCisScanReportResponse,
   GetCisScanReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCisScanReportRequest,
   output: GetCisScanReportResponse,
@@ -7292,7 +7291,7 @@ export const getCisScanResultDetails: API.PaginatedOperationMethod<
   GetCisScanResultDetailsRequest,
   GetCisScanResultDetailsResponse,
   GetCisScanResultDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CisScanResultDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCisScanResultDetailsRequest,
@@ -7327,7 +7326,7 @@ export const getClustersForImage: API.PaginatedOperationMethod<
   GetClustersForImageRequest,
   GetClustersForImageResponse,
   GetClustersForImageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetClustersForImageRequest,
@@ -7363,7 +7362,7 @@ export const getCodeSecurityIntegration: API.OperationMethod<
   GetCodeSecurityIntegrationRequest,
   GetCodeSecurityIntegrationResponse,
   GetCodeSecurityIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeSecurityIntegrationRequest,
   output: GetCodeSecurityIntegrationResponse,
@@ -7394,7 +7393,7 @@ export const getCodeSecurityScan: API.OperationMethod<
   GetCodeSecurityScanRequest,
   GetCodeSecurityScanResponse,
   GetCodeSecurityScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeSecurityScanRequest,
   output: GetCodeSecurityScanResponse,
@@ -7425,7 +7424,7 @@ export const getCodeSecurityScanConfiguration: API.OperationMethod<
   GetCodeSecurityScanConfigurationRequest,
   GetCodeSecurityScanConfigurationResponse,
   GetCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeSecurityScanConfigurationRequest,
   output: GetCodeSecurityScanConfigurationResponse,
@@ -7453,7 +7452,7 @@ export const getConfiguration: API.OperationMethod<
   GetConfigurationRequest,
   GetConfigurationResponse,
   GetConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationRequest,
   output: GetConfigurationResponse,
@@ -7482,7 +7481,7 @@ export const getDelegatedAdminAccount: API.OperationMethod<
   GetDelegatedAdminAccountRequest,
   GetDelegatedAdminAccountResponse,
   GetDelegatedAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDelegatedAdminAccountRequest,
   output: GetDelegatedAdminAccountResponse,
@@ -7512,7 +7511,7 @@ export const getEc2DeepInspectionConfiguration: API.OperationMethod<
   GetEc2DeepInspectionConfigurationRequest,
   GetEc2DeepInspectionConfigurationResponse,
   GetEc2DeepInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEc2DeepInspectionConfigurationRequest,
   output: GetEc2DeepInspectionConfigurationResponse,
@@ -7541,7 +7540,7 @@ export const getEncryptionKey: API.OperationMethod<
   GetEncryptionKeyRequest,
   GetEncryptionKeyResponse,
   GetEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEncryptionKeyRequest,
   output: GetEncryptionKeyResponse,
@@ -7571,7 +7570,7 @@ export const getFindingsReportStatus: API.OperationMethod<
   GetFindingsReportStatusRequest,
   GetFindingsReportStatusResponse,
   GetFindingsReportStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsReportStatusRequest,
   output: GetFindingsReportStatusResponse,
@@ -7601,7 +7600,7 @@ export const getMember: API.OperationMethod<
   GetMemberRequest,
   GetMemberResponse,
   GetMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemberRequest,
   output: GetMemberResponse,
@@ -7631,7 +7630,7 @@ export const getSbomExport: API.OperationMethod<
   GetSbomExportRequest,
   GetSbomExportResponse,
   GetSbomExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSbomExportRequest,
   output: GetSbomExportResponse,
@@ -7661,7 +7660,7 @@ export const listAccountPermissions: API.PaginatedOperationMethod<
   ListAccountPermissionsRequest,
   ListAccountPermissionsResponse,
   ListAccountPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Permission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountPermissionsRequest,
@@ -7696,7 +7695,7 @@ export const listCisScanConfigurations: API.PaginatedOperationMethod<
   ListCisScanConfigurationsRequest,
   ListCisScanConfigurationsResponse,
   ListCisScanConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CisScanConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCisScanConfigurationsRequest,
@@ -7731,7 +7730,7 @@ export const listCisScanResultsAggregatedByChecks: API.PaginatedOperationMethod<
   ListCisScanResultsAggregatedByChecksRequest,
   ListCisScanResultsAggregatedByChecksResponse,
   ListCisScanResultsAggregatedByChecksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CisCheckAggregation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCisScanResultsAggregatedByChecksRequest,
@@ -7766,7 +7765,7 @@ export const listCisScanResultsAggregatedByTargetResource: API.PaginatedOperatio
   ListCisScanResultsAggregatedByTargetResourceRequest,
   ListCisScanResultsAggregatedByTargetResourceResponse,
   ListCisScanResultsAggregatedByTargetResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CisTargetResourceAggregation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCisScanResultsAggregatedByTargetResourceRequest,
@@ -7801,7 +7800,7 @@ export const listCisScans: API.PaginatedOperationMethod<
   ListCisScansRequest,
   ListCisScansResponse,
   ListCisScansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CisScan
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCisScansRequest,
@@ -7836,7 +7835,7 @@ export const listCodeSecurityIntegrations: API.OperationMethod<
   ListCodeSecurityIntegrationsRequest,
   ListCodeSecurityIntegrationsResponse,
   ListCodeSecurityIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCodeSecurityIntegrationsRequest,
   output: ListCodeSecurityIntegrationsResponse,
@@ -7866,7 +7865,7 @@ export const listCodeSecurityScanConfigurationAssociations: API.OperationMethod<
   ListCodeSecurityScanConfigurationAssociationsRequest,
   ListCodeSecurityScanConfigurationAssociationsResponse,
   ListCodeSecurityScanConfigurationAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCodeSecurityScanConfigurationAssociationsRequest,
   output: ListCodeSecurityScanConfigurationAssociationsResponse,
@@ -7896,7 +7895,7 @@ export const listCodeSecurityScanConfigurations: API.OperationMethod<
   ListCodeSecurityScanConfigurationsRequest,
   ListCodeSecurityScanConfigurationsResponse,
   ListCodeSecurityScanConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCodeSecurityScanConfigurationsRequest,
   output: ListCodeSecurityScanConfigurationsResponse,
@@ -7924,7 +7923,7 @@ export const listCoverage: API.PaginatedOperationMethod<
   ListCoverageRequest,
   ListCoverageResponse,
   ListCoverageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoveredResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoverageRequest,
@@ -7953,7 +7952,7 @@ export const listCoverageStatistics: API.PaginatedOperationMethod<
   ListCoverageStatisticsRequest,
   ListCoverageStatisticsResponse,
   ListCoverageStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Counts
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoverageStatisticsRequest,
@@ -7982,7 +7981,7 @@ export const listDelegatedAdminAccounts: API.PaginatedOperationMethod<
   ListDelegatedAdminAccountsRequest,
   ListDelegatedAdminAccountsResponse,
   ListDelegatedAdminAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DelegatedAdminAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDelegatedAdminAccountsRequest,
@@ -8017,7 +8016,7 @@ export const listFilters: API.PaginatedOperationMethod<
   ListFiltersRequest,
   ListFiltersResponse,
   ListFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Filter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFiltersRequest,
@@ -8051,7 +8050,7 @@ export const listFindingAggregations: API.PaginatedOperationMethod<
   ListFindingAggregationsRequest,
   ListFindingAggregationsResponse,
   ListFindingAggregationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregationResponse
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingAggregationsRequest,
@@ -8080,7 +8079,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsRequest,
   ListFindingsResponse,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Finding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsRequest,
@@ -8111,7 +8110,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersRequest,
   ListMembersResponse,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Member
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersRequest,
@@ -8146,7 +8145,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8174,7 +8173,7 @@ export const listUsageTotals: API.PaginatedOperationMethod<
   ListUsageTotalsRequest,
   ListUsageTotalsResponse,
   ListUsageTotalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsageTotal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsageTotalsRequest,
@@ -8211,7 +8210,7 @@ export const resetEncryptionKey: API.OperationMethod<
   ResetEncryptionKeyRequest,
   ResetEncryptionKeyResponse,
   ResetEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetEncryptionKeyRequest,
   output: ResetEncryptionKeyResponse,
@@ -8240,7 +8239,7 @@ export const searchVulnerabilities: API.PaginatedOperationMethod<
   SearchVulnerabilitiesRequest,
   SearchVulnerabilitiesResponse,
   SearchVulnerabilitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Vulnerability
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchVulnerabilitiesRequest,
@@ -8277,7 +8276,7 @@ export const sendCisSessionHealth: API.OperationMethod<
   SendCisSessionHealthRequest,
   SendCisSessionHealthResponse,
   SendCisSessionHealthError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendCisSessionHealthRequest,
   output: SendCisSessionHealthResponse,
@@ -8309,7 +8308,7 @@ export const sendCisSessionTelemetry: API.OperationMethod<
   SendCisSessionTelemetryRequest,
   SendCisSessionTelemetryResponse,
   SendCisSessionTelemetryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendCisSessionTelemetryRequest,
   output: SendCisSessionTelemetryResponse,
@@ -8341,7 +8340,7 @@ export const startCisSession: API.OperationMethod<
   StartCisSessionRequest,
   StartCisSessionResponse,
   StartCisSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCisSessionRequest,
   output: StartCisSessionResponse,
@@ -8372,7 +8371,7 @@ export const startCodeSecurityScan: API.OperationMethod<
   StartCodeSecurityScanRequest,
   StartCodeSecurityScanResponse,
   StartCodeSecurityScanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCodeSecurityScanRequest,
   output: StartCodeSecurityScanResponse,
@@ -8405,7 +8404,7 @@ export const stopCisSession: API.OperationMethod<
   StopCisSessionRequest,
   StopCisSessionResponse,
   StopCisSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCisSessionRequest,
   output: StopCisSessionResponse,
@@ -8435,7 +8434,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8464,7 +8463,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8493,7 +8492,7 @@ export const updateCisScanConfiguration: API.OperationMethod<
   UpdateCisScanConfigurationRequest,
   UpdateCisScanConfigurationResponse,
   UpdateCisScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCisScanConfigurationRequest,
   output: UpdateCisScanConfigurationResponse,
@@ -8529,7 +8528,7 @@ export const updateCodeSecurityIntegration: API.OperationMethod<
   UpdateCodeSecurityIntegrationRequest,
   UpdateCodeSecurityIntegrationResponse,
   UpdateCodeSecurityIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCodeSecurityIntegrationRequest,
   output: UpdateCodeSecurityIntegrationResponse,
@@ -8561,7 +8560,7 @@ export const updateCodeSecurityScanConfiguration: API.OperationMethod<
   UpdateCodeSecurityScanConfigurationRequest,
   UpdateCodeSecurityScanConfigurationResponse,
   UpdateCodeSecurityScanConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCodeSecurityScanConfigurationRequest,
   output: UpdateCodeSecurityScanConfigurationResponse,
@@ -8593,7 +8592,7 @@ export const updateConfiguration: API.OperationMethod<
   UpdateConfigurationRequest,
   UpdateConfigurationResponse,
   UpdateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationRequest,
   output: UpdateConfigurationResponse,
@@ -8621,7 +8620,7 @@ export const updateEc2DeepInspectionConfiguration: API.OperationMethod<
   UpdateEc2DeepInspectionConfigurationRequest,
   UpdateEc2DeepInspectionConfigurationResponse,
   UpdateEc2DeepInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEc2DeepInspectionConfigurationRequest,
   output: UpdateEc2DeepInspectionConfigurationResponse,
@@ -8651,7 +8650,7 @@ export const updateEncryptionKey: API.OperationMethod<
   UpdateEncryptionKeyRequest,
   UpdateEncryptionKeyResponse,
   UpdateEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEncryptionKeyRequest,
   output: UpdateEncryptionKeyResponse,
@@ -8681,7 +8680,7 @@ export const updateFilter: API.OperationMethod<
   UpdateFilterRequest,
   UpdateFilterResponse,
   UpdateFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFilterRequest,
   output: UpdateFilterResponse,
@@ -8710,7 +8709,7 @@ export const updateOrganizationConfiguration: API.OperationMethod<
   UpdateOrganizationConfigurationRequest,
   UpdateOrganizationConfigurationResponse,
   UpdateOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationConfigurationRequest,
   output: UpdateOrganizationConfigurationResponse,
@@ -8739,7 +8738,7 @@ export const updateOrgEc2DeepInspectionConfiguration: API.OperationMethod<
   UpdateOrgEc2DeepInspectionConfigurationRequest,
   UpdateOrgEc2DeepInspectionConfigurationResponse,
   UpdateOrgEc2DeepInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrgEc2DeepInspectionConfigurationRequest,
   output: UpdateOrgEc2DeepInspectionConfigurationResponse,

--- a/packages/aws/src/services/interconnect.ts
+++ b/packages/aws/src/services/interconnect.ts
@@ -7,7 +7,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Interconnect",
@@ -564,7 +563,7 @@ export const acceptConnectionProposal: API.OperationMethod<
   AcceptConnectionProposalRequest,
   AcceptConnectionProposalResponse,
   AcceptConnectionProposalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptConnectionProposalRequest,
   output: AcceptConnectionProposalResponse,
@@ -588,7 +587,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -608,7 +607,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -626,7 +625,7 @@ export const describeConnectionProposal: API.OperationMethod<
   DescribeConnectionProposalRequest,
   DescribeConnectionProposalResponse,
   DescribeConnectionProposalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionProposalRequest,
   output: DescribeConnectionProposalResponse,
@@ -644,7 +643,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -662,7 +661,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -680,7 +679,7 @@ export const listAttachPoints: API.PaginatedOperationMethod<
   ListAttachPointsRequest,
   ListAttachPointsResponse,
   ListAttachPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachPointDescriptor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachPointsRequest,
@@ -717,7 +716,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsRequest,
   ListConnectionsResponse,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsRequest,
@@ -742,7 +741,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Environment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -767,7 +766,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -785,7 +784,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -803,7 +802,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -821,7 +820,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   UpdateConnectionResponse,
   UpdateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: UpdateConnectionResponse,

--- a/packages/aws/src/services/internetmonitor.ts
+++ b/packages/aws/src/services/internetmonitor.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "InternetMonitor",
   serviceShapeName: "InternetMonitor20210603",
@@ -1119,7 +1118,7 @@ export const createMonitor: API.OperationMethod<
   CreateMonitorInput,
   CreateMonitorOutput,
   CreateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitorInput,
   output: CreateMonitorOutput,
@@ -1150,7 +1149,7 @@ export const deleteMonitor: API.OperationMethod<
   DeleteMonitorInput,
   DeleteMonitorOutput,
   DeleteMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitorInput,
   output: DeleteMonitorOutput,
@@ -1185,7 +1184,7 @@ export const getHealthEvent: API.OperationMethod<
   GetHealthEventInput,
   GetHealthEventOutput,
   GetHealthEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHealthEventInput,
   output: GetHealthEventOutput,
@@ -1219,7 +1218,7 @@ export const getInternetEvent: API.OperationMethod<
   GetInternetEventInput,
   GetInternetEventOutput,
   GetInternetEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInternetEventInput,
   output: GetInternetEventOutput,
@@ -1249,7 +1248,7 @@ export const getMonitor: API.OperationMethod<
   GetMonitorInput,
   GetMonitorOutput,
   GetMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitorInput,
   output: GetMonitorOutput,
@@ -1284,7 +1283,7 @@ export const getQueryResults: API.PaginatedOperationMethod<
   GetQueryResultsInput,
   GetQueryResultsOutput,
   GetQueryResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsInput,
@@ -1331,7 +1330,7 @@ export const getQueryStatus: API.OperationMethod<
   GetQueryStatusInput,
   GetQueryStatusOutput,
   GetQueryStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStatusInput,
   output: GetQueryStatusOutput,
@@ -1363,7 +1362,7 @@ export const listHealthEvents: API.PaginatedOperationMethod<
   ListHealthEventsInput,
   ListHealthEventsOutput,
   ListHealthEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HealthEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHealthEventsInput,
@@ -1407,7 +1406,7 @@ export const listInternetEvents: API.PaginatedOperationMethod<
   ListInternetEventsInput,
   ListInternetEventsOutput,
   ListInternetEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InternetEventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInternetEventsInput,
@@ -1442,7 +1441,7 @@ export const listMonitors: API.PaginatedOperationMethod<
   ListMonitorsInput,
   ListMonitorsOutput,
   ListMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Monitor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorsInput,
@@ -1478,7 +1477,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1514,7 +1513,7 @@ export const startQuery: API.OperationMethod<
   StartQueryInput,
   StartQueryOutput,
   StartQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryInput,
   output: StartQueryOutput,
@@ -1544,7 +1543,7 @@ export const stopQuery: API.OperationMethod<
   StopQueryInput,
   StopQueryOutput,
   StopQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryInput,
   output: StopQueryOutput,
@@ -1576,7 +1575,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1606,7 +1605,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1641,7 +1640,7 @@ export const updateMonitor: API.OperationMethod<
   UpdateMonitorInput,
   UpdateMonitorOutput,
   UpdateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitorInput,
   output: UpdateMonitorOutput,

--- a/packages/aws/src/services/invoicing.ts
+++ b/packages/aws/src/services/invoicing.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Invoicing",
@@ -1397,7 +1396,7 @@ export const batchGetInvoiceProfile: API.OperationMethod<
   BatchGetInvoiceProfileRequest,
   BatchGetInvoiceProfileResponse,
   BatchGetInvoiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetInvoiceProfileRequest,
   output: BatchGetInvoiceProfileResponse,
@@ -1426,7 +1425,7 @@ export const createInvoiceUnit: API.OperationMethod<
   CreateInvoiceUnitRequest,
   CreateInvoiceUnitResponse,
   CreateInvoiceUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvoiceUnitRequest,
   output: CreateInvoiceUnitResponse,
@@ -1458,7 +1457,7 @@ export const createProcurementPortalPreference: API.OperationMethod<
   CreateProcurementPortalPreferenceRequest,
   CreateProcurementPortalPreferenceResponse,
   CreateProcurementPortalPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProcurementPortalPreferenceRequest,
   output: CreateProcurementPortalPreferenceResponse,
@@ -1489,7 +1488,7 @@ export const deleteInvoiceUnit: API.OperationMethod<
   DeleteInvoiceUnitRequest,
   DeleteInvoiceUnitResponse,
   DeleteInvoiceUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvoiceUnitRequest,
   output: DeleteInvoiceUnitResponse,
@@ -1522,7 +1521,7 @@ export const deleteProcurementPortalPreference: API.OperationMethod<
   DeleteProcurementPortalPreferenceRequest,
   DeleteProcurementPortalPreferenceResponse,
   DeleteProcurementPortalPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProcurementPortalPreferenceRequest,
   output: DeleteProcurementPortalPreferenceResponse,
@@ -1553,7 +1552,7 @@ export const getInvoicePDF: API.OperationMethod<
   GetInvoicePDFRequest,
   GetInvoicePDFResponse,
   GetInvoicePDFError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvoicePDFRequest,
   output: GetInvoicePDFResponse,
@@ -1583,7 +1582,7 @@ export const getInvoiceUnit: API.OperationMethod<
   GetInvoiceUnitRequest,
   GetInvoiceUnitResponse,
   GetInvoiceUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvoiceUnitRequest,
   output: GetInvoiceUnitResponse,
@@ -1617,7 +1616,7 @@ export const getProcurementPortalPreference: API.OperationMethod<
   GetProcurementPortalPreferenceRequest,
   GetProcurementPortalPreferenceResponse,
   GetProcurementPortalPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProcurementPortalPreferenceRequest,
   output: GetProcurementPortalPreferenceResponse,
@@ -1649,7 +1648,7 @@ export const listInvoiceSummaries: API.PaginatedOperationMethod<
   ListInvoiceSummariesRequest,
   ListInvoiceSummariesResponse,
   ListInvoiceSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvoiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvoiceSummariesRequest,
@@ -1685,7 +1684,7 @@ export const listInvoiceUnits: API.PaginatedOperationMethod<
   ListInvoiceUnitsRequest,
   ListInvoiceUnitsResponse,
   ListInvoiceUnitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvoiceUnit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvoiceUnitsRequest,
@@ -1724,7 +1723,7 @@ export const listProcurementPortalPreferences: API.PaginatedOperationMethod<
   ListProcurementPortalPreferencesRequest,
   ListProcurementPortalPreferencesResponse,
   ListProcurementPortalPreferencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProcurementPortalPreferenceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProcurementPortalPreferencesRequest,
@@ -1762,7 +1761,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1796,7 +1795,7 @@ export const putProcurementPortalPreference: API.OperationMethod<
   PutProcurementPortalPreferenceRequest,
   PutProcurementPortalPreferenceResponse,
   PutProcurementPortalPreferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProcurementPortalPreferenceRequest,
   output: PutProcurementPortalPreferenceResponse,
@@ -1829,7 +1828,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1860,7 +1859,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1890,7 +1889,7 @@ export const updateInvoiceUnit: API.OperationMethod<
   UpdateInvoiceUnitRequest,
   UpdateInvoiceUnitResponse,
   UpdateInvoiceUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInvoiceUnitRequest,
   output: UpdateInvoiceUnitResponse,
@@ -1924,7 +1923,7 @@ export const updateProcurementPortalPreferenceStatus: API.OperationMethod<
   UpdateProcurementPortalPreferenceStatusRequest,
   UpdateProcurementPortalPreferenceStatusResponse,
   UpdateProcurementPortalPreferenceStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProcurementPortalPreferenceStatusRequest,
   output: UpdateProcurementPortalPreferenceStatusResponse,

--- a/packages/aws/src/services/iot-data-plane.ts
+++ b/packages/aws/src/services/iot-data-plane.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Data Plane",
   serviceShapeName: "IotMoonrakerService",
@@ -700,7 +699,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -738,7 +737,7 @@ export const deleteThingShadow: API.OperationMethod<
   DeleteThingShadowRequest,
   DeleteThingShadowResponse,
   DeleteThingShadowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThingShadowRequest,
   output: DeleteThingShadowResponse,
@@ -774,7 +773,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -816,7 +815,7 @@ export const getRetainedMessage: API.OperationMethod<
   GetRetainedMessageRequest,
   GetRetainedMessageResponse,
   GetRetainedMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRetainedMessageRequest,
   output: GetRetainedMessageResponse,
@@ -858,7 +857,7 @@ export const getThingShadow: API.OperationMethod<
   GetThingShadowRequest,
   GetThingShadowResponse,
   GetThingShadowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThingShadowRequest,
   output: GetThingShadowResponse,
@@ -897,7 +896,7 @@ export const listNamedShadowsForThing: API.OperationMethod<
   ListNamedShadowsForThingRequest,
   ListNamedShadowsForThingResponse,
   ListNamedShadowsForThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListNamedShadowsForThingRequest,
   output: ListNamedShadowsForThingResponse,
@@ -945,7 +944,7 @@ export const listRetainedMessages: API.PaginatedOperationMethod<
   ListRetainedMessagesRequest,
   ListRetainedMessagesResponse,
   ListRetainedMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RetainedMessageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRetainedMessagesRequest,
@@ -986,7 +985,7 @@ export const listSubscriptions: API.PaginatedOperationMethod<
   ListSubscriptionsRequest,
   ListSubscriptionsResponse,
   ListSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriptionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsRequest,
@@ -1033,7 +1032,7 @@ export const publish: API.OperationMethod<
   PublishRequest,
   PublishResponse,
   PublishError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishRequest,
   output: PublishResponse,
@@ -1075,7 +1074,7 @@ export const sendDirectMessage: API.OperationMethod<
   SendDirectMessageRequest,
   SendDirectMessageResponse,
   SendDirectMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDirectMessageRequest,
   output: SendDirectMessageResponse,
@@ -1118,7 +1117,7 @@ export const updateThingShadow: API.OperationMethod<
   UpdateThingShadowRequest,
   UpdateThingShadowResponse,
   UpdateThingShadowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingShadowRequest,
   output: UpdateThingShadowResponse,

--- a/packages/aws/src/services/iot-events-data.ts
+++ b/packages/aws/src/services/iot-events-data.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Events Data",
   serviceShapeName: "IotColumboDataService",
@@ -1039,7 +1038,7 @@ export const batchAcknowledgeAlarm: API.OperationMethod<
   BatchAcknowledgeAlarmRequest,
   BatchAcknowledgeAlarmResponse,
   BatchAcknowledgeAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAcknowledgeAlarmRequest,
   output: BatchAcknowledgeAlarmResponse,
@@ -1067,7 +1066,7 @@ export const batchDeleteDetector: API.OperationMethod<
   BatchDeleteDetectorRequest,
   BatchDeleteDetectorResponse,
   BatchDeleteDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDetectorRequest,
   output: BatchDeleteDetectorResponse,
@@ -1096,7 +1095,7 @@ export const batchDisableAlarm: API.OperationMethod<
   BatchDisableAlarmRequest,
   BatchDisableAlarmResponse,
   BatchDisableAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisableAlarmRequest,
   output: BatchDisableAlarmResponse,
@@ -1125,7 +1124,7 @@ export const batchEnableAlarm: API.OperationMethod<
   BatchEnableAlarmRequest,
   BatchEnableAlarmResponse,
   BatchEnableAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchEnableAlarmRequest,
   output: BatchEnableAlarmResponse,
@@ -1157,7 +1156,7 @@ export const batchPutMessage: API.OperationMethod<
   BatchPutMessageRequest,
   BatchPutMessageResponse,
   BatchPutMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutMessageRequest,
   output: BatchPutMessageResponse,
@@ -1186,7 +1185,7 @@ export const batchResetAlarm: API.OperationMethod<
   BatchResetAlarmRequest,
   BatchResetAlarmResponse,
   BatchResetAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchResetAlarmRequest,
   output: BatchResetAlarmResponse,
@@ -1215,7 +1214,7 @@ export const batchSnoozeAlarm: API.OperationMethod<
   BatchSnoozeAlarmRequest,
   BatchSnoozeAlarmResponse,
   BatchSnoozeAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchSnoozeAlarmRequest,
   output: BatchSnoozeAlarmResponse,
@@ -1244,7 +1243,7 @@ export const batchUpdateDetector: API.OperationMethod<
   BatchUpdateDetectorRequest,
   BatchUpdateDetectorResponse,
   BatchUpdateDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateDetectorRequest,
   output: BatchUpdateDetectorResponse,
@@ -1273,7 +1272,7 @@ export const describeAlarm: API.OperationMethod<
   DescribeAlarmRequest,
   DescribeAlarmResponse,
   DescribeAlarmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlarmRequest,
   output: DescribeAlarmResponse,
@@ -1303,7 +1302,7 @@ export const describeDetector: API.OperationMethod<
   DescribeDetectorRequest,
   DescribeDetectorResponse,
   DescribeDetectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDetectorRequest,
   output: DescribeDetectorResponse,
@@ -1334,7 +1333,7 @@ export const listAlarms: API.OperationMethod<
   ListAlarmsRequest,
   ListAlarmsResponse,
   ListAlarmsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAlarmsRequest,
   output: ListAlarmsResponse,
@@ -1364,7 +1363,7 @@ export const listDetectors: API.OperationMethod<
   ListDetectorsRequest,
   ListDetectorsResponse,
   ListDetectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDetectorsRequest,
   output: ListDetectorsResponse,

--- a/packages/aws/src/services/iot-events.ts
+++ b/packages/aws/src/services/iot-events.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Events",
   serviceShapeName: "IotColumboService",
@@ -1941,7 +1940,7 @@ export const createAlarmModel: API.OperationMethod<
   CreateAlarmModelRequest,
   CreateAlarmModelResponse,
   CreateAlarmModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAlarmModelRequest,
   output: CreateAlarmModelResponse,
@@ -1975,7 +1974,7 @@ export const createDetectorModel: API.OperationMethod<
   CreateDetectorModelRequest,
   CreateDetectorModelResponse,
   CreateDetectorModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDetectorModelRequest,
   output: CreateDetectorModelResponse,
@@ -2007,7 +2006,7 @@ export const createInput: API.OperationMethod<
   CreateInputRequest,
   CreateInputResponse,
   CreateInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInputRequest,
   output: CreateInputResponse,
@@ -2039,7 +2038,7 @@ export const deleteAlarmModel: API.OperationMethod<
   DeleteAlarmModelRequest,
   DeleteAlarmModelResponse,
   DeleteAlarmModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlarmModelRequest,
   output: DeleteAlarmModelResponse,
@@ -2072,7 +2071,7 @@ export const deleteDetectorModel: API.OperationMethod<
   DeleteDetectorModelRequest,
   DeleteDetectorModelResponse,
   DeleteDetectorModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDetectorModelRequest,
   output: DeleteDetectorModelResponse,
@@ -2104,7 +2103,7 @@ export const deleteInput: API.OperationMethod<
   DeleteInputRequest,
   DeleteInputResponse,
   DeleteInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInputRequest,
   output: DeleteInputResponse,
@@ -2136,7 +2135,7 @@ export const describeAlarmModel: API.OperationMethod<
   DescribeAlarmModelRequest,
   DescribeAlarmModelResponse,
   DescribeAlarmModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlarmModelRequest,
   output: DescribeAlarmModelResponse,
@@ -2167,7 +2166,7 @@ export const describeDetectorModel: API.OperationMethod<
   DescribeDetectorModelRequest,
   DescribeDetectorModelResponse,
   DescribeDetectorModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDetectorModelRequest,
   output: DescribeDetectorModelResponse,
@@ -2199,7 +2198,7 @@ export const describeDetectorModelAnalysis: API.OperationMethod<
   DescribeDetectorModelAnalysisRequest,
   DescribeDetectorModelAnalysisResponse,
   DescribeDetectorModelAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDetectorModelAnalysisRequest,
   output: DescribeDetectorModelAnalysisResponse,
@@ -2229,7 +2228,7 @@ export const describeInput: API.OperationMethod<
   DescribeInputRequest,
   DescribeInputResponse,
   DescribeInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInputRequest,
   output: DescribeInputResponse,
@@ -2260,7 +2259,7 @@ export const describeLoggingOptions: API.OperationMethod<
   DescribeLoggingOptionsRequest,
   DescribeLoggingOptionsResponse,
   DescribeLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoggingOptionsRequest,
   output: DescribeLoggingOptionsResponse,
@@ -2293,7 +2292,7 @@ export const getDetectorModelAnalysisResults: API.OperationMethod<
   GetDetectorModelAnalysisResultsRequest,
   GetDetectorModelAnalysisResultsResponse,
   GetDetectorModelAnalysisResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDetectorModelAnalysisResultsRequest,
   output: GetDetectorModelAnalysisResultsResponse,
@@ -2323,7 +2322,7 @@ export const listAlarmModels: API.OperationMethod<
   ListAlarmModelsRequest,
   ListAlarmModelsResponse,
   ListAlarmModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAlarmModelsRequest,
   output: ListAlarmModelsResponse,
@@ -2353,7 +2352,7 @@ export const listAlarmModelVersions: API.OperationMethod<
   ListAlarmModelVersionsRequest,
   ListAlarmModelVersionsResponse,
   ListAlarmModelVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAlarmModelVersionsRequest,
   output: ListAlarmModelVersionsResponse,
@@ -2383,7 +2382,7 @@ export const listDetectorModels: API.OperationMethod<
   ListDetectorModelsRequest,
   ListDetectorModelsResponse,
   ListDetectorModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDetectorModelsRequest,
   output: ListDetectorModelsResponse,
@@ -2413,7 +2412,7 @@ export const listDetectorModelVersions: API.OperationMethod<
   ListDetectorModelVersionsRequest,
   ListDetectorModelVersionsResponse,
   ListDetectorModelVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDetectorModelVersionsRequest,
   output: ListDetectorModelVersionsResponse,
@@ -2443,7 +2442,7 @@ export const listInputRoutings: API.OperationMethod<
   ListInputRoutingsRequest,
   ListInputRoutingsResponse,
   ListInputRoutingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInputRoutingsRequest,
   output: ListInputRoutingsResponse,
@@ -2472,7 +2471,7 @@ export const listInputs: API.OperationMethod<
   ListInputsRequest,
   ListInputsResponse,
   ListInputsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInputsRequest,
   output: ListInputsResponse,
@@ -2501,7 +2500,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2537,7 +2536,7 @@ export const putLoggingOptions: API.OperationMethod<
   PutLoggingOptionsRequest,
   PutLoggingOptionsResponse,
   PutLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingOptionsRequest,
   output: PutLoggingOptionsResponse,
@@ -2570,7 +2569,7 @@ export const startDetectorModelAnalysis: API.OperationMethod<
   StartDetectorModelAnalysisRequest,
   StartDetectorModelAnalysisResponse,
   StartDetectorModelAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDetectorModelAnalysisRequest,
   output: StartDetectorModelAnalysisResponse,
@@ -2602,7 +2601,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2633,7 +2632,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2665,7 +2664,7 @@ export const updateAlarmModel: API.OperationMethod<
   UpdateAlarmModelRequest,
   UpdateAlarmModelResponse,
   UpdateAlarmModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAlarmModelRequest,
   output: UpdateAlarmModelResponse,
@@ -2698,7 +2697,7 @@ export const updateDetectorModel: API.OperationMethod<
   UpdateDetectorModelRequest,
   UpdateDetectorModelResponse,
   UpdateDetectorModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDetectorModelRequest,
   output: UpdateDetectorModelResponse,
@@ -2730,7 +2729,7 @@ export const updateInput: API.OperationMethod<
   UpdateInputRequest,
   UpdateInputResponse,
   UpdateInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInputRequest,
   output: UpdateInputResponse,

--- a/packages/aws/src/services/iot-jobs-data-plane.ts
+++ b/packages/aws/src/services/iot-jobs-data-plane.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Jobs Data Plane",
   serviceShapeName: "IotLaserThingJobManagerExternalService",
@@ -493,7 +492,7 @@ export const describeJobExecution: API.OperationMethod<
   DescribeJobExecutionRequest,
   DescribeJobExecutionResponse,
   DescribeJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobExecutionRequest,
   output: DescribeJobExecutionResponse,
@@ -526,7 +525,7 @@ export const getPendingJobExecutions: API.OperationMethod<
   GetPendingJobExecutionsRequest,
   GetPendingJobExecutionsResponse,
   GetPendingJobExecutionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPendingJobExecutionsRequest,
   output: GetPendingJobExecutionsResponse,
@@ -558,7 +557,7 @@ export const startCommandExecution: API.OperationMethod<
   StartCommandExecutionRequest,
   StartCommandExecutionResponse,
   StartCommandExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCommandExecutionRequest,
   output: StartCommandExecutionResponse,
@@ -592,7 +591,7 @@ export const startNextPendingJobExecution: API.OperationMethod<
   StartNextPendingJobExecutionRequest,
   StartNextPendingJobExecutionResponse,
   StartNextPendingJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNextPendingJobExecutionRequest,
   output: StartNextPendingJobExecutionResponse,
@@ -625,7 +624,7 @@ export const updateJobExecution: API.OperationMethod<
   UpdateJobExecutionRequest,
   UpdateJobExecutionResponse,
   UpdateJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobExecutionRequest,
   output: UpdateJobExecutionResponse,

--- a/packages/aws/src/services/iot-managed-integrations.ts
+++ b/packages/aws/src/services/iot-managed-integrations.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Managed Integrations",
@@ -4576,7 +4575,7 @@ export const createAccountAssociation: API.OperationMethod<
   CreateAccountAssociationRequest,
   CreateAccountAssociationResponse,
   CreateAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountAssociationRequest,
   output: CreateAccountAssociationResponse,
@@ -4609,7 +4608,7 @@ export const createCloudConnector: API.OperationMethod<
   CreateCloudConnectorRequest,
   CreateCloudConnectorResponse,
   CreateCloudConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudConnectorRequest,
   output: CreateCloudConnectorResponse,
@@ -4641,7 +4640,7 @@ export const createConnectorDestination: API.OperationMethod<
   CreateConnectorDestinationRequest,
   CreateConnectorDestinationResponse,
   CreateConnectorDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorDestinationRequest,
   output: CreateConnectorDestinationResponse,
@@ -4677,7 +4676,7 @@ export const createCredentialLocker: API.OperationMethod<
   CreateCredentialLockerRequest,
   CreateCredentialLockerResponse,
   CreateCredentialLockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCredentialLockerRequest,
   output: CreateCredentialLockerResponse,
@@ -4709,7 +4708,7 @@ export const createDestination: API.OperationMethod<
   CreateDestinationRequest,
   CreateDestinationResponse,
   CreateDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDestinationRequest,
   output: CreateDestinationResponse,
@@ -4740,7 +4739,7 @@ export const createEventLogConfiguration: API.OperationMethod<
   CreateEventLogConfigurationRequest,
   CreateEventLogConfigurationResponse,
   CreateEventLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventLogConfigurationRequest,
   output: CreateEventLogConfigurationResponse,
@@ -4774,7 +4773,7 @@ export const createManagedThing: API.OperationMethod<
   CreateManagedThingRequest,
   CreateManagedThingResponse,
   CreateManagedThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateManagedThingRequest,
   output: CreateManagedThingResponse,
@@ -4807,7 +4806,7 @@ export const createNotificationConfiguration: API.OperationMethod<
   CreateNotificationConfigurationRequest,
   CreateNotificationConfigurationResponse,
   CreateNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationConfigurationRequest,
   output: CreateNotificationConfigurationResponse,
@@ -4839,7 +4838,7 @@ export const createOtaTask: API.OperationMethod<
   CreateOtaTaskRequest,
   CreateOtaTaskResponse,
   CreateOtaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOtaTaskRequest,
   output: CreateOtaTaskResponse,
@@ -4871,7 +4870,7 @@ export const createOtaTaskConfiguration: API.OperationMethod<
   CreateOtaTaskConfigurationRequest,
   CreateOtaTaskConfigurationResponse,
   CreateOtaTaskConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOtaTaskConfigurationRequest,
   output: CreateOtaTaskConfigurationResponse,
@@ -4904,7 +4903,7 @@ export const createProvisioningProfile: API.OperationMethod<
   CreateProvisioningProfileRequest,
   CreateProvisioningProfileResponse,
   CreateProvisioningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisioningProfileRequest,
   output: CreateProvisioningProfileResponse,
@@ -4940,7 +4939,7 @@ export const deleteAccountAssociation: API.OperationMethod<
   DeleteAccountAssociationRequest,
   DeleteAccountAssociationResponse,
   DeleteAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountAssociationRequest,
   output: DeleteAccountAssociationResponse,
@@ -4972,7 +4971,7 @@ export const deleteCloudConnector: API.OperationMethod<
   DeleteCloudConnectorRequest,
   DeleteCloudConnectorResponse,
   DeleteCloudConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudConnectorRequest,
   output: DeleteCloudConnectorResponse,
@@ -5005,7 +5004,7 @@ export const deleteConnectorDestination: API.OperationMethod<
   DeleteConnectorDestinationRequest,
   DeleteConnectorDestinationResponse,
   DeleteConnectorDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorDestinationRequest,
   output: DeleteConnectorDestinationResponse,
@@ -5038,7 +5037,7 @@ export const deleteCredentialLocker: API.OperationMethod<
   DeleteCredentialLockerRequest,
   DeleteCredentialLockerResponse,
   DeleteCredentialLockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCredentialLockerRequest,
   output: DeleteCredentialLockerResponse,
@@ -5069,7 +5068,7 @@ export const deleteDestination: API.OperationMethod<
   DeleteDestinationRequest,
   DeleteDestinationResponse,
   DeleteDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDestinationRequest,
   output: DeleteDestinationResponse,
@@ -5099,7 +5098,7 @@ export const deleteEventLogConfiguration: API.OperationMethod<
   DeleteEventLogConfigurationRequest,
   DeleteEventLogConfigurationResponse,
   DeleteEventLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventLogConfigurationRequest,
   output: DeleteEventLogConfigurationResponse,
@@ -5132,7 +5131,7 @@ export const deleteManagedThing: API.OperationMethod<
   DeleteManagedThingRequest,
   DeleteManagedThingResponse,
   DeleteManagedThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteManagedThingRequest,
   output: DeleteManagedThingResponse,
@@ -5165,7 +5164,7 @@ export const deleteNotificationConfiguration: API.OperationMethod<
   DeleteNotificationConfigurationRequest,
   DeleteNotificationConfigurationResponse,
   DeleteNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationConfigurationRequest,
   output: DeleteNotificationConfigurationResponse,
@@ -5196,7 +5195,7 @@ export const deleteOtaTask: API.OperationMethod<
   DeleteOtaTaskRequest,
   DeleteOtaTaskResponse,
   DeleteOtaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOtaTaskRequest,
   output: DeleteOtaTaskResponse,
@@ -5227,7 +5226,7 @@ export const deleteOtaTaskConfiguration: API.OperationMethod<
   DeleteOtaTaskConfigurationRequest,
   DeleteOtaTaskConfigurationResponse,
   DeleteOtaTaskConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOtaTaskConfigurationRequest,
   output: DeleteOtaTaskConfigurationResponse,
@@ -5260,7 +5259,7 @@ export const deleteProvisioningProfile: API.OperationMethod<
   DeleteProvisioningProfileRequest,
   DeleteProvisioningProfileResponse,
   DeleteProvisioningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisioningProfileRequest,
   output: DeleteProvisioningProfileResponse,
@@ -5294,7 +5293,7 @@ export const deregisterAccountAssociation: API.OperationMethod<
   DeregisterAccountAssociationRequest,
   DeregisterAccountAssociationResponse,
   DeregisterAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterAccountAssociationRequest,
   output: DeregisterAccountAssociationResponse,
@@ -5326,7 +5325,7 @@ export const getAccountAssociation: API.OperationMethod<
   GetAccountAssociationRequest,
   GetAccountAssociationResponse,
   GetAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountAssociationRequest,
   output: GetAccountAssociationResponse,
@@ -5357,7 +5356,7 @@ export const getCloudConnector: API.OperationMethod<
   GetCloudConnectorRequest,
   GetCloudConnectorResponse,
   GetCloudConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudConnectorRequest,
   output: GetCloudConnectorResponse,
@@ -5387,7 +5386,7 @@ export const getConnectorDestination: API.OperationMethod<
   GetConnectorDestinationRequest,
   GetConnectorDestinationResponse,
   GetConnectorDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorDestinationRequest,
   output: GetConnectorDestinationResponse,
@@ -5418,7 +5417,7 @@ export const getCredentialLocker: API.OperationMethod<
   GetCredentialLockerRequest,
   GetCredentialLockerResponse,
   GetCredentialLockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCredentialLockerRequest,
   output: GetCredentialLockerResponse,
@@ -5451,7 +5450,7 @@ export const getCustomEndpoint: API.OperationMethod<
   GetCustomEndpointRequest,
   GetCustomEndpointResponse,
   GetCustomEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomEndpointRequest,
   output: GetCustomEndpointResponse,
@@ -5485,7 +5484,7 @@ export const getDefaultEncryptionConfiguration: API.OperationMethod<
   GetDefaultEncryptionConfigurationRequest,
   GetDefaultEncryptionConfigurationResponse,
   GetDefaultEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultEncryptionConfigurationRequest,
   output: GetDefaultEncryptionConfigurationResponse,
@@ -5517,7 +5516,7 @@ export const getDestination: API.OperationMethod<
   GetDestinationRequest,
   GetDestinationResponse,
   GetDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDestinationRequest,
   output: GetDestinationResponse,
@@ -5549,7 +5548,7 @@ export const getDeviceDiscovery: API.OperationMethod<
   GetDeviceDiscoveryRequest,
   GetDeviceDiscoveryResponse,
   GetDeviceDiscoveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceDiscoveryRequest,
   output: GetDeviceDiscoveryResponse,
@@ -5581,7 +5580,7 @@ export const getEventLogConfiguration: API.OperationMethod<
   GetEventLogConfigurationRequest,
   GetEventLogConfigurationResponse,
   GetEventLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventLogConfigurationRequest,
   output: GetEventLogConfigurationResponse,
@@ -5612,7 +5611,7 @@ export const getHubConfiguration: API.OperationMethod<
   GetHubConfigurationRequest,
   GetHubConfigurationResponse,
   GetHubConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHubConfigurationRequest,
   output: GetHubConfigurationResponse,
@@ -5645,7 +5644,7 @@ export const getManagedThing: API.OperationMethod<
   GetManagedThingRequest,
   GetManagedThingResponse,
   GetManagedThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingRequest,
   output: GetManagedThingResponse,
@@ -5679,7 +5678,7 @@ export const getManagedThingCapabilities: API.OperationMethod<
   GetManagedThingCapabilitiesRequest,
   GetManagedThingCapabilitiesResponse,
   GetManagedThingCapabilitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingCapabilitiesRequest,
   output: GetManagedThingCapabilitiesResponse,
@@ -5713,7 +5712,7 @@ export const getManagedThingCertificate: API.OperationMethod<
   GetManagedThingCertificateRequest,
   GetManagedThingCertificateResponse,
   GetManagedThingCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingCertificateRequest,
   output: GetManagedThingCertificateResponse,
@@ -5747,7 +5746,7 @@ export const getManagedThingConnectivityData: API.OperationMethod<
   GetManagedThingConnectivityDataRequest,
   GetManagedThingConnectivityDataResponse,
   GetManagedThingConnectivityDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingConnectivityDataRequest,
   output: GetManagedThingConnectivityDataResponse,
@@ -5783,7 +5782,7 @@ export const getManagedThingMetaData: API.OperationMethod<
   GetManagedThingMetaDataRequest,
   GetManagedThingMetaDataResponse,
   GetManagedThingMetaDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingMetaDataRequest,
   output: GetManagedThingMetaDataResponse,
@@ -5817,7 +5816,7 @@ export const getManagedThingState: API.OperationMethod<
   GetManagedThingStateRequest,
   GetManagedThingStateResponse,
   GetManagedThingStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedThingStateRequest,
   output: GetManagedThingStateResponse,
@@ -5849,7 +5848,7 @@ export const getNotificationConfiguration: API.OperationMethod<
   GetNotificationConfigurationRequest,
   GetNotificationConfigurationResponse,
   GetNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationConfigurationRequest,
   output: GetNotificationConfigurationResponse,
@@ -5879,7 +5878,7 @@ export const getOtaTask: API.OperationMethod<
   GetOtaTaskRequest,
   GetOtaTaskResponse,
   GetOtaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOtaTaskRequest,
   output: GetOtaTaskResponse,
@@ -5909,7 +5908,7 @@ export const getOtaTaskConfiguration: API.OperationMethod<
   GetOtaTaskConfigurationRequest,
   GetOtaTaskConfigurationResponse,
   GetOtaTaskConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOtaTaskConfigurationRequest,
   output: GetOtaTaskConfigurationResponse,
@@ -5941,7 +5940,7 @@ export const getProvisioningProfile: API.OperationMethod<
   GetProvisioningProfileRequest,
   GetProvisioningProfileResponse,
   GetProvisioningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProvisioningProfileRequest,
   output: GetProvisioningProfileResponse,
@@ -5973,7 +5972,7 @@ export const getRuntimeLogConfiguration: API.OperationMethod<
   GetRuntimeLogConfigurationRequest,
   GetRuntimeLogConfigurationResponse,
   GetRuntimeLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuntimeLogConfigurationRequest,
   output: GetRuntimeLogConfigurationResponse,
@@ -6005,7 +6004,7 @@ export const getSchemaVersion: API.OperationMethod<
   GetSchemaVersionRequest,
   GetSchemaVersionResponse,
   GetSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaVersionRequest,
   output: GetSchemaVersionResponse,
@@ -6037,7 +6036,7 @@ export const listAccountAssociations: API.PaginatedOperationMethod<
   ListAccountAssociationsRequest,
   ListAccountAssociationsResponse,
   ListAccountAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssociationItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssociationsRequest,
@@ -6073,7 +6072,7 @@ export const listCloudConnectors: API.PaginatedOperationMethod<
   ListCloudConnectorsRequest,
   ListCloudConnectorsResponse,
   ListCloudConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudConnectorsRequest,
@@ -6108,7 +6107,7 @@ export const listConnectorDestinations: API.PaginatedOperationMethod<
   ListConnectorDestinationsRequest,
   ListConnectorDestinationsResponse,
   ListConnectorDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorDestinationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorDestinationsRequest,
@@ -6144,7 +6143,7 @@ export const listCredentialLockers: API.PaginatedOperationMethod<
   ListCredentialLockersRequest,
   ListCredentialLockersResponse,
   ListCredentialLockersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CredentialLockerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCredentialLockersRequest,
@@ -6180,7 +6179,7 @@ export const listDestinations: API.PaginatedOperationMethod<
   ListDestinationsRequest,
   ListDestinationsResponse,
   ListDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DestinationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDestinationsRequest,
@@ -6217,7 +6216,7 @@ export const listDeviceDiscoveries: API.PaginatedOperationMethod<
   ListDeviceDiscoveriesRequest,
   ListDeviceDiscoveriesResponse,
   ListDeviceDiscoveriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceDiscoverySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeviceDiscoveriesRequest,
@@ -6257,7 +6256,7 @@ export const listDiscoveredDevices: API.PaginatedOperationMethod<
   ListDiscoveredDevicesRequest,
   ListDiscoveredDevicesResponse,
   ListDiscoveredDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DiscoveredDeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDiscoveredDevicesRequest,
@@ -6295,7 +6294,7 @@ export const listEventLogConfigurations: API.PaginatedOperationMethod<
   ListEventLogConfigurationsRequest,
   ListEventLogConfigurationsResponse,
   ListEventLogConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventLogConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventLogConfigurationsRequest,
@@ -6330,7 +6329,7 @@ export const listManagedThingAccountAssociations: API.PaginatedOperationMethod<
   ListManagedThingAccountAssociationsRequest,
   ListManagedThingAccountAssociationsResponse,
   ListManagedThingAccountAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedThingAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedThingAccountAssociationsRequest,
@@ -6367,7 +6366,7 @@ export const listManagedThings: API.PaginatedOperationMethod<
   ListManagedThingsRequest,
   ListManagedThingsResponse,
   ListManagedThingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedThingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedThingsRequest,
@@ -6407,7 +6406,7 @@ export const listManagedThingSchemas: API.PaginatedOperationMethod<
   ListManagedThingSchemasRequest,
   ListManagedThingSchemasResponse,
   ListManagedThingSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedThingSchemaListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedThingSchemasRequest,
@@ -6445,7 +6444,7 @@ export const listNotificationConfigurations: API.PaginatedOperationMethod<
   ListNotificationConfigurationsRequest,
   ListNotificationConfigurationsResponse,
   ListNotificationConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationConfigurationsRequest,
@@ -6480,7 +6479,7 @@ export const listOtaTaskConfigurations: API.PaginatedOperationMethod<
   ListOtaTaskConfigurationsRequest,
   ListOtaTaskConfigurationsResponse,
   ListOtaTaskConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OtaTaskConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOtaTaskConfigurationsRequest,
@@ -6516,7 +6515,7 @@ export const listOtaTaskExecutions: API.PaginatedOperationMethod<
   ListOtaTaskExecutionsRequest,
   ListOtaTaskExecutionsResponse,
   ListOtaTaskExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OtaTaskExecutionSummaries
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOtaTaskExecutionsRequest,
@@ -6553,7 +6552,7 @@ export const listOtaTasks: API.PaginatedOperationMethod<
   ListOtaTasksRequest,
   ListOtaTasksResponse,
   ListOtaTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OtaTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOtaTasksRequest,
@@ -6591,7 +6590,7 @@ export const listProvisioningProfiles: API.PaginatedOperationMethod<
   ListProvisioningProfilesRequest,
   ListProvisioningProfilesResponse,
   ListProvisioningProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisioningProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisioningProfilesRequest,
@@ -6630,7 +6629,7 @@ export const listSchemaVersions: API.PaginatedOperationMethod<
   ListSchemaVersionsRequest,
   ListSchemaVersionsResponse,
   ListSchemaVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaVersionListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemaVersionsRequest,
@@ -6667,7 +6666,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6698,7 +6697,7 @@ export const putDefaultEncryptionConfiguration: API.OperationMethod<
   PutDefaultEncryptionConfigurationRequest,
   PutDefaultEncryptionConfigurationResponse,
   PutDefaultEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDefaultEncryptionConfigurationRequest,
   output: PutDefaultEncryptionConfigurationResponse,
@@ -6731,7 +6730,7 @@ export const putHubConfiguration: API.OperationMethod<
   PutHubConfigurationRequest,
   PutHubConfigurationResponse,
   PutHubConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutHubConfigurationRequest,
   output: PutHubConfigurationResponse,
@@ -6762,7 +6761,7 @@ export const putRuntimeLogConfiguration: API.OperationMethod<
   PutRuntimeLogConfigurationRequest,
   PutRuntimeLogConfigurationResponse,
   PutRuntimeLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRuntimeLogConfigurationRequest,
   output: PutRuntimeLogConfigurationResponse,
@@ -6793,7 +6792,7 @@ export const registerAccountAssociation: API.OperationMethod<
   RegisterAccountAssociationRequest,
   RegisterAccountAssociationResponse,
   RegisterAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAccountAssociationRequest,
   output: RegisterAccountAssociationResponse,
@@ -6826,7 +6825,7 @@ export const registerCustomEndpoint: API.OperationMethod<
   RegisterCustomEndpointRequest,
   RegisterCustomEndpointResponse,
   RegisterCustomEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCustomEndpointRequest,
   output: RegisterCustomEndpointResponse,
@@ -6858,7 +6857,7 @@ export const resetRuntimeLogConfiguration: API.OperationMethod<
   ResetRuntimeLogConfigurationRequest,
   ResetRuntimeLogConfigurationResponse,
   ResetRuntimeLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetRuntimeLogConfigurationRequest,
   output: ResetRuntimeLogConfigurationResponse,
@@ -6889,7 +6888,7 @@ export const sendConnectorEvent: API.OperationMethod<
   SendConnectorEventRequest,
   SendConnectorEventResponse,
   SendConnectorEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendConnectorEventRequest,
   output: SendConnectorEventResponse,
@@ -6922,7 +6921,7 @@ export const sendManagedThingCommand: API.OperationMethod<
   SendManagedThingCommandRequest,
   SendManagedThingCommandResponse,
   SendManagedThingCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendManagedThingCommandRequest,
   output: SendManagedThingCommandResponse,
@@ -6956,7 +6955,7 @@ export const startAccountAssociationRefresh: API.OperationMethod<
   StartAccountAssociationRefreshRequest,
   StartAccountAssociationRefreshResponse,
   StartAccountAssociationRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAccountAssociationRefreshRequest,
   output: StartAccountAssociationRefreshResponse,
@@ -6991,7 +6990,7 @@ export const startDeviceDiscovery: API.OperationMethod<
   StartDeviceDiscoveryRequest,
   StartDeviceDiscoveryResponse,
   StartDeviceDiscoveryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeviceDiscoveryRequest,
   output: StartDeviceDiscoveryResponse,
@@ -7024,7 +7023,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7054,7 +7053,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7086,7 +7085,7 @@ export const updateAccountAssociation: API.OperationMethod<
   UpdateAccountAssociationRequest,
   UpdateAccountAssociationResponse,
   UpdateAccountAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountAssociationRequest,
   output: UpdateAccountAssociationResponse,
@@ -7119,7 +7118,7 @@ export const updateCloudConnector: API.OperationMethod<
   UpdateCloudConnectorRequest,
   UpdateCloudConnectorResponse,
   UpdateCloudConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCloudConnectorRequest,
   output: UpdateCloudConnectorResponse,
@@ -7150,7 +7149,7 @@ export const updateConnectorDestination: API.OperationMethod<
   UpdateConnectorDestinationRequest,
   UpdateConnectorDestinationResponse,
   UpdateConnectorDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorDestinationRequest,
   output: UpdateConnectorDestinationResponse,
@@ -7180,7 +7179,7 @@ export const updateDestination: API.OperationMethod<
   UpdateDestinationRequest,
   UpdateDestinationResponse,
   UpdateDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDestinationRequest,
   output: UpdateDestinationResponse,
@@ -7210,7 +7209,7 @@ export const updateEventLogConfiguration: API.OperationMethod<
   UpdateEventLogConfigurationRequest,
   UpdateEventLogConfigurationResponse,
   UpdateEventLogConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventLogConfigurationRequest,
   output: UpdateEventLogConfigurationResponse,
@@ -7243,7 +7242,7 @@ export const updateManagedThing: API.OperationMethod<
   UpdateManagedThingRequest,
   UpdateManagedThingResponse,
   UpdateManagedThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateManagedThingRequest,
   output: UpdateManagedThingResponse,
@@ -7276,7 +7275,7 @@ export const updateNotificationConfiguration: API.OperationMethod<
   UpdateNotificationConfigurationRequest,
   UpdateNotificationConfigurationResponse,
   UpdateNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationConfigurationRequest,
   output: UpdateNotificationConfigurationResponse,
@@ -7306,7 +7305,7 @@ export const updateOtaTask: API.OperationMethod<
   UpdateOtaTaskRequest,
   UpdateOtaTaskResponse,
   UpdateOtaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOtaTaskRequest,
   output: UpdateOtaTaskResponse,

--- a/packages/aws/src/services/iot-wireless.ts
+++ b/packages/aws/src/services/iot-wireless.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT Wireless",
@@ -6406,7 +6405,7 @@ export const associateAwsAccountWithPartnerAccount: API.OperationMethod<
   AssociateAwsAccountWithPartnerAccountRequest,
   AssociateAwsAccountWithPartnerAccountResponse,
   AssociateAwsAccountWithPartnerAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAwsAccountWithPartnerAccountRequest,
   output: AssociateAwsAccountWithPartnerAccountResponse,
@@ -6438,7 +6437,7 @@ export const associateMulticastGroupWithFuotaTask: API.OperationMethod<
   AssociateMulticastGroupWithFuotaTaskRequest,
   AssociateMulticastGroupWithFuotaTaskResponse,
   AssociateMulticastGroupWithFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMulticastGroupWithFuotaTaskRequest,
   output: AssociateMulticastGroupWithFuotaTaskResponse,
@@ -6470,7 +6469,7 @@ export const associateWirelessDeviceWithFuotaTask: API.OperationMethod<
   AssociateWirelessDeviceWithFuotaTaskRequest,
   AssociateWirelessDeviceWithFuotaTaskResponse,
   AssociateWirelessDeviceWithFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWirelessDeviceWithFuotaTaskRequest,
   output: AssociateWirelessDeviceWithFuotaTaskResponse,
@@ -6502,7 +6501,7 @@ export const associateWirelessDeviceWithMulticastGroup: API.OperationMethod<
   AssociateWirelessDeviceWithMulticastGroupRequest,
   AssociateWirelessDeviceWithMulticastGroupResponse,
   AssociateWirelessDeviceWithMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWirelessDeviceWithMulticastGroupRequest,
   output: AssociateWirelessDeviceWithMulticastGroupResponse,
@@ -6534,7 +6533,7 @@ export const associateWirelessDeviceWithThing: API.OperationMethod<
   AssociateWirelessDeviceWithThingRequest,
   AssociateWirelessDeviceWithThingResponse,
   AssociateWirelessDeviceWithThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWirelessDeviceWithThingRequest,
   output: AssociateWirelessDeviceWithThingResponse,
@@ -6566,7 +6565,7 @@ export const associateWirelessGatewayWithCertificate: API.OperationMethod<
   AssociateWirelessGatewayWithCertificateRequest,
   AssociateWirelessGatewayWithCertificateResponse,
   AssociateWirelessGatewayWithCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWirelessGatewayWithCertificateRequest,
   output: AssociateWirelessGatewayWithCertificateResponse,
@@ -6598,7 +6597,7 @@ export const associateWirelessGatewayWithThing: API.OperationMethod<
   AssociateWirelessGatewayWithThingRequest,
   AssociateWirelessGatewayWithThingResponse,
   AssociateWirelessGatewayWithThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWirelessGatewayWithThingRequest,
   output: AssociateWirelessGatewayWithThingResponse,
@@ -6630,7 +6629,7 @@ export const cancelMulticastGroupSession: API.OperationMethod<
   CancelMulticastGroupSessionRequest,
   CancelMulticastGroupSessionResponse,
   CancelMulticastGroupSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMulticastGroupSessionRequest,
   output: CancelMulticastGroupSessionResponse,
@@ -6662,7 +6661,7 @@ export const createDestination: API.OperationMethod<
   CreateDestinationRequest,
   CreateDestinationResponse,
   CreateDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDestinationRequest,
   output: CreateDestinationResponse,
@@ -6693,7 +6692,7 @@ export const createDeviceProfile: API.OperationMethod<
   CreateDeviceProfileRequest,
   CreateDeviceProfileResponse,
   CreateDeviceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeviceProfileRequest,
   output: CreateDeviceProfileResponse,
@@ -6724,7 +6723,7 @@ export const createFuotaTask: API.OperationMethod<
   CreateFuotaTaskRequest,
   CreateFuotaTaskResponse,
   CreateFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFuotaTaskRequest,
   output: CreateFuotaTaskResponse,
@@ -6756,7 +6755,7 @@ export const createMulticastGroup: API.OperationMethod<
   CreateMulticastGroupRequest,
   CreateMulticastGroupResponse,
   CreateMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMulticastGroupRequest,
   output: CreateMulticastGroupResponse,
@@ -6788,7 +6787,7 @@ export const createNetworkAnalyzerConfiguration: API.OperationMethod<
   CreateNetworkAnalyzerConfigurationRequest,
   CreateNetworkAnalyzerConfigurationResponse,
   CreateNetworkAnalyzerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkAnalyzerConfigurationRequest,
   output: CreateNetworkAnalyzerConfigurationResponse,
@@ -6819,7 +6818,7 @@ export const createServiceProfile: API.OperationMethod<
   CreateServiceProfileRequest,
   CreateServiceProfileResponse,
   CreateServiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceProfileRequest,
   output: CreateServiceProfileResponse,
@@ -6850,7 +6849,7 @@ export const createWirelessDevice: API.OperationMethod<
   CreateWirelessDeviceRequest,
   CreateWirelessDeviceResponse,
   CreateWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWirelessDeviceRequest,
   output: CreateWirelessDeviceResponse,
@@ -6892,7 +6891,7 @@ export const createWirelessGateway: API.OperationMethod<
   CreateWirelessGatewayRequest,
   CreateWirelessGatewayResponse,
   CreateWirelessGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWirelessGatewayRequest,
   output: CreateWirelessGatewayResponse,
@@ -6923,7 +6922,7 @@ export const createWirelessGatewayTask: API.OperationMethod<
   CreateWirelessGatewayTaskRequest,
   CreateWirelessGatewayTaskResponse,
   CreateWirelessGatewayTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWirelessGatewayTaskRequest,
   output: CreateWirelessGatewayTaskResponse,
@@ -6955,7 +6954,7 @@ export const createWirelessGatewayTaskDefinition: API.OperationMethod<
   CreateWirelessGatewayTaskDefinitionRequest,
   CreateWirelessGatewayTaskDefinitionResponse,
   CreateWirelessGatewayTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWirelessGatewayTaskDefinitionRequest,
   output: CreateWirelessGatewayTaskDefinitionResponse,
@@ -6987,7 +6986,7 @@ export const deleteDestination: API.OperationMethod<
   DeleteDestinationRequest,
   DeleteDestinationResponse,
   DeleteDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDestinationRequest,
   output: DeleteDestinationResponse,
@@ -7019,7 +7018,7 @@ export const deleteDeviceProfile: API.OperationMethod<
   DeleteDeviceProfileRequest,
   DeleteDeviceProfileResponse,
   DeleteDeviceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceProfileRequest,
   output: DeleteDeviceProfileResponse,
@@ -7050,7 +7049,7 @@ export const deleteFuotaTask: API.OperationMethod<
   DeleteFuotaTaskRequest,
   DeleteFuotaTaskResponse,
   DeleteFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFuotaTaskRequest,
   output: DeleteFuotaTaskResponse,
@@ -7081,7 +7080,7 @@ export const deleteMulticastGroup: API.OperationMethod<
   DeleteMulticastGroupRequest,
   DeleteMulticastGroupResponse,
   DeleteMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMulticastGroupRequest,
   output: DeleteMulticastGroupResponse,
@@ -7113,7 +7112,7 @@ export const deleteNetworkAnalyzerConfiguration: API.OperationMethod<
   DeleteNetworkAnalyzerConfigurationRequest,
   DeleteNetworkAnalyzerConfigurationResponse,
   DeleteNetworkAnalyzerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkAnalyzerConfigurationRequest,
   output: DeleteNetworkAnalyzerConfigurationResponse,
@@ -7144,7 +7143,7 @@ export const deleteQueuedMessages: API.OperationMethod<
   DeleteQueuedMessagesRequest,
   DeleteQueuedMessagesResponse,
   DeleteQueuedMessagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueuedMessagesRequest,
   output: DeleteQueuedMessagesResponse,
@@ -7175,7 +7174,7 @@ export const deleteServiceProfile: API.OperationMethod<
   DeleteServiceProfileRequest,
   DeleteServiceProfileResponse,
   DeleteServiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceProfileRequest,
   output: DeleteServiceProfileResponse,
@@ -7206,7 +7205,7 @@ export const deleteWirelessDevice: API.OperationMethod<
   DeleteWirelessDeviceRequest,
   DeleteWirelessDeviceResponse,
   DeleteWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWirelessDeviceRequest,
   output: DeleteWirelessDeviceResponse,
@@ -7237,7 +7236,7 @@ export const deleteWirelessDeviceImportTask: API.OperationMethod<
   DeleteWirelessDeviceImportTaskRequest,
   DeleteWirelessDeviceImportTaskResponse,
   DeleteWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWirelessDeviceImportTaskRequest,
   output: DeleteWirelessDeviceImportTaskResponse,
@@ -7279,7 +7278,7 @@ export const deleteWirelessGateway: API.OperationMethod<
   DeleteWirelessGatewayRequest,
   DeleteWirelessGatewayResponse,
   DeleteWirelessGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWirelessGatewayRequest,
   output: DeleteWirelessGatewayResponse,
@@ -7309,7 +7308,7 @@ export const deleteWirelessGatewayTask: API.OperationMethod<
   DeleteWirelessGatewayTaskRequest,
   DeleteWirelessGatewayTaskResponse,
   DeleteWirelessGatewayTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWirelessGatewayTaskRequest,
   output: DeleteWirelessGatewayTaskResponse,
@@ -7340,7 +7339,7 @@ export const deleteWirelessGatewayTaskDefinition: API.OperationMethod<
   DeleteWirelessGatewayTaskDefinitionRequest,
   DeleteWirelessGatewayTaskDefinitionResponse,
   DeleteWirelessGatewayTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWirelessGatewayTaskDefinitionRequest,
   output: DeleteWirelessGatewayTaskDefinitionResponse,
@@ -7369,7 +7368,7 @@ export const deregisterWirelessDevice: API.OperationMethod<
   DeregisterWirelessDeviceRequest,
   DeregisterWirelessDeviceResponse,
   DeregisterWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterWirelessDeviceRequest,
   output: DeregisterWirelessDeviceResponse,
@@ -7399,7 +7398,7 @@ export const disassociateAwsAccountFromPartnerAccount: API.OperationMethod<
   DisassociateAwsAccountFromPartnerAccountRequest,
   DisassociateAwsAccountFromPartnerAccountResponse,
   DisassociateAwsAccountFromPartnerAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAwsAccountFromPartnerAccountRequest,
   output: DisassociateAwsAccountFromPartnerAccountResponse,
@@ -7428,7 +7427,7 @@ export const disassociateMulticastGroupFromFuotaTask: API.OperationMethod<
   DisassociateMulticastGroupFromFuotaTaskRequest,
   DisassociateMulticastGroupFromFuotaTaskResponse,
   DisassociateMulticastGroupFromFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMulticastGroupFromFuotaTaskRequest,
   output: DisassociateMulticastGroupFromFuotaTaskResponse,
@@ -7459,7 +7458,7 @@ export const disassociateWirelessDeviceFromFuotaTask: API.OperationMethod<
   DisassociateWirelessDeviceFromFuotaTaskRequest,
   DisassociateWirelessDeviceFromFuotaTaskResponse,
   DisassociateWirelessDeviceFromFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWirelessDeviceFromFuotaTaskRequest,
   output: DisassociateWirelessDeviceFromFuotaTaskResponse,
@@ -7490,7 +7489,7 @@ export const disassociateWirelessDeviceFromMulticastGroup: API.OperationMethod<
   DisassociateWirelessDeviceFromMulticastGroupRequest,
   DisassociateWirelessDeviceFromMulticastGroupResponse,
   DisassociateWirelessDeviceFromMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWirelessDeviceFromMulticastGroupRequest,
   output: DisassociateWirelessDeviceFromMulticastGroupResponse,
@@ -7521,7 +7520,7 @@ export const disassociateWirelessDeviceFromThing: API.OperationMethod<
   DisassociateWirelessDeviceFromThingRequest,
   DisassociateWirelessDeviceFromThingResponse,
   DisassociateWirelessDeviceFromThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWirelessDeviceFromThingRequest,
   output: DisassociateWirelessDeviceFromThingResponse,
@@ -7552,7 +7551,7 @@ export const disassociateWirelessGatewayFromCertificate: API.OperationMethod<
   DisassociateWirelessGatewayFromCertificateRequest,
   DisassociateWirelessGatewayFromCertificateResponse,
   DisassociateWirelessGatewayFromCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWirelessGatewayFromCertificateRequest,
   output: DisassociateWirelessGatewayFromCertificateResponse,
@@ -7583,7 +7582,7 @@ export const disassociateWirelessGatewayFromThing: API.OperationMethod<
   DisassociateWirelessGatewayFromThingRequest,
   DisassociateWirelessGatewayFromThingResponse,
   DisassociateWirelessGatewayFromThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWirelessGatewayFromThingRequest,
   output: DisassociateWirelessGatewayFromThingResponse,
@@ -7614,7 +7613,7 @@ export const getDestination: API.OperationMethod<
   GetDestinationRequest,
   GetDestinationResponse,
   GetDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDestinationRequest,
   output: GetDestinationResponse,
@@ -7644,7 +7643,7 @@ export const getDeviceProfile: API.OperationMethod<
   GetDeviceProfileRequest,
   GetDeviceProfileResponse,
   GetDeviceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceProfileRequest,
   output: GetDeviceProfileResponse,
@@ -7672,7 +7671,7 @@ export const getEventConfigurationByResourceTypes: API.OperationMethod<
   GetEventConfigurationByResourceTypesRequest,
   GetEventConfigurationByResourceTypesResponse,
   GetEventConfigurationByResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventConfigurationByResourceTypesRequest,
   output: GetEventConfigurationByResourceTypesResponse,
@@ -7696,7 +7695,7 @@ export const getFuotaTask: API.OperationMethod<
   GetFuotaTaskRequest,
   GetFuotaTaskResponse,
   GetFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFuotaTaskRequest,
   output: GetFuotaTaskResponse,
@@ -7728,7 +7727,7 @@ export const getLogLevelsByResourceTypes: API.OperationMethod<
   GetLogLevelsByResourceTypesRequest,
   GetLogLevelsByResourceTypesResponse,
   GetLogLevelsByResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLogLevelsByResourceTypesRequest,
   output: GetLogLevelsByResourceTypesResponse,
@@ -7759,7 +7758,7 @@ export const getMetricConfiguration: API.OperationMethod<
   GetMetricConfigurationRequest,
   GetMetricConfigurationResponse,
   GetMetricConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricConfigurationRequest,
   output: GetMetricConfigurationResponse,
@@ -7791,7 +7790,7 @@ export const getMetrics: API.OperationMethod<
   GetMetricsRequest,
   GetMetricsResponse,
   GetMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricsRequest,
   output: GetMetricsResponse,
@@ -7822,7 +7821,7 @@ export const getMulticastGroup: API.OperationMethod<
   GetMulticastGroupRequest,
   GetMulticastGroupResponse,
   GetMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMulticastGroupRequest,
   output: GetMulticastGroupResponse,
@@ -7852,7 +7851,7 @@ export const getMulticastGroupSession: API.OperationMethod<
   GetMulticastGroupSessionRequest,
   GetMulticastGroupSessionResponse,
   GetMulticastGroupSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMulticastGroupSessionRequest,
   output: GetMulticastGroupSessionResponse,
@@ -7882,7 +7881,7 @@ export const getNetworkAnalyzerConfiguration: API.OperationMethod<
   GetNetworkAnalyzerConfigurationRequest,
   GetNetworkAnalyzerConfigurationResponse,
   GetNetworkAnalyzerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkAnalyzerConfigurationRequest,
   output: GetNetworkAnalyzerConfigurationResponse,
@@ -7912,7 +7911,7 @@ export const getPartnerAccount: API.OperationMethod<
   GetPartnerAccountRequest,
   GetPartnerAccountResponse,
   GetPartnerAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPartnerAccountRequest,
   output: GetPartnerAccountResponse,
@@ -7944,7 +7943,7 @@ export const getPosition: API.OperationMethod<
   GetPositionRequest,
   GetPositionResponse,
   GetPositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPositionRequest,
   output: GetPositionResponse,
@@ -7977,7 +7976,7 @@ export const getPositionConfiguration: API.OperationMethod<
   GetPositionConfigurationRequest,
   GetPositionConfigurationResponse,
   GetPositionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPositionConfigurationRequest,
   output: GetPositionConfigurationResponse,
@@ -8009,7 +8008,7 @@ export const getPositionEstimate: API.OperationMethod<
   GetPositionEstimateRequest,
   GetPositionEstimateResponse,
   GetPositionEstimateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPositionEstimateRequest,
   output: GetPositionEstimateResponse,
@@ -8039,7 +8038,7 @@ export const getResourceEventConfiguration: API.OperationMethod<
   GetResourceEventConfigurationRequest,
   GetResourceEventConfigurationResponse,
   GetResourceEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceEventConfigurationRequest,
   output: GetResourceEventConfigurationResponse,
@@ -8070,7 +8069,7 @@ export const getResourceLogLevel: API.OperationMethod<
   GetResourceLogLevelRequest,
   GetResourceLogLevelResponse,
   GetResourceLogLevelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceLogLevelRequest,
   output: GetResourceLogLevelResponse,
@@ -8102,7 +8101,7 @@ export const getResourcePosition: API.OperationMethod<
   GetResourcePositionRequest,
   GetResourcePositionResponse,
   GetResourcePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePositionRequest,
   output: GetResourcePositionResponse,
@@ -8132,7 +8131,7 @@ export const getServiceEndpoint: API.OperationMethod<
   GetServiceEndpointRequest,
   GetServiceEndpointResponse,
   GetServiceEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceEndpointRequest,
   output: GetServiceEndpointResponse,
@@ -8161,7 +8160,7 @@ export const getServiceProfile: API.OperationMethod<
   GetServiceProfileRequest,
   GetServiceProfileResponse,
   GetServiceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceProfileRequest,
   output: GetServiceProfileResponse,
@@ -8191,7 +8190,7 @@ export const getWirelessDevice: API.OperationMethod<
   GetWirelessDeviceRequest,
   GetWirelessDeviceResponse,
   GetWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessDeviceRequest,
   output: GetWirelessDeviceResponse,
@@ -8223,7 +8222,7 @@ export const getWirelessDeviceImportTask: API.OperationMethod<
   GetWirelessDeviceImportTaskRequest,
   GetWirelessDeviceImportTaskResponse,
   GetWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessDeviceImportTaskRequest,
   output: GetWirelessDeviceImportTaskResponse,
@@ -8254,7 +8253,7 @@ export const getWirelessDeviceStatistics: API.OperationMethod<
   GetWirelessDeviceStatisticsRequest,
   GetWirelessDeviceStatisticsResponse,
   GetWirelessDeviceStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessDeviceStatisticsRequest,
   output: GetWirelessDeviceStatisticsResponse,
@@ -8284,7 +8283,7 @@ export const getWirelessGateway: API.OperationMethod<
   GetWirelessGatewayRequest,
   GetWirelessGatewayResponse,
   GetWirelessGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayRequest,
   output: GetWirelessGatewayResponse,
@@ -8315,7 +8314,7 @@ export const getWirelessGatewayCertificate: API.OperationMethod<
   GetWirelessGatewayCertificateRequest,
   GetWirelessGatewayCertificateResponse,
   GetWirelessGatewayCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayCertificateRequest,
   output: GetWirelessGatewayCertificateResponse,
@@ -8345,7 +8344,7 @@ export const getWirelessGatewayFirmwareInformation: API.OperationMethod<
   GetWirelessGatewayFirmwareInformationRequest,
   GetWirelessGatewayFirmwareInformationResponse,
   GetWirelessGatewayFirmwareInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayFirmwareInformationRequest,
   output: GetWirelessGatewayFirmwareInformationResponse,
@@ -8375,7 +8374,7 @@ export const getWirelessGatewayStatistics: API.OperationMethod<
   GetWirelessGatewayStatisticsRequest,
   GetWirelessGatewayStatisticsResponse,
   GetWirelessGatewayStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayStatisticsRequest,
   output: GetWirelessGatewayStatisticsResponse,
@@ -8405,7 +8404,7 @@ export const getWirelessGatewayTask: API.OperationMethod<
   GetWirelessGatewayTaskRequest,
   GetWirelessGatewayTaskResponse,
   GetWirelessGatewayTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayTaskRequest,
   output: GetWirelessGatewayTaskResponse,
@@ -8435,7 +8434,7 @@ export const getWirelessGatewayTaskDefinition: API.OperationMethod<
   GetWirelessGatewayTaskDefinitionRequest,
   GetWirelessGatewayTaskDefinitionResponse,
   GetWirelessGatewayTaskDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWirelessGatewayTaskDefinitionRequest,
   output: GetWirelessGatewayTaskDefinitionResponse,
@@ -8464,7 +8463,7 @@ export const listDestinations: API.PaginatedOperationMethod<
   ListDestinationsRequest,
   ListDestinationsResponse,
   ListDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDestinationsRequest,
@@ -8498,7 +8497,7 @@ export const listDeviceProfiles: API.PaginatedOperationMethod<
   ListDeviceProfilesRequest,
   ListDeviceProfilesResponse,
   ListDeviceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeviceProfilesRequest,
@@ -8534,7 +8533,7 @@ export const listDevicesForWirelessDeviceImportTask: API.OperationMethod<
   ListDevicesForWirelessDeviceImportTaskRequest,
   ListDevicesForWirelessDeviceImportTaskResponse,
   ListDevicesForWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDevicesForWirelessDeviceImportTaskRequest,
   output: ListDevicesForWirelessDeviceImportTaskResponse,
@@ -8564,7 +8563,7 @@ export const listEventConfigurations: API.OperationMethod<
   ListEventConfigurationsRequest,
   ListEventConfigurationsResponse,
   ListEventConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListEventConfigurationsRequest,
   output: ListEventConfigurationsResponse,
@@ -8592,7 +8591,7 @@ export const listFuotaTasks: API.PaginatedOperationMethod<
   ListFuotaTasksRequest,
   ListFuotaTasksResponse,
   ListFuotaTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFuotaTasksRequest,
@@ -8626,7 +8625,7 @@ export const listMulticastGroups: API.PaginatedOperationMethod<
   ListMulticastGroupsRequest,
   ListMulticastGroupsResponse,
   ListMulticastGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMulticastGroupsRequest,
@@ -8661,7 +8660,7 @@ export const listMulticastGroupsByFuotaTask: API.PaginatedOperationMethod<
   ListMulticastGroupsByFuotaTaskRequest,
   ListMulticastGroupsByFuotaTaskResponse,
   ListMulticastGroupsByFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMulticastGroupsByFuotaTaskRequest,
@@ -8696,7 +8695,7 @@ export const listNetworkAnalyzerConfigurations: API.PaginatedOperationMethod<
   ListNetworkAnalyzerConfigurationsRequest,
   ListNetworkAnalyzerConfigurationsResponse,
   ListNetworkAnalyzerConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkAnalyzerConfigurationsRequest,
@@ -8730,7 +8729,7 @@ export const listPartnerAccounts: API.OperationMethod<
   ListPartnerAccountsRequest,
   ListPartnerAccountsResponse,
   ListPartnerAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPartnerAccountsRequest,
   output: ListPartnerAccountsResponse,
@@ -8761,7 +8760,7 @@ export const listPositionConfigurations: API.PaginatedOperationMethod<
   ListPositionConfigurationsRequest,
   ListPositionConfigurationsResponse,
   ListPositionConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPositionConfigurationsRequest,
@@ -8796,7 +8795,7 @@ export const listQueuedMessages: API.PaginatedOperationMethod<
   ListQueuedMessagesRequest,
   ListQueuedMessagesResponse,
   ListQueuedMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuedMessagesRequest,
@@ -8831,7 +8830,7 @@ export const listServiceProfiles: API.PaginatedOperationMethod<
   ListServiceProfilesRequest,
   ListServiceProfilesResponse,
   ListServiceProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceProfilesRequest,
@@ -8866,7 +8865,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8898,7 +8897,7 @@ export const listWirelessDeviceImportTasks: API.OperationMethod<
   ListWirelessDeviceImportTasksRequest,
   ListWirelessDeviceImportTasksResponse,
   ListWirelessDeviceImportTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWirelessDeviceImportTasksRequest,
   output: ListWirelessDeviceImportTasksResponse,
@@ -8928,7 +8927,7 @@ export const listWirelessDevices: API.PaginatedOperationMethod<
   ListWirelessDevicesRequest,
   ListWirelessDevicesResponse,
   ListWirelessDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWirelessDevicesRequest,
@@ -8962,7 +8961,7 @@ export const listWirelessGateways: API.PaginatedOperationMethod<
   ListWirelessGatewaysRequest,
   ListWirelessGatewaysResponse,
   ListWirelessGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWirelessGatewaysRequest,
@@ -8996,7 +8995,7 @@ export const listWirelessGatewayTaskDefinitions: API.OperationMethod<
   ListWirelessGatewayTaskDefinitionsRequest,
   ListWirelessGatewayTaskDefinitionsResponse,
   ListWirelessGatewayTaskDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWirelessGatewayTaskDefinitionsRequest,
   output: ListWirelessGatewayTaskDefinitionsResponse,
@@ -9028,7 +9027,7 @@ export const putPositionConfiguration: API.OperationMethod<
   PutPositionConfigurationRequest,
   PutPositionConfigurationResponse,
   PutPositionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPositionConfigurationRequest,
   output: PutPositionConfigurationResponse,
@@ -9059,7 +9058,7 @@ export const putResourceLogLevel: API.OperationMethod<
   PutResourceLogLevelRequest,
   PutResourceLogLevelResponse,
   PutResourceLogLevelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourceLogLevelRequest,
   output: PutResourceLogLevelResponse,
@@ -9090,7 +9089,7 @@ export const resetAllResourceLogLevels: API.OperationMethod<
   ResetAllResourceLogLevelsRequest,
   ResetAllResourceLogLevelsResponse,
   ResetAllResourceLogLevelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetAllResourceLogLevelsRequest,
   output: ResetAllResourceLogLevelsResponse,
@@ -9121,7 +9120,7 @@ export const resetResourceLogLevel: API.OperationMethod<
   ResetResourceLogLevelRequest,
   ResetResourceLogLevelResponse,
   ResetResourceLogLevelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetResourceLogLevelRequest,
   output: ResetResourceLogLevelResponse,
@@ -9152,7 +9151,7 @@ export const sendDataToMulticastGroup: API.OperationMethod<
   SendDataToMulticastGroupRequest,
   SendDataToMulticastGroupResponse,
   SendDataToMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDataToMulticastGroupRequest,
   output: SendDataToMulticastGroupResponse,
@@ -9182,7 +9181,7 @@ export const sendDataToWirelessDevice: API.OperationMethod<
   SendDataToWirelessDeviceRequest,
   SendDataToWirelessDeviceResponse,
   SendDataToWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDataToWirelessDeviceRequest,
   output: SendDataToWirelessDeviceResponse,
@@ -9212,7 +9211,7 @@ export const startBulkAssociateWirelessDeviceWithMulticastGroup: API.OperationMe
   StartBulkAssociateWirelessDeviceWithMulticastGroupRequest,
   StartBulkAssociateWirelessDeviceWithMulticastGroupResponse,
   StartBulkAssociateWirelessDeviceWithMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBulkAssociateWirelessDeviceWithMulticastGroupRequest,
   output: StartBulkAssociateWirelessDeviceWithMulticastGroupResponse,
@@ -9243,7 +9242,7 @@ export const startBulkDisassociateWirelessDeviceFromMulticastGroup: API.Operatio
   StartBulkDisassociateWirelessDeviceFromMulticastGroupRequest,
   StartBulkDisassociateWirelessDeviceFromMulticastGroupResponse,
   StartBulkDisassociateWirelessDeviceFromMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBulkDisassociateWirelessDeviceFromMulticastGroupRequest,
   output: StartBulkDisassociateWirelessDeviceFromMulticastGroupResponse,
@@ -9274,7 +9273,7 @@ export const startFuotaTask: API.OperationMethod<
   StartFuotaTaskRequest,
   StartFuotaTaskResponse,
   StartFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFuotaTaskRequest,
   output: StartFuotaTaskResponse,
@@ -9306,7 +9305,7 @@ export const startMulticastGroupSession: API.OperationMethod<
   StartMulticastGroupSessionRequest,
   StartMulticastGroupSessionResponse,
   StartMulticastGroupSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMulticastGroupSessionRequest,
   output: StartMulticastGroupSessionResponse,
@@ -9338,7 +9337,7 @@ export const startSingleWirelessDeviceImportTask: API.OperationMethod<
   StartSingleWirelessDeviceImportTaskRequest,
   StartSingleWirelessDeviceImportTaskResponse,
   StartSingleWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSingleWirelessDeviceImportTaskRequest,
   output: StartSingleWirelessDeviceImportTaskResponse,
@@ -9371,7 +9370,7 @@ export const startWirelessDeviceImportTask: API.OperationMethod<
   StartWirelessDeviceImportTaskRequest,
   StartWirelessDeviceImportTaskResponse,
   StartWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWirelessDeviceImportTaskRequest,
   output: StartWirelessDeviceImportTaskResponse,
@@ -9403,7 +9402,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -9434,7 +9433,7 @@ export const testWirelessDevice: API.OperationMethod<
   TestWirelessDeviceRequest,
   TestWirelessDeviceResponse,
   TestWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestWirelessDeviceRequest,
   output: TestWirelessDeviceResponse,
@@ -9463,7 +9462,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -9493,7 +9492,7 @@ export const updateDestination: API.OperationMethod<
   UpdateDestinationRequest,
   UpdateDestinationResponse,
   UpdateDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDestinationRequest,
   output: UpdateDestinationResponse,
@@ -9522,7 +9521,7 @@ export const updateEventConfigurationByResourceTypes: API.OperationMethod<
   UpdateEventConfigurationByResourceTypesRequest,
   UpdateEventConfigurationByResourceTypesResponse,
   UpdateEventConfigurationByResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventConfigurationByResourceTypesRequest,
   output: UpdateEventConfigurationByResourceTypesResponse,
@@ -9552,7 +9551,7 @@ export const updateFuotaTask: API.OperationMethod<
   UpdateFuotaTaskRequest,
   UpdateFuotaTaskResponse,
   UpdateFuotaTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFuotaTaskRequest,
   output: UpdateFuotaTaskResponse,
@@ -9586,7 +9585,7 @@ export const updateLogLevelsByResourceTypes: API.OperationMethod<
   UpdateLogLevelsByResourceTypesRequest,
   UpdateLogLevelsByResourceTypesResponse,
   UpdateLogLevelsByResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLogLevelsByResourceTypesRequest,
   output: UpdateLogLevelsByResourceTypesResponse,
@@ -9618,7 +9617,7 @@ export const updateMetricConfiguration: API.OperationMethod<
   UpdateMetricConfigurationRequest,
   UpdateMetricConfigurationResponse,
   UpdateMetricConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMetricConfigurationRequest,
   output: UpdateMetricConfigurationResponse,
@@ -9650,7 +9649,7 @@ export const updateMulticastGroup: API.OperationMethod<
   UpdateMulticastGroupRequest,
   UpdateMulticastGroupResponse,
   UpdateMulticastGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMulticastGroupRequest,
   output: UpdateMulticastGroupResponse,
@@ -9681,7 +9680,7 @@ export const updateNetworkAnalyzerConfiguration: API.OperationMethod<
   UpdateNetworkAnalyzerConfigurationRequest,
   UpdateNetworkAnalyzerConfigurationResponse,
   UpdateNetworkAnalyzerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkAnalyzerConfigurationRequest,
   output: UpdateNetworkAnalyzerConfigurationResponse,
@@ -9710,7 +9709,7 @@ export const updatePartnerAccount: API.OperationMethod<
   UpdatePartnerAccountRequest,
   UpdatePartnerAccountResponse,
   UpdatePartnerAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePartnerAccountRequest,
   output: UpdatePartnerAccountResponse,
@@ -9742,7 +9741,7 @@ export const updatePosition: API.OperationMethod<
   UpdatePositionRequest,
   UpdatePositionResponse,
   UpdatePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePositionRequest,
   output: UpdatePositionResponse,
@@ -9773,7 +9772,7 @@ export const updateResourceEventConfiguration: API.OperationMethod<
   UpdateResourceEventConfigurationRequest,
   UpdateResourceEventConfigurationResponse,
   UpdateResourceEventConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceEventConfigurationRequest,
   output: UpdateResourceEventConfigurationResponse,
@@ -9806,7 +9805,7 @@ export const updateResourcePosition: API.OperationMethod<
   UpdateResourcePositionRequest,
   UpdateResourcePositionResponse,
   UpdateResourcePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourcePositionRequest,
   output: UpdateResourcePositionResponse,
@@ -9836,7 +9835,7 @@ export const updateWirelessDevice: API.OperationMethod<
   UpdateWirelessDeviceRequest,
   UpdateWirelessDeviceResponse,
   UpdateWirelessDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWirelessDeviceRequest,
   output: UpdateWirelessDeviceResponse,
@@ -9867,7 +9866,7 @@ export const updateWirelessDeviceImportTask: API.OperationMethod<
   UpdateWirelessDeviceImportTaskRequest,
   UpdateWirelessDeviceImportTaskResponse,
   UpdateWirelessDeviceImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWirelessDeviceImportTaskRequest,
   output: UpdateWirelessDeviceImportTaskResponse,
@@ -9898,7 +9897,7 @@ export const updateWirelessGateway: API.OperationMethod<
   UpdateWirelessGatewayRequest,
   UpdateWirelessGatewayResponse,
   UpdateWirelessGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWirelessGatewayRequest,
   output: UpdateWirelessGatewayResponse,

--- a/packages/aws/src/services/iot.ts
+++ b/packages/aws/src/services/iot.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoT",
@@ -14972,7 +14971,7 @@ export const acceptCertificateTransfer: API.OperationMethod<
   AcceptCertificateTransferRequest,
   AcceptCertificateTransferResponse,
   AcceptCertificateTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptCertificateTransferRequest,
   output: AcceptCertificateTransferResponse,
@@ -15005,7 +15004,7 @@ export const addThingToBillingGroup: API.OperationMethod<
   AddThingToBillingGroupRequest,
   AddThingToBillingGroupResponse,
   AddThingToBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddThingToBillingGroupRequest,
   output: AddThingToBillingGroupResponse,
@@ -15035,7 +15034,7 @@ export const addThingToThingGroup: API.OperationMethod<
   AddThingToThingGroupRequest,
   AddThingToThingGroupResponse,
   AddThingToThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddThingToThingGroupRequest,
   output: AddThingToThingGroupResponse,
@@ -15067,7 +15066,7 @@ export const associateSbomWithPackageVersion: API.OperationMethod<
   AssociateSbomWithPackageVersionRequest,
   AssociateSbomWithPackageVersionResponse,
   AssociateSbomWithPackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSbomWithPackageVersionRequest,
   output: AssociateSbomWithPackageVersionResponse,
@@ -15108,7 +15107,7 @@ export const associateTargetsWithJob: API.OperationMethod<
   AssociateTargetsWithJobRequest,
   AssociateTargetsWithJobResponse,
   AssociateTargetsWithJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTargetsWithJobRequest,
   output: AssociateTargetsWithJobResponse,
@@ -15143,7 +15142,7 @@ export const attachPolicy: API.OperationMethod<
   AttachPolicyRequest,
   AttachPolicyResponse,
   AttachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachPolicyRequest,
   output: AttachPolicyResponse,
@@ -15183,7 +15182,7 @@ export const attachPrincipalPolicy: API.OperationMethod<
   AttachPrincipalPolicyRequest,
   AttachPrincipalPolicyResponse,
   AttachPrincipalPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachPrincipalPolicyRequest,
   output: AttachPrincipalPolicyResponse,
@@ -15219,7 +15218,7 @@ export const attachSecurityProfile: API.OperationMethod<
   AttachSecurityProfileRequest,
   AttachSecurityProfileResponse,
   AttachSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachSecurityProfileRequest,
   output: AttachSecurityProfileResponse,
@@ -15254,7 +15253,7 @@ export const attachThingPrincipal: API.OperationMethod<
   AttachThingPrincipalRequest,
   AttachThingPrincipalResponse,
   AttachThingPrincipalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachThingPrincipalRequest,
   output: AttachThingPrincipalResponse,
@@ -15288,7 +15287,7 @@ export const cancelAuditMitigationActionsTask: API.OperationMethod<
   CancelAuditMitigationActionsTaskRequest,
   CancelAuditMitigationActionsTaskResponse,
   CancelAuditMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAuditMitigationActionsTaskRequest,
   output: CancelAuditMitigationActionsTaskResponse,
@@ -15318,7 +15317,7 @@ export const cancelAuditTask: API.OperationMethod<
   CancelAuditTaskRequest,
   CancelAuditTaskResponse,
   CancelAuditTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAuditTaskRequest,
   output: CancelAuditTaskResponse,
@@ -15359,7 +15358,7 @@ export const cancelCertificateTransfer: API.OperationMethod<
   CancelCertificateTransferRequest,
   CancelCertificateTransferResponse,
   CancelCertificateTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCertificateTransferRequest,
   output: CancelCertificateTransferResponse,
@@ -15392,7 +15391,7 @@ export const cancelDetectMitigationActionsTask: API.OperationMethod<
   CancelDetectMitigationActionsTaskRequest,
   CancelDetectMitigationActionsTaskResponse,
   CancelDetectMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDetectMitigationActionsTaskRequest,
   output: CancelDetectMitigationActionsTaskResponse,
@@ -15423,7 +15422,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -15456,7 +15455,7 @@ export const cancelJobExecution: API.OperationMethod<
   CancelJobExecutionRequest,
   CancelJobExecutionResponse,
   CancelJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobExecutionRequest,
   output: CancelJobExecutionResponse,
@@ -15490,7 +15489,7 @@ export const clearDefaultAuthorizer: API.OperationMethod<
   ClearDefaultAuthorizerRequest,
   ClearDefaultAuthorizerResponse,
   ClearDefaultAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClearDefaultAuthorizerRequest,
   output: ClearDefaultAuthorizerResponse,
@@ -15526,7 +15525,7 @@ export const confirmTopicRuleDestination: API.OperationMethod<
   ConfirmTopicRuleDestinationRequest,
   ConfirmTopicRuleDestinationResponse,
   ConfirmTopicRuleDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmTopicRuleDestinationRequest,
   output: ConfirmTopicRuleDestinationResponse,
@@ -15558,7 +15557,7 @@ export const createAuditSuppression: API.OperationMethod<
   CreateAuditSuppressionRequest,
   CreateAuditSuppressionResponse,
   CreateAuditSuppressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAuditSuppressionRequest,
   output: CreateAuditSuppressionResponse,
@@ -15592,7 +15591,7 @@ export const createAuthorizer: API.OperationMethod<
   CreateAuthorizerRequest,
   CreateAuthorizerResponse,
   CreateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAuthorizerRequest,
   output: CreateAuthorizerResponse,
@@ -15627,7 +15626,7 @@ export const createBillingGroup: API.OperationMethod<
   CreateBillingGroupRequest,
   CreateBillingGroupResponse,
   CreateBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillingGroupRequest,
   output: CreateBillingGroupResponse,
@@ -15699,7 +15698,7 @@ export const createCertificateFromCsr: API.OperationMethod<
   CreateCertificateFromCsrRequest,
   CreateCertificateFromCsrResponse,
   CreateCertificateFromCsrError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCertificateFromCsrRequest,
   output: CreateCertificateFromCsrResponse,
@@ -15743,7 +15742,7 @@ export const createCertificateProvider: API.OperationMethod<
   CreateCertificateProviderRequest,
   CreateCertificateProviderResponse,
   CreateCertificateProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCertificateProviderRequest,
   output: CreateCertificateProviderResponse,
@@ -15776,7 +15775,7 @@ export const createCommand: API.OperationMethod<
   CreateCommandRequest,
   CreateCommandResponse,
   CreateCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCommandRequest,
   output: CreateCommandResponse,
@@ -15811,7 +15810,7 @@ export const createCustomMetric: API.OperationMethod<
   CreateCustomMetricRequest,
   CreateCustomMetricResponse,
   CreateCustomMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomMetricRequest,
   output: CreateCustomMetricResponse,
@@ -15844,7 +15843,7 @@ export const createDimension: API.OperationMethod<
   CreateDimensionRequest,
   CreateDimensionResponse,
   CreateDimensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDimensionRequest,
   output: CreateDimensionResponse,
@@ -15879,7 +15878,7 @@ export const createDomainConfiguration: API.OperationMethod<
   CreateDomainConfigurationRequest,
   CreateDomainConfigurationResponse,
   CreateDomainConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainConfigurationRequest,
   output: CreateDomainConfigurationResponse,
@@ -15916,7 +15915,7 @@ export const createDynamicThingGroup: API.OperationMethod<
   CreateDynamicThingGroupRequest,
   CreateDynamicThingGroupResponse,
   CreateDynamicThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDynamicThingGroupRequest,
   output: CreateDynamicThingGroupResponse,
@@ -15956,7 +15955,7 @@ export const createFleetMetric: API.OperationMethod<
   CreateFleetMetricRequest,
   CreateFleetMetricResponse,
   CreateFleetMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetMetricRequest,
   output: CreateFleetMetricResponse,
@@ -15995,7 +15994,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -16029,7 +16028,7 @@ export const createJobTemplate: API.OperationMethod<
   CreateJobTemplateRequest,
   CreateJobTemplateResponse,
   CreateJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobTemplateRequest,
   output: CreateJobTemplateResponse,
@@ -16067,7 +16066,7 @@ export const createKeysAndCertificate: API.OperationMethod<
   CreateKeysAndCertificateRequest,
   CreateKeysAndCertificateResponse,
   CreateKeysAndCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeysAndCertificateRequest,
   output: CreateKeysAndCertificateResponse,
@@ -16100,7 +16099,7 @@ export const createMitigationAction: API.OperationMethod<
   CreateMitigationActionRequest,
   CreateMitigationActionResponse,
   CreateMitigationActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMitigationActionRequest,
   output: CreateMitigationActionResponse,
@@ -16135,7 +16134,7 @@ export const createOTAUpdate: API.OperationMethod<
   CreateOTAUpdateRequest,
   CreateOTAUpdateResponse,
   CreateOTAUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOTAUpdateRequest,
   output: CreateOTAUpdateResponse,
@@ -16170,7 +16169,7 @@ export const createPackage: API.OperationMethod<
   CreatePackageRequest,
   CreatePackageResponse,
   CreatePackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageRequest,
   output: CreatePackageResponse,
@@ -16202,7 +16201,7 @@ export const createPackageVersion: API.OperationMethod<
   CreatePackageVersionRequest,
   CreatePackageVersionResponse,
   CreatePackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageVersionRequest,
   output: CreatePackageVersionResponse,
@@ -16240,7 +16239,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyRequest,
   CreatePolicyResponse,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyRequest,
   output: CreatePolicyResponse,
@@ -16284,7 +16283,7 @@ export const createPolicyVersion: API.OperationMethod<
   CreatePolicyVersionRequest,
   CreatePolicyVersionResponse,
   CreatePolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyVersionRequest,
   output: CreatePolicyVersionResponse,
@@ -16320,7 +16319,7 @@ export const createProvisioningClaim: API.OperationMethod<
   CreateProvisioningClaimRequest,
   CreateProvisioningClaimResponse,
   CreateProvisioningClaimError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisioningClaimRequest,
   output: CreateProvisioningClaimResponse,
@@ -16354,7 +16353,7 @@ export const createProvisioningTemplate: API.OperationMethod<
   CreateProvisioningTemplateRequest,
   CreateProvisioningTemplateResponse,
   CreateProvisioningTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisioningTemplateRequest,
   output: CreateProvisioningTemplateResponse,
@@ -16389,7 +16388,7 @@ export const createProvisioningTemplateVersion: API.OperationMethod<
   CreateProvisioningTemplateVersionRequest,
   CreateProvisioningTemplateVersionResponse,
   CreateProvisioningTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisioningTemplateVersionRequest,
   output: CreateProvisioningTemplateVersionResponse,
@@ -16432,7 +16431,7 @@ export const createRoleAlias: API.OperationMethod<
   CreateRoleAliasRequest,
   CreateRoleAliasResponse,
   CreateRoleAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoleAliasRequest,
   output: CreateRoleAliasResponse,
@@ -16467,7 +16466,7 @@ export const createScheduledAudit: API.OperationMethod<
   CreateScheduledAuditRequest,
   CreateScheduledAuditResponse,
   CreateScheduledAuditError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledAuditRequest,
   output: CreateScheduledAuditResponse,
@@ -16498,7 +16497,7 @@ export const createSecurityProfile: API.OperationMethod<
   CreateSecurityProfileRequest,
   CreateSecurityProfileResponse,
   CreateSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityProfileRequest,
   output: CreateSecurityProfileResponse,
@@ -16534,7 +16533,7 @@ export const createStream: API.OperationMethod<
   CreateStreamRequest,
   CreateStreamResponse,
   CreateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamRequest,
   output: CreateStreamResponse,
@@ -16577,7 +16576,7 @@ export const createThing: API.OperationMethod<
   CreateThingRequest,
   CreateThingResponse,
   CreateThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThingRequest,
   output: CreateThingResponse,
@@ -16616,7 +16615,7 @@ export const createThingGroup: API.OperationMethod<
   CreateThingGroupRequest,
   CreateThingGroupResponse,
   CreateThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThingGroupRequest,
   output: CreateThingGroupResponse,
@@ -16650,7 +16649,7 @@ export const createThingType: API.OperationMethod<
   CreateThingTypeRequest,
   CreateThingTypeResponse,
   CreateThingTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThingTypeRequest,
   output: CreateThingTypeResponse,
@@ -16686,7 +16685,7 @@ export const createTopicRule: API.OperationMethod<
   CreateTopicRuleRequest,
   CreateTopicRuleResponse,
   CreateTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicRuleRequest,
   output: CreateTopicRuleResponse,
@@ -16721,7 +16720,7 @@ export const createTopicRuleDestination: API.OperationMethod<
   CreateTopicRuleDestinationRequest,
   CreateTopicRuleDestinationResponse,
   CreateTopicRuleDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicRuleDestinationRequest,
   output: CreateTopicRuleDestinationResponse,
@@ -16755,7 +16754,7 @@ export const deleteAccountAuditConfiguration: API.OperationMethod<
   DeleteAccountAuditConfigurationRequest,
   DeleteAccountAuditConfigurationResponse,
   DeleteAccountAuditConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountAuditConfigurationRequest,
   output: DeleteAccountAuditConfigurationResponse,
@@ -16784,7 +16783,7 @@ export const deleteAuditSuppression: API.OperationMethod<
   DeleteAuditSuppressionRequest,
   DeleteAuditSuppressionResponse,
   DeleteAuditSuppressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuditSuppressionRequest,
   output: DeleteAuditSuppressionResponse,
@@ -16816,7 +16815,7 @@ export const deleteAuthorizer: API.OperationMethod<
   DeleteAuthorizerRequest,
   DeleteAuthorizerResponse,
   DeleteAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuthorizerRequest,
   output: DeleteAuthorizerResponse,
@@ -16849,7 +16848,7 @@ export const deleteBillingGroup: API.OperationMethod<
   DeleteBillingGroupRequest,
   DeleteBillingGroupResponse,
   DeleteBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBillingGroupRequest,
   output: DeleteBillingGroupResponse,
@@ -16882,7 +16881,7 @@ export const deleteCACertificate: API.OperationMethod<
   DeleteCACertificateRequest,
   DeleteCACertificateResponse,
   DeleteCACertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCACertificateRequest,
   output: DeleteCACertificateResponse,
@@ -16923,7 +16922,7 @@ export const deleteCertificate: API.OperationMethod<
   DeleteCertificateRequest,
   DeleteCertificateResponse,
   DeleteCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateRequest,
   output: DeleteCertificateResponse,
@@ -16964,7 +16963,7 @@ export const deleteCertificateProvider: API.OperationMethod<
   DeleteCertificateProviderRequest,
   DeleteCertificateProviderResponse,
   DeleteCertificateProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateProviderRequest,
   output: DeleteCertificateProviderResponse,
@@ -16995,7 +16994,7 @@ export const deleteCommand: API.OperationMethod<
   DeleteCommandRequest,
   DeleteCommandResponse,
   DeleteCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCommandRequest,
   output: DeleteCommandResponse,
@@ -17026,7 +17025,7 @@ export const deleteCommandExecution: API.OperationMethod<
   DeleteCommandExecutionRequest,
   DeleteCommandExecutionResponse,
   DeleteCommandExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCommandExecutionRequest,
   output: DeleteCommandExecutionResponse,
@@ -17062,7 +17061,7 @@ export const deleteCustomMetric: API.OperationMethod<
   DeleteCustomMetricRequest,
   DeleteCustomMetricResponse,
   DeleteCustomMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomMetricRequest,
   output: DeleteCustomMetricResponse,
@@ -17090,7 +17089,7 @@ export const deleteDimension: API.OperationMethod<
   DeleteDimensionRequest,
   DeleteDimensionResponse,
   DeleteDimensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDimensionRequest,
   output: DeleteDimensionResponse,
@@ -17121,7 +17120,7 @@ export const deleteDomainConfiguration: API.OperationMethod<
   DeleteDomainConfigurationRequest,
   DeleteDomainConfigurationResponse,
   DeleteDomainConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainConfigurationRequest,
   output: DeleteDomainConfigurationResponse,
@@ -17153,7 +17152,7 @@ export const deleteDynamicThingGroup: API.OperationMethod<
   DeleteDynamicThingGroupRequest,
   DeleteDynamicThingGroupResponse,
   DeleteDynamicThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDynamicThingGroupRequest,
   output: DeleteDynamicThingGroupResponse,
@@ -17186,7 +17185,7 @@ export const deleteFleetMetric: API.OperationMethod<
   DeleteFleetMetricRequest,
   DeleteFleetMetricResponse,
   DeleteFleetMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetMetricRequest,
   output: DeleteFleetMetricResponse,
@@ -17228,7 +17227,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -17261,7 +17260,7 @@ export const deleteJobExecution: API.OperationMethod<
   DeleteJobExecutionRequest,
   DeleteJobExecutionResponse,
   DeleteJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobExecutionRequest,
   output: DeleteJobExecutionResponse,
@@ -17290,7 +17289,7 @@ export const deleteJobTemplate: API.OperationMethod<
   DeleteJobTemplateRequest,
   DeleteJobTemplateResponse,
   DeleteJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobTemplateRequest,
   output: DeleteJobTemplateResponse,
@@ -17319,7 +17318,7 @@ export const deleteMitigationAction: API.OperationMethod<
   DeleteMitigationActionRequest,
   DeleteMitigationActionResponse,
   DeleteMitigationActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMitigationActionRequest,
   output: DeleteMitigationActionResponse,
@@ -17351,7 +17350,7 @@ export const deleteOTAUpdate: API.OperationMethod<
   DeleteOTAUpdateRequest,
   DeleteOTAUpdateResponse,
   DeleteOTAUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOTAUpdateRequest,
   output: DeleteOTAUpdateResponse,
@@ -17385,7 +17384,7 @@ export const deletePackage: API.OperationMethod<
   DeletePackageRequest,
   DeletePackageResponse,
   DeletePackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageRequest,
   output: DeletePackageResponse,
@@ -17409,7 +17408,7 @@ export const deletePackageVersion: API.OperationMethod<
   DeletePackageVersionRequest,
   DeletePackageVersionResponse,
   DeletePackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageVersionRequest,
   output: DeletePackageVersionResponse,
@@ -17450,7 +17449,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -17488,7 +17487,7 @@ export const deletePolicyVersion: API.OperationMethod<
   DeletePolicyVersionRequest,
   DeletePolicyVersionResponse,
   DeletePolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyVersionRequest,
   output: DeletePolicyVersionResponse,
@@ -17524,7 +17523,7 @@ export const deleteProvisioningTemplate: API.OperationMethod<
   DeleteProvisioningTemplateRequest,
   DeleteProvisioningTemplateResponse,
   DeleteProvisioningTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisioningTemplateRequest,
   output: DeleteProvisioningTemplateResponse,
@@ -17560,7 +17559,7 @@ export const deleteProvisioningTemplateVersion: API.OperationMethod<
   DeleteProvisioningTemplateVersionRequest,
   DeleteProvisioningTemplateVersionResponse,
   DeleteProvisioningTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisioningTemplateVersionRequest,
   output: DeleteProvisioningTemplateVersionResponse,
@@ -17594,7 +17593,7 @@ export const deleteRegistrationCode: API.OperationMethod<
   DeleteRegistrationCodeRequest,
   DeleteRegistrationCodeResponse,
   DeleteRegistrationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistrationCodeRequest,
   output: DeleteRegistrationCodeResponse,
@@ -17628,7 +17627,7 @@ export const deleteRoleAlias: API.OperationMethod<
   DeleteRoleAliasRequest,
   DeleteRoleAliasResponse,
   DeleteRoleAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoleAliasRequest,
   output: DeleteRoleAliasResponse,
@@ -17661,7 +17660,7 @@ export const deleteScheduledAudit: API.OperationMethod<
   DeleteScheduledAuditRequest,
   DeleteScheduledAuditResponse,
   DeleteScheduledAuditError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledAuditRequest,
   output: DeleteScheduledAuditResponse,
@@ -17691,7 +17690,7 @@ export const deleteSecurityProfile: API.OperationMethod<
   DeleteSecurityProfileRequest,
   DeleteSecurityProfileResponse,
   DeleteSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityProfileRequest,
   output: DeleteSecurityProfileResponse,
@@ -17724,7 +17723,7 @@ export const deleteStream: API.OperationMethod<
   DeleteStreamRequest,
   DeleteStreamResponse,
   DeleteStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamRequest,
   output: DeleteStreamResponse,
@@ -17761,7 +17760,7 @@ export const deleteThing: API.OperationMethod<
   DeleteThingRequest,
   DeleteThingResponse,
   DeleteThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThingRequest,
   output: DeleteThingResponse,
@@ -17794,7 +17793,7 @@ export const deleteThingGroup: API.OperationMethod<
   DeleteThingGroupRequest,
   DeleteThingGroupResponse,
   DeleteThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThingGroupRequest,
   output: DeleteThingGroupResponse,
@@ -17828,7 +17827,7 @@ export const deleteThingType: API.OperationMethod<
   DeleteThingTypeRequest,
   DeleteThingTypeResponse,
   DeleteThingTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThingTypeRequest,
   output: DeleteThingTypeResponse,
@@ -17862,7 +17861,7 @@ export const deleteTopicRule: API.OperationMethod<
   DeleteTopicRuleRequest,
   DeleteTopicRuleResponse,
   DeleteTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicRuleRequest,
   output: DeleteTopicRuleResponse,
@@ -17895,7 +17894,7 @@ export const deleteTopicRuleDestination: API.OperationMethod<
   DeleteTopicRuleDestinationRequest,
   DeleteTopicRuleDestinationResponse,
   DeleteTopicRuleDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicRuleDestinationRequest,
   output: DeleteTopicRuleDestinationResponse,
@@ -17925,7 +17924,7 @@ export const deleteV2LoggingLevel: API.OperationMethod<
   DeleteV2LoggingLevelRequest,
   DeleteV2LoggingLevelResponse,
   DeleteV2LoggingLevelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteV2LoggingLevelRequest,
   output: DeleteV2LoggingLevelResponse,
@@ -17957,7 +17956,7 @@ export const deprecateThingType: API.OperationMethod<
   DeprecateThingTypeRequest,
   DeprecateThingTypeResponse,
   DeprecateThingTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateThingTypeRequest,
   output: DeprecateThingTypeResponse,
@@ -17989,7 +17988,7 @@ export const describeAccountAuditConfiguration: API.OperationMethod<
   DescribeAccountAuditConfigurationRequest,
   DescribeAccountAuditConfigurationResponse,
   DescribeAccountAuditConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAuditConfigurationRequest,
   output: DescribeAccountAuditConfigurationResponse,
@@ -18018,7 +18017,7 @@ export const describeAuditFinding: API.OperationMethod<
   DescribeAuditFindingRequest,
   DescribeAuditFindingResponse,
   DescribeAuditFindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuditFindingRequest,
   output: DescribeAuditFindingResponse,
@@ -18046,7 +18045,7 @@ export const describeAuditMitigationActionsTask: API.OperationMethod<
   DescribeAuditMitigationActionsTaskRequest,
   DescribeAuditMitigationActionsTaskResponse,
   DescribeAuditMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuditMitigationActionsTaskRequest,
   output: DescribeAuditMitigationActionsTaskResponse,
@@ -18074,7 +18073,7 @@ export const describeAuditSuppression: API.OperationMethod<
   DescribeAuditSuppressionRequest,
   DescribeAuditSuppressionResponse,
   DescribeAuditSuppressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuditSuppressionRequest,
   output: DescribeAuditSuppressionResponse,
@@ -18104,7 +18103,7 @@ export const describeAuditTask: API.OperationMethod<
   DescribeAuditTaskRequest,
   DescribeAuditTaskResponse,
   DescribeAuditTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuditTaskRequest,
   output: DescribeAuditTaskResponse,
@@ -18136,7 +18135,7 @@ export const describeAuthorizer: API.OperationMethod<
   DescribeAuthorizerRequest,
   DescribeAuthorizerResponse,
   DescribeAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuthorizerRequest,
   output: DescribeAuthorizerResponse,
@@ -18168,7 +18167,7 @@ export const describeBillingGroup: API.OperationMethod<
   DescribeBillingGroupRequest,
   DescribeBillingGroupResponse,
   DescribeBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBillingGroupRequest,
   output: DescribeBillingGroupResponse,
@@ -18200,7 +18199,7 @@ export const describeCACertificate: API.OperationMethod<
   DescribeCACertificateRequest,
   DescribeCACertificateResponse,
   DescribeCACertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCACertificateRequest,
   output: DescribeCACertificateResponse,
@@ -18234,7 +18233,7 @@ export const describeCertificate: API.OperationMethod<
   DescribeCertificateRequest,
   DescribeCertificateResponse,
   DescribeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateRequest,
   output: DescribeCertificateResponse,
@@ -18268,7 +18267,7 @@ export const describeCertificateProvider: API.OperationMethod<
   DescribeCertificateProviderRequest,
   DescribeCertificateProviderResponse,
   DescribeCertificateProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateProviderRequest,
   output: DescribeCertificateProviderResponse,
@@ -18300,7 +18299,7 @@ export const describeCustomMetric: API.OperationMethod<
   DescribeCustomMetricRequest,
   DescribeCustomMetricResponse,
   DescribeCustomMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomMetricRequest,
   output: DescribeCustomMetricResponse,
@@ -18332,7 +18331,7 @@ export const describeDefaultAuthorizer: API.OperationMethod<
   DescribeDefaultAuthorizerRequest,
   DescribeDefaultAuthorizerResponse,
   DescribeDefaultAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDefaultAuthorizerRequest,
   output: DescribeDefaultAuthorizerResponse,
@@ -18364,7 +18363,7 @@ export const describeDetectMitigationActionsTask: API.OperationMethod<
   DescribeDetectMitigationActionsTaskRequest,
   DescribeDetectMitigationActionsTaskResponse,
   DescribeDetectMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDetectMitigationActionsTaskRequest,
   output: DescribeDetectMitigationActionsTaskResponse,
@@ -18394,7 +18393,7 @@ export const describeDimension: API.OperationMethod<
   DescribeDimensionRequest,
   DescribeDimensionResponse,
   DescribeDimensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDimensionRequest,
   output: DescribeDimensionResponse,
@@ -18426,7 +18425,7 @@ export const describeDomainConfiguration: API.OperationMethod<
   DescribeDomainConfigurationRequest,
   DescribeDomainConfigurationResponse,
   DescribeDomainConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainConfigurationRequest,
   output: DescribeDomainConfigurationResponse,
@@ -18459,7 +18458,7 @@ export const describeEncryptionConfiguration: API.OperationMethod<
   DescribeEncryptionConfigurationRequest,
   DescribeEncryptionConfigurationResponse,
   DescribeEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEncryptionConfigurationRequest,
   output: DescribeEncryptionConfigurationResponse,
@@ -18493,7 +18492,7 @@ export const describeEndpoint: API.OperationMethod<
   DescribeEndpointRequest,
   DescribeEndpointResponse,
   DescribeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointRequest,
   output: DescribeEndpointResponse,
@@ -18521,7 +18520,7 @@ export const describeEventConfigurations: API.OperationMethod<
   DescribeEventConfigurationsRequest,
   DescribeEventConfigurationsResponse,
   DescribeEventConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventConfigurationsRequest,
   output: DescribeEventConfigurationsResponse,
@@ -18548,7 +18547,7 @@ export const describeFleetMetric: API.OperationMethod<
   DescribeFleetMetricRequest,
   DescribeFleetMetricResponse,
   DescribeFleetMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFleetMetricRequest,
   output: DescribeFleetMetricResponse,
@@ -18582,7 +18581,7 @@ export const describeIndex: API.OperationMethod<
   DescribeIndexRequest,
   DescribeIndexResponse,
   DescribeIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIndexRequest,
   output: DescribeIndexResponse,
@@ -18614,7 +18613,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobRequest,
   DescribeJobResponse,
   DescribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRequest,
   output: DescribeJobResponse,
@@ -18644,7 +18643,7 @@ export const describeJobExecution: API.OperationMethod<
   DescribeJobExecutionRequest,
   DescribeJobExecutionResponse,
   DescribeJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobExecutionRequest,
   output: DescribeJobExecutionResponse,
@@ -18672,7 +18671,7 @@ export const describeJobTemplate: API.OperationMethod<
   DescribeJobTemplateRequest,
   DescribeJobTemplateResponse,
   DescribeJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobTemplateRequest,
   output: DescribeJobTemplateResponse,
@@ -18700,7 +18699,7 @@ export const describeManagedJobTemplate: API.OperationMethod<
   DescribeManagedJobTemplateRequest,
   DescribeManagedJobTemplateResponse,
   DescribeManagedJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedJobTemplateRequest,
   output: DescribeManagedJobTemplateResponse,
@@ -18730,7 +18729,7 @@ export const describeMitigationAction: API.OperationMethod<
   DescribeMitigationActionRequest,
   DescribeMitigationActionResponse,
   DescribeMitigationActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMitigationActionRequest,
   output: DescribeMitigationActionResponse,
@@ -18761,7 +18760,7 @@ export const describeProvisioningTemplate: API.OperationMethod<
   DescribeProvisioningTemplateRequest,
   DescribeProvisioningTemplateResponse,
   DescribeProvisioningTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisioningTemplateRequest,
   output: DescribeProvisioningTemplateResponse,
@@ -18793,7 +18792,7 @@ export const describeProvisioningTemplateVersion: API.OperationMethod<
   DescribeProvisioningTemplateVersionRequest,
   DescribeProvisioningTemplateVersionResponse,
   DescribeProvisioningTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisioningTemplateVersionRequest,
   output: DescribeProvisioningTemplateVersionResponse,
@@ -18826,7 +18825,7 @@ export const describeRoleAlias: API.OperationMethod<
   DescribeRoleAliasRequest,
   DescribeRoleAliasResponse,
   DescribeRoleAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRoleAliasRequest,
   output: DescribeRoleAliasResponse,
@@ -18858,7 +18857,7 @@ export const describeScheduledAudit: API.OperationMethod<
   DescribeScheduledAuditRequest,
   DescribeScheduledAuditResponse,
   DescribeScheduledAuditError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScheduledAuditRequest,
   output: DescribeScheduledAuditResponse,
@@ -18888,7 +18887,7 @@ export const describeSecurityProfile: API.OperationMethod<
   DescribeSecurityProfileRequest,
   DescribeSecurityProfileResponse,
   DescribeSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityProfileRequest,
   output: DescribeSecurityProfileResponse,
@@ -18920,7 +18919,7 @@ export const describeStream: API.OperationMethod<
   DescribeStreamRequest,
   DescribeStreamResponse,
   DescribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamRequest,
   output: DescribeStreamResponse,
@@ -18954,7 +18953,7 @@ export const describeThing: API.OperationMethod<
   DescribeThingRequest,
   DescribeThingResponse,
   DescribeThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThingRequest,
   output: DescribeThingResponse,
@@ -18986,7 +18985,7 @@ export const describeThingGroup: API.OperationMethod<
   DescribeThingGroupRequest,
   DescribeThingGroupResponse,
   DescribeThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThingGroupRequest,
   output: DescribeThingGroupResponse,
@@ -19017,7 +19016,7 @@ export const describeThingRegistrationTask: API.OperationMethod<
   DescribeThingRegistrationTaskRequest,
   DescribeThingRegistrationTaskResponse,
   DescribeThingRegistrationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThingRegistrationTaskRequest,
   output: DescribeThingRegistrationTaskResponse,
@@ -19050,7 +19049,7 @@ export const describeThingType: API.OperationMethod<
   DescribeThingTypeRequest,
   DescribeThingTypeResponse,
   DescribeThingTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThingTypeRequest,
   output: DescribeThingTypeResponse,
@@ -19087,7 +19086,7 @@ export const detachPolicy: API.OperationMethod<
   DetachPolicyRequest,
   DetachPolicyResponse,
   DetachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachPolicyRequest,
   output: DetachPolicyResponse,
@@ -19124,7 +19123,7 @@ export const detachPrincipalPolicy: API.OperationMethod<
   DetachPrincipalPolicyRequest,
   DetachPrincipalPolicyResponse,
   DetachPrincipalPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachPrincipalPolicyRequest,
   output: DetachPrincipalPolicyResponse,
@@ -19156,7 +19155,7 @@ export const detachSecurityProfile: API.OperationMethod<
   DetachSecurityProfileRequest,
   DetachSecurityProfileResponse,
   DetachSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachSecurityProfileRequest,
   output: DetachSecurityProfileResponse,
@@ -19193,7 +19192,7 @@ export const detachThingPrincipal: API.OperationMethod<
   DetachThingPrincipalRequest,
   DetachThingPrincipalResponse,
   DetachThingPrincipalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachThingPrincipalRequest,
   output: DetachThingPrincipalResponse,
@@ -19226,7 +19225,7 @@ export const disableTopicRule: API.OperationMethod<
   DisableTopicRuleRequest,
   DisableTopicRuleResponse,
   DisableTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableTopicRuleRequest,
   output: DisableTopicRuleResponse,
@@ -19258,7 +19257,7 @@ export const disassociateSbomFromPackageVersion: API.OperationMethod<
   DisassociateSbomFromPackageVersionRequest,
   DisassociateSbomFromPackageVersionResponse,
   DisassociateSbomFromPackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSbomFromPackageVersionRequest,
   output: DisassociateSbomFromPackageVersionResponse,
@@ -19290,7 +19289,7 @@ export const enableTopicRule: API.OperationMethod<
   EnableTopicRuleRequest,
   EnableTopicRuleResponse,
   EnableTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableTopicRuleRequest,
   output: EnableTopicRuleResponse,
@@ -19321,7 +19320,7 @@ export const getBehaviorModelTrainingSummaries: API.PaginatedOperationMethod<
   GetBehaviorModelTrainingSummariesRequest,
   GetBehaviorModelTrainingSummariesResponse,
   GetBehaviorModelTrainingSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BehaviorModelTrainingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBehaviorModelTrainingSummariesRequest,
@@ -19363,7 +19362,7 @@ export const getBucketsAggregation: API.OperationMethod<
   GetBucketsAggregationRequest,
   GetBucketsAggregationResponse,
   GetBucketsAggregationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketsAggregationRequest,
   output: GetBucketsAggregationResponse,
@@ -19403,7 +19402,7 @@ export const getCardinality: API.OperationMethod<
   GetCardinalityRequest,
   GetCardinalityResponse,
   GetCardinalityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCardinalityRequest,
   output: GetCardinalityResponse,
@@ -19436,7 +19435,7 @@ export const getCommand: API.OperationMethod<
   GetCommandRequest,
   GetCommandResponse,
   GetCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommandRequest,
   output: GetCommandResponse,
@@ -19464,7 +19463,7 @@ export const getCommandExecution: API.OperationMethod<
   GetCommandExecutionRequest,
   GetCommandExecutionResponse,
   GetCommandExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommandExecutionRequest,
   output: GetCommandExecutionResponse,
@@ -19498,7 +19497,7 @@ export const getEffectivePolicies: API.OperationMethod<
   GetEffectivePoliciesRequest,
   GetEffectivePoliciesResponse,
   GetEffectivePoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEffectivePoliciesRequest,
   output: GetEffectivePoliciesResponse,
@@ -19532,7 +19531,7 @@ export const getIndexingConfiguration: API.OperationMethod<
   GetIndexingConfigurationRequest,
   GetIndexingConfigurationResponse,
   GetIndexingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexingConfigurationRequest,
   output: GetIndexingConfigurationResponse,
@@ -19563,7 +19562,7 @@ export const getJobDocument: API.OperationMethod<
   GetJobDocumentRequest,
   GetJobDocumentResponse,
   GetJobDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobDocumentRequest,
   output: GetJobDocumentResponse,
@@ -19595,7 +19594,7 @@ export const getLoggingOptions: API.OperationMethod<
   GetLoggingOptionsRequest,
   GetLoggingOptionsResponse,
   GetLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingOptionsRequest,
   output: GetLoggingOptionsResponse,
@@ -19626,7 +19625,7 @@ export const getOTAUpdate: API.OperationMethod<
   GetOTAUpdateRequest,
   GetOTAUpdateResponse,
   GetOTAUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOTAUpdateRequest,
   output: GetOTAUpdateResponse,
@@ -19658,7 +19657,7 @@ export const getPackage: API.OperationMethod<
   GetPackageRequest,
   GetPackageResponse,
   GetPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPackageRequest,
   output: GetPackageResponse,
@@ -19686,7 +19685,7 @@ export const getPackageConfiguration: API.OperationMethod<
   GetPackageConfigurationRequest,
   GetPackageConfigurationResponse,
   GetPackageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPackageConfigurationRequest,
   output: GetPackageConfigurationResponse,
@@ -19711,7 +19710,7 @@ export const getPackageVersion: API.OperationMethod<
   GetPackageVersionRequest,
   GetPackageVersionResponse,
   GetPackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPackageVersionRequest,
   output: GetPackageVersionResponse,
@@ -19754,7 +19753,7 @@ export const getPercentiles: API.OperationMethod<
   GetPercentilesRequest,
   GetPercentilesResponse,
   GetPercentilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPercentilesRequest,
   output: GetPercentilesResponse,
@@ -19792,7 +19791,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -19826,7 +19825,7 @@ export const getPolicyVersion: API.OperationMethod<
   GetPolicyVersionRequest,
   GetPolicyVersionResponse,
   GetPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyVersionRequest,
   output: GetPolicyVersionResponse,
@@ -19863,7 +19862,7 @@ export const getRegistrationCode: API.OperationMethod<
   GetRegistrationCodeRequest,
   GetRegistrationCodeResponse,
   GetRegistrationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegistrationCodeRequest,
   output: GetRegistrationCodeResponse,
@@ -19901,7 +19900,7 @@ export const getStatistics: API.OperationMethod<
   GetStatisticsRequest,
   GetStatisticsResponse,
   GetStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStatisticsRequest,
   output: GetStatisticsResponse,
@@ -19937,7 +19936,7 @@ export const getThingConnectivityData: API.OperationMethod<
   GetThingConnectivityDataRequest,
   GetThingConnectivityDataResponse,
   GetThingConnectivityDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetThingConnectivityDataRequest,
   output: GetThingConnectivityDataResponse,
@@ -19971,7 +19970,7 @@ export const getTopicRule: API.OperationMethod<
   GetTopicRuleRequest,
   GetTopicRuleResponse,
   GetTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTopicRuleRequest,
   output: GetTopicRuleResponse,
@@ -20002,7 +20001,7 @@ export const getTopicRuleDestination: API.OperationMethod<
   GetTopicRuleDestinationRequest,
   GetTopicRuleDestinationResponse,
   GetTopicRuleDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTopicRuleDestinationRequest,
   output: GetTopicRuleDestinationResponse,
@@ -20031,7 +20030,7 @@ export const getV2LoggingOptions: API.OperationMethod<
   GetV2LoggingOptionsRequest,
   GetV2LoggingOptionsResponse,
   GetV2LoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetV2LoggingOptionsRequest,
   output: GetV2LoggingOptionsResponse,
@@ -20060,7 +20059,7 @@ export const listActiveViolations: API.PaginatedOperationMethod<
   ListActiveViolationsRequest,
   ListActiveViolationsResponse,
   ListActiveViolationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActiveViolation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActiveViolationsRequest,
@@ -20100,7 +20099,7 @@ export const listAttachedPolicies: API.PaginatedOperationMethod<
   ListAttachedPoliciesRequest,
   ListAttachedPoliciesResponse,
   ListAttachedPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedPoliciesRequest,
@@ -20140,7 +20139,7 @@ export const listAuditFindings: API.PaginatedOperationMethod<
   ListAuditFindingsRequest,
   ListAuditFindingsResponse,
   ListAuditFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuditFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuditFindingsRequest,
@@ -20176,7 +20175,7 @@ export const listAuditMitigationActionsExecutions: API.PaginatedOperationMethod<
   ListAuditMitigationActionsExecutionsRequest,
   ListAuditMitigationActionsExecutionsResponse,
   ListAuditMitigationActionsExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuditMitigationActionExecutionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuditMitigationActionsExecutionsRequest,
@@ -20211,7 +20210,7 @@ export const listAuditMitigationActionsTasks: API.PaginatedOperationMethod<
   ListAuditMitigationActionsTasksRequest,
   ListAuditMitigationActionsTasksResponse,
   ListAuditMitigationActionsTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuditMitigationActionsTaskMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuditMitigationActionsTasksRequest,
@@ -20246,7 +20245,7 @@ export const listAuditSuppressions: API.PaginatedOperationMethod<
   ListAuditSuppressionsRequest,
   ListAuditSuppressionsResponse,
   ListAuditSuppressionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuditSuppression
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuditSuppressionsRequest,
@@ -20282,7 +20281,7 @@ export const listAuditTasks: API.PaginatedOperationMethod<
   ListAuditTasksRequest,
   ListAuditTasksResponse,
   ListAuditTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuditTaskMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuditTasksRequest,
@@ -20319,7 +20318,7 @@ export const listAuthorizers: API.PaginatedOperationMethod<
   ListAuthorizersRequest,
   ListAuthorizersResponse,
   ListAuthorizersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuthorizerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAuthorizersRequest,
@@ -20357,7 +20356,7 @@ export const listBillingGroups: API.PaginatedOperationMethod<
   ListBillingGroupsRequest,
   ListBillingGroupsResponse,
   ListBillingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupNameAndArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillingGroupsRequest,
@@ -20398,7 +20397,7 @@ export const listCACertificates: API.PaginatedOperationMethod<
   ListCACertificatesRequest,
   ListCACertificatesResponse,
   ListCACertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CACertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCACertificatesRequest,
@@ -20437,7 +20436,7 @@ export const listCertificateProviders: API.OperationMethod<
   ListCertificateProvidersRequest,
   ListCertificateProvidersResponse,
   ListCertificateProvidersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCertificateProvidersRequest,
   output: ListCertificateProvidersResponse,
@@ -20472,7 +20471,7 @@ export const listCertificates: API.PaginatedOperationMethod<
   ListCertificatesRequest,
   ListCertificatesResponse,
   ListCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Certificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificatesRequest,
@@ -20511,7 +20510,7 @@ export const listCertificatesByCA: API.PaginatedOperationMethod<
   ListCertificatesByCARequest,
   ListCertificatesByCAResponse,
   ListCertificatesByCAError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Certificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificatesByCARequest,
@@ -20562,7 +20561,7 @@ export const listCommandExecutions: API.PaginatedOperationMethod<
   ListCommandExecutionsRequest,
   ListCommandExecutionsResponse,
   ListCommandExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CommandExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommandExecutionsRequest,
@@ -20596,7 +20595,7 @@ export const listCommands: API.PaginatedOperationMethod<
   ListCommandsRequest,
   ListCommandsResponse,
   ListCommandsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CommandSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommandsRequest,
@@ -20627,7 +20626,7 @@ export const listCustomMetrics: API.PaginatedOperationMethod<
   ListCustomMetricsRequest,
   ListCustomMetricsResponse,
   ListCustomMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomMetricsRequest,
@@ -20662,7 +20661,7 @@ export const listDetectMitigationActionsExecutions: API.PaginatedOperationMethod
   ListDetectMitigationActionsExecutionsRequest,
   ListDetectMitigationActionsExecutionsResponse,
   ListDetectMitigationActionsExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DetectMitigationActionExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDetectMitigationActionsExecutionsRequest,
@@ -20697,7 +20696,7 @@ export const listDetectMitigationActionsTasks: API.PaginatedOperationMethod<
   ListDetectMitigationActionsTasksRequest,
   ListDetectMitigationActionsTasksResponse,
   ListDetectMitigationActionsTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DetectMitigationActionsTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDetectMitigationActionsTasksRequest,
@@ -20732,7 +20731,7 @@ export const listDimensions: API.PaginatedOperationMethod<
   ListDimensionsRequest,
   ListDimensionsResponse,
   ListDimensionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DimensionName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDimensionsRequest,
@@ -20770,7 +20769,7 @@ export const listDomainConfigurations: API.PaginatedOperationMethod<
   ListDomainConfigurationsRequest,
   ListDomainConfigurationsResponse,
   ListDomainConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainConfigurationsRequest,
@@ -20809,7 +20808,7 @@ export const listFleetMetrics: API.PaginatedOperationMethod<
   ListFleetMetricsRequest,
   ListFleetMetricsResponse,
   ListFleetMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetMetricNameAndArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetMetricsRequest,
@@ -20848,7 +20847,7 @@ export const listIndices: API.PaginatedOperationMethod<
   ListIndicesRequest,
   ListIndicesResponse,
   ListIndicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IndexName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndicesRequest,
@@ -20886,7 +20885,7 @@ export const listJobExecutionsForJob: API.PaginatedOperationMethod<
   ListJobExecutionsForJobRequest,
   ListJobExecutionsForJobResponse,
   ListJobExecutionsForJobError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobExecutionSummaryForJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobExecutionsForJobRequest,
@@ -20923,7 +20922,7 @@ export const listJobExecutionsForThing: API.PaginatedOperationMethod<
   ListJobExecutionsForThingRequest,
   ListJobExecutionsForThingResponse,
   ListJobExecutionsForThingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobExecutionSummaryForThing
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobExecutionsForThingRequest,
@@ -20960,7 +20959,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -20996,7 +20995,7 @@ export const listJobTemplates: API.PaginatedOperationMethod<
   ListJobTemplatesRequest,
   ListJobTemplatesResponse,
   ListJobTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobTemplatesRequest,
@@ -21030,7 +21029,7 @@ export const listManagedJobTemplates: API.PaginatedOperationMethod<
   ListManagedJobTemplatesRequest,
   ListManagedJobTemplatesResponse,
   ListManagedJobTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedJobTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedJobTemplatesRequest,
@@ -21066,7 +21065,7 @@ export const listMetricValues: API.PaginatedOperationMethod<
   ListMetricValuesRequest,
   ListMetricValuesResponse,
   ListMetricValuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricDatum
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricValuesRequest,
@@ -21102,7 +21101,7 @@ export const listMitigationActions: API.PaginatedOperationMethod<
   ListMitigationActionsRequest,
   ListMitigationActionsResponse,
   ListMitigationActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MitigationActionIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMitigationActionsRequest,
@@ -21139,7 +21138,7 @@ export const listOTAUpdates: API.PaginatedOperationMethod<
   ListOTAUpdatesRequest,
   ListOTAUpdatesResponse,
   ListOTAUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OTAUpdateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOTAUpdatesRequest,
@@ -21178,7 +21177,7 @@ export const listOutgoingCertificates: API.PaginatedOperationMethod<
   ListOutgoingCertificatesRequest,
   ListOutgoingCertificatesResponse,
   ListOutgoingCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OutgoingCertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOutgoingCertificatesRequest,
@@ -21215,7 +21214,7 @@ export const listPackages: API.PaginatedOperationMethod<
   ListPackagesRequest,
   ListPackagesResponse,
   ListPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagesRequest,
@@ -21246,7 +21245,7 @@ export const listPackageVersions: API.PaginatedOperationMethod<
   ListPackageVersionsRequest,
   ListPackageVersionsResponse,
   ListPackageVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackageVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackageVersionsRequest,
@@ -21279,7 +21278,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -21322,7 +21321,7 @@ export const listPolicyPrincipals: API.PaginatedOperationMethod<
   ListPolicyPrincipalsRequest,
   ListPolicyPrincipalsResponse,
   ListPolicyPrincipalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrincipalArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyPrincipalsRequest,
@@ -21364,7 +21363,7 @@ export const listPolicyVersions: API.OperationMethod<
   ListPolicyVersionsRequest,
   ListPolicyVersionsResponse,
   ListPolicyVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPolicyVersionsRequest,
   output: ListPolicyVersionsResponse,
@@ -21402,7 +21401,7 @@ export const listPrincipalPolicies: API.PaginatedOperationMethod<
   ListPrincipalPoliciesRequest,
   ListPrincipalPoliciesResponse,
   ListPrincipalPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrincipalPoliciesRequest,
@@ -21445,7 +21444,7 @@ export const listPrincipalThings: API.PaginatedOperationMethod<
   ListPrincipalThingsRequest,
   ListPrincipalThingsResponse,
   ListPrincipalThingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrincipalThingsRequest,
@@ -21487,7 +21486,7 @@ export const listPrincipalThingsV2: API.PaginatedOperationMethod<
   ListPrincipalThingsV2Request,
   ListPrincipalThingsV2Response,
   ListPrincipalThingsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrincipalThingObject
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrincipalThingsV2Request,
@@ -21526,7 +21525,7 @@ export const listProvisioningTemplates: API.PaginatedOperationMethod<
   ListProvisioningTemplatesRequest,
   ListProvisioningTemplatesResponse,
   ListProvisioningTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisioningTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisioningTemplatesRequest,
@@ -21564,7 +21563,7 @@ export const listProvisioningTemplateVersions: API.PaginatedOperationMethod<
   ListProvisioningTemplateVersionsRequest,
   ListProvisioningTemplateVersionsResponse,
   ListProvisioningTemplateVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisioningTemplateVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisioningTemplateVersionsRequest,
@@ -21624,7 +21623,7 @@ export const listRelatedResourcesForAuditFinding: API.PaginatedOperationMethod<
   ListRelatedResourcesForAuditFindingRequest,
   ListRelatedResourcesForAuditFindingResponse,
   ListRelatedResourcesForAuditFindingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RelatedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRelatedResourcesForAuditFindingRequest,
@@ -21662,7 +21661,7 @@ export const listRoleAliases: API.PaginatedOperationMethod<
   ListRoleAliasesRequest,
   ListRoleAliasesResponse,
   ListRoleAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RoleAlias
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoleAliasesRequest,
@@ -21700,7 +21699,7 @@ export const listSbomValidationResults: API.PaginatedOperationMethod<
   ListSbomValidationResultsRequest,
   ListSbomValidationResultsResponse,
   ListSbomValidationResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SbomValidationResultSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSbomValidationResultsRequest,
@@ -21736,7 +21735,7 @@ export const listScheduledAudits: API.PaginatedOperationMethod<
   ListScheduledAuditsRequest,
   ListScheduledAuditsResponse,
   ListScheduledAuditsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledAuditMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledAuditsRequest,
@@ -21776,7 +21775,7 @@ export const listSecurityProfiles: API.PaginatedOperationMethod<
   ListSecurityProfilesRequest,
   ListSecurityProfilesResponse,
   ListSecurityProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityProfileIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfilesRequest,
@@ -21813,7 +21812,7 @@ export const listSecurityProfilesForTarget: API.PaginatedOperationMethod<
   ListSecurityProfilesForTargetRequest,
   ListSecurityProfilesForTargetResponse,
   ListSecurityProfilesForTargetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityProfileTargetMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityProfilesForTargetRequest,
@@ -21851,7 +21850,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsRequest,
   ListStreamsResponse,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsRequest,
@@ -21889,7 +21888,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -21928,7 +21927,7 @@ export const listTargetsForPolicy: API.PaginatedOperationMethod<
   ListTargetsForPolicyRequest,
   ListTargetsForPolicyResponse,
   ListTargetsForPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetsForPolicyRequest,
@@ -21968,7 +21967,7 @@ export const listTargetsForSecurityProfile: API.PaginatedOperationMethod<
   ListTargetsForSecurityProfileRequest,
   ListTargetsForSecurityProfileResponse,
   ListTargetsForSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityProfileTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetsForSecurityProfileRequest,
@@ -22005,7 +22004,7 @@ export const listThingGroups: API.PaginatedOperationMethod<
   ListThingGroupsRequest,
   ListThingGroupsResponse,
   ListThingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupNameAndArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingGroupsRequest,
@@ -22042,7 +22041,7 @@ export const listThingGroupsForThing: API.PaginatedOperationMethod<
   ListThingGroupsForThingRequest,
   ListThingGroupsForThingResponse,
   ListThingGroupsForThingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupNameAndArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingGroupsForThingRequest,
@@ -22083,7 +22082,7 @@ export const listThingPrincipals: API.PaginatedOperationMethod<
   ListThingPrincipalsRequest,
   ListThingPrincipalsResponse,
   ListThingPrincipalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrincipalArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingPrincipalsRequest,
@@ -22125,7 +22124,7 @@ export const listThingPrincipalsV2: API.PaginatedOperationMethod<
   ListThingPrincipalsV2Request,
   ListThingPrincipalsV2Response,
   ListThingPrincipalsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingPrincipalObject
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingPrincipalsV2Request,
@@ -22162,7 +22161,7 @@ export const listThingRegistrationTaskReports: API.PaginatedOperationMethod<
   ListThingRegistrationTaskReportsRequest,
   ListThingRegistrationTaskReportsResponse,
   ListThingRegistrationTaskReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   S3FileUrl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingRegistrationTaskReportsRequest,
@@ -22199,7 +22198,7 @@ export const listThingRegistrationTasks: API.PaginatedOperationMethod<
   ListThingRegistrationTasksRequest,
   ListThingRegistrationTasksResponse,
   ListThingRegistrationTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingRegistrationTasksRequest,
@@ -22243,7 +22242,7 @@ export const listThings: API.PaginatedOperationMethod<
   ListThingsRequest,
   ListThingsResponse,
   ListThingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingsRequest,
@@ -22281,7 +22280,7 @@ export const listThingsInBillingGroup: API.PaginatedOperationMethod<
   ListThingsInBillingGroupRequest,
   ListThingsInBillingGroupResponse,
   ListThingsInBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingsInBillingGroupRequest,
@@ -22318,7 +22317,7 @@ export const listThingsInThingGroup: API.PaginatedOperationMethod<
   ListThingsInThingGroupRequest,
   ListThingsInThingGroupResponse,
   ListThingsInThingGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingsInThingGroupRequest,
@@ -22356,7 +22355,7 @@ export const listThingTypes: API.PaginatedOperationMethod<
   ListThingTypesRequest,
   ListThingTypesResponse,
   ListThingTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThingTypeDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThingTypesRequest,
@@ -22394,7 +22393,7 @@ export const listTopicRuleDestinations: API.PaginatedOperationMethod<
   ListTopicRuleDestinationsRequest,
   ListTopicRuleDestinationsResponse,
   ListTopicRuleDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicRuleDestinationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicRuleDestinationsRequest,
@@ -22431,7 +22430,7 @@ export const listTopicRules: API.PaginatedOperationMethod<
   ListTopicRulesRequest,
   ListTopicRulesResponse,
   ListTopicRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicRuleListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicRulesRequest,
@@ -22468,7 +22467,7 @@ export const listV2LoggingLevels: API.PaginatedOperationMethod<
   ListV2LoggingLevelsRequest,
   ListV2LoggingLevelsResponse,
   ListV2LoggingLevelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogTargetConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListV2LoggingLevelsRequest,
@@ -22506,7 +22505,7 @@ export const listViolationEvents: API.PaginatedOperationMethod<
   ListViolationEventsRequest,
   ListViolationEventsResponse,
   ListViolationEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ViolationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListViolationEventsRequest,
@@ -22539,7 +22538,7 @@ export const putVerificationStateOnViolation: API.OperationMethod<
   PutVerificationStateOnViolationRequest,
   PutVerificationStateOnViolationResponse,
   PutVerificationStateOnViolationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVerificationStateOnViolationRequest,
   output: PutVerificationStateOnViolationResponse,
@@ -22576,7 +22575,7 @@ export const registerCACertificate: API.OperationMethod<
   RegisterCACertificateRequest,
   RegisterCACertificateResponse,
   RegisterCACertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCACertificateRequest,
   output: RegisterCACertificateResponse,
@@ -22619,7 +22618,7 @@ export const registerCertificate: API.OperationMethod<
   RegisterCertificateRequest,
   RegisterCertificateResponse,
   RegisterCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCertificateRequest,
   output: RegisterCertificateResponse,
@@ -22658,7 +22657,7 @@ export const registerCertificateWithoutCA: API.OperationMethod<
   RegisterCertificateWithoutCARequest,
   RegisterCertificateWithoutCAResponse,
   RegisterCertificateWithoutCAError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCertificateWithoutCARequest,
   output: RegisterCertificateWithoutCAResponse,
@@ -22698,7 +22697,7 @@ export const registerThing: API.OperationMethod<
   RegisterThingRequest,
   RegisterThingResponse,
   RegisterThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterThingRequest,
   output: RegisterThingResponse,
@@ -22742,7 +22741,7 @@ export const rejectCertificateTransfer: API.OperationMethod<
   RejectCertificateTransferRequest,
   RejectCertificateTransferResponse,
   RejectCertificateTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectCertificateTransferRequest,
   output: RejectCertificateTransferResponse,
@@ -22777,7 +22776,7 @@ export const removeThingFromBillingGroup: API.OperationMethod<
   RemoveThingFromBillingGroupRequest,
   RemoveThingFromBillingGroupResponse,
   RemoveThingFromBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveThingFromBillingGroupRequest,
   output: RemoveThingFromBillingGroupResponse,
@@ -22812,7 +22811,7 @@ export const removeThingFromThingGroup: API.OperationMethod<
   RemoveThingFromThingGroupRequest,
   RemoveThingFromThingGroupResponse,
   RemoveThingFromThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveThingFromThingGroupRequest,
   output: RemoveThingFromThingGroupResponse,
@@ -22846,7 +22845,7 @@ export const replaceTopicRule: API.OperationMethod<
   ReplaceTopicRuleRequest,
   ReplaceTopicRuleResponse,
   ReplaceTopicRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplaceTopicRuleRequest,
   output: ReplaceTopicRuleResponse,
@@ -22884,7 +22883,7 @@ export const searchIndex: API.OperationMethod<
   SearchIndexRequest,
   SearchIndexResponse,
   SearchIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchIndexRequest,
   output: SearchIndexResponse,
@@ -22922,7 +22921,7 @@ export const setDefaultAuthorizer: API.OperationMethod<
   SetDefaultAuthorizerRequest,
   SetDefaultAuthorizerResponse,
   SetDefaultAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultAuthorizerRequest,
   output: SetDefaultAuthorizerResponse,
@@ -22960,7 +22959,7 @@ export const setDefaultPolicyVersion: API.OperationMethod<
   SetDefaultPolicyVersionRequest,
   SetDefaultPolicyVersionResponse,
   SetDefaultPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultPolicyVersionRequest,
   output: SetDefaultPolicyVersionResponse,
@@ -22994,7 +22993,7 @@ export const setLoggingOptions: API.OperationMethod<
   SetLoggingOptionsRequest,
   SetLoggingOptionsResponse,
   SetLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLoggingOptionsRequest,
   output: SetLoggingOptionsResponse,
@@ -23024,7 +23023,7 @@ export const setV2LoggingLevel: API.OperationMethod<
   SetV2LoggingLevelRequest,
   SetV2LoggingLevelResponse,
   SetV2LoggingLevelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetV2LoggingLevelRequest,
   output: SetV2LoggingLevelResponse,
@@ -23054,7 +23053,7 @@ export const setV2LoggingOptions: API.OperationMethod<
   SetV2LoggingOptionsRequest,
   SetV2LoggingOptionsResponse,
   SetV2LoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetV2LoggingOptionsRequest,
   output: SetV2LoggingOptionsResponse,
@@ -23084,7 +23083,7 @@ export const startAuditMitigationActionsTask: API.OperationMethod<
   StartAuditMitigationActionsTaskRequest,
   StartAuditMitigationActionsTaskResponse,
   StartAuditMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAuditMitigationActionsTaskRequest,
   output: StartAuditMitigationActionsTaskResponse,
@@ -23116,7 +23115,7 @@ export const startDetectMitigationActionsTask: API.OperationMethod<
   StartDetectMitigationActionsTaskRequest,
   StartDetectMitigationActionsTaskResponse,
   StartDetectMitigationActionsTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDetectMitigationActionsTaskRequest,
   output: StartDetectMitigationActionsTaskResponse,
@@ -23147,7 +23146,7 @@ export const startOnDemandAuditTask: API.OperationMethod<
   StartOnDemandAuditTaskRequest,
   StartOnDemandAuditTaskResponse,
   StartOnDemandAuditTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOnDemandAuditTaskRequest,
   output: StartOnDemandAuditTaskResponse,
@@ -23177,7 +23176,7 @@ export const startThingRegistrationTask: API.OperationMethod<
   StartThingRegistrationTaskRequest,
   StartThingRegistrationTaskResponse,
   StartThingRegistrationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartThingRegistrationTaskRequest,
   output: StartThingRegistrationTaskResponse,
@@ -23208,7 +23207,7 @@ export const stopThingRegistrationTask: API.OperationMethod<
   StopThingRegistrationTaskRequest,
   StopThingRegistrationTaskResponse,
   StopThingRegistrationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopThingRegistrationTaskRequest,
   output: StopThingRegistrationTaskResponse,
@@ -23241,7 +23240,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -23277,7 +23276,7 @@ export const testAuthorization: API.OperationMethod<
   TestAuthorizationRequest,
   TestAuthorizationResponse,
   TestAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestAuthorizationRequest,
   output: TestAuthorizationResponse,
@@ -23315,7 +23314,7 @@ export const testInvokeAuthorizer: API.OperationMethod<
   TestInvokeAuthorizerRequest,
   TestInvokeAuthorizerResponse,
   TestInvokeAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestInvokeAuthorizerRequest,
   output: TestInvokeAuthorizerResponse,
@@ -23376,7 +23375,7 @@ export const transferCertificate: API.OperationMethod<
   TransferCertificateRequest,
   TransferCertificateResponse,
   TransferCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransferCertificateRequest,
   output: TransferCertificateResponse,
@@ -23410,7 +23409,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -23441,7 +23440,7 @@ export const updateAccountAuditConfiguration: API.OperationMethod<
   UpdateAccountAuditConfigurationRequest,
   UpdateAccountAuditConfigurationResponse,
   UpdateAccountAuditConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountAuditConfigurationRequest,
   output: UpdateAccountAuditConfigurationResponse,
@@ -23468,7 +23467,7 @@ export const updateAuditSuppression: API.OperationMethod<
   UpdateAuditSuppressionRequest,
   UpdateAuditSuppressionResponse,
   UpdateAuditSuppressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuditSuppressionRequest,
   output: UpdateAuditSuppressionResponse,
@@ -23501,7 +23500,7 @@ export const updateAuthorizer: API.OperationMethod<
   UpdateAuthorizerRequest,
   UpdateAuthorizerResponse,
   UpdateAuthorizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAuthorizerRequest,
   output: UpdateAuthorizerResponse,
@@ -23535,7 +23534,7 @@ export const updateBillingGroup: API.OperationMethod<
   UpdateBillingGroupRequest,
   UpdateBillingGroupResponse,
   UpdateBillingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBillingGroupRequest,
   output: UpdateBillingGroupResponse,
@@ -23568,7 +23567,7 @@ export const updateCACertificate: API.OperationMethod<
   UpdateCACertificateRequest,
   UpdateCACertificateResponse,
   UpdateCACertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCACertificateRequest,
   output: UpdateCACertificateResponse,
@@ -23611,7 +23610,7 @@ export const updateCertificate: API.OperationMethod<
   UpdateCertificateRequest,
   UpdateCertificateResponse,
   UpdateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCertificateRequest,
   output: UpdateCertificateResponse,
@@ -23646,7 +23645,7 @@ export const updateCertificateProvider: API.OperationMethod<
   UpdateCertificateProviderRequest,
   UpdateCertificateProviderResponse,
   UpdateCertificateProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCertificateProviderRequest,
   output: UpdateCertificateProviderResponse,
@@ -23677,7 +23676,7 @@ export const updateCommand: API.OperationMethod<
   UpdateCommandRequest,
   UpdateCommandResponse,
   UpdateCommandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCommandRequest,
   output: UpdateCommandResponse,
@@ -23709,7 +23708,7 @@ export const updateCustomMetric: API.OperationMethod<
   UpdateCustomMetricRequest,
   UpdateCustomMetricResponse,
   UpdateCustomMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomMetricRequest,
   output: UpdateCustomMetricResponse,
@@ -23744,7 +23743,7 @@ export const updateDimension: API.OperationMethod<
   UpdateDimensionRequest,
   UpdateDimensionResponse,
   UpdateDimensionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDimensionRequest,
   output: UpdateDimensionResponse,
@@ -23778,7 +23777,7 @@ export const updateDomainConfiguration: API.OperationMethod<
   UpdateDomainConfigurationRequest,
   UpdateDomainConfigurationResponse,
   UpdateDomainConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainConfigurationRequest,
   output: UpdateDomainConfigurationResponse,
@@ -23813,7 +23812,7 @@ export const updateDynamicThingGroup: API.OperationMethod<
   UpdateDynamicThingGroupRequest,
   UpdateDynamicThingGroupResponse,
   UpdateDynamicThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDynamicThingGroupRequest,
   output: UpdateDynamicThingGroupResponse,
@@ -23848,7 +23847,7 @@ export const updateEncryptionConfiguration: API.OperationMethod<
   UpdateEncryptionConfigurationRequest,
   UpdateEncryptionConfigurationResponse,
   UpdateEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEncryptionConfigurationRequest,
   output: UpdateEncryptionConfigurationResponse,
@@ -23878,7 +23877,7 @@ export const updateEventConfigurations: API.OperationMethod<
   UpdateEventConfigurationsRequest,
   UpdateEventConfigurationsResponse,
   UpdateEventConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventConfigurationsRequest,
   output: UpdateEventConfigurationsResponse,
@@ -23913,7 +23912,7 @@ export const updateFleetMetric: API.OperationMethod<
   UpdateFleetMetricRequest,
   UpdateFleetMetricResponse,
   UpdateFleetMetricError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetMetricRequest,
   output: UpdateFleetMetricResponse,
@@ -23950,7 +23949,7 @@ export const updateIndexingConfiguration: API.OperationMethod<
   UpdateIndexingConfigurationRequest,
   UpdateIndexingConfigurationResponse,
   UpdateIndexingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexingConfigurationRequest,
   output: UpdateIndexingConfigurationResponse,
@@ -23981,7 +23980,7 @@ export const updateJob: API.OperationMethod<
   UpdateJobRequest,
   UpdateJobResponse,
   UpdateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobRequest,
   output: UpdateJobResponse,
@@ -24011,7 +24010,7 @@ export const updateMitigationAction: API.OperationMethod<
   UpdateMitigationActionRequest,
   UpdateMitigationActionResponse,
   UpdateMitigationActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMitigationActionRequest,
   output: UpdateMitigationActionResponse,
@@ -24042,7 +24041,7 @@ export const updatePackage: API.OperationMethod<
   UpdatePackageRequest,
   UpdatePackageResponse,
   UpdatePackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageRequest,
   output: UpdatePackageResponse,
@@ -24073,7 +24072,7 @@ export const updatePackageConfiguration: API.OperationMethod<
   UpdatePackageConfigurationRequest,
   UpdatePackageConfigurationResponse,
   UpdatePackageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageConfigurationRequest,
   output: UpdatePackageConfigurationResponse,
@@ -24104,7 +24103,7 @@ export const updatePackageVersion: API.OperationMethod<
   UpdatePackageVersionRequest,
   UpdatePackageVersionResponse,
   UpdatePackageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageVersionRequest,
   output: UpdatePackageVersionResponse,
@@ -24136,7 +24135,7 @@ export const updateProvisioningTemplate: API.OperationMethod<
   UpdateProvisioningTemplateRequest,
   UpdateProvisioningTemplateResponse,
   UpdateProvisioningTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProvisioningTemplateRequest,
   output: UpdateProvisioningTemplateResponse,
@@ -24176,7 +24175,7 @@ export const updateRoleAlias: API.OperationMethod<
   UpdateRoleAliasRequest,
   UpdateRoleAliasResponse,
   UpdateRoleAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoleAliasRequest,
   output: UpdateRoleAliasResponse,
@@ -24209,7 +24208,7 @@ export const updateScheduledAudit: API.OperationMethod<
   UpdateScheduledAuditRequest,
   UpdateScheduledAuditResponse,
   UpdateScheduledAuditError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledAuditRequest,
   output: UpdateScheduledAuditResponse,
@@ -24240,7 +24239,7 @@ export const updateSecurityProfile: API.OperationMethod<
   UpdateSecurityProfileRequest,
   UpdateSecurityProfileResponse,
   UpdateSecurityProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityProfileRequest,
   output: UpdateSecurityProfileResponse,
@@ -24274,7 +24273,7 @@ export const updateStream: API.OperationMethod<
   UpdateStreamRequest,
   UpdateStreamResponse,
   UpdateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamRequest,
   output: UpdateStreamResponse,
@@ -24310,7 +24309,7 @@ export const updateThing: API.OperationMethod<
   UpdateThingRequest,
   UpdateThingResponse,
   UpdateThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingRequest,
   output: UpdateThingResponse,
@@ -24344,7 +24343,7 @@ export const updateThingGroup: API.OperationMethod<
   UpdateThingGroupRequest,
   UpdateThingGroupResponse,
   UpdateThingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingGroupRequest,
   output: UpdateThingGroupResponse,
@@ -24375,7 +24374,7 @@ export const updateThingGroupsForThing: API.OperationMethod<
   UpdateThingGroupsForThingRequest,
   UpdateThingGroupsForThingResponse,
   UpdateThingGroupsForThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingGroupsForThingRequest,
   output: UpdateThingGroupsForThingResponse,
@@ -24405,7 +24404,7 @@ export const updateThingType: API.OperationMethod<
   UpdateThingTypeRequest,
   UpdateThingTypeResponse,
   UpdateThingTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThingTypeRequest,
   output: UpdateThingTypeResponse,
@@ -24439,7 +24438,7 @@ export const updateTopicRuleDestination: API.OperationMethod<
   UpdateTopicRuleDestinationRequest,
   UpdateTopicRuleDestinationResponse,
   UpdateTopicRuleDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTopicRuleDestinationRequest,
   output: UpdateTopicRuleDestinationResponse,
@@ -24469,7 +24468,7 @@ export const validateSecurityProfileBehaviors: API.OperationMethod<
   ValidateSecurityProfileBehaviorsRequest,
   ValidateSecurityProfileBehaviorsResponse,
   ValidateSecurityProfileBehaviorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateSecurityProfileBehaviorsRequest,
   output: ValidateSecurityProfileBehaviorsResponse,

--- a/packages/aws/src/services/iotdeviceadvisor.ts
+++ b/packages/aws/src/services/iotdeviceadvisor.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IotDeviceAdvisor",
   serviceShapeName: "IotSenateService",
@@ -896,7 +895,7 @@ export const createSuiteDefinition: API.OperationMethod<
   CreateSuiteDefinitionRequest,
   CreateSuiteDefinitionResponse,
   CreateSuiteDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSuiteDefinitionRequest,
   output: CreateSuiteDefinitionResponse,
@@ -919,7 +918,7 @@ export const deleteSuiteDefinition: API.OperationMethod<
   DeleteSuiteDefinitionRequest,
   DeleteSuiteDefinitionResponse,
   DeleteSuiteDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSuiteDefinitionRequest,
   output: DeleteSuiteDefinitionResponse,
@@ -941,7 +940,7 @@ export const getEndpoint: API.OperationMethod<
   GetEndpointRequest,
   GetEndpointResponse,
   GetEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEndpointRequest,
   output: GetEndpointResponse,
@@ -969,7 +968,7 @@ export const getSuiteDefinition: API.OperationMethod<
   GetSuiteDefinitionRequest,
   GetSuiteDefinitionResponse,
   GetSuiteDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSuiteDefinitionRequest,
   output: GetSuiteDefinitionResponse,
@@ -997,7 +996,7 @@ export const getSuiteRun: API.OperationMethod<
   GetSuiteRunRequest,
   GetSuiteRunResponse,
   GetSuiteRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSuiteRunRequest,
   output: GetSuiteRunResponse,
@@ -1025,7 +1024,7 @@ export const getSuiteRunReport: API.OperationMethod<
   GetSuiteRunReportRequest,
   GetSuiteRunReportResponse,
   GetSuiteRunReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSuiteRunReportRequest,
   output: GetSuiteRunReportResponse,
@@ -1052,7 +1051,7 @@ export const listSuiteDefinitions: API.PaginatedOperationMethod<
   ListSuiteDefinitionsRequest,
   ListSuiteDefinitionsResponse,
   ListSuiteDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSuiteDefinitionsRequest,
@@ -1082,7 +1081,7 @@ export const listSuiteRuns: API.PaginatedOperationMethod<
   ListSuiteRunsRequest,
   ListSuiteRunsResponse,
   ListSuiteRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSuiteRunsRequest,
@@ -1112,7 +1111,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1140,7 +1139,7 @@ export const startSuiteRun: API.OperationMethod<
   StartSuiteRunRequest,
   StartSuiteRunResponse,
   StartSuiteRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSuiteRunRequest,
   output: StartSuiteRunResponse,
@@ -1164,7 +1163,7 @@ export const stopSuiteRun: API.OperationMethod<
   StopSuiteRunRequest,
   StopSuiteRunResponse,
   StopSuiteRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSuiteRunRequest,
   output: StopSuiteRunResponse,
@@ -1192,7 +1191,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1220,7 +1219,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1247,7 +1246,7 @@ export const updateSuiteDefinition: API.OperationMethod<
   UpdateSuiteDefinitionRequest,
   UpdateSuiteDefinitionResponse,
   UpdateSuiteDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSuiteDefinitionRequest,
   output: UpdateSuiteDefinitionResponse,

--- a/packages/aws/src/services/iotfleetwise.ts
+++ b/packages/aws/src/services/iotfleetwise.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoTFleetWise",
@@ -3782,7 +3781,7 @@ export const associateVehicleFleet: API.OperationMethod<
   AssociateVehicleFleetRequest,
   AssociateVehicleFleetResponse,
   AssociateVehicleFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateVehicleFleetRequest,
   output: AssociateVehicleFleetResponse,
@@ -3819,7 +3818,7 @@ export const batchCreateVehicle: API.OperationMethod<
   BatchCreateVehicleRequest,
   BatchCreateVehicleResponse,
   BatchCreateVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateVehicleRequest,
   output: BatchCreateVehicleResponse,
@@ -3855,7 +3854,7 @@ export const batchUpdateVehicle: API.OperationMethod<
   BatchUpdateVehicleRequest,
   BatchUpdateVehicleResponse,
   BatchUpdateVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateVehicleRequest,
   output: BatchUpdateVehicleResponse,
@@ -3894,7 +3893,7 @@ export const createCampaign: API.OperationMethod<
   CreateCampaignRequest,
   CreateCampaignResponse,
   CreateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCampaignRequest,
   output: CreateCampaignResponse,
@@ -3936,7 +3935,7 @@ export const createDecoderManifest: API.OperationMethod<
   CreateDecoderManifestRequest,
   CreateDecoderManifestResponse,
   CreateDecoderManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDecoderManifestRequest,
   output: CreateDecoderManifestResponse,
@@ -3975,7 +3974,7 @@ export const createFleet: API.OperationMethod<
   CreateFleetRequest,
   CreateFleetResponse,
   CreateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFleetRequest,
   output: CreateFleetResponse,
@@ -4013,7 +4012,7 @@ export const createModelManifest: API.OperationMethod<
   CreateModelManifestRequest,
   CreateModelManifestResponse,
   CreateModelManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelManifestRequest,
   output: CreateModelManifestResponse,
@@ -4048,7 +4047,7 @@ export const createSignalCatalog: API.OperationMethod<
   CreateSignalCatalogRequest,
   CreateSignalCatalogResponse,
   CreateSignalCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSignalCatalogRequest,
   output: CreateSignalCatalogResponse,
@@ -4085,7 +4084,7 @@ export const createStateTemplate: API.OperationMethod<
   CreateStateTemplateRequest,
   CreateStateTemplateResponse,
   CreateStateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStateTemplateRequest,
   output: CreateStateTemplateResponse,
@@ -4128,7 +4127,7 @@ export const createVehicle: API.OperationMethod<
   CreateVehicleRequest,
   CreateVehicleResponse,
   CreateVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVehicleRequest,
   output: CreateVehicleResponse,
@@ -4160,7 +4159,7 @@ export const deleteCampaign: API.OperationMethod<
   DeleteCampaignRequest,
   DeleteCampaignResponse,
   DeleteCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignRequest,
   output: DeleteCampaignResponse,
@@ -4190,7 +4189,7 @@ export const deleteDecoderManifest: API.OperationMethod<
   DeleteDecoderManifestRequest,
   DeleteDecoderManifestResponse,
   DeleteDecoderManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDecoderManifestRequest,
   output: DeleteDecoderManifestResponse,
@@ -4221,7 +4220,7 @@ export const deleteFleet: API.OperationMethod<
   DeleteFleetRequest,
   DeleteFleetResponse,
   DeleteFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFleetRequest,
   output: DeleteFleetResponse,
@@ -4250,7 +4249,7 @@ export const deleteModelManifest: API.OperationMethod<
   DeleteModelManifestRequest,
   DeleteModelManifestResponse,
   DeleteModelManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelManifestRequest,
   output: DeleteModelManifestResponse,
@@ -4280,7 +4279,7 @@ export const deleteSignalCatalog: API.OperationMethod<
   DeleteSignalCatalogRequest,
   DeleteSignalCatalogResponse,
   DeleteSignalCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSignalCatalogRequest,
   output: DeleteSignalCatalogResponse,
@@ -4309,7 +4308,7 @@ export const deleteStateTemplate: API.OperationMethod<
   DeleteStateTemplateRequest,
   DeleteStateTemplateResponse,
   DeleteStateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStateTemplateRequest,
   output: DeleteStateTemplateResponse,
@@ -4337,7 +4336,7 @@ export const deleteVehicle: API.OperationMethod<
   DeleteVehicleRequest,
   DeleteVehicleResponse,
   DeleteVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVehicleRequest,
   output: DeleteVehicleResponse,
@@ -4367,7 +4366,7 @@ export const disassociateVehicleFleet: API.OperationMethod<
   DisassociateVehicleFleetRequest,
   DisassociateVehicleFleetResponse,
   DisassociateVehicleFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateVehicleFleetRequest,
   output: DisassociateVehicleFleetResponse,
@@ -4398,7 +4397,7 @@ export const getCampaign: API.OperationMethod<
   GetCampaignRequest,
   GetCampaignResponse,
   GetCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignRequest,
   output: GetCampaignResponse,
@@ -4426,7 +4425,7 @@ export const getDecoderManifest: API.OperationMethod<
   GetDecoderManifestRequest,
   GetDecoderManifestResponse,
   GetDecoderManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDecoderManifestRequest,
   output: GetDecoderManifestResponse,
@@ -4455,7 +4454,7 @@ export const getEncryptionConfiguration: API.OperationMethod<
   GetEncryptionConfigurationRequest,
   GetEncryptionConfigurationResponse,
   GetEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEncryptionConfigurationRequest,
   output: GetEncryptionConfigurationResponse,
@@ -4485,7 +4484,7 @@ export const getFleet: API.OperationMethod<
   GetFleetRequest,
   GetFleetResponse,
   GetFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFleetRequest,
   output: GetFleetResponse,
@@ -4512,7 +4511,7 @@ export const getLoggingOptions: API.OperationMethod<
   GetLoggingOptionsRequest,
   GetLoggingOptionsResponse,
   GetLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingOptionsRequest,
   output: GetLoggingOptionsResponse,
@@ -4535,7 +4534,7 @@ export const getModelManifest: API.OperationMethod<
   GetModelManifestRequest,
   GetModelManifestResponse,
   GetModelManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelManifestRequest,
   output: GetModelManifestResponse,
@@ -4570,7 +4569,7 @@ export const getRegisterAccountStatus: API.OperationMethod<
   GetRegisterAccountStatusRequest,
   GetRegisterAccountStatusResponse,
   GetRegisterAccountStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegisterAccountStatusRequest,
   output: GetRegisterAccountStatusResponse,
@@ -4599,7 +4598,7 @@ export const getSignalCatalog: API.OperationMethod<
   GetSignalCatalogRequest,
   GetSignalCatalogResponse,
   GetSignalCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSignalCatalogRequest,
   output: GetSignalCatalogResponse,
@@ -4630,7 +4629,7 @@ export const getStateTemplate: API.OperationMethod<
   GetStateTemplateRequest,
   GetStateTemplateResponse,
   GetStateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStateTemplateRequest,
   output: GetStateTemplateResponse,
@@ -4660,7 +4659,7 @@ export const getVehicle: API.OperationMethod<
   GetVehicleRequest,
   GetVehicleResponse,
   GetVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVehicleRequest,
   output: GetVehicleResponse,
@@ -4690,7 +4689,7 @@ export const getVehicleStatus: API.PaginatedOperationMethod<
   GetVehicleStatusRequest,
   GetVehicleStatusResponse,
   GetVehicleStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VehicleStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetVehicleStatusRequest,
@@ -4730,7 +4729,7 @@ export const importDecoderManifest: API.OperationMethod<
   ImportDecoderManifestRequest,
   ImportDecoderManifestResponse,
   ImportDecoderManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportDecoderManifestRequest,
   output: ImportDecoderManifestResponse,
@@ -4766,7 +4765,7 @@ export const importSignalCatalog: API.OperationMethod<
   ImportSignalCatalogRequest,
   ImportSignalCatalogResponse,
   ImportSignalCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportSignalCatalogRequest,
   output: ImportSignalCatalogResponse,
@@ -4799,7 +4798,7 @@ export const listCampaigns: API.PaginatedOperationMethod<
   ListCampaignsRequest,
   ListCampaignsResponse,
   ListCampaignsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CampaignSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCampaignsRequest,
@@ -4832,7 +4831,7 @@ export const listDecoderManifestNetworkInterfaces: API.PaginatedOperationMethod<
   ListDecoderManifestNetworkInterfacesRequest,
   ListDecoderManifestNetworkInterfacesResponse,
   ListDecoderManifestNetworkInterfacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkInterface
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDecoderManifestNetworkInterfacesRequest,
@@ -4870,7 +4869,7 @@ export const listDecoderManifests: API.PaginatedOperationMethod<
   ListDecoderManifestsRequest,
   ListDecoderManifestsResponse,
   ListDecoderManifestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DecoderManifestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDecoderManifestsRequest,
@@ -4908,7 +4907,7 @@ export const listDecoderManifestSignals: API.PaginatedOperationMethod<
   ListDecoderManifestSignalsRequest,
   ListDecoderManifestSignalsResponse,
   ListDecoderManifestSignalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SignalDecoder
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDecoderManifestSignalsRequest,
@@ -4947,7 +4946,7 @@ export const listFleets: API.PaginatedOperationMethod<
   ListFleetsRequest,
   ListFleetsResponse,
   ListFleetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetsRequest,
@@ -4986,7 +4985,7 @@ export const listFleetsForVehicle: API.PaginatedOperationMethod<
   ListFleetsForVehicleRequest,
   ListFleetsForVehicleResponse,
   ListFleetsForVehicleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FleetId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFleetsForVehicleRequest,
@@ -5026,7 +5025,7 @@ export const listModelManifestNodes: API.PaginatedOperationMethod<
   ListModelManifestNodesRequest,
   ListModelManifestNodesResponse,
   ListModelManifestNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Node
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelManifestNodesRequest,
@@ -5065,7 +5064,7 @@ export const listModelManifests: API.PaginatedOperationMethod<
   ListModelManifestsRequest,
   ListModelManifestsResponse,
   ListModelManifestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelManifestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelManifestsRequest,
@@ -5104,7 +5103,7 @@ export const listSignalCatalogNodes: API.PaginatedOperationMethod<
   ListSignalCatalogNodesRequest,
   ListSignalCatalogNodesResponse,
   ListSignalCatalogNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Node
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSignalCatalogNodesRequest,
@@ -5146,7 +5145,7 @@ export const listSignalCatalogs: API.PaginatedOperationMethod<
   ListSignalCatalogsRequest,
   ListSignalCatalogsResponse,
   ListSignalCatalogsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SignalCatalogSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSignalCatalogsRequest,
@@ -5183,7 +5182,7 @@ export const listStateTemplates: API.PaginatedOperationMethod<
   ListStateTemplatesRequest,
   ListStateTemplatesResponse,
   ListStateTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StateTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStateTemplatesRequest,
@@ -5219,7 +5218,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5250,7 +5249,7 @@ export const listVehicles: API.PaginatedOperationMethod<
   ListVehiclesRequest,
   ListVehiclesResponse,
   ListVehiclesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VehicleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVehiclesRequest,
@@ -5288,7 +5287,7 @@ export const listVehiclesInFleet: API.PaginatedOperationMethod<
   ListVehiclesInFleetRequest,
   ListVehiclesInFleetResponse,
   ListVehiclesInFleetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VehicleName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVehiclesInFleetRequest,
@@ -5329,7 +5328,7 @@ export const putEncryptionConfiguration: API.OperationMethod<
   PutEncryptionConfigurationRequest,
   PutEncryptionConfigurationResponse,
   PutEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEncryptionConfigurationRequest,
   output: PutEncryptionConfigurationResponse,
@@ -5360,7 +5359,7 @@ export const putLoggingOptions: API.OperationMethod<
   PutLoggingOptionsRequest,
   PutLoggingOptionsResponse,
   PutLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingOptionsRequest,
   output: PutLoggingOptionsResponse,
@@ -5413,7 +5412,7 @@ export const registerAccount: API.OperationMethod<
   RegisterAccountRequest,
   RegisterAccountResponse,
   RegisterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAccountRequest,
   output: RegisterAccountResponse,
@@ -5445,7 +5444,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5475,7 +5474,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5505,7 +5504,7 @@ export const updateCampaign: API.OperationMethod<
   UpdateCampaignRequest,
   UpdateCampaignResponse,
   UpdateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignRequest,
   output: UpdateCampaignResponse,
@@ -5540,7 +5539,7 @@ export const updateDecoderManifest: API.OperationMethod<
   UpdateDecoderManifestRequest,
   UpdateDecoderManifestResponse,
   UpdateDecoderManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDecoderManifestRequest,
   output: UpdateDecoderManifestResponse,
@@ -5573,7 +5572,7 @@ export const updateFleet: API.OperationMethod<
   UpdateFleetRequest,
   UpdateFleetResponse,
   UpdateFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFleetRequest,
   output: UpdateFleetResponse,
@@ -5607,7 +5606,7 @@ export const updateModelManifest: API.OperationMethod<
   UpdateModelManifestRequest,
   UpdateModelManifestResponse,
   UpdateModelManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelManifestRequest,
   output: UpdateModelManifestResponse,
@@ -5643,7 +5642,7 @@ export const updateSignalCatalog: API.OperationMethod<
   UpdateSignalCatalogRequest,
   UpdateSignalCatalogResponse,
   UpdateSignalCatalogError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSignalCatalogRequest,
   output: UpdateSignalCatalogResponse,
@@ -5681,7 +5680,7 @@ export const updateStateTemplate: API.OperationMethod<
   UpdateStateTemplateRequest,
   UpdateStateTemplateResponse,
   UpdateStateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStateTemplateRequest,
   output: UpdateStateTemplateResponse,
@@ -5717,7 +5716,7 @@ export const updateVehicle: API.OperationMethod<
   UpdateVehicleRequest,
   UpdateVehicleResponse,
   UpdateVehicleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVehicleRequest,
   output: UpdateVehicleResponse,

--- a/packages/aws/src/services/iotsecuretunneling.ts
+++ b/packages/aws/src/services/iotsecuretunneling.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoTSecureTunneling",
@@ -493,7 +492,7 @@ export const closeTunnel: API.OperationMethod<
   CloseTunnelRequest,
   CloseTunnelResponse,
   CloseTunnelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloseTunnelRequest,
   output: CloseTunnelResponse,
@@ -513,7 +512,7 @@ export const describeTunnel: API.OperationMethod<
   DescribeTunnelRequest,
   DescribeTunnelResponse,
   DescribeTunnelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTunnelRequest,
   output: DescribeTunnelResponse,
@@ -531,7 +530,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -552,7 +551,7 @@ export const listTunnels: API.PaginatedOperationMethod<
   ListTunnelsRequest,
   ListTunnelsResponse,
   ListTunnelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTunnelsRequest,
@@ -579,7 +578,7 @@ export const openTunnel: API.OperationMethod<
   OpenTunnelRequest,
   OpenTunnelResponse,
   OpenTunnelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OpenTunnelRequest,
   output: OpenTunnelResponse,
@@ -607,7 +606,7 @@ export const rotateTunnelAccessToken: API.OperationMethod<
   RotateTunnelAccessTokenRequest,
   RotateTunnelAccessTokenResponse,
   RotateTunnelAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateTunnelAccessTokenRequest,
   output: RotateTunnelAccessTokenResponse,
@@ -625,7 +624,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -643,7 +642,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/iotsitewise.ts
+++ b/packages/aws/src/services/iotsitewise.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IoTSiteWise",
@@ -7132,7 +7131,7 @@ export const associateAssets: API.OperationMethod<
   AssociateAssetsRequest,
   AssociateAssetsResponse,
   AssociateAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAssetsRequest,
   output: AssociateAssetsResponse,
@@ -7165,7 +7164,7 @@ export const associateTimeSeriesToAssetProperty: API.OperationMethod<
   AssociateTimeSeriesToAssetPropertyRequest,
   AssociateTimeSeriesToAssetPropertyResponse,
   AssociateTimeSeriesToAssetPropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTimeSeriesToAssetPropertyRequest,
   output: AssociateTimeSeriesToAssetPropertyResponse,
@@ -7196,7 +7195,7 @@ export const batchAssociateProjectAssets: API.OperationMethod<
   BatchAssociateProjectAssetsRequest,
   BatchAssociateProjectAssetsResponse,
   BatchAssociateProjectAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateProjectAssetsRequest,
   output: BatchAssociateProjectAssetsResponse,
@@ -7226,7 +7225,7 @@ export const batchDisassociateProjectAssets: API.OperationMethod<
   BatchDisassociateProjectAssetsRequest,
   BatchDisassociateProjectAssetsResponse,
   BatchDisassociateProjectAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateProjectAssetsRequest,
   output: BatchDisassociateProjectAssetsResponse,
@@ -7257,7 +7256,7 @@ export const batchGetAssetPropertyAggregates: API.PaginatedOperationMethod<
   BatchGetAssetPropertyAggregatesRequest,
   BatchGetAssetPropertyAggregatesResponse,
   BatchGetAssetPropertyAggregatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetAssetPropertyAggregatesRequest,
@@ -7293,7 +7292,7 @@ export const batchGetAssetPropertyValue: API.PaginatedOperationMethod<
   BatchGetAssetPropertyValueRequest,
   BatchGetAssetPropertyValueResponse,
   BatchGetAssetPropertyValueError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetAssetPropertyValueRequest,
@@ -7325,7 +7324,7 @@ export const batchGetAssetPropertyValueHistory: API.PaginatedOperationMethod<
   BatchGetAssetPropertyValueHistoryRequest,
   BatchGetAssetPropertyValueHistoryResponse,
   BatchGetAssetPropertyValueHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetAssetPropertyValueHistoryRequest,
@@ -7385,7 +7384,7 @@ export const batchPutAssetPropertyValue: API.OperationMethod<
   BatchPutAssetPropertyValueRequest,
   BatchPutAssetPropertyValueResponse,
   BatchPutAssetPropertyValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutAssetPropertyValueRequest,
   output: BatchPutAssetPropertyValueResponse,
@@ -7421,7 +7420,7 @@ export const createAccessPolicy: API.OperationMethod<
   CreateAccessPolicyRequest,
   CreateAccessPolicyResponse,
   CreateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPolicyRequest,
   output: CreateAccessPolicyResponse,
@@ -7455,7 +7454,7 @@ export const createAsset: API.OperationMethod<
   CreateAssetRequest,
   CreateAssetResponse,
   CreateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetRequest,
   output: CreateAssetResponse,
@@ -7508,7 +7507,7 @@ export const createAssetModel: API.OperationMethod<
   CreateAssetModelRequest,
   CreateAssetModelResponse,
   CreateAssetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetModelRequest,
   output: CreateAssetModelResponse,
@@ -7564,7 +7563,7 @@ export const createAssetModelCompositeModel: API.OperationMethod<
   CreateAssetModelCompositeModelRequest,
   CreateAssetModelCompositeModelResponse,
   CreateAssetModelCompositeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetModelCompositeModelRequest,
   output: CreateAssetModelCompositeModelResponse,
@@ -7613,7 +7612,7 @@ export const createBulkImportJob: API.OperationMethod<
   CreateBulkImportJobRequest,
   CreateBulkImportJobResponse,
   CreateBulkImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBulkImportJobRequest,
   output: CreateBulkImportJobResponse,
@@ -7648,7 +7647,7 @@ export const createComputationModel: API.OperationMethod<
   CreateComputationModelRequest,
   CreateComputationModelResponse,
   CreateComputationModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComputationModelRequest,
   output: CreateComputationModelResponse,
@@ -7681,7 +7680,7 @@ export const createDashboard: API.OperationMethod<
   CreateDashboardRequest,
   CreateDashboardResponse,
   CreateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDashboardRequest,
   output: CreateDashboardResponse,
@@ -7714,7 +7713,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -7749,7 +7748,7 @@ export const createGateway: API.OperationMethod<
   CreateGatewayRequest,
   CreateGatewayResponse,
   CreateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayRequest,
   output: CreateGatewayResponse,
@@ -7785,7 +7784,7 @@ export const createPortal: API.OperationMethod<
   CreatePortalRequest,
   CreatePortalResponse,
   CreatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortalRequest,
   output: CreatePortalResponse,
@@ -7819,7 +7818,7 @@ export const createProject: API.OperationMethod<
   CreateProjectRequest,
   CreateProjectResponse,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectRequest,
   output: CreateProjectResponse,
@@ -7851,7 +7850,7 @@ export const deleteAccessPolicy: API.OperationMethod<
   DeleteAccessPolicyRequest,
   DeleteAccessPolicyResponse,
   DeleteAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPolicyRequest,
   output: DeleteAccessPolicyResponse,
@@ -7885,7 +7884,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetRequest,
   DeleteAssetResponse,
   DeleteAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetRequest,
   output: DeleteAssetResponse,
@@ -7921,7 +7920,7 @@ export const deleteAssetModel: API.OperationMethod<
   DeleteAssetModelRequest,
   DeleteAssetModelResponse,
   DeleteAssetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetModelRequest,
   output: DeleteAssetModelResponse,
@@ -7958,7 +7957,7 @@ export const deleteAssetModelCompositeModel: API.OperationMethod<
   DeleteAssetModelCompositeModelRequest,
   DeleteAssetModelCompositeModelResponse,
   DeleteAssetModelCompositeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetModelCompositeModelRequest,
   output: DeleteAssetModelCompositeModelResponse,
@@ -7991,7 +7990,7 @@ export const deleteAssetModelInterfaceRelationship: API.OperationMethod<
   DeleteAssetModelInterfaceRelationshipRequest,
   DeleteAssetModelInterfaceRelationshipResponse,
   DeleteAssetModelInterfaceRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetModelInterfaceRelationshipRequest,
   output: DeleteAssetModelInterfaceRelationshipResponse,
@@ -8022,7 +8021,7 @@ export const deleteComputationModel: API.OperationMethod<
   DeleteComputationModelRequest,
   DeleteComputationModelResponse,
   DeleteComputationModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComputationModelRequest,
   output: DeleteComputationModelResponse,
@@ -8052,7 +8051,7 @@ export const deleteDashboard: API.OperationMethod<
   DeleteDashboardRequest,
   DeleteDashboardResponse,
   DeleteDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDashboardRequest,
   output: DeleteDashboardResponse,
@@ -8082,7 +8081,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -8114,7 +8113,7 @@ export const deleteGateway: API.OperationMethod<
   DeleteGatewayRequest,
   DeleteGatewayResponse,
   DeleteGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayRequest,
   output: DeleteGatewayResponse,
@@ -8145,7 +8144,7 @@ export const deletePortal: API.OperationMethod<
   DeletePortalRequest,
   DeletePortalResponse,
   DeletePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortalRequest,
   output: DeletePortalResponse,
@@ -8175,7 +8174,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectRequest,
   DeleteProjectResponse,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectRequest,
   output: DeleteProjectResponse,
@@ -8219,7 +8218,7 @@ export const deleteTimeSeries: API.OperationMethod<
   DeleteTimeSeriesRequest,
   DeleteTimeSeriesResponse,
   DeleteTimeSeriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTimeSeriesRequest,
   output: DeleteTimeSeriesResponse,
@@ -8250,7 +8249,7 @@ export const describeAccessPolicy: API.OperationMethod<
   DescribeAccessPolicyRequest,
   DescribeAccessPolicyResponse,
   DescribeAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccessPolicyRequest,
   output: DescribeAccessPolicyResponse,
@@ -8279,7 +8278,7 @@ export const describeAction: API.OperationMethod<
   DescribeActionRequest,
   DescribeActionResponse,
   DescribeActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActionRequest,
   output: DescribeActionResponse,
@@ -8308,7 +8307,7 @@ export const describeAsset: API.OperationMethod<
   DescribeAssetRequest,
   DescribeAssetResponse,
   DescribeAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetRequest,
   output: DescribeAssetResponse,
@@ -8340,7 +8339,7 @@ export const describeAssetCompositeModel: API.OperationMethod<
   DescribeAssetCompositeModelRequest,
   DescribeAssetCompositeModelResponse,
   DescribeAssetCompositeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetCompositeModelRequest,
   output: DescribeAssetCompositeModelResponse,
@@ -8371,7 +8370,7 @@ export const describeAssetModel: API.OperationMethod<
   DescribeAssetModelRequest,
   DescribeAssetModelResponse,
   DescribeAssetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetModelRequest,
   output: DescribeAssetModelResponse,
@@ -8402,7 +8401,7 @@ export const describeAssetModelCompositeModel: API.OperationMethod<
   DescribeAssetModelCompositeModelRequest,
   DescribeAssetModelCompositeModelResponse,
   DescribeAssetModelCompositeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetModelCompositeModelRequest,
   output: DescribeAssetModelCompositeModelResponse,
@@ -8432,7 +8431,7 @@ export const describeAssetModelInterfaceRelationship: API.OperationMethod<
   DescribeAssetModelInterfaceRelationshipRequest,
   DescribeAssetModelInterfaceRelationshipResponse,
   DescribeAssetModelInterfaceRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetModelInterfaceRelationshipRequest,
   output: DescribeAssetModelInterfaceRelationshipResponse,
@@ -8468,7 +8467,7 @@ export const describeAssetProperty: API.OperationMethod<
   DescribeAssetPropertyRequest,
   DescribeAssetPropertyResponse,
   DescribeAssetPropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetPropertyRequest,
   output: DescribeAssetPropertyResponse,
@@ -8498,7 +8497,7 @@ export const describeBulkImportJob: API.OperationMethod<
   DescribeBulkImportJobRequest,
   DescribeBulkImportJobResponse,
   DescribeBulkImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBulkImportJobRequest,
   output: DescribeBulkImportJobResponse,
@@ -8527,7 +8526,7 @@ export const describeComputationModel: API.OperationMethod<
   DescribeComputationModelRequest,
   DescribeComputationModelResponse,
   DescribeComputationModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComputationModelRequest,
   output: DescribeComputationModelResponse,
@@ -8556,7 +8555,7 @@ export const describeComputationModelExecutionSummary: API.OperationMethod<
   DescribeComputationModelExecutionSummaryRequest,
   DescribeComputationModelExecutionSummaryResponse,
   DescribeComputationModelExecutionSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComputationModelExecutionSummaryRequest,
   output: DescribeComputationModelExecutionSummaryResponse,
@@ -8585,7 +8584,7 @@ export const describeDashboard: API.OperationMethod<
   DescribeDashboardRequest,
   DescribeDashboardResponse,
   DescribeDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardRequest,
   output: DescribeDashboardResponse,
@@ -8614,7 +8613,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -8644,7 +8643,7 @@ export const describeDefaultEncryptionConfiguration: API.OperationMethod<
   DescribeDefaultEncryptionConfigurationRequest,
   DescribeDefaultEncryptionConfigurationResponse,
   DescribeDefaultEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDefaultEncryptionConfigurationRequest,
   output: DescribeDefaultEncryptionConfigurationResponse,
@@ -8672,7 +8671,7 @@ export const describeExecution: API.OperationMethod<
   DescribeExecutionRequest,
   DescribeExecutionResponse,
   DescribeExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExecutionRequest,
   output: DescribeExecutionResponse,
@@ -8701,7 +8700,7 @@ export const describeGateway: API.OperationMethod<
   DescribeGatewayRequest,
   DescribeGatewayResponse,
   DescribeGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayRequest,
   output: DescribeGatewayResponse,
@@ -8742,7 +8741,7 @@ export const describeGatewayCapabilityConfiguration: API.OperationMethod<
   DescribeGatewayCapabilityConfigurationRequest,
   DescribeGatewayCapabilityConfigurationResponse,
   DescribeGatewayCapabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayCapabilityConfigurationRequest,
   output: DescribeGatewayCapabilityConfigurationResponse,
@@ -8771,7 +8770,7 @@ export const describeLoggingOptions: API.OperationMethod<
   DescribeLoggingOptionsRequest,
   DescribeLoggingOptionsResponse,
   DescribeLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoggingOptionsRequest,
   output: DescribeLoggingOptionsResponse,
@@ -8800,7 +8799,7 @@ export const describePortal: API.OperationMethod<
   DescribePortalRequest,
   DescribePortalResponse,
   DescribePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePortalRequest,
   output: DescribePortalResponse,
@@ -8829,7 +8828,7 @@ export const describeProject: API.OperationMethod<
   DescribeProjectRequest,
   DescribeProjectResponse,
   DescribeProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProjectRequest,
   output: DescribeProjectResponse,
@@ -8860,7 +8859,7 @@ export const describeStorageConfiguration: API.OperationMethod<
   DescribeStorageConfigurationRequest,
   DescribeStorageConfigurationResponse,
   DescribeStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStorageConfigurationRequest,
   output: DescribeStorageConfigurationResponse,
@@ -8903,7 +8902,7 @@ export const describeTimeSeries: API.OperationMethod<
   DescribeTimeSeriesRequest,
   DescribeTimeSeriesResponse,
   DescribeTimeSeriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTimeSeriesRequest,
   output: DescribeTimeSeriesResponse,
@@ -8934,7 +8933,7 @@ export const disassociateAssets: API.OperationMethod<
   DisassociateAssetsRequest,
   DisassociateAssetsResponse,
   DisassociateAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAssetsRequest,
   output: DisassociateAssetsResponse,
@@ -8965,7 +8964,7 @@ export const disassociateTimeSeriesFromAssetProperty: API.OperationMethod<
   DisassociateTimeSeriesFromAssetPropertyRequest,
   DisassociateTimeSeriesFromAssetPropertyResponse,
   DisassociateTimeSeriesFromAssetPropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTimeSeriesFromAssetPropertyRequest,
   output: DisassociateTimeSeriesFromAssetPropertyResponse,
@@ -8997,7 +8996,7 @@ export const executeAction: API.OperationMethod<
   ExecuteActionRequest,
   ExecuteActionResponse,
   ExecuteActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteActionRequest,
   output: ExecuteActionResponse,
@@ -9032,7 +9031,7 @@ export const executeQuery: API.PaginatedOperationMethod<
   ExecuteQueryRequest,
   ExecuteQueryResponse,
   ExecuteQueryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Row
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ExecuteQueryRequest,
@@ -9080,7 +9079,7 @@ export const getAssetPropertyAggregates: API.PaginatedOperationMethod<
   GetAssetPropertyAggregatesRequest,
   GetAssetPropertyAggregatesResponse,
   GetAssetPropertyAggregatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregatedValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAssetPropertyAggregatesRequest,
@@ -9126,7 +9125,7 @@ export const getAssetPropertyValue: API.OperationMethod<
   GetAssetPropertyValueRequest,
   GetAssetPropertyValueResponse,
   GetAssetPropertyValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetPropertyValueRequest,
   output: GetAssetPropertyValueResponse,
@@ -9165,7 +9164,7 @@ export const getAssetPropertyValueHistory: API.PaginatedOperationMethod<
   GetAssetPropertyValueHistoryRequest,
   GetAssetPropertyValueHistoryResponse,
   GetAssetPropertyValueHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetPropertyValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAssetPropertyValueHistoryRequest,
@@ -9215,7 +9214,7 @@ export const getInterpolatedAssetPropertyValues: API.PaginatedOperationMethod<
   GetInterpolatedAssetPropertyValuesRequest,
   GetInterpolatedAssetPropertyValuesResponse,
   GetInterpolatedAssetPropertyValuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InterpolatedAssetPropertyValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInterpolatedAssetPropertyValuesRequest,
@@ -9255,7 +9254,7 @@ export const invokeAssistant: API.OperationMethod<
   InvokeAssistantRequest,
   InvokeAssistantResponse,
   InvokeAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeAssistantRequest,
   output: InvokeAssistantResponse,
@@ -9287,7 +9286,7 @@ export const listAccessPolicies: API.PaginatedOperationMethod<
   ListAccessPoliciesRequest,
   ListAccessPoliciesResponse,
   ListAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessPolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPoliciesRequest,
@@ -9322,7 +9321,7 @@ export const listActions: API.PaginatedOperationMethod<
   ListActionsRequest,
   ListActionsResponse,
   ListActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionsRequest,
@@ -9358,7 +9357,7 @@ export const listAssetModelCompositeModels: API.PaginatedOperationMethod<
   ListAssetModelCompositeModelsRequest,
   ListAssetModelCompositeModelsResponse,
   ListAssetModelCompositeModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetModelCompositeModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetModelCompositeModelsRequest,
@@ -9396,7 +9395,7 @@ export const listAssetModelProperties: API.PaginatedOperationMethod<
   ListAssetModelPropertiesRequest,
   ListAssetModelPropertiesResponse,
   ListAssetModelPropertiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetModelPropertySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetModelPropertiesRequest,
@@ -9431,7 +9430,7 @@ export const listAssetModels: API.PaginatedOperationMethod<
   ListAssetModelsRequest,
   ListAssetModelsResponse,
   ListAssetModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetModelsRequest,
@@ -9468,7 +9467,7 @@ export const listAssetProperties: API.PaginatedOperationMethod<
   ListAssetPropertiesRequest,
   ListAssetPropertiesResponse,
   ListAssetPropertiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetPropertySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetPropertiesRequest,
@@ -9506,7 +9505,7 @@ export const listAssetRelationships: API.PaginatedOperationMethod<
   ListAssetRelationshipsRequest,
   ListAssetRelationshipsResponse,
   ListAssetRelationshipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetRelationshipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetRelationshipsRequest,
@@ -9552,7 +9551,7 @@ export const listAssets: API.PaginatedOperationMethod<
   ListAssetsRequest,
   ListAssetsResponse,
   ListAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetsRequest,
@@ -9594,7 +9593,7 @@ export const listAssociatedAssets: API.PaginatedOperationMethod<
   ListAssociatedAssetsRequest,
   ListAssociatedAssetsResponse,
   ListAssociatedAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedAssetsSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedAssetsRequest,
@@ -9631,7 +9630,7 @@ export const listBulkImportJobs: API.PaginatedOperationMethod<
   ListBulkImportJobsRequest,
   ListBulkImportJobsResponse,
   ListBulkImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBulkImportJobsRequest,
@@ -9668,7 +9667,7 @@ export const listCompositionRelationships: API.PaginatedOperationMethod<
   ListCompositionRelationshipsRequest,
   ListCompositionRelationshipsResponse,
   ListCompositionRelationshipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CompositionRelationshipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCompositionRelationshipsRequest,
@@ -9705,7 +9704,7 @@ export const listComputationModelDataBindingUsages: API.PaginatedOperationMethod
   ListComputationModelDataBindingUsagesRequest,
   ListComputationModelDataBindingUsagesResponse,
   ListComputationModelDataBindingUsagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputationModelDataBindingUsageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputationModelDataBindingUsagesRequest,
@@ -9741,7 +9740,7 @@ export const listComputationModelResolveToResources: API.PaginatedOperationMetho
   ListComputationModelResolveToResourcesRequest,
   ListComputationModelResolveToResourcesResponse,
   ListComputationModelResolveToResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputationModelResolveToResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputationModelResolveToResourcesRequest,
@@ -9776,7 +9775,7 @@ export const listComputationModels: API.PaginatedOperationMethod<
   ListComputationModelsRequest,
   ListComputationModelsResponse,
   ListComputationModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputationModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputationModelsRequest,
@@ -9810,7 +9809,7 @@ export const listDashboards: API.PaginatedOperationMethod<
   ListDashboardsRequest,
   ListDashboardsResponse,
   ListDashboardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDashboardsRequest,
@@ -9844,7 +9843,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -9879,7 +9878,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsRequest,
   ListExecutionsResponse,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsRequest,
@@ -9914,7 +9913,7 @@ export const listGateways: API.PaginatedOperationMethod<
   ListGatewaysRequest,
   ListGatewaysResponse,
   ListGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewaySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewaysRequest,
@@ -9950,7 +9949,7 @@ export const listInterfaceRelationships: API.PaginatedOperationMethod<
   ListInterfaceRelationshipsRequest,
   ListInterfaceRelationshipsResponse,
   ListInterfaceRelationshipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InterfaceRelationshipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInterfaceRelationshipsRequest,
@@ -9985,7 +9984,7 @@ export const listPortals: API.PaginatedOperationMethod<
   ListPortalsRequest,
   ListPortalsResponse,
   ListPortalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PortalSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPortalsRequest,
@@ -10019,7 +10018,7 @@ export const listProjectAssets: API.PaginatedOperationMethod<
   ListProjectAssetsRequest,
   ListProjectAssetsResponse,
   ListProjectAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ID
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectAssetsRequest,
@@ -10053,7 +10052,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsRequest,
   ListProjectsResponse,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsRequest,
@@ -10091,7 +10090,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -10123,7 +10122,7 @@ export const listTimeSeries: API.PaginatedOperationMethod<
   ListTimeSeriesRequest,
   ListTimeSeriesResponse,
   ListTimeSeriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TimeSeriesSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTimeSeriesRequest,
@@ -10162,7 +10161,7 @@ export const putAssetModelInterfaceRelationship: API.OperationMethod<
   PutAssetModelInterfaceRelationshipRequest,
   PutAssetModelInterfaceRelationshipResponse,
   PutAssetModelInterfaceRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAssetModelInterfaceRelationshipRequest,
   output: PutAssetModelInterfaceRelationshipResponse,
@@ -10196,7 +10195,7 @@ export const putDefaultEncryptionConfiguration: API.OperationMethod<
   PutDefaultEncryptionConfigurationRequest,
   PutDefaultEncryptionConfigurationResponse,
   PutDefaultEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDefaultEncryptionConfigurationRequest,
   output: PutDefaultEncryptionConfigurationResponse,
@@ -10227,7 +10226,7 @@ export const putLoggingOptions: API.OperationMethod<
   PutLoggingOptionsRequest,
   PutLoggingOptionsResponse,
   PutLoggingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingOptionsRequest,
   output: PutLoggingOptionsResponse,
@@ -10260,7 +10259,7 @@ export const putStorageConfiguration: API.OperationMethod<
   PutStorageConfigurationRequest,
   PutStorageConfigurationResponse,
   PutStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutStorageConfigurationRequest,
   output: PutStorageConfigurationResponse,
@@ -10297,7 +10296,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10333,7 +10332,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10366,7 +10365,7 @@ export const updateAccessPolicy: API.OperationMethod<
   UpdateAccessPolicyRequest,
   UpdateAccessPolicyResponse,
   UpdateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessPolicyRequest,
   output: UpdateAccessPolicyResponse,
@@ -10398,7 +10397,7 @@ export const updateAsset: API.OperationMethod<
   UpdateAssetRequest,
   UpdateAssetResponse,
   UpdateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetRequest,
   output: UpdateAssetResponse,
@@ -10449,7 +10448,7 @@ export const updateAssetModel: API.OperationMethod<
   UpdateAssetModelRequest,
   UpdateAssetModelResponse,
   UpdateAssetModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetModelRequest,
   output: UpdateAssetModelResponse,
@@ -10502,7 +10501,7 @@ export const updateAssetModelCompositeModel: API.OperationMethod<
   UpdateAssetModelCompositeModelRequest,
   UpdateAssetModelCompositeModelResponse,
   UpdateAssetModelCompositeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetModelCompositeModelRequest,
   output: UpdateAssetModelCompositeModelResponse,
@@ -10540,7 +10539,7 @@ export const updateAssetProperty: API.OperationMethod<
   UpdateAssetPropertyRequest,
   UpdateAssetPropertyResponse,
   UpdateAssetPropertyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssetPropertyRequest,
   output: UpdateAssetPropertyResponse,
@@ -10573,7 +10572,7 @@ export const updateComputationModel: API.OperationMethod<
   UpdateComputationModelRequest,
   UpdateComputationModelResponse,
   UpdateComputationModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComputationModelRequest,
   output: UpdateComputationModelResponse,
@@ -10605,7 +10604,7 @@ export const updateDashboard: API.OperationMethod<
   UpdateDashboardRequest,
   UpdateDashboardResponse,
   UpdateDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardRequest,
   output: UpdateDashboardResponse,
@@ -10636,7 +10635,7 @@ export const updateDataset: API.OperationMethod<
   UpdateDatasetRequest,
   UpdateDatasetResponse,
   UpdateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetRequest,
   output: UpdateDatasetResponse,
@@ -10668,7 +10667,7 @@ export const updateGateway: API.OperationMethod<
   UpdateGatewayRequest,
   UpdateGatewayResponse,
   UpdateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayRequest,
   output: UpdateGatewayResponse,
@@ -10716,7 +10715,7 @@ export const updateGatewayCapabilityConfiguration: API.OperationMethod<
   UpdateGatewayCapabilityConfigurationRequest,
   UpdateGatewayCapabilityConfigurationResponse,
   UpdateGatewayCapabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayCapabilityConfigurationRequest,
   output: UpdateGatewayCapabilityConfigurationResponse,
@@ -10748,7 +10747,7 @@ export const updatePortal: API.OperationMethod<
   UpdatePortalRequest,
   UpdatePortalResponse,
   UpdatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortalRequest,
   output: UpdatePortalResponse,
@@ -10778,7 +10777,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectRequest,
   UpdateProjectResponse,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectRequest,
   output: UpdateProjectResponse,

--- a/packages/aws/src/services/iotthingsgraph.ts
+++ b/packages/aws/src/services/iotthingsgraph.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoTThingsGraph",
   serviceShapeName: "IotThingsGraphFrontEndService",
@@ -1382,7 +1381,7 @@ export const associateEntityToThing: API.OperationMethod<
   AssociateEntityToThingRequest,
   AssociateEntityToThingResponse,
   AssociateEntityToThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEntityToThingRequest,
   output: AssociateEntityToThingResponse,
@@ -1413,7 +1412,7 @@ export const createFlowTemplate: API.OperationMethod<
   CreateFlowTemplateRequest,
   CreateFlowTemplateResponse,
   CreateFlowTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowTemplateRequest,
   output: CreateFlowTemplateResponse,
@@ -1455,7 +1454,7 @@ export const createSystemInstance: API.OperationMethod<
   CreateSystemInstanceRequest,
   CreateSystemInstanceResponse,
   CreateSystemInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSystemInstanceRequest,
   output: CreateSystemInstanceResponse,
@@ -1485,7 +1484,7 @@ export const createSystemTemplate: API.OperationMethod<
   CreateSystemTemplateRequest,
   CreateSystemTemplateResponse,
   CreateSystemTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSystemTemplateRequest,
   output: CreateSystemTemplateResponse,
@@ -1514,7 +1513,7 @@ export const deleteFlowTemplate: API.OperationMethod<
   DeleteFlowTemplateRequest,
   DeleteFlowTemplateResponse,
   DeleteFlowTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowTemplateRequest,
   output: DeleteFlowTemplateResponse,
@@ -1541,7 +1540,7 @@ export const deleteNamespace: API.OperationMethod<
   DeleteNamespaceRequest,
   DeleteNamespaceResponse,
   DeleteNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamespaceRequest,
   output: DeleteNamespaceResponse,
@@ -1567,7 +1566,7 @@ export const deleteSystemInstance: API.OperationMethod<
   DeleteSystemInstanceRequest,
   DeleteSystemInstanceResponse,
   DeleteSystemInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSystemInstanceRequest,
   output: DeleteSystemInstanceResponse,
@@ -1596,7 +1595,7 @@ export const deleteSystemTemplate: API.OperationMethod<
   DeleteSystemTemplateRequest,
   DeleteSystemTemplateResponse,
   DeleteSystemTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSystemTemplateRequest,
   output: DeleteSystemTemplateResponse,
@@ -1637,7 +1636,7 @@ export const deploySystemInstance: API.OperationMethod<
   DeploySystemInstanceRequest,
   DeploySystemInstanceResponse,
   DeploySystemInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeploySystemInstanceRequest,
   output: DeploySystemInstanceResponse,
@@ -1666,7 +1665,7 @@ export const deprecateFlowTemplate: API.OperationMethod<
   DeprecateFlowTemplateRequest,
   DeprecateFlowTemplateResponse,
   DeprecateFlowTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateFlowTemplateRequest,
   output: DeprecateFlowTemplateResponse,
@@ -1694,7 +1693,7 @@ export const deprecateSystemTemplate: API.OperationMethod<
   DeprecateSystemTemplateRequest,
   DeprecateSystemTemplateResponse,
   DeprecateSystemTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateSystemTemplateRequest,
   output: DeprecateSystemTemplateResponse,
@@ -1722,7 +1721,7 @@ export const describeNamespace: API.OperationMethod<
   DescribeNamespaceRequest,
   DescribeNamespaceResponse,
   DescribeNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNamespaceRequest,
   output: DescribeNamespaceResponse,
@@ -1751,7 +1750,7 @@ export const dissociateEntityFromThing: API.OperationMethod<
   DissociateEntityFromThingRequest,
   DissociateEntityFromThingResponse,
   DissociateEntityFromThingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DissociateEntityFromThingRequest,
   output: DissociateEntityFromThingResponse,
@@ -1800,7 +1799,7 @@ export const getEntities: API.OperationMethod<
   GetEntitiesRequest,
   GetEntitiesResponse,
   GetEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEntitiesRequest,
   output: GetEntitiesResponse,
@@ -1828,7 +1827,7 @@ export const getFlowTemplate: API.OperationMethod<
   GetFlowTemplateRequest,
   GetFlowTemplateResponse,
   GetFlowTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowTemplateRequest,
   output: GetFlowTemplateResponse,
@@ -1857,7 +1856,7 @@ export const getFlowTemplateRevisions: API.PaginatedOperationMethod<
   GetFlowTemplateRevisionsRequest,
   GetFlowTemplateRevisionsResponse,
   GetFlowTemplateRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFlowTemplateRevisionsRequest,
@@ -1891,7 +1890,7 @@ export const getNamespaceDeletionStatus: API.OperationMethod<
   GetNamespaceDeletionStatusRequest,
   GetNamespaceDeletionStatusResponse,
   GetNamespaceDeletionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNamespaceDeletionStatusRequest,
   output: GetNamespaceDeletionStatusResponse,
@@ -1918,7 +1917,7 @@ export const getSystemInstance: API.OperationMethod<
   GetSystemInstanceRequest,
   GetSystemInstanceResponse,
   GetSystemInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSystemInstanceRequest,
   output: GetSystemInstanceResponse,
@@ -1946,7 +1945,7 @@ export const getSystemTemplate: API.OperationMethod<
   GetSystemTemplateRequest,
   GetSystemTemplateResponse,
   GetSystemTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSystemTemplateRequest,
   output: GetSystemTemplateResponse,
@@ -1975,7 +1974,7 @@ export const getSystemTemplateRevisions: API.PaginatedOperationMethod<
   GetSystemTemplateRevisionsRequest,
   GetSystemTemplateRevisionsResponse,
   GetSystemTemplateRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSystemTemplateRevisionsRequest,
@@ -2010,7 +2009,7 @@ export const getUploadStatus: API.OperationMethod<
   GetUploadStatusRequest,
   GetUploadStatusResponse,
   GetUploadStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUploadStatusRequest,
   output: GetUploadStatusResponse,
@@ -2038,7 +2037,7 @@ export const listFlowExecutionMessages: API.PaginatedOperationMethod<
   ListFlowExecutionMessagesRequest,
   ListFlowExecutionMessagesResponse,
   ListFlowExecutionMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowExecutionMessage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowExecutionMessagesRequest,
@@ -2073,7 +2072,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -2107,7 +2106,7 @@ export const searchEntities: API.PaginatedOperationMethod<
   SearchEntitiesRequest,
   SearchEntitiesResponse,
   SearchEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EntityDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchEntitiesRequest,
@@ -2141,7 +2140,7 @@ export const searchFlowExecutions: API.PaginatedOperationMethod<
   SearchFlowExecutionsRequest,
   SearchFlowExecutionsResponse,
   SearchFlowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchFlowExecutionsRequest,
@@ -2175,7 +2174,7 @@ export const searchFlowTemplates: API.PaginatedOperationMethod<
   SearchFlowTemplatesRequest,
   SearchFlowTemplatesResponse,
   SearchFlowTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchFlowTemplatesRequest,
@@ -2208,7 +2207,7 @@ export const searchSystemInstances: API.PaginatedOperationMethod<
   SearchSystemInstancesRequest,
   SearchSystemInstancesResponse,
   SearchSystemInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSystemInstancesRequest,
@@ -2241,7 +2240,7 @@ export const searchSystemTemplates: API.PaginatedOperationMethod<
   SearchSystemTemplatesRequest,
   SearchSystemTemplatesResponse,
   SearchSystemTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSystemTemplatesRequest,
@@ -2280,7 +2279,7 @@ export const searchThings: API.PaginatedOperationMethod<
   SearchThingsRequest,
   SearchThingsResponse,
   SearchThingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Thing
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchThingsRequest,
@@ -2315,7 +2314,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2344,7 +2343,7 @@ export const undeploySystemInstance: API.OperationMethod<
   UndeploySystemInstanceRequest,
   UndeploySystemInstanceResponse,
   UndeploySystemInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UndeploySystemInstanceRequest,
   output: UndeploySystemInstanceResponse,
@@ -2373,7 +2372,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2402,7 +2401,7 @@ export const updateFlowTemplate: API.OperationMethod<
   UpdateFlowTemplateRequest,
   UpdateFlowTemplateResponse,
   UpdateFlowTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowTemplateRequest,
   output: UpdateFlowTemplateResponse,
@@ -2430,7 +2429,7 @@ export const updateSystemTemplate: API.OperationMethod<
   UpdateSystemTemplateRequest,
   UpdateSystemTemplateResponse,
   UpdateSystemTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSystemTemplateRequest,
   output: UpdateSystemTemplateResponse,
@@ -2469,7 +2468,7 @@ export const uploadEntityDefinitions: API.OperationMethod<
   UploadEntityDefinitionsRequest,
   UploadEntityDefinitionsResponse,
   UploadEntityDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadEntityDefinitionsRequest,
   output: UploadEntityDefinitionsResponse,

--- a/packages/aws/src/services/iottwinmaker.ts
+++ b/packages/aws/src/services/iottwinmaker.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "IoTTwinMaker",
   serviceShapeName: "AWSIoTTwinMaker",
@@ -3133,7 +3132,7 @@ export const batchPutPropertyValues: API.OperationMethod<
   BatchPutPropertyValuesRequest,
   BatchPutPropertyValuesResponse,
   BatchPutPropertyValuesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutPropertyValuesRequest,
   output: BatchPutPropertyValuesResponse,
@@ -3164,7 +3163,7 @@ export const cancelMetadataTransferJob: API.OperationMethod<
   CancelMetadataTransferJobRequest,
   CancelMetadataTransferJobResponse,
   CancelMetadataTransferJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMetadataTransferJobRequest,
   output: CancelMetadataTransferJobResponse,
@@ -3197,7 +3196,7 @@ export const createComponentType: API.OperationMethod<
   CreateComponentTypeRequest,
   CreateComponentTypeResponse,
   CreateComponentTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentTypeRequest,
   output: CreateComponentTypeResponse,
@@ -3230,7 +3229,7 @@ export const createEntity: API.OperationMethod<
   CreateEntityRequest,
   CreateEntityResponse,
   CreateEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEntityRequest,
   output: CreateEntityResponse,
@@ -3264,7 +3263,7 @@ export const createMetadataTransferJob: API.OperationMethod<
   CreateMetadataTransferJobRequest,
   CreateMetadataTransferJobResponse,
   CreateMetadataTransferJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMetadataTransferJobRequest,
   output: CreateMetadataTransferJobResponse,
@@ -3298,7 +3297,7 @@ export const createScene: API.OperationMethod<
   CreateSceneRequest,
   CreateSceneResponse,
   CreateSceneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSceneRequest,
   output: CreateSceneResponse,
@@ -3331,7 +3330,7 @@ export const createSyncJob: API.OperationMethod<
   CreateSyncJobRequest,
   CreateSyncJobResponse,
   CreateSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSyncJobRequest,
   output: CreateSyncJobResponse,
@@ -3364,7 +3363,7 @@ export const createWorkspace: API.OperationMethod<
   CreateWorkspaceRequest,
   CreateWorkspaceResponse,
   CreateWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceRequest,
   output: CreateWorkspaceResponse,
@@ -3396,7 +3395,7 @@ export const deleteComponentType: API.OperationMethod<
   DeleteComponentTypeRequest,
   DeleteComponentTypeResponse,
   DeleteComponentTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentTypeRequest,
   output: DeleteComponentTypeResponse,
@@ -3427,7 +3426,7 @@ export const deleteEntity: API.OperationMethod<
   DeleteEntityRequest,
   DeleteEntityResponse,
   DeleteEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEntityRequest,
   output: DeleteEntityResponse,
@@ -3458,7 +3457,7 @@ export const deleteScene: API.OperationMethod<
   DeleteSceneRequest,
   DeleteSceneResponse,
   DeleteSceneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSceneRequest,
   output: DeleteSceneResponse,
@@ -3490,7 +3489,7 @@ export const deleteSyncJob: API.OperationMethod<
   DeleteSyncJobRequest,
   DeleteSyncJobResponse,
   DeleteSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSyncJobRequest,
   output: DeleteSyncJobResponse,
@@ -3522,7 +3521,7 @@ export const deleteWorkspace: API.OperationMethod<
   DeleteWorkspaceRequest,
   DeleteWorkspaceResponse,
   DeleteWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceRequest,
   output: DeleteWorkspaceResponse,
@@ -3558,7 +3557,7 @@ export const executeQuery: API.PaginatedOperationMethod<
   ExecuteQueryRequest,
   ExecuteQueryResponse,
   ExecuteQueryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ExecuteQueryRequest,
@@ -3596,7 +3595,7 @@ export const getComponentType: API.OperationMethod<
   GetComponentTypeRequest,
   GetComponentTypeResponse,
   GetComponentTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentTypeRequest,
   output: GetComponentTypeResponse,
@@ -3627,7 +3626,7 @@ export const getEntity: API.OperationMethod<
   GetEntityRequest,
   GetEntityResponse,
   GetEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEntityRequest,
   output: GetEntityResponse,
@@ -3658,7 +3657,7 @@ export const getMetadataTransferJob: API.OperationMethod<
   GetMetadataTransferJobRequest,
   GetMetadataTransferJobResponse,
   GetMetadataTransferJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetadataTransferJobRequest,
   output: GetMetadataTransferJobResponse,
@@ -3688,7 +3687,7 @@ export const getPricingPlan: API.OperationMethod<
   GetPricingPlanRequest,
   GetPricingPlanResponse,
   GetPricingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPricingPlanRequest,
   output: GetPricingPlanResponse,
@@ -3723,7 +3722,7 @@ export const getPropertyValue: API.PaginatedOperationMethod<
   GetPropertyValueRequest,
   GetPropertyValueResponse,
   GetPropertyValueError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPropertyValueRequest,
@@ -3769,7 +3768,7 @@ export const getPropertyValueHistory: API.PaginatedOperationMethod<
   GetPropertyValueHistoryRequest,
   GetPropertyValueHistoryResponse,
   GetPropertyValueHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPropertyValueHistoryRequest,
@@ -3808,7 +3807,7 @@ export const getScene: API.OperationMethod<
   GetSceneRequest,
   GetSceneResponse,
   GetSceneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSceneRequest,
   output: GetSceneResponse,
@@ -3840,7 +3839,7 @@ export const getSyncJob: API.OperationMethod<
   GetSyncJobRequest,
   GetSyncJobResponse,
   GetSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSyncJobRequest,
   output: GetSyncJobResponse,
@@ -3872,7 +3871,7 @@ export const getWorkspace: API.OperationMethod<
   GetWorkspaceRequest,
   GetWorkspaceResponse,
   GetWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkspaceRequest,
   output: GetWorkspaceResponse,
@@ -3903,7 +3902,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsRequest,
   ListComponentsResponse,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsRequest,
@@ -3939,7 +3938,7 @@ export const listComponentTypes: API.PaginatedOperationMethod<
   ListComponentTypesRequest,
   ListComponentTypesResponse,
   ListComponentTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentTypesRequest,
@@ -3974,7 +3973,7 @@ export const listEntities: API.PaginatedOperationMethod<
   ListEntitiesRequest,
   ListEntitiesResponse,
   ListEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitiesRequest,
@@ -4009,7 +4008,7 @@ export const listMetadataTransferJobs: API.PaginatedOperationMethod<
   ListMetadataTransferJobsRequest,
   ListMetadataTransferJobsResponse,
   ListMetadataTransferJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetadataTransferJobsRequest,
@@ -4045,7 +4044,7 @@ export const listProperties: API.PaginatedOperationMethod<
   ListPropertiesRequest,
   ListPropertiesResponse,
   ListPropertiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPropertiesRequest,
@@ -4081,7 +4080,7 @@ export const listScenes: API.PaginatedOperationMethod<
   ListScenesRequest,
   ListScenesResponse,
   ListScenesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScenesRequest,
@@ -4117,7 +4116,7 @@ export const listSyncJobs: API.PaginatedOperationMethod<
   ListSyncJobsRequest,
   ListSyncJobsResponse,
   ListSyncJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSyncJobsRequest,
@@ -4154,7 +4153,7 @@ export const listSyncResources: API.PaginatedOperationMethod<
   ListSyncResourcesRequest,
   ListSyncResourcesResponse,
   ListSyncResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSyncResourcesRequest,
@@ -4188,7 +4187,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4212,7 +4211,7 @@ export const listWorkspaces: API.PaginatedOperationMethod<
   ListWorkspacesRequest,
   ListWorkspacesResponse,
   ListWorkspacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspacesRequest,
@@ -4246,7 +4245,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4272,7 +4271,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4298,7 +4297,7 @@ export const updateComponentType: API.OperationMethod<
   UpdateComponentTypeRequest,
   UpdateComponentTypeResponse,
   UpdateComponentTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComponentTypeRequest,
   output: UpdateComponentTypeResponse,
@@ -4332,7 +4331,7 @@ export const updateEntity: API.OperationMethod<
   UpdateEntityRequest,
   UpdateEntityResponse,
   UpdateEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEntityRequest,
   output: UpdateEntityResponse,
@@ -4364,7 +4363,7 @@ export const updatePricingPlan: API.OperationMethod<
   UpdatePricingPlanRequest,
   UpdatePricingPlanResponse,
   UpdatePricingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePricingPlanRequest,
   output: UpdatePricingPlanResponse,
@@ -4394,7 +4393,7 @@ export const updateScene: API.OperationMethod<
   UpdateSceneRequest,
   UpdateSceneResponse,
   UpdateSceneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSceneRequest,
   output: UpdateSceneResponse,
@@ -4426,7 +4425,7 @@ export const updateWorkspace: API.OperationMethod<
   UpdateWorkspaceRequest,
   UpdateWorkspaceResponse,
   UpdateWorkspaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceRequest,
   output: UpdateWorkspaceResponse,

--- a/packages/aws/src/services/ivs-realtime.ts
+++ b/packages/aws/src/services/ivs-realtime.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "IVS RealTime",
@@ -2483,7 +2482,7 @@ export const createEncoderConfiguration: API.OperationMethod<
   CreateEncoderConfigurationRequest,
   CreateEncoderConfigurationResponse,
   CreateEncoderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEncoderConfigurationRequest,
   output: CreateEncoderConfigurationResponse,
@@ -2514,7 +2513,7 @@ export const createIngestConfiguration: API.OperationMethod<
   CreateIngestConfigurationRequest,
   CreateIngestConfigurationResponse,
   CreateIngestConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIngestConfigurationRequest,
   output: CreateIngestConfigurationResponse,
@@ -2548,7 +2547,7 @@ export const createParticipantToken: API.OperationMethod<
   CreateParticipantTokenRequest,
   CreateParticipantTokenResponse,
   CreateParticipantTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParticipantTokenRequest,
   output: CreateParticipantTokenResponse,
@@ -2578,7 +2577,7 @@ export const createStage: API.OperationMethod<
   CreateStageRequest,
   CreateStageResponse,
   CreateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStageRequest,
   output: CreateStageResponse,
@@ -2612,7 +2611,7 @@ export const createStorageConfiguration: API.OperationMethod<
   CreateStorageConfigurationRequest,
   CreateStorageConfigurationResponse,
   CreateStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorageConfigurationRequest,
   output: CreateStorageConfigurationResponse,
@@ -2646,7 +2645,7 @@ export const deleteEncoderConfiguration: API.OperationMethod<
   DeleteEncoderConfigurationRequest,
   DeleteEncoderConfigurationResponse,
   DeleteEncoderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEncoderConfigurationRequest,
   output: DeleteEncoderConfigurationResponse,
@@ -2677,7 +2676,7 @@ export const deleteIngestConfiguration: API.OperationMethod<
   DeleteIngestConfigurationRequest,
   DeleteIngestConfigurationResponse,
   DeleteIngestConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIngestConfigurationRequest,
   output: DeleteIngestConfigurationResponse,
@@ -2708,7 +2707,7 @@ export const deletePublicKey: API.OperationMethod<
   DeletePublicKeyRequest,
   DeletePublicKeyResponse,
   DeletePublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublicKeyRequest,
   output: DeletePublicKeyResponse,
@@ -2741,7 +2740,7 @@ export const deleteStage: API.OperationMethod<
   DeleteStageRequest,
   DeleteStageResponse,
   DeleteStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStageRequest,
   output: DeleteStageResponse,
@@ -2777,7 +2776,7 @@ export const deleteStorageConfiguration: API.OperationMethod<
   DeleteStorageConfigurationRequest,
   DeleteStorageConfigurationResponse,
   DeleteStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageConfigurationRequest,
   output: DeleteStorageConfigurationResponse,
@@ -2809,7 +2808,7 @@ export const disconnectParticipant: API.OperationMethod<
   DisconnectParticipantRequest,
   DisconnectParticipantResponse,
   DisconnectParticipantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectParticipantRequest,
   output: DisconnectParticipantResponse,
@@ -2839,7 +2838,7 @@ export const getComposition: API.OperationMethod<
   GetCompositionRequest,
   GetCompositionResponse,
   GetCompositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCompositionRequest,
   output: GetCompositionResponse,
@@ -2871,7 +2870,7 @@ export const getEncoderConfiguration: API.OperationMethod<
   GetEncoderConfigurationRequest,
   GetEncoderConfigurationResponse,
   GetEncoderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEncoderConfigurationRequest,
   output: GetEncoderConfigurationResponse,
@@ -2900,7 +2899,7 @@ export const getIngestConfiguration: API.OperationMethod<
   GetIngestConfigurationRequest,
   GetIngestConfigurationResponse,
   GetIngestConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIngestConfigurationRequest,
   output: GetIngestConfigurationResponse,
@@ -2926,7 +2925,7 @@ export const getParticipant: API.OperationMethod<
   GetParticipantRequest,
   GetParticipantResponse,
   GetParticipantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParticipantRequest,
   output: GetParticipantResponse,
@@ -2952,7 +2951,7 @@ export const getPublicKey: API.OperationMethod<
   GetPublicKeyRequest,
   GetPublicKeyResponse,
   GetPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicKeyRequest,
   output: GetPublicKeyResponse,
@@ -2979,7 +2978,7 @@ export const getStage: API.OperationMethod<
   GetStageRequest,
   GetStageResponse,
   GetStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStageRequest,
   output: GetStageResponse,
@@ -3006,7 +3005,7 @@ export const getStageSession: API.OperationMethod<
   GetStageSessionRequest,
   GetStageSessionResponse,
   GetStageSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStageSessionRequest,
   output: GetStageSessionResponse,
@@ -3035,7 +3034,7 @@ export const getStorageConfiguration: API.OperationMethod<
   GetStorageConfigurationRequest,
   GetStorageConfigurationResponse,
   GetStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageConfigurationRequest,
   output: GetStorageConfigurationResponse,
@@ -3066,7 +3065,7 @@ export const importPublicKey: API.OperationMethod<
   ImportPublicKeyRequest,
   ImportPublicKeyResponse,
   ImportPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportPublicKeyRequest,
   output: ImportPublicKeyResponse,
@@ -3097,7 +3096,7 @@ export const listCompositions: API.PaginatedOperationMethod<
   ListCompositionsRequest,
   ListCompositionsResponse,
   ListCompositionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCompositionsRequest,
@@ -3134,7 +3133,7 @@ export const listEncoderConfigurations: API.PaginatedOperationMethod<
   ListEncoderConfigurationsRequest,
   ListEncoderConfigurationsResponse,
   ListEncoderConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEncoderConfigurationsRequest,
@@ -3167,7 +3166,7 @@ export const listIngestConfigurations: API.PaginatedOperationMethod<
   ListIngestConfigurationsRequest,
   ListIngestConfigurationsResponse,
   ListIngestConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IngestConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngestConfigurationsRequest,
@@ -3196,7 +3195,7 @@ export const listParticipantEvents: API.PaginatedOperationMethod<
   ListParticipantEventsRequest,
   ListParticipantEventsResponse,
   ListParticipantEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListParticipantEventsRequest,
@@ -3223,7 +3222,7 @@ export const listParticipantReplicas: API.PaginatedOperationMethod<
   ListParticipantReplicasRequest,
   ListParticipantReplicasResponse,
   ListParticipantReplicasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ParticipantReplica
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListParticipantReplicasRequest,
@@ -3251,7 +3250,7 @@ export const listParticipants: API.PaginatedOperationMethod<
   ListParticipantsRequest,
   ListParticipantsResponse,
   ListParticipantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListParticipantsRequest,
@@ -3278,7 +3277,7 @@ export const listPublicKeys: API.PaginatedOperationMethod<
   ListPublicKeysRequest,
   ListPublicKeysResponse,
   ListPublicKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PublicKeySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPublicKeysRequest,
@@ -3309,7 +3308,7 @@ export const listStages: API.PaginatedOperationMethod<
   ListStagesRequest,
   ListStagesResponse,
   ListStagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStagesRequest,
@@ -3341,7 +3340,7 @@ export const listStageSessions: API.PaginatedOperationMethod<
   ListStageSessionsRequest,
   ListStageSessionsResponse,
   ListStageSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStageSessionsRequest,
@@ -3372,7 +3371,7 @@ export const listStorageConfigurations: API.PaginatedOperationMethod<
   ListStorageConfigurationsRequest,
   ListStorageConfigurationsResponse,
   ListStorageConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStorageConfigurationsRequest,
@@ -3407,7 +3406,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3455,7 +3454,7 @@ export const startComposition: API.OperationMethod<
   StartCompositionRequest,
   StartCompositionResponse,
   StartCompositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCompositionRequest,
   output: StartCompositionResponse,
@@ -3489,7 +3488,7 @@ export const startParticipantReplication: API.OperationMethod<
   StartParticipantReplicationRequest,
   StartParticipantReplicationResponse,
   StartParticipantReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartParticipantReplicationRequest,
   output: StartParticipantReplicationResponse,
@@ -3523,7 +3522,7 @@ export const stopComposition: API.OperationMethod<
   StopCompositionRequest,
   StopCompositionResponse,
   StopCompositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCompositionRequest,
   output: StopCompositionResponse,
@@ -3553,7 +3552,7 @@ export const stopParticipantReplication: API.OperationMethod<
   StopParticipantReplicationRequest,
   StopParticipantReplicationResponse,
   StopParticipantReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopParticipantReplicationRequest,
   output: StopParticipantReplicationResponse,
@@ -3581,7 +3580,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3609,7 +3608,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3638,7 +3637,7 @@ export const updateIngestConfiguration: API.OperationMethod<
   UpdateIngestConfigurationRequest,
   UpdateIngestConfigurationResponse,
   UpdateIngestConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIngestConfigurationRequest,
   output: UpdateIngestConfigurationResponse,
@@ -3670,7 +3669,7 @@ export const updateStage: API.OperationMethod<
   UpdateStageRequest,
   UpdateStageResponse,
   UpdateStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStageRequest,
   output: UpdateStageResponse,

--- a/packages/aws/src/services/ivs.ts
+++ b/packages/aws/src/services/ivs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ivs",
@@ -2416,7 +2415,7 @@ export const batchGetChannel: API.OperationMethod<
   BatchGetChannelRequest,
   BatchGetChannelResponse,
   BatchGetChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetChannelRequest,
   output: BatchGetChannelResponse,
@@ -2438,7 +2437,7 @@ export const batchGetStreamKey: API.OperationMethod<
   BatchGetStreamKeyRequest,
   BatchGetStreamKeyResponse,
   BatchGetStreamKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetStreamKeyRequest,
   output: BatchGetStreamKeyResponse,
@@ -2461,7 +2460,7 @@ export const batchStartViewerSessionRevocation: API.OperationMethod<
   BatchStartViewerSessionRevocationRequest,
   BatchStartViewerSessionRevocationResponse,
   BatchStartViewerSessionRevocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStartViewerSessionRevocationRequest,
   output: BatchStartViewerSessionRevocationResponse,
@@ -2493,7 +2492,7 @@ export const createAdConfiguration: API.OperationMethod<
   CreateAdConfigurationRequest,
   CreateAdConfigurationResponse,
   CreateAdConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAdConfigurationRequest,
   output: CreateAdConfigurationResponse,
@@ -2527,7 +2526,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -2558,7 +2557,7 @@ export const createPlaybackRestrictionPolicy: API.OperationMethod<
   CreatePlaybackRestrictionPolicyRequest,
   CreatePlaybackRestrictionPolicyResponse,
   CreatePlaybackRestrictionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlaybackRestrictionPolicyRequest,
   output: CreatePlaybackRestrictionPolicyResponse,
@@ -2594,7 +2593,7 @@ export const createRecordingConfiguration: API.OperationMethod<
   CreateRecordingConfigurationRequest,
   CreateRecordingConfigurationResponse,
   CreateRecordingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecordingConfigurationRequest,
   output: CreateRecordingConfigurationResponse,
@@ -2629,7 +2628,7 @@ export const createStreamKey: API.OperationMethod<
   CreateStreamKeyRequest,
   CreateStreamKeyResponse,
   CreateStreamKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamKeyRequest,
   output: CreateStreamKeyResponse,
@@ -2661,7 +2660,7 @@ export const deleteAdConfiguration: API.OperationMethod<
   DeleteAdConfigurationRequest,
   DeleteAdConfigurationResponse,
   DeleteAdConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAdConfigurationRequest,
   output: DeleteAdConfigurationResponse,
@@ -2695,7 +2694,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -2727,7 +2726,7 @@ export const deletePlaybackKeyPair: API.OperationMethod<
   DeletePlaybackKeyPairRequest,
   DeletePlaybackKeyPairResponse,
   DeletePlaybackKeyPairError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlaybackKeyPairRequest,
   output: DeletePlaybackKeyPairResponse,
@@ -2759,7 +2758,7 @@ export const deletePlaybackRestrictionPolicy: API.OperationMethod<
   DeletePlaybackRestrictionPolicyRequest,
   DeletePlaybackRestrictionPolicyResponse,
   DeletePlaybackRestrictionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlaybackRestrictionPolicyRequest,
   output: DeletePlaybackRestrictionPolicyResponse,
@@ -2793,7 +2792,7 @@ export const deleteRecordingConfiguration: API.OperationMethod<
   DeleteRecordingConfigurationRequest,
   DeleteRecordingConfigurationResponse,
   DeleteRecordingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecordingConfigurationRequest,
   output: DeleteRecordingConfigurationResponse,
@@ -2824,7 +2823,7 @@ export const deleteStreamKey: API.OperationMethod<
   DeleteStreamKeyRequest,
   DeleteStreamKeyResponse,
   DeleteStreamKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamKeyRequest,
   output: DeleteStreamKeyResponse,
@@ -2854,7 +2853,7 @@ export const getAdConfiguration: API.OperationMethod<
   GetAdConfigurationRequest,
   GetAdConfigurationResponse,
   GetAdConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdConfigurationRequest,
   output: GetAdConfigurationResponse,
@@ -2883,7 +2882,7 @@ export const getChannel: API.OperationMethod<
   GetChannelRequest,
   GetChannelResponse,
   GetChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelRequest,
   output: GetChannelResponse,
@@ -2911,7 +2910,7 @@ export const getPlaybackKeyPair: API.OperationMethod<
   GetPlaybackKeyPairRequest,
   GetPlaybackKeyPairResponse,
   GetPlaybackKeyPairError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlaybackKeyPairRequest,
   output: GetPlaybackKeyPairResponse,
@@ -2940,7 +2939,7 @@ export const getPlaybackRestrictionPolicy: API.OperationMethod<
   GetPlaybackRestrictionPolicyRequest,
   GetPlaybackRestrictionPolicyResponse,
   GetPlaybackRestrictionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlaybackRestrictionPolicyRequest,
   output: GetPlaybackRestrictionPolicyResponse,
@@ -2970,7 +2969,7 @@ export const getRecordingConfiguration: API.OperationMethod<
   GetRecordingConfigurationRequest,
   GetRecordingConfigurationResponse,
   GetRecordingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecordingConfigurationRequest,
   output: GetRecordingConfigurationResponse,
@@ -3000,7 +2999,7 @@ export const getStream: API.OperationMethod<
   GetStreamRequest,
   GetStreamResponse,
   GetStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamRequest,
   output: GetStreamResponse,
@@ -3029,7 +3028,7 @@ export const getStreamKey: API.OperationMethod<
   GetStreamKeyRequest,
   GetStreamKeyResponse,
   GetStreamKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamKeyRequest,
   output: GetStreamKeyResponse,
@@ -3057,7 +3056,7 @@ export const getStreamSession: API.OperationMethod<
   GetStreamSessionRequest,
   GetStreamSessionResponse,
   GetStreamSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStreamSessionRequest,
   output: GetStreamSessionResponse,
@@ -3087,7 +3086,7 @@ export const importPlaybackKeyPair: API.OperationMethod<
   ImportPlaybackKeyPairRequest,
   ImportPlaybackKeyPairResponse,
   ImportPlaybackKeyPairError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportPlaybackKeyPairRequest,
   output: ImportPlaybackKeyPairResponse,
@@ -3122,7 +3121,7 @@ export const insertAdBreak: API.OperationMethod<
   InsertAdBreakRequest,
   InsertAdBreakResponse,
   InsertAdBreakError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InsertAdBreakRequest,
   output: InsertAdBreakResponse,
@@ -3153,7 +3152,7 @@ export const listAdConfigurations: API.PaginatedOperationMethod<
   ListAdConfigurationsRequest,
   ListAdConfigurationsResponse,
   ListAdConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdConfigurationsRequest,
@@ -3188,7 +3187,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -3221,7 +3220,7 @@ export const listPlaybackKeyPairs: API.PaginatedOperationMethod<
   ListPlaybackKeyPairsRequest,
   ListPlaybackKeyPairsResponse,
   ListPlaybackKeyPairsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlaybackKeyPairsRequest,
@@ -3251,7 +3250,7 @@ export const listPlaybackRestrictionPolicies: API.PaginatedOperationMethod<
   ListPlaybackRestrictionPoliciesRequest,
   ListPlaybackRestrictionPoliciesResponse,
   ListPlaybackRestrictionPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlaybackRestrictionPoliciesRequest,
@@ -3286,7 +3285,7 @@ export const listRecordingConfigurations: API.PaginatedOperationMethod<
   ListRecordingConfigurationsRequest,
   ListRecordingConfigurationsResponse,
   ListRecordingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecordingConfigurationsRequest,
@@ -3320,7 +3319,7 @@ export const listStreamKeys: API.PaginatedOperationMethod<
   ListStreamKeysRequest,
   ListStreamKeysResponse,
   ListStreamKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamKeysRequest,
@@ -3353,7 +3352,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsRequest,
   ListStreamsResponse,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsRequest,
@@ -3382,7 +3381,7 @@ export const listStreamSessions: API.PaginatedOperationMethod<
   ListStreamSessionsRequest,
   ListStreamSessionsResponse,
   ListStreamSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamSessionsRequest,
@@ -3416,7 +3415,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3445,7 +3444,7 @@ export const putMetadata: API.OperationMethod<
   PutMetadataRequest,
   PutMetadataResponse,
   PutMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetadataRequest,
   output: PutMetadataResponse,
@@ -3476,7 +3475,7 @@ export const startViewerSessionRevocation: API.OperationMethod<
   StartViewerSessionRevocationRequest,
   StartViewerSessionRevocationResponse,
   StartViewerSessionRevocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartViewerSessionRevocationRequest,
   output: StartViewerSessionRevocationResponse,
@@ -3510,7 +3509,7 @@ export const stopStream: API.OperationMethod<
   StopStreamRequest,
   StopStreamResponse,
   StopStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopStreamRequest,
   output: StopStreamResponse,
@@ -3540,7 +3539,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3568,7 +3567,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3600,7 +3599,7 @@ export const updateAdConfiguration: API.OperationMethod<
   UpdateAdConfigurationRequest,
   UpdateAdConfigurationResponse,
   UpdateAdConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAdConfigurationRequest,
   output: UpdateAdConfigurationResponse,
@@ -3634,7 +3633,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -3665,7 +3664,7 @@ export const updatePlaybackRestrictionPolicy: API.OperationMethod<
   UpdatePlaybackRestrictionPolicyRequest,
   UpdatePlaybackRestrictionPolicyResponse,
   UpdatePlaybackRestrictionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePlaybackRestrictionPolicyRequest,
   output: UpdatePlaybackRestrictionPolicyResponse,

--- a/packages/aws/src/services/ivschat.ts
+++ b/packages/aws/src/services/ivschat.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ivschat",
@@ -1026,7 +1025,7 @@ export const createChatToken: API.OperationMethod<
   CreateChatTokenRequest,
   CreateChatTokenResponse,
   CreateChatTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChatTokenRequest,
   output: CreateChatTokenResponse,
@@ -1058,7 +1057,7 @@ export const createLoggingConfiguration: API.OperationMethod<
   CreateLoggingConfigurationRequest,
   CreateLoggingConfigurationResponse,
   CreateLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoggingConfigurationRequest,
   output: CreateLoggingConfigurationResponse,
@@ -1092,7 +1091,7 @@ export const createRoom: API.OperationMethod<
   CreateRoomRequest,
   CreateRoomResponse,
   CreateRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoomRequest,
   output: CreateRoomResponse,
@@ -1125,7 +1124,7 @@ export const deleteLoggingConfiguration: API.OperationMethod<
   DeleteLoggingConfigurationRequest,
   DeleteLoggingConfigurationResponse,
   DeleteLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggingConfigurationRequest,
   output: DeleteLoggingConfigurationResponse,
@@ -1159,7 +1158,7 @@ export const deleteMessage: API.OperationMethod<
   DeleteMessageRequest,
   DeleteMessageResponse,
   DeleteMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessageRequest,
   output: DeleteMessageResponse,
@@ -1189,7 +1188,7 @@ export const deleteRoom: API.OperationMethod<
   DeleteRoomRequest,
   DeleteRoomResponse,
   DeleteRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoomRequest,
   output: DeleteRoomResponse,
@@ -1221,7 +1220,7 @@ export const disconnectUser: API.OperationMethod<
   DisconnectUserRequest,
   DisconnectUserResponse,
   DisconnectUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectUserRequest,
   output: DisconnectUserResponse,
@@ -1250,7 +1249,7 @@ export const getLoggingConfiguration: API.OperationMethod<
   GetLoggingConfigurationRequest,
   GetLoggingConfigurationResponse,
   GetLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingConfigurationRequest,
   output: GetLoggingConfigurationResponse,
@@ -1278,7 +1277,7 @@ export const getRoom: API.OperationMethod<
   GetRoomRequest,
   GetRoomResponse,
   GetRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoomRequest,
   output: GetRoomResponse,
@@ -1306,7 +1305,7 @@ export const listLoggingConfigurations: API.PaginatedOperationMethod<
   ListLoggingConfigurationsRequest,
   ListLoggingConfigurationsResponse,
   ListLoggingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLoggingConfigurationsRequest,
@@ -1336,7 +1335,7 @@ export const listRooms: API.PaginatedOperationMethod<
   ListRoomsRequest,
   ListRoomsResponse,
   ListRoomsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoomsRequest,
@@ -1370,7 +1369,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1401,7 +1400,7 @@ export const sendEvent: API.OperationMethod<
   SendEventRequest,
   SendEventResponse,
   SendEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEventRequest,
   output: SendEventResponse,
@@ -1430,7 +1429,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1458,7 +1457,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1488,7 +1487,7 @@ export const updateLoggingConfiguration: API.OperationMethod<
   UpdateLoggingConfigurationRequest,
   UpdateLoggingConfigurationResponse,
   UpdateLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoggingConfigurationRequest,
   output: UpdateLoggingConfigurationResponse,
@@ -1519,7 +1518,7 @@ export const updateRoom: API.OperationMethod<
   UpdateRoomRequest,
   UpdateRoomResponse,
   UpdateRoomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoomRequest,
   output: UpdateRoomResponse,

--- a/packages/aws/src/services/kafka.ts
+++ b/packages/aws/src/services/kafka.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "Kafka", serviceShapeName: "Kafka" });
 const auth = T.AwsAuthSigv4({ name: "kafka" });
 const ver = T.ServiceVersion("2018-11-14");
@@ -5354,7 +5353,7 @@ export const batchAssociateScramSecret: API.OperationMethod<
   BatchAssociateScramSecretRequest,
   BatchAssociateScramSecretResponse,
   BatchAssociateScramSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateScramSecretRequest,
   output: BatchAssociateScramSecretResponse,
@@ -5388,7 +5387,7 @@ export const batchDisassociateScramSecret: API.OperationMethod<
   BatchDisassociateScramSecretRequest,
   BatchDisassociateScramSecretResponse,
   BatchDisassociateScramSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateScramSecretRequest,
   output: BatchDisassociateScramSecretResponse,
@@ -5422,7 +5421,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -5456,7 +5455,7 @@ export const createClusterV2: API.OperationMethod<
   CreateClusterV2Request,
   CreateClusterV2Response,
   CreateClusterV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterV2Request,
   output: CreateClusterV2Response,
@@ -5490,7 +5489,7 @@ export const createConfiguration: API.OperationMethod<
   CreateConfigurationRequest,
   CreateConfigurationResponse,
   CreateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationRequest,
   output: CreateConfigurationResponse,
@@ -5525,7 +5524,7 @@ export const createReplicator: API.OperationMethod<
   CreateReplicatorRequest,
   CreateReplicatorResponse,
   CreateReplicatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicatorRequest,
   output: CreateReplicatorResponse,
@@ -5569,7 +5568,7 @@ export const createTopic: API.OperationMethod<
   CreateTopicRequest,
   CreateTopicResponse,
   CreateTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicRequest,
   output: CreateTopicResponse,
@@ -5611,7 +5610,7 @@ export const createVpcConnection: API.OperationMethod<
   CreateVpcConnectionRequest,
   CreateVpcConnectionResponse,
   CreateVpcConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcConnectionRequest,
   output: CreateVpcConnectionResponse,
@@ -5641,7 +5640,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -5669,7 +5668,7 @@ export const deleteClusterPolicy: API.OperationMethod<
   DeleteClusterPolicyRequest,
   DeleteClusterPolicyResponse,
   DeleteClusterPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterPolicyRequest,
   output: DeleteClusterPolicyResponse,
@@ -5697,7 +5696,7 @@ export const deleteConfiguration: API.OperationMethod<
   DeleteConfigurationRequest,
   DeleteConfigurationResponse,
   DeleteConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationRequest,
   output: DeleteConfigurationResponse,
@@ -5728,7 +5727,7 @@ export const deleteReplicator: API.OperationMethod<
   DeleteReplicatorRequest,
   DeleteReplicatorResponse,
   DeleteReplicatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicatorRequest,
   output: DeleteReplicatorResponse,
@@ -5767,7 +5766,7 @@ export const deleteTopic: API.OperationMethod<
   DeleteTopicRequest,
   DeleteTopicResponse,
   DeleteTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicRequest,
   output: DeleteTopicResponse,
@@ -5803,7 +5802,7 @@ export const deleteVpcConnection: API.OperationMethod<
   DeleteVpcConnectionRequest,
   DeleteVpcConnectionResponse,
   DeleteVpcConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcConnectionRequest,
   output: DeleteVpcConnectionResponse,
@@ -5832,7 +5831,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResponse,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResponse,
@@ -5862,7 +5861,7 @@ export const describeClusterOperation: API.OperationMethod<
   DescribeClusterOperationRequest,
   DescribeClusterOperationResponse,
   DescribeClusterOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterOperationRequest,
   output: DescribeClusterOperationResponse,
@@ -5894,7 +5893,7 @@ export const describeClusterOperationV2: API.OperationMethod<
   DescribeClusterOperationV2Request,
   DescribeClusterOperationV2Response,
   DescribeClusterOperationV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterOperationV2Request,
   output: DescribeClusterOperationV2Response,
@@ -5926,7 +5925,7 @@ export const describeClusterV2: API.OperationMethod<
   DescribeClusterV2Request,
   DescribeClusterV2Response,
   DescribeClusterV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterV2Request,
   output: DescribeClusterV2Response,
@@ -5957,7 +5956,7 @@ export const describeConfiguration: API.OperationMethod<
   DescribeConfigurationRequest,
   DescribeConfigurationResponse,
   DescribeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRequest,
   output: DescribeConfigurationResponse,
@@ -5989,7 +5988,7 @@ export const describeConfigurationRevision: API.OperationMethod<
   DescribeConfigurationRevisionRequest,
   DescribeConfigurationRevisionResponse,
   DescribeConfigurationRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRevisionRequest,
   output: DescribeConfigurationRevisionResponse,
@@ -6022,7 +6021,7 @@ export const describeReplicator: API.OperationMethod<
   DescribeReplicatorRequest,
   DescribeReplicatorResponse,
   DescribeReplicatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReplicatorRequest,
   output: DescribeReplicatorResponse,
@@ -6054,7 +6053,7 @@ export const describeTopic: API.OperationMethod<
   DescribeTopicRequest,
   DescribeTopicResponse,
   DescribeTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicRequest,
   output: DescribeTopicResponse,
@@ -6084,7 +6083,7 @@ export const describeTopicPartitions: API.PaginatedOperationMethod<
   DescribeTopicPartitionsRequest,
   DescribeTopicPartitionsResponse,
   DescribeTopicPartitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicPartitionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTopicPartitionsRequest,
@@ -6122,7 +6121,7 @@ export const describeVpcConnection: API.OperationMethod<
   DescribeVpcConnectionRequest,
   DescribeVpcConnectionResponse,
   DescribeVpcConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcConnectionRequest,
   output: DescribeVpcConnectionResponse,
@@ -6154,7 +6153,7 @@ export const getBootstrapBrokers: API.OperationMethod<
   GetBootstrapBrokersRequest,
   GetBootstrapBrokersResponse,
   GetBootstrapBrokersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBootstrapBrokersRequest,
   output: GetBootstrapBrokersResponse,
@@ -6184,7 +6183,7 @@ export const getClusterPolicy: API.OperationMethod<
   GetClusterPolicyRequest,
   GetClusterPolicyResponse,
   GetClusterPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterPolicyRequest,
   output: GetClusterPolicyResponse,
@@ -6215,7 +6214,7 @@ export const getCompatibleKafkaVersions: API.OperationMethod<
   GetCompatibleKafkaVersionsRequest,
   GetCompatibleKafkaVersionsResponse,
   GetCompatibleKafkaVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCompatibleKafkaVersionsRequest,
   output: GetCompatibleKafkaVersionsResponse,
@@ -6247,7 +6246,7 @@ export const listClientVpcConnections: API.PaginatedOperationMethod<
   ListClientVpcConnectionsRequest,
   ListClientVpcConnectionsResponse,
   ListClientVpcConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClientVpcConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClientVpcConnectionsRequest,
@@ -6283,7 +6282,7 @@ export const listClusterOperations: API.PaginatedOperationMethod<
   ListClusterOperationsRequest,
   ListClusterOperationsResponse,
   ListClusterOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterOperationInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterOperationsRequest,
@@ -6321,7 +6320,7 @@ export const listClusterOperationsV2: API.PaginatedOperationMethod<
   ListClusterOperationsV2Request,
   ListClusterOperationsV2Response,
   ListClusterOperationsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterOperationV2Summary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterOperationsV2Request,
@@ -6359,7 +6358,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -6394,7 +6393,7 @@ export const listClustersV2: API.PaginatedOperationMethod<
   ListClustersV2Request,
   ListClustersV2Response,
   ListClustersV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Cluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersV2Request,
@@ -6431,7 +6430,7 @@ export const listConfigurationRevisions: API.PaginatedOperationMethod<
   ListConfigurationRevisionsRequest,
   ListConfigurationRevisionsResponse,
   ListConfigurationRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationRevision
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationRevisionsRequest,
@@ -6469,7 +6468,7 @@ export const listConfigurations: API.PaginatedOperationMethod<
   ListConfigurationsRequest,
   ListConfigurationsResponse,
   ListConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Configuration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationsRequest,
@@ -6505,7 +6504,7 @@ export const listKafkaVersions: API.PaginatedOperationMethod<
   ListKafkaVersionsRequest,
   ListKafkaVersionsResponse,
   ListKafkaVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KafkaVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKafkaVersionsRequest,
@@ -6540,7 +6539,7 @@ export const listNodes: API.PaginatedOperationMethod<
   ListNodesRequest,
   ListNodesResponse,
   ListNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NodeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesRequest,
@@ -6578,7 +6577,7 @@ export const listReplicators: API.PaginatedOperationMethod<
   ListReplicatorsRequest,
   ListReplicatorsResponse,
   ListReplicatorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplicatorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReplicatorsRequest,
@@ -6619,7 +6618,7 @@ export const listScramSecrets: API.PaginatedOperationMethod<
   ListScramSecretsRequest,
   ListScramSecretsResponse,
   ListScramSecretsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScramSecretsRequest,
@@ -6656,7 +6655,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6685,7 +6684,7 @@ export const listTopics: API.PaginatedOperationMethod<
   ListTopicsRequest,
   ListTopicsResponse,
   ListTopicsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicsRequest,
@@ -6723,7 +6722,7 @@ export const listVpcConnections: API.PaginatedOperationMethod<
   ListVpcConnectionsRequest,
   ListVpcConnectionsResponse,
   ListVpcConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVpcConnectionsRequest,
@@ -6758,7 +6757,7 @@ export const putClusterPolicy: API.OperationMethod<
   PutClusterPolicyRequest,
   PutClusterPolicyResponse,
   PutClusterPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutClusterPolicyRequest,
   output: PutClusterPolicyResponse,
@@ -6788,7 +6787,7 @@ export const rebootBroker: API.OperationMethod<
   RebootBrokerRequest,
   RebootBrokerResponse,
   RebootBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootBrokerRequest,
   output: RebootBrokerResponse,
@@ -6820,7 +6819,7 @@ export const rejectClientVpcConnection: API.OperationMethod<
   RejectClientVpcConnectionRequest,
   RejectClientVpcConnectionResponse,
   RejectClientVpcConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectClientVpcConnectionRequest,
   output: RejectClientVpcConnectionResponse,
@@ -6848,7 +6847,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6874,7 +6873,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6902,7 +6901,7 @@ export const updateBrokerCount: API.OperationMethod<
   UpdateBrokerCountRequest,
   UpdateBrokerCountResponse,
   UpdateBrokerCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrokerCountRequest,
   output: UpdateBrokerCountResponse,
@@ -6932,7 +6931,7 @@ export const updateBrokerStorage: API.OperationMethod<
   UpdateBrokerStorageRequest,
   UpdateBrokerStorageResponse,
   UpdateBrokerStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrokerStorageRequest,
   output: UpdateBrokerStorageResponse,
@@ -6964,7 +6963,7 @@ export const updateBrokerType: API.OperationMethod<
   UpdateBrokerTypeRequest,
   UpdateBrokerTypeResponse,
   UpdateBrokerTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrokerTypeRequest,
   output: UpdateBrokerTypeResponse,
@@ -6997,7 +6996,7 @@ export const updateClusterConfiguration: API.OperationMethod<
   UpdateClusterConfigurationRequest,
   UpdateClusterConfigurationResponse,
   UpdateClusterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterConfigurationRequest,
   output: UpdateClusterConfigurationResponse,
@@ -7030,7 +7029,7 @@ export const updateClusterKafkaVersion: API.OperationMethod<
   UpdateClusterKafkaVersionRequest,
   UpdateClusterKafkaVersionResponse,
   UpdateClusterKafkaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterKafkaVersionRequest,
   output: UpdateClusterKafkaVersionResponse,
@@ -7063,7 +7062,7 @@ export const updateConfiguration: API.OperationMethod<
   UpdateConfigurationRequest,
   UpdateConfigurationResponse,
   UpdateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationRequest,
   output: UpdateConfigurationResponse,
@@ -7095,7 +7094,7 @@ export const updateConnectivity: API.OperationMethod<
   UpdateConnectivityRequest,
   UpdateConnectivityResponse,
   UpdateConnectivityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectivityRequest,
   output: UpdateConnectivityResponse,
@@ -7126,7 +7125,7 @@ export const updateMonitoring: API.OperationMethod<
   UpdateMonitoringRequest,
   UpdateMonitoringResponse,
   UpdateMonitoringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitoringRequest,
   output: UpdateMonitoringResponse,
@@ -7158,7 +7157,7 @@ export const updateRebalancing: API.OperationMethod<
   UpdateRebalancingRequest,
   UpdateRebalancingResponse,
   UpdateRebalancingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRebalancingRequest,
   output: UpdateRebalancingResponse,
@@ -7192,7 +7191,7 @@ export const updateReplicationInfo: API.OperationMethod<
   UpdateReplicationInfoRequest,
   UpdateReplicationInfoResponse,
   UpdateReplicationInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationInfoRequest,
   output: UpdateReplicationInfoResponse,
@@ -7226,7 +7225,7 @@ export const updateSecurity: API.OperationMethod<
   UpdateSecurityRequest,
   UpdateSecurityResponse,
   UpdateSecurityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityRequest,
   output: UpdateSecurityResponse,
@@ -7260,7 +7259,7 @@ export const updateStorage: API.OperationMethod<
   UpdateStorageRequest,
   UpdateStorageResponse,
   UpdateStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStorageRequest,
   output: UpdateStorageResponse,
@@ -7301,7 +7300,7 @@ export const updateTopic: API.OperationMethod<
   UpdateTopicRequest,
   UpdateTopicResponse,
   UpdateTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTopicRequest,
   output: UpdateTopicResponse,

--- a/packages/aws/src/services/kafkaconnect.ts
+++ b/packages/aws/src/services/kafkaconnect.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "KafkaConnect",
@@ -1612,7 +1611,7 @@ export const createConnector: API.OperationMethod<
   CreateConnectorRequest,
   CreateConnectorResponse,
   CreateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorRequest,
   output: CreateConnectorResponse,
@@ -1648,7 +1647,7 @@ export const createCustomPlugin: API.OperationMethod<
   CreateCustomPluginRequest,
   CreateCustomPluginResponse,
   CreateCustomPluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomPluginRequest,
   output: CreateCustomPluginResponse,
@@ -1684,7 +1683,7 @@ export const createWorkerConfiguration: API.OperationMethod<
   CreateWorkerConfigurationRequest,
   CreateWorkerConfigurationResponse,
   CreateWorkerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkerConfigurationRequest,
   output: CreateWorkerConfigurationResponse,
@@ -1719,7 +1718,7 @@ export const deleteConnector: API.OperationMethod<
   DeleteConnectorRequest,
   DeleteConnectorResponse,
   DeleteConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorRequest,
   output: DeleteConnectorResponse,
@@ -1753,7 +1752,7 @@ export const deleteCustomPlugin: API.OperationMethod<
   DeleteCustomPluginRequest,
   DeleteCustomPluginResponse,
   DeleteCustomPluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomPluginRequest,
   output: DeleteCustomPluginResponse,
@@ -1787,7 +1786,7 @@ export const deleteWorkerConfiguration: API.OperationMethod<
   DeleteWorkerConfigurationRequest,
   DeleteWorkerConfigurationResponse,
   DeleteWorkerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkerConfigurationRequest,
   output: DeleteWorkerConfigurationResponse,
@@ -1821,7 +1820,7 @@ export const describeConnector: API.OperationMethod<
   DescribeConnectorRequest,
   DescribeConnectorResponse,
   DescribeConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectorRequest,
   output: DescribeConnectorResponse,
@@ -1855,7 +1854,7 @@ export const describeConnectorOperation: API.OperationMethod<
   DescribeConnectorOperationRequest,
   DescribeConnectorOperationResponse,
   DescribeConnectorOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectorOperationRequest,
   output: DescribeConnectorOperationResponse,
@@ -1889,7 +1888,7 @@ export const describeCustomPlugin: API.OperationMethod<
   DescribeCustomPluginRequest,
   DescribeCustomPluginResponse,
   DescribeCustomPluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomPluginRequest,
   output: DescribeCustomPluginResponse,
@@ -1923,7 +1922,7 @@ export const describeWorkerConfiguration: API.OperationMethod<
   DescribeWorkerConfigurationRequest,
   DescribeWorkerConfigurationResponse,
   DescribeWorkerConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkerConfigurationRequest,
   output: DescribeWorkerConfigurationResponse,
@@ -1957,7 +1956,7 @@ export const listConnectorOperations: API.PaginatedOperationMethod<
   ListConnectorOperationsRequest,
   ListConnectorOperationsResponse,
   ListConnectorOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorOperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorOperationsRequest,
@@ -1998,7 +1997,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -2039,7 +2038,7 @@ export const listCustomPlugins: API.PaginatedOperationMethod<
   ListCustomPluginsRequest,
   ListCustomPluginsResponse,
   ListCustomPluginsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomPluginSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomPluginsRequest,
@@ -2080,7 +2079,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2114,7 +2113,7 @@ export const listWorkerConfigurations: API.PaginatedOperationMethod<
   ListWorkerConfigurationsRequest,
   ListWorkerConfigurationsResponse,
   ListWorkerConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkerConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkerConfigurationsRequest,
@@ -2156,7 +2155,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2191,7 +2190,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2225,7 +2224,7 @@ export const updateConnector: API.OperationMethod<
   UpdateConnectorRequest,
   UpdateConnectorResponse,
   UpdateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorRequest,
   output: UpdateConnectorResponse,

--- a/packages/aws/src/services/kendra-ranking.ts
+++ b/packages/aws/src/services/kendra-ranking.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Kendra Ranking",
   serviceShapeName: "AWSKendraRerankingFrontendService",
@@ -505,7 +504,7 @@ export const createRescoreExecutionPlan: API.OperationMethod<
   CreateRescoreExecutionPlanRequest,
   CreateRescoreExecutionPlanResponse,
   CreateRescoreExecutionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRescoreExecutionPlanRequest,
   output: CreateRescoreExecutionPlanResponse,
@@ -539,7 +538,7 @@ export const deleteRescoreExecutionPlan: API.OperationMethod<
   DeleteRescoreExecutionPlanRequest,
   DeleteRescoreExecutionPlanResponse,
   DeleteRescoreExecutionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRescoreExecutionPlanRequest,
   output: DeleteRescoreExecutionPlanResponse,
@@ -572,7 +571,7 @@ export const describeRescoreExecutionPlan: API.OperationMethod<
   DescribeRescoreExecutionPlanRequest,
   DescribeRescoreExecutionPlanResponse,
   DescribeRescoreExecutionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRescoreExecutionPlanRequest,
   output: DescribeRescoreExecutionPlanResponse,
@@ -603,7 +602,7 @@ export const listRescoreExecutionPlans: API.PaginatedOperationMethod<
   ListRescoreExecutionPlansRequest,
   ListRescoreExecutionPlansResponse,
   ListRescoreExecutionPlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRescoreExecutionPlansRequest,
@@ -640,7 +639,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -674,7 +673,7 @@ export const rescore: API.OperationMethod<
   RescoreRequest,
   RescoreResult,
   RescoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RescoreRequest,
   output: RescoreResult,
@@ -709,7 +708,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -742,7 +741,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -779,7 +778,7 @@ export const updateRescoreExecutionPlan: API.OperationMethod<
   UpdateRescoreExecutionPlanRequest,
   UpdateRescoreExecutionPlanResponse,
   UpdateRescoreExecutionPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRescoreExecutionPlanRequest,
   output: UpdateRescoreExecutionPlanResponse,

--- a/packages/aws/src/services/kendra.ts
+++ b/packages/aws/src/services/kendra.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "kendra",
@@ -5458,7 +5457,7 @@ export const associateEntitiesToExperience: API.OperationMethod<
   AssociateEntitiesToExperienceRequest,
   AssociateEntitiesToExperienceResponse,
   AssociateEntitiesToExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateEntitiesToExperienceRequest,
   output: AssociateEntitiesToExperienceResponse,
@@ -5494,7 +5493,7 @@ export const associatePersonasToEntities: API.OperationMethod<
   AssociatePersonasToEntitiesRequest,
   AssociatePersonasToEntitiesResponse,
   AssociatePersonasToEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePersonasToEntitiesRequest,
   output: AssociatePersonasToEntitiesResponse,
@@ -5537,7 +5536,7 @@ export const batchDeleteDocument: API.OperationMethod<
   BatchDeleteDocumentRequest,
   BatchDeleteDocumentResponse,
   BatchDeleteDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDocumentRequest,
   output: BatchDeleteDocumentResponse,
@@ -5570,7 +5569,7 @@ export const batchDeleteFeaturedResultsSet: API.OperationMethod<
   BatchDeleteFeaturedResultsSetRequest,
   BatchDeleteFeaturedResultsSetResponse,
   BatchDeleteFeaturedResultsSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteFeaturedResultsSetRequest,
   output: BatchDeleteFeaturedResultsSetResponse,
@@ -5611,7 +5610,7 @@ export const batchGetDocumentStatus: API.OperationMethod<
   BatchGetDocumentStatusRequest,
   BatchGetDocumentStatusResponse,
   BatchGetDocumentStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDocumentStatusRequest,
   output: BatchGetDocumentStatusResponse,
@@ -5659,7 +5658,7 @@ export const batchPutDocument: API.OperationMethod<
   BatchPutDocumentRequest,
   BatchPutDocumentResponse,
   BatchPutDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutDocumentRequest,
   output: BatchPutDocumentResponse,
@@ -5702,7 +5701,7 @@ export const clearQuerySuggestions: API.OperationMethod<
   ClearQuerySuggestionsRequest,
   ClearQuerySuggestionsResponse,
   ClearQuerySuggestionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClearQuerySuggestionsRequest,
   output: ClearQuerySuggestionsResponse,
@@ -5760,7 +5759,7 @@ export const createAccessControlConfiguration: API.OperationMethod<
   CreateAccessControlConfigurationRequest,
   CreateAccessControlConfigurationResponse,
   CreateAccessControlConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessControlConfigurationRequest,
   output: CreateAccessControlConfigurationResponse,
@@ -5807,7 +5806,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceRequest,
   CreateDataSourceResponse,
   CreateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceRequest,
   output: CreateDataSourceResponse,
@@ -5845,7 +5844,7 @@ export const createExperience: API.OperationMethod<
   CreateExperienceRequest,
   CreateExperienceResponse,
   CreateExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExperienceRequest,
   output: CreateExperienceResponse,
@@ -5884,7 +5883,7 @@ export const createFaq: API.OperationMethod<
   CreateFaqRequest,
   CreateFaqResponse,
   CreateFaqError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFaqRequest,
   output: CreateFaqResponse,
@@ -5925,7 +5924,7 @@ export const createFeaturedResultsSet: API.OperationMethod<
   CreateFeaturedResultsSetRequest,
   CreateFeaturedResultsSetResponse,
   CreateFeaturedResultsSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFeaturedResultsSetRequest,
   output: CreateFeaturedResultsSetResponse,
@@ -5970,7 +5969,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexRequest,
   CreateIndexResponse,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
@@ -6022,7 +6021,7 @@ export const createQuerySuggestionsBlockList: API.OperationMethod<
   CreateQuerySuggestionsBlockListRequest,
   CreateQuerySuggestionsBlockListResponse,
   CreateQuerySuggestionsBlockListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuerySuggestionsBlockListRequest,
   output: CreateQuerySuggestionsBlockListResponse,
@@ -6061,7 +6060,7 @@ export const createThesaurus: API.OperationMethod<
   CreateThesaurusRequest,
   CreateThesaurusResponse,
   CreateThesaurusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThesaurusRequest,
   output: CreateThesaurusResponse,
@@ -6097,7 +6096,7 @@ export const deleteAccessControlConfiguration: API.OperationMethod<
   DeleteAccessControlConfigurationRequest,
   DeleteAccessControlConfigurationResponse,
   DeleteAccessControlConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessControlConfigurationRequest,
   output: DeleteAccessControlConfigurationResponse,
@@ -6136,7 +6135,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -6170,7 +6169,7 @@ export const deleteExperience: API.OperationMethod<
   DeleteExperienceRequest,
   DeleteExperienceResponse,
   DeleteExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExperienceRequest,
   output: DeleteExperienceResponse,
@@ -6202,7 +6201,7 @@ export const deleteFaq: API.OperationMethod<
   DeleteFaqRequest,
   DeleteFaqResponse,
   DeleteFaqError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFaqRequest,
   output: DeleteFaqResponse,
@@ -6236,7 +6235,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexRequest,
   DeleteIndexResponse,
   DeleteIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexRequest,
   output: DeleteIndexResponse,
@@ -6282,7 +6281,7 @@ export const deletePrincipalMapping: API.OperationMethod<
   DeletePrincipalMappingRequest,
   DeletePrincipalMappingResponse,
   DeletePrincipalMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrincipalMappingRequest,
   output: DeletePrincipalMappingResponse,
@@ -6321,7 +6320,7 @@ export const deleteQuerySuggestionsBlockList: API.OperationMethod<
   DeleteQuerySuggestionsBlockListRequest,
   DeleteQuerySuggestionsBlockListResponse,
   DeleteQuerySuggestionsBlockListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuerySuggestionsBlockListRequest,
   output: DeleteQuerySuggestionsBlockListResponse,
@@ -6353,7 +6352,7 @@ export const deleteThesaurus: API.OperationMethod<
   DeleteThesaurusRequest,
   DeleteThesaurusResponse,
   DeleteThesaurusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThesaurusRequest,
   output: DeleteThesaurusResponse,
@@ -6387,7 +6386,7 @@ export const describeAccessControlConfiguration: API.OperationMethod<
   DescribeAccessControlConfigurationRequest,
   DescribeAccessControlConfigurationResponse,
   DescribeAccessControlConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccessControlConfigurationRequest,
   output: DescribeAccessControlConfigurationResponse,
@@ -6417,7 +6416,7 @@ export const describeDataSource: API.OperationMethod<
   DescribeDataSourceRequest,
   DescribeDataSourceResponse,
   DescribeDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSourceRequest,
   output: DescribeDataSourceResponse,
@@ -6450,7 +6449,7 @@ export const describeExperience: API.OperationMethod<
   DescribeExperienceRequest,
   DescribeExperienceResponse,
   DescribeExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExperienceRequest,
   output: DescribeExperienceResponse,
@@ -6480,7 +6479,7 @@ export const describeFaq: API.OperationMethod<
   DescribeFaqRequest,
   DescribeFaqResponse,
   DescribeFaqError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFaqRequest,
   output: DescribeFaqResponse,
@@ -6512,7 +6511,7 @@ export const describeFeaturedResultsSet: API.OperationMethod<
   DescribeFeaturedResultsSetRequest,
   DescribeFeaturedResultsSetResponse,
   DescribeFeaturedResultsSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFeaturedResultsSetRequest,
   output: DescribeFeaturedResultsSetResponse,
@@ -6542,7 +6541,7 @@ export const describeIndex: API.OperationMethod<
   DescribeIndexRequest,
   DescribeIndexResponse,
   DescribeIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIndexRequest,
   output: DescribeIndexResponse,
@@ -6579,7 +6578,7 @@ export const describePrincipalMapping: API.OperationMethod<
   DescribePrincipalMappingRequest,
   DescribePrincipalMappingResponse,
   DescribePrincipalMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePrincipalMappingRequest,
   output: DescribePrincipalMappingResponse,
@@ -6616,7 +6615,7 @@ export const describeQuerySuggestionsBlockList: API.OperationMethod<
   DescribeQuerySuggestionsBlockListRequest,
   DescribeQuerySuggestionsBlockListResponse,
   DescribeQuerySuggestionsBlockListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQuerySuggestionsBlockListRequest,
   output: DescribeQuerySuggestionsBlockListResponse,
@@ -6652,7 +6651,7 @@ export const describeQuerySuggestionsConfig: API.OperationMethod<
   DescribeQuerySuggestionsConfigRequest,
   DescribeQuerySuggestionsConfigResponse,
   DescribeQuerySuggestionsConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQuerySuggestionsConfigRequest,
   output: DescribeQuerySuggestionsConfigResponse,
@@ -6682,7 +6681,7 @@ export const describeThesaurus: API.OperationMethod<
   DescribeThesaurusRequest,
   DescribeThesaurusResponse,
   DescribeThesaurusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThesaurusRequest,
   output: DescribeThesaurusResponse,
@@ -6716,7 +6715,7 @@ export const disassociateEntitiesFromExperience: API.OperationMethod<
   DisassociateEntitiesFromExperienceRequest,
   DisassociateEntitiesFromExperienceResponse,
   DisassociateEntitiesFromExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateEntitiesFromExperienceRequest,
   output: DisassociateEntitiesFromExperienceResponse,
@@ -6750,7 +6749,7 @@ export const disassociatePersonasFromEntities: API.OperationMethod<
   DisassociatePersonasFromEntitiesRequest,
   DisassociatePersonasFromEntitiesResponse,
   DisassociatePersonasFromEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePersonasFromEntitiesRequest,
   output: DisassociatePersonasFromEntitiesResponse,
@@ -6785,7 +6784,7 @@ export const getQuerySuggestions: API.OperationMethod<
   GetQuerySuggestionsRequest,
   GetQuerySuggestionsResponse,
   GetQuerySuggestionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuerySuggestionsRequest,
   output: GetQuerySuggestionsResponse,
@@ -6817,7 +6816,7 @@ export const getSnapshots: API.PaginatedOperationMethod<
   GetSnapshotsRequest,
   GetSnapshotsResponse,
   GetSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSnapshotsRequest,
@@ -6855,7 +6854,7 @@ export const listAccessControlConfigurations: API.PaginatedOperationMethod<
   ListAccessControlConfigurationsRequest,
   ListAccessControlConfigurationsResponse,
   ListAccessControlConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessControlConfigurationsRequest,
@@ -6891,7 +6890,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesRequest,
@@ -6928,7 +6927,7 @@ export const listDataSourceSyncJobs: API.PaginatedOperationMethod<
   ListDataSourceSyncJobsRequest,
   ListDataSourceSyncJobsResponse,
   ListDataSourceSyncJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourceSyncJobsRequest,
@@ -6966,7 +6965,7 @@ export const listEntityPersonas: API.PaginatedOperationMethod<
   ListEntityPersonasRequest,
   ListEntityPersonasResponse,
   ListEntityPersonasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntityPersonasRequest,
@@ -7006,7 +7005,7 @@ export const listExperienceEntities: API.PaginatedOperationMethod<
   ListExperienceEntitiesRequest,
   ListExperienceEntitiesResponse,
   ListExperienceEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperienceEntitiesRequest,
@@ -7041,7 +7040,7 @@ export const listExperiences: API.PaginatedOperationMethod<
   ListExperiencesRequest,
   ListExperiencesResponse,
   ListExperiencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperiencesRequest,
@@ -7077,7 +7076,7 @@ export const listFaqs: API.PaginatedOperationMethod<
   ListFaqsRequest,
   ListFaqsResponse,
   ListFaqsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFaqsRequest,
@@ -7115,7 +7114,7 @@ export const listFeaturedResultsSets: API.OperationMethod<
   ListFeaturedResultsSetsRequest,
   ListFeaturedResultsSetsResponse,
   ListFeaturedResultsSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFeaturedResultsSetsRequest,
   output: ListFeaturedResultsSetsResponse,
@@ -7149,7 +7148,7 @@ export const listGroupsOlderThanOrderingId: API.PaginatedOperationMethod<
   ListGroupsOlderThanOrderingIdRequest,
   ListGroupsOlderThanOrderingIdResponse,
   ListGroupsOlderThanOrderingIdError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsOlderThanOrderingIdRequest,
@@ -7185,7 +7184,7 @@ export const listIndices: API.PaginatedOperationMethod<
   ListIndicesRequest,
   ListIndicesResponse,
   ListIndicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndicesRequest,
@@ -7227,7 +7226,7 @@ export const listQuerySuggestionsBlockLists: API.PaginatedOperationMethod<
   ListQuerySuggestionsBlockListsRequest,
   ListQuerySuggestionsBlockListsResponse,
   ListQuerySuggestionsBlockListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuerySuggestionsBlockListsRequest,
@@ -7265,7 +7264,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -7296,7 +7295,7 @@ export const listThesauri: API.PaginatedOperationMethod<
   ListThesauriRequest,
   ListThesauriResponse,
   ListThesauriError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThesauriRequest,
@@ -7348,7 +7347,7 @@ export const putPrincipalMapping: API.OperationMethod<
   PutPrincipalMappingRequest,
   PutPrincipalMappingResponse,
   PutPrincipalMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPrincipalMappingRequest,
   output: PutPrincipalMappingResponse,
@@ -7414,7 +7413,7 @@ export const query: API.OperationMethod<
   QueryRequest,
   QueryResult,
   QueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: QueryRequest,
   output: QueryResult,
@@ -7486,7 +7485,7 @@ export const retrieve: API.OperationMethod<
   RetrieveRequest,
   RetrieveResult,
   RetrieveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveRequest,
   output: RetrieveResult,
@@ -7526,7 +7525,7 @@ export const startDataSourceSyncJob: API.OperationMethod<
   StartDataSourceSyncJobRequest,
   StartDataSourceSyncJobResponse,
   StartDataSourceSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataSourceSyncJobRequest,
   output: StartDataSourceSyncJobResponse,
@@ -7559,7 +7558,7 @@ export const stopDataSourceSyncJob: API.OperationMethod<
   StopDataSourceSyncJobRequest,
   StopDataSourceSyncJobResponse,
   StopDataSourceSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDataSourceSyncJobRequest,
   output: StopDataSourceSyncJobResponse,
@@ -7594,7 +7593,7 @@ export const submitFeedback: API.OperationMethod<
   SubmitFeedbackRequest,
   SubmitFeedbackResponse,
   SubmitFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitFeedbackRequest,
   output: SubmitFeedbackResponse,
@@ -7626,7 +7625,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7656,7 +7655,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7713,7 +7712,7 @@ export const updateAccessControlConfiguration: API.OperationMethod<
   UpdateAccessControlConfigurationRequest,
   UpdateAccessControlConfigurationResponse,
   UpdateAccessControlConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessControlConfigurationRequest,
   output: UpdateAccessControlConfigurationResponse,
@@ -7746,7 +7745,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -7780,7 +7779,7 @@ export const updateExperience: API.OperationMethod<
   UpdateExperienceRequest,
   UpdateExperienceResponse,
   UpdateExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExperienceRequest,
   output: UpdateExperienceResponse,
@@ -7816,7 +7815,7 @@ export const updateFeaturedResultsSet: API.OperationMethod<
   UpdateFeaturedResultsSetRequest,
   UpdateFeaturedResultsSetResponse,
   UpdateFeaturedResultsSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFeaturedResultsSetRequest,
   output: UpdateFeaturedResultsSetResponse,
@@ -7849,7 +7848,7 @@ export const updateIndex: API.OperationMethod<
   UpdateIndexRequest,
   UpdateIndexResponse,
   UpdateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexRequest,
   output: UpdateIndexResponse,
@@ -7895,7 +7894,7 @@ export const updateQuerySuggestionsBlockList: API.OperationMethod<
   UpdateQuerySuggestionsBlockListRequest,
   UpdateQuerySuggestionsBlockListResponse,
   UpdateQuerySuggestionsBlockListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuerySuggestionsBlockListRequest,
   output: UpdateQuerySuggestionsBlockListResponse,
@@ -7942,7 +7941,7 @@ export const updateQuerySuggestionsConfig: API.OperationMethod<
   UpdateQuerySuggestionsConfigRequest,
   UpdateQuerySuggestionsConfigResponse,
   UpdateQuerySuggestionsConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuerySuggestionsConfigRequest,
   output: UpdateQuerySuggestionsConfigResponse,
@@ -7974,7 +7973,7 @@ export const updateThesaurus: API.OperationMethod<
   UpdateThesaurusRequest,
   UpdateThesaurusResponse,
   UpdateThesaurusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThesaurusRequest,
   output: UpdateThesaurusResponse,

--- a/packages/aws/src/services/keyspaces.ts
+++ b/packages/aws/src/services/keyspaces.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Keyspaces",
   serviceShapeName: "KeyspacesService",
@@ -1128,7 +1127,7 @@ export const createKeyspace: API.OperationMethod<
   CreateKeyspaceRequest,
   CreateKeyspaceResponse,
   CreateKeyspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyspaceRequest,
   output: CreateKeyspaceResponse,
@@ -1163,7 +1162,7 @@ export const createTable: API.OperationMethod<
   CreateTableRequest,
   CreateTableResponse,
   CreateTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableRequest,
   output: CreateTableResponse,
@@ -1199,7 +1198,7 @@ export const createType: API.OperationMethod<
   CreateTypeRequest,
   CreateTypeResponse,
   CreateTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTypeRequest,
   output: CreateTypeResponse,
@@ -1231,7 +1230,7 @@ export const deleteKeyspace: API.OperationMethod<
   DeleteKeyspaceRequest,
   DeleteKeyspaceResponse,
   DeleteKeyspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyspaceRequest,
   output: DeleteKeyspaceResponse,
@@ -1263,7 +1262,7 @@ export const deleteTable: API.OperationMethod<
   DeleteTableRequest,
   DeleteTableResponse,
   DeleteTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableRequest,
   output: DeleteTableResponse,
@@ -1297,7 +1296,7 @@ export const deleteType: API.OperationMethod<
   DeleteTypeRequest,
   DeleteTypeResponse,
   DeleteTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTypeRequest,
   output: DeleteTypeResponse,
@@ -1328,7 +1327,7 @@ export const getKeyspace: API.OperationMethod<
   GetKeyspaceRequest,
   GetKeyspaceResponse,
   GetKeyspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyspaceRequest,
   output: GetKeyspaceResponse,
@@ -1360,7 +1359,7 @@ export const getTable: API.OperationMethod<
   GetTableRequest,
   GetTableResponse,
   GetTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRequest,
   output: GetTableResponse,
@@ -1400,7 +1399,7 @@ export const getTableAutoScalingSettings: API.OperationMethod<
   GetTableAutoScalingSettingsRequest,
   GetTableAutoScalingSettingsResponse,
   GetTableAutoScalingSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableAutoScalingSettingsRequest,
   output: GetTableAutoScalingSettingsResponse,
@@ -1432,7 +1431,7 @@ export const getType: API.OperationMethod<
   GetTypeRequest,
   GetTypeResponse,
   GetTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTypeRequest,
   output: GetTypeResponse,
@@ -1462,7 +1461,7 @@ export const listKeyspaces: API.PaginatedOperationMethod<
   ListKeyspacesRequest,
   ListKeyspacesResponse,
   ListKeyspacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KeyspaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeyspacesRequest,
@@ -1501,7 +1500,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesRequest,
   ListTablesResponse,
   ListTablesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesRequest,
@@ -1540,7 +1539,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -1579,7 +1578,7 @@ export const listTypes: API.PaginatedOperationMethod<
   ListTypesRequest,
   ListTypesResponse,
   ListTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TypeName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTypesRequest,
@@ -1643,7 +1642,7 @@ export const restoreTable: API.OperationMethod<
   RestoreTableRequest,
   RestoreTableResponse,
   RestoreTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableRequest,
   output: RestoreTableResponse,
@@ -1677,7 +1676,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1709,7 +1708,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1781,7 +1780,7 @@ export const updateKeyspace: API.OperationMethod<
   UpdateKeyspaceRequest,
   UpdateKeyspaceResponse,
   UpdateKeyspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyspaceRequest,
   output: UpdateKeyspaceResponse,
@@ -1813,7 +1812,7 @@ export const updateTable: API.OperationMethod<
   UpdateTableRequest,
   UpdateTableResponse,
   UpdateTableError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableRequest,
   output: UpdateTableResponse,

--- a/packages/aws/src/services/keyspacesstreams.ts
+++ b/packages/aws/src/services/keyspacesstreams.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "KeyspacesStreams",
   serviceShapeName: "KeyspacesStreams",
@@ -1253,7 +1252,7 @@ export const getRecords: API.OperationMethod<
   GetRecordsInput,
   GetRecordsOutput,
   GetRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecordsInput,
   output: GetRecordsOutput,
@@ -1283,7 +1282,7 @@ export const getShardIterator: API.OperationMethod<
   GetShardIteratorInput,
   GetShardIteratorOutput,
   GetShardIteratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetShardIteratorInput,
   output: GetShardIteratorOutput,
@@ -1313,7 +1312,7 @@ export const getStream: API.PaginatedOperationMethod<
   GetStreamInput,
   GetStreamOutput,
   GetStreamError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Shard
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetStreamInput,
@@ -1350,7 +1349,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsInput,
   ListStreamsOutput,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Stream
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsInput,

--- a/packages/aws/src/services/kinesis-analytics-v2.ts
+++ b/packages/aws/src/services/kinesis-analytics-v2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace(
   "http://analytics.kinesis.amazonaws.com/doc/2018-05-23",
 );
@@ -3298,7 +3297,7 @@ export const addApplicationCloudWatchLoggingOption: API.OperationMethod<
   AddApplicationCloudWatchLoggingOptionRequest,
   AddApplicationCloudWatchLoggingOptionResponse,
   AddApplicationCloudWatchLoggingOptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationCloudWatchLoggingOptionRequest,
   output: AddApplicationCloudWatchLoggingOptionResponse,
@@ -3338,7 +3337,7 @@ export const addApplicationInput: API.OperationMethod<
   AddApplicationInputRequest,
   AddApplicationInputResponse,
   AddApplicationInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationInputRequest,
   output: AddApplicationInputResponse,
@@ -3371,7 +3370,7 @@ export const addApplicationInputProcessingConfiguration: API.OperationMethod<
   AddApplicationInputProcessingConfigurationRequest,
   AddApplicationInputProcessingConfigurationResponse,
   AddApplicationInputProcessingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationInputProcessingConfigurationRequest,
   output: AddApplicationInputProcessingConfigurationResponse,
@@ -3416,7 +3415,7 @@ export const addApplicationOutput: API.OperationMethod<
   AddApplicationOutputRequest,
   AddApplicationOutputResponse,
   AddApplicationOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationOutputRequest,
   output: AddApplicationOutputResponse,
@@ -3452,7 +3451,7 @@ export const addApplicationReferenceDataSource: API.OperationMethod<
   AddApplicationReferenceDataSourceRequest,
   AddApplicationReferenceDataSourceResponse,
   AddApplicationReferenceDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationReferenceDataSourceRequest,
   output: AddApplicationReferenceDataSourceResponse,
@@ -3490,7 +3489,7 @@ export const addApplicationVpcConfiguration: API.OperationMethod<
   AddApplicationVpcConfigurationRequest,
   AddApplicationVpcConfigurationResponse,
   AddApplicationVpcConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationVpcConfigurationRequest,
   output: AddApplicationVpcConfigurationResponse,
@@ -3525,7 +3524,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -3569,7 +3568,7 @@ export const createApplicationPresignedUrl: API.OperationMethod<
   CreateApplicationPresignedUrlRequest,
   CreateApplicationPresignedUrlResponse,
   CreateApplicationPresignedUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationPresignedUrlRequest,
   output: CreateApplicationPresignedUrlResponse,
@@ -3599,7 +3598,7 @@ export const createApplicationSnapshot: API.OperationMethod<
   CreateApplicationSnapshotRequest,
   CreateApplicationSnapshotResponse,
   CreateApplicationSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationSnapshotRequest,
   output: CreateApplicationSnapshotResponse,
@@ -3632,7 +3631,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -3664,7 +3663,7 @@ export const deleteApplicationCloudWatchLoggingOption: API.OperationMethod<
   DeleteApplicationCloudWatchLoggingOptionRequest,
   DeleteApplicationCloudWatchLoggingOptionResponse,
   DeleteApplicationCloudWatchLoggingOptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationCloudWatchLoggingOptionRequest,
   output: DeleteApplicationCloudWatchLoggingOptionResponse,
@@ -3695,7 +3694,7 @@ export const deleteApplicationInputProcessingConfiguration: API.OperationMethod<
   DeleteApplicationInputProcessingConfigurationRequest,
   DeleteApplicationInputProcessingConfigurationResponse,
   DeleteApplicationInputProcessingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationInputProcessingConfigurationRequest,
   output: DeleteApplicationInputProcessingConfigurationResponse,
@@ -3727,7 +3726,7 @@ export const deleteApplicationOutput: API.OperationMethod<
   DeleteApplicationOutputRequest,
   DeleteApplicationOutputResponse,
   DeleteApplicationOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationOutputRequest,
   output: DeleteApplicationOutputResponse,
@@ -3760,7 +3759,7 @@ export const deleteApplicationReferenceDataSource: API.OperationMethod<
   DeleteApplicationReferenceDataSourceRequest,
   DeleteApplicationReferenceDataSourceResponse,
   DeleteApplicationReferenceDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationReferenceDataSourceRequest,
   output: DeleteApplicationReferenceDataSourceResponse,
@@ -3791,7 +3790,7 @@ export const deleteApplicationSnapshot: API.OperationMethod<
   DeleteApplicationSnapshotRequest,
   DeleteApplicationSnapshotResponse,
   DeleteApplicationSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationSnapshotRequest,
   output: DeleteApplicationSnapshotResponse,
@@ -3822,7 +3821,7 @@ export const deleteApplicationVpcConfiguration: API.OperationMethod<
   DeleteApplicationVpcConfigurationRequest,
   DeleteApplicationVpcConfigurationResponse,
   DeleteApplicationVpcConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationVpcConfigurationRequest,
   output: DeleteApplicationVpcConfigurationResponse,
@@ -3853,7 +3852,7 @@ export const describeApplication: API.OperationMethod<
   DescribeApplicationRequest,
   DescribeApplicationResponse,
   DescribeApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationRequest,
   output: DescribeApplicationResponse,
@@ -3881,7 +3880,7 @@ export const describeApplicationOperation: API.OperationMethod<
   DescribeApplicationOperationRequest,
   DescribeApplicationOperationResponse,
   DescribeApplicationOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationOperationRequest,
   output: DescribeApplicationOperationResponse,
@@ -3907,7 +3906,7 @@ export const describeApplicationSnapshot: API.OperationMethod<
   DescribeApplicationSnapshotRequest,
   DescribeApplicationSnapshotResponse,
   DescribeApplicationSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationSnapshotRequest,
   output: DescribeApplicationSnapshotResponse,
@@ -3935,7 +3934,7 @@ export const describeApplicationVersion: API.OperationMethod<
   DescribeApplicationVersionRequest,
   DescribeApplicationVersionResponse,
   DescribeApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationVersionRequest,
   output: DescribeApplicationVersionResponse,
@@ -3971,7 +3970,7 @@ export const discoverInputSchema: API.OperationMethod<
   DiscoverInputSchemaRequest,
   DiscoverInputSchemaResponse,
   DiscoverInputSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscoverInputSchemaRequest,
   output: DiscoverInputSchemaResponse,
@@ -4005,7 +4004,7 @@ export const listApplicationOperations: API.PaginatedOperationMethod<
   ListApplicationOperationsRequest,
   ListApplicationOperationsResponse,
   ListApplicationOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationOperationInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationOperationsRequest,
@@ -4039,7 +4038,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -4067,7 +4066,7 @@ export const listApplicationSnapshots: API.PaginatedOperationMethod<
   ListApplicationSnapshotsRequest,
   ListApplicationSnapshotsResponse,
   ListApplicationSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationSnapshotsRequest,
@@ -4101,7 +4100,7 @@ export const listApplicationVersions: API.PaginatedOperationMethod<
   ListApplicationVersionsRequest,
   ListApplicationVersionsResponse,
   ListApplicationVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationVersionsRequest,
@@ -4135,7 +4134,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4171,7 +4170,7 @@ export const rollbackApplication: API.OperationMethod<
   RollbackApplicationRequest,
   RollbackApplicationResponse,
   RollbackApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackApplicationRequest,
   output: RollbackApplicationResponse,
@@ -4203,7 +4202,7 @@ export const startApplication: API.OperationMethod<
   StartApplicationRequest,
   StartApplicationResponse,
   StartApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationRequest,
   output: StartApplicationResponse,
@@ -4241,7 +4240,7 @@ export const stopApplication: API.OperationMethod<
   StopApplicationRequest,
   StopApplicationResponse,
   StopApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopApplicationRequest,
   output: StopApplicationResponse,
@@ -4274,7 +4273,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4305,7 +4304,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4342,7 +4341,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -4392,7 +4391,7 @@ export const updateApplicationMaintenanceConfiguration: API.OperationMethod<
   UpdateApplicationMaintenanceConfigurationRequest,
   UpdateApplicationMaintenanceConfigurationResponse,
   UpdateApplicationMaintenanceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationMaintenanceConfigurationRequest,
   output: UpdateApplicationMaintenanceConfigurationResponse,

--- a/packages/aws/src/services/kinesis-analytics.ts
+++ b/packages/aws/src/services/kinesis-analytics.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace(
   "http://analytics.kinesis.amazonaws.com/doc/2015-08-14",
 );
@@ -1575,7 +1574,7 @@ export const addApplicationCloudWatchLoggingOption: API.OperationMethod<
   AddApplicationCloudWatchLoggingOptionRequest,
   AddApplicationCloudWatchLoggingOptionResponse,
   AddApplicationCloudWatchLoggingOptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationCloudWatchLoggingOptionRequest,
   output: AddApplicationCloudWatchLoggingOptionResponse,
@@ -1621,7 +1620,7 @@ export const addApplicationInput: API.OperationMethod<
   AddApplicationInputRequest,
   AddApplicationInputResponse,
   AddApplicationInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationInputRequest,
   output: AddApplicationInputResponse,
@@ -1656,7 +1655,7 @@ export const addApplicationInputProcessingConfiguration: API.OperationMethod<
   AddApplicationInputProcessingConfigurationRequest,
   AddApplicationInputProcessingConfigurationResponse,
   AddApplicationInputProcessingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationInputProcessingConfigurationRequest,
   output: AddApplicationInputProcessingConfigurationResponse,
@@ -1709,7 +1708,7 @@ export const addApplicationOutput: API.OperationMethod<
   AddApplicationOutputRequest,
   AddApplicationOutputResponse,
   AddApplicationOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationOutputRequest,
   output: AddApplicationOutputResponse,
@@ -1750,7 +1749,7 @@ export const addApplicationReferenceDataSource: API.OperationMethod<
   AddApplicationReferenceDataSourceRequest,
   AddApplicationReferenceDataSourceResponse,
   AddApplicationReferenceDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddApplicationReferenceDataSourceRequest,
   output: AddApplicationReferenceDataSourceResponse,
@@ -1803,7 +1802,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1837,7 +1836,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1870,7 +1869,7 @@ export const deleteApplicationCloudWatchLoggingOption: API.OperationMethod<
   DeleteApplicationCloudWatchLoggingOptionRequest,
   DeleteApplicationCloudWatchLoggingOptionResponse,
   DeleteApplicationCloudWatchLoggingOptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationCloudWatchLoggingOptionRequest,
   output: DeleteApplicationCloudWatchLoggingOptionResponse,
@@ -1902,7 +1901,7 @@ export const deleteApplicationInputProcessingConfiguration: API.OperationMethod<
   DeleteApplicationInputProcessingConfigurationRequest,
   DeleteApplicationInputProcessingConfigurationResponse,
   DeleteApplicationInputProcessingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationInputProcessingConfigurationRequest,
   output: DeleteApplicationInputProcessingConfigurationResponse,
@@ -1937,7 +1936,7 @@ export const deleteApplicationOutput: API.OperationMethod<
   DeleteApplicationOutputRequest,
   DeleteApplicationOutputResponse,
   DeleteApplicationOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationOutputRequest,
   output: DeleteApplicationOutputResponse,
@@ -1975,7 +1974,7 @@ export const deleteApplicationReferenceDataSource: API.OperationMethod<
   DeleteApplicationReferenceDataSourceRequest,
   DeleteApplicationReferenceDataSourceResponse,
   DeleteApplicationReferenceDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationReferenceDataSourceRequest,
   output: DeleteApplicationReferenceDataSourceResponse,
@@ -2011,7 +2010,7 @@ export const describeApplication: API.OperationMethod<
   DescribeApplicationRequest,
   DescribeApplicationResponse,
   DescribeApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationRequest,
   output: DescribeApplicationResponse,
@@ -2045,7 +2044,7 @@ export const discoverInputSchema: API.OperationMethod<
   DiscoverInputSchemaRequest,
   DiscoverInputSchemaResponse,
   DiscoverInputSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscoverInputSchemaRequest,
   output: DiscoverInputSchemaResponse,
@@ -2084,7 +2083,7 @@ export const listApplications: API.OperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListApplicationsRequest,
   output: ListApplicationsResponse,
@@ -2106,7 +2105,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2147,7 +2146,7 @@ export const startApplication: API.OperationMethod<
   StartApplicationRequest,
   StartApplicationResponse,
   StartApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationRequest,
   output: StartApplicationResponse,
@@ -2185,7 +2184,7 @@ export const stopApplication: API.OperationMethod<
   StopApplicationRequest,
   StopApplicationResponse,
   StopApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopApplicationRequest,
   output: StopApplicationResponse,
@@ -2214,7 +2213,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2244,7 +2243,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2285,7 +2284,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,

--- a/packages/aws/src/services/kinesis-video-archived-media.ts
+++ b/packages/aws/src/services/kinesis-video-archived-media.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Kinesis Video Archived Media",
   serviceShapeName: "AWSAcuityReader",
@@ -656,7 +655,7 @@ export const getClip: API.OperationMethod<
   GetClipInput,
   GetClipOutput,
   GetClipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClipInput,
   output: GetClipOutput,
@@ -815,7 +814,7 @@ export const getDASHStreamingSessionURL: API.OperationMethod<
   GetDASHStreamingSessionURLInput,
   GetDASHStreamingSessionURLOutput,
   GetDASHStreamingSessionURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDASHStreamingSessionURLInput,
   output: GetDASHStreamingSessionURLOutput,
@@ -1013,7 +1012,7 @@ export const getHLSStreamingSessionURL: API.OperationMethod<
   GetHLSStreamingSessionURLInput,
   GetHLSStreamingSessionURLOutput,
   GetHLSStreamingSessionURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHLSStreamingSessionURLInput,
   output: GetHLSStreamingSessionURLOutput,
@@ -1047,7 +1046,7 @@ export const getImages: API.PaginatedOperationMethod<
   GetImagesInput,
   GetImagesOutput,
   GetImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Image
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetImagesInput,
@@ -1110,7 +1109,7 @@ export const getMediaForFragmentList: API.OperationMethod<
   GetMediaForFragmentListInput,
   GetMediaForFragmentListOutput,
   GetMediaForFragmentListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaForFragmentListInput,
   output: GetMediaForFragmentListOutput,
@@ -1167,7 +1166,7 @@ export const listFragments: API.PaginatedOperationMethod<
   ListFragmentsInput,
   ListFragmentsOutput,
   ListFragmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Fragment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFragmentsInput,

--- a/packages/aws/src/services/kinesis-video-media.ts
+++ b/packages/aws/src/services/kinesis-video-media.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Kinesis Video Media",
   serviceShapeName: "AWSAcuityInletService",
@@ -230,7 +229,7 @@ export const getMedia: API.OperationMethod<
   GetMediaInput,
   GetMediaOutput,
   GetMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaInput,
   output: GetMediaOutput,

--- a/packages/aws/src/services/kinesis-video-signaling.ts
+++ b/packages/aws/src/services/kinesis-video-signaling.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Kinesis Video Signaling",
@@ -246,7 +245,7 @@ export const getIceServerConfig: API.OperationMethod<
   GetIceServerConfigRequest,
   GetIceServerConfigResponse,
   GetIceServerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIceServerConfigRequest,
   output: GetIceServerConfigResponse,
@@ -281,7 +280,7 @@ export const sendAlexaOfferToMaster: API.OperationMethod<
   SendAlexaOfferToMasterRequest,
   SendAlexaOfferToMasterResponse,
   SendAlexaOfferToMasterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendAlexaOfferToMasterRequest,
   output: SendAlexaOfferToMasterResponse,

--- a/packages/aws/src/services/kinesis-video-webrtc-storage.ts
+++ b/packages/aws/src/services/kinesis-video-webrtc-storage.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Kinesis Video WebRTC Storage",
   serviceShapeName: "AWSAcuityRoutingServiceLambda",
@@ -212,7 +211,7 @@ export const joinStorageSession: API.OperationMethod<
   JoinStorageSessionInput,
   JoinStorageSessionResponse,
   JoinStorageSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: JoinStorageSessionInput,
   output: JoinStorageSessionResponse,
@@ -256,7 +255,7 @@ export const joinStorageSessionAsViewer: API.OperationMethod<
   JoinStorageSessionAsViewerInput,
   JoinStorageSessionAsViewerResponse,
   JoinStorageSessionAsViewerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: JoinStorageSessionAsViewerInput,
   output: JoinStorageSessionAsViewerResponse,

--- a/packages/aws/src/services/kinesis-video.ts
+++ b/packages/aws/src/services/kinesis-video.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("https://kinesisvideo.amazonaws.com/doc/2017-09-30/");
 const svc = T.AwsApiService({
@@ -1769,7 +1768,7 @@ export const createSignalingChannel: API.OperationMethod<
   CreateSignalingChannelInput,
   CreateSignalingChannelOutput,
   CreateSignalingChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSignalingChannelInput,
   output: CreateSignalingChannelOutput,
@@ -1812,7 +1811,7 @@ export const createStream: API.OperationMethod<
   CreateStreamInput,
   CreateStreamOutput,
   CreateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamInput,
   output: CreateStreamOutput,
@@ -1848,7 +1847,7 @@ export const deleteEdgeConfiguration: API.OperationMethod<
   DeleteEdgeConfigurationInput,
   DeleteEdgeConfigurationOutput,
   DeleteEdgeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEdgeConfigurationInput,
   output: DeleteEdgeConfigurationOutput,
@@ -1881,7 +1880,7 @@ export const deleteSignalingChannel: API.OperationMethod<
   DeleteSignalingChannelInput,
   DeleteSignalingChannelOutput,
   DeleteSignalingChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSignalingChannelInput,
   output: DeleteSignalingChannelOutput,
@@ -1924,7 +1923,7 @@ export const deleteStream: API.OperationMethod<
   DeleteStreamInput,
   DeleteStreamOutput,
   DeleteStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamInput,
   output: DeleteStreamOutput,
@@ -1959,7 +1958,7 @@ export const describeEdgeConfiguration: API.OperationMethod<
   DescribeEdgeConfigurationInput,
   DescribeEdgeConfigurationOutput,
   DescribeEdgeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEdgeConfigurationInput,
   output: DescribeEdgeConfigurationOutput,
@@ -1988,7 +1987,7 @@ export const describeImageGenerationConfiguration: API.OperationMethod<
   DescribeImageGenerationConfigurationInput,
   DescribeImageGenerationConfigurationOutput,
   DescribeImageGenerationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageGenerationConfigurationInput,
   output: DescribeImageGenerationConfigurationOutput,
@@ -2017,7 +2016,7 @@ export const describeMappedResourceConfiguration: API.PaginatedOperationMethod<
   DescribeMappedResourceConfigurationInput,
   DescribeMappedResourceConfigurationOutput,
   DescribeMappedResourceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MappedResourceConfigurationListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMappedResourceConfigurationInput,
@@ -2053,7 +2052,7 @@ export const describeMediaStorageConfiguration: API.OperationMethod<
   DescribeMediaStorageConfigurationInput,
   DescribeMediaStorageConfigurationOutput,
   DescribeMediaStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMediaStorageConfigurationInput,
   output: DescribeMediaStorageConfigurationOutput,
@@ -2081,7 +2080,7 @@ export const describeNotificationConfiguration: API.OperationMethod<
   DescribeNotificationConfigurationInput,
   DescribeNotificationConfigurationOutput,
   DescribeNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotificationConfigurationInput,
   output: DescribeNotificationConfigurationOutput,
@@ -2111,7 +2110,7 @@ export const describeSignalingChannel: API.OperationMethod<
   DescribeSignalingChannelInput,
   DescribeSignalingChannelOutput,
   DescribeSignalingChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSignalingChannelInput,
   output: DescribeSignalingChannelOutput,
@@ -2140,7 +2139,7 @@ export const describeStream: API.OperationMethod<
   DescribeStreamInput,
   DescribeStreamOutput,
   DescribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamInput,
   output: DescribeStreamOutput,
@@ -2172,7 +2171,7 @@ export const describeStreamStorageConfiguration: API.OperationMethod<
   DescribeStreamStorageConfigurationInput,
   DescribeStreamStorageConfigurationOutput,
   DescribeStreamStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamStorageConfigurationInput,
   output: DescribeStreamStorageConfigurationOutput,
@@ -2209,7 +2208,7 @@ export const getDataEndpoint: API.OperationMethod<
   GetDataEndpointInput,
   GetDataEndpointOutput,
   GetDataEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataEndpointInput,
   output: GetDataEndpointOutput,
@@ -2252,7 +2251,7 @@ export const getSignalingChannelEndpoint: API.OperationMethod<
   GetSignalingChannelEndpointInput,
   GetSignalingChannelEndpointOutput,
   GetSignalingChannelEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSignalingChannelEndpointInput,
   output: GetSignalingChannelEndpointOutput,
@@ -2282,7 +2281,7 @@ export const listEdgeAgentConfigurations: API.PaginatedOperationMethod<
   ListEdgeAgentConfigurationsInput,
   ListEdgeAgentConfigurationsOutput,
   ListEdgeAgentConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListEdgeAgentConfigurationsEdgeConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEdgeAgentConfigurationsInput,
@@ -2317,7 +2316,7 @@ export const listSignalingChannels: API.PaginatedOperationMethod<
   ListSignalingChannelsInput,
   ListSignalingChannelsOutput,
   ListSignalingChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSignalingChannelsInput,
@@ -2351,7 +2350,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsInput,
   ListStreamsOutput,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsInput,
@@ -2381,7 +2380,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2413,7 +2412,7 @@ export const listTagsForStream: API.OperationMethod<
   ListTagsForStreamInput,
   ListTagsForStreamOutput,
   ListTagsForStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForStreamInput,
   output: ListTagsForStreamOutput,
@@ -2459,7 +2458,7 @@ export const startEdgeConfigurationUpdate: API.OperationMethod<
   StartEdgeConfigurationUpdateInput,
   StartEdgeConfigurationUpdateOutput,
   StartEdgeConfigurationUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEdgeConfigurationUpdateInput,
   output: StartEdgeConfigurationUpdateOutput,
@@ -2496,7 +2495,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2541,7 +2540,7 @@ export const tagStream: API.OperationMethod<
   TagStreamInput,
   TagStreamOutput,
   TagStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagStreamInput,
   output: TagStreamOutput,
@@ -2575,7 +2574,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2611,7 +2610,7 @@ export const untagStream: API.OperationMethod<
   UntagStreamInput,
   UntagStreamOutput,
   UntagStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagStreamInput,
   output: UntagStreamOutput,
@@ -2663,7 +2662,7 @@ export const updateDataRetention: API.OperationMethod<
   UpdateDataRetentionInput,
   UpdateDataRetentionOutput,
   UpdateDataRetentionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataRetentionInput,
   output: UpdateDataRetentionOutput,
@@ -2696,7 +2695,7 @@ export const updateImageGenerationConfiguration: API.OperationMethod<
   UpdateImageGenerationConfigurationInput,
   UpdateImageGenerationConfigurationOutput,
   UpdateImageGenerationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImageGenerationConfigurationInput,
   output: UpdateImageGenerationConfigurationOutput,
@@ -2741,7 +2740,7 @@ export const updateMediaStorageConfiguration: API.OperationMethod<
   UpdateMediaStorageConfigurationInput,
   UpdateMediaStorageConfigurationOutput,
   UpdateMediaStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMediaStorageConfigurationInput,
   output: UpdateMediaStorageConfigurationOutput,
@@ -2773,7 +2772,7 @@ export const updateNotificationConfiguration: API.OperationMethod<
   UpdateNotificationConfigurationInput,
   UpdateNotificationConfigurationOutput,
   UpdateNotificationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationConfigurationInput,
   output: UpdateNotificationConfigurationOutput,
@@ -2812,7 +2811,7 @@ export const updateSignalingChannel: API.OperationMethod<
   UpdateSignalingChannelInput,
   UpdateSignalingChannelOutput,
   UpdateSignalingChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSignalingChannelInput,
   output: UpdateSignalingChannelOutput,
@@ -2857,7 +2856,7 @@ export const updateStream: API.OperationMethod<
   UpdateStreamInput,
   UpdateStreamOutput,
   UpdateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamInput,
   output: UpdateStreamOutput,
@@ -2896,7 +2895,7 @@ export const updateStreamStorageConfiguration: API.OperationMethod<
   UpdateStreamStorageConfigurationInput,
   UpdateStreamStorageConfigurationOutput,
   UpdateStreamStorageConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamStorageConfigurationInput,
   output: UpdateStreamStorageConfigurationOutput,

--- a/packages/aws/src/services/kinesis.ts
+++ b/packages/aws/src/services/kinesis.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://kinesis.amazonaws.com/doc/2013-12-02");
 const svc = T.AwsApiService({
   sdkId: "Kinesis",
@@ -2755,7 +2754,7 @@ export const addTagsToStream: API.OperationMethod<
   AddTagsToStreamInput,
   AddTagsToStreamResponse,
   AddTagsToStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToStreamInput,
   output: AddTagsToStreamResponse,
@@ -2822,7 +2821,7 @@ export const createStream: API.OperationMethod<
   CreateStreamInput,
   CreateStreamResponse,
   CreateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamInput,
   output: CreateStreamResponse,
@@ -2861,7 +2860,7 @@ export const decreaseStreamRetentionPeriod: API.OperationMethod<
   DecreaseStreamRetentionPeriodInput,
   DecreaseStreamRetentionPeriodResponse,
   DecreaseStreamRetentionPeriodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecreaseStreamRetentionPeriodInput,
   output: DecreaseStreamRetentionPeriodResponse,
@@ -2895,7 +2894,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyInput,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyInput,
   output: DeleteResourcePolicyResponse,
@@ -2950,7 +2949,7 @@ export const deleteStream: API.OperationMethod<
   DeleteStreamInput,
   DeleteStreamResponse,
   DeleteStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamInput,
   output: DeleteStreamResponse,
@@ -2986,7 +2985,7 @@ export const deregisterStreamConsumer: API.OperationMethod<
   DeregisterStreamConsumerInput,
   DeregisterStreamConsumerResponse,
   DeregisterStreamConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterStreamConsumerInput,
   output: DeregisterStreamConsumerResponse,
@@ -3012,7 +3011,7 @@ export const describeAccountSettings: API.OperationMethod<
   DescribeAccountSettingsInput,
   DescribeAccountSettingsOutput,
   DescribeAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountSettingsInput,
   output: DescribeAccountSettingsOutput,
@@ -3035,7 +3034,7 @@ export const describeLimits: API.OperationMethod<
   DescribeLimitsInput,
   DescribeLimitsOutput,
   DescribeLimitsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLimitsInput,
   output: DescribeLimitsOutput,
@@ -3084,7 +3083,7 @@ export const describeStream: API.OperationMethod<
   DescribeStreamInput,
   DescribeStreamOutput,
   DescribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamInput,
   output: DescribeStreamOutput,
@@ -3121,7 +3120,7 @@ export const describeStreamConsumer: API.OperationMethod<
   DescribeStreamConsumerInput,
   DescribeStreamConsumerOutput,
   DescribeStreamConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamConsumerInput,
   output: DescribeStreamConsumerOutput,
@@ -3160,7 +3159,7 @@ export const describeStreamSummary: API.OperationMethod<
   DescribeStreamSummaryInput,
   DescribeStreamSummaryOutput,
   DescribeStreamSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamSummaryInput,
   output: DescribeStreamSummaryOutput,
@@ -3193,7 +3192,7 @@ export const disableEnhancedMonitoring: API.OperationMethod<
   DisableEnhancedMonitoringInput,
   EnhancedMonitoringOutput,
   DisableEnhancedMonitoringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableEnhancedMonitoringInput,
   output: EnhancedMonitoringOutput,
@@ -3227,7 +3226,7 @@ export const enableEnhancedMonitoring: API.OperationMethod<
   EnableEnhancedMonitoringInput,
   EnhancedMonitoringOutput,
   EnableEnhancedMonitoringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableEnhancedMonitoringInput,
   output: EnhancedMonitoringOutput,
@@ -3322,7 +3321,7 @@ export const getRecords: API.OperationMethod<
   GetRecordsInput,
   GetRecordsOutput,
   GetRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecordsInput,
   output: GetRecordsOutput,
@@ -3363,7 +3362,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -3435,7 +3434,7 @@ export const getShardIterator: API.OperationMethod<
   GetShardIteratorInput,
   GetShardIteratorOutput,
   GetShardIteratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetShardIteratorInput,
   output: GetShardIteratorOutput,
@@ -3478,7 +3477,7 @@ export const increaseStreamRetentionPeriod: API.OperationMethod<
   IncreaseStreamRetentionPeriodInput,
   IncreaseStreamRetentionPeriodResponse,
   IncreaseStreamRetentionPeriodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IncreaseStreamRetentionPeriodInput,
   output: IncreaseStreamRetentionPeriodResponse,
@@ -3523,7 +3522,7 @@ export const listShards: API.OperationMethod<
   ListShardsInput,
   ListShardsOutput,
   ListShardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListShardsInput,
   output: ListShardsOutput,
@@ -3557,7 +3556,7 @@ export const listStreamConsumers: API.PaginatedOperationMethod<
   ListStreamConsumersInput,
   ListStreamConsumersOutput,
   ListStreamConsumersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamConsumersInput,
@@ -3608,7 +3607,7 @@ export const listStreams: API.PaginatedOperationMethod<
   ListStreamsInput,
   ListStreamsOutput,
   ListStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamsInput,
@@ -3644,7 +3643,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -3678,7 +3677,7 @@ export const listTagsForStream: API.OperationMethod<
   ListTagsForStreamInput,
   ListTagsForStreamOutput,
   ListTagsForStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForStreamInput,
   output: ListTagsForStreamOutput,
@@ -3752,7 +3751,7 @@ export const mergeShards: API.OperationMethod<
   MergeShardsInput,
   MergeShardsResponse,
   MergeShardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MergeShardsInput,
   output: MergeShardsResponse,
@@ -3834,7 +3833,7 @@ export const putRecord: API.OperationMethod<
   PutRecordInput,
   PutRecordOutput,
   PutRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecordInput,
   output: PutRecordOutput,
@@ -3944,7 +3943,7 @@ export const putRecords: API.OperationMethod<
   PutRecordsInput,
   PutRecordsOutput,
   PutRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecordsInput,
   output: PutRecordsOutput,
@@ -3992,7 +3991,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyInput,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyInput,
   output: PutResourcePolicyResponse,
@@ -4039,7 +4038,7 @@ export const registerStreamConsumer: API.OperationMethod<
   RegisterStreamConsumerInput,
   RegisterStreamConsumerOutput,
   RegisterStreamConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterStreamConsumerInput,
   output: RegisterStreamConsumerOutput,
@@ -4078,7 +4077,7 @@ export const removeTagsFromStream: API.OperationMethod<
   RemoveTagsFromStreamInput,
   RemoveTagsFromStreamResponse,
   RemoveTagsFromStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromStreamInput,
   output: RemoveTagsFromStreamResponse,
@@ -4159,7 +4158,7 @@ export const splitShard: API.OperationMethod<
   SplitShardInput,
   SplitShardResponse,
   SplitShardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SplitShardInput,
   output: SplitShardResponse,
@@ -4218,7 +4217,7 @@ export const startStreamEncryption: API.OperationMethod<
   StartStreamEncryptionInput,
   StartStreamEncryptionResponse,
   StartStreamEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartStreamEncryptionInput,
   output: StartStreamEncryptionResponse,
@@ -4275,7 +4274,7 @@ export const stopStreamEncryption: API.OperationMethod<
   StopStreamEncryptionInput,
   StopStreamEncryptionResponse,
   StopStreamEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopStreamEncryptionInput,
   output: StopStreamEncryptionResponse,
@@ -4331,7 +4330,7 @@ export const subscribeToShard: API.OperationMethod<
   SubscribeToShardInput,
   SubscribeToShardOutput,
   SubscribeToShardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubscribeToShardInput,
   output: SubscribeToShardOutput,
@@ -4361,7 +4360,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -4391,7 +4390,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -4427,7 +4426,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsInput,
   UpdateAccountSettingsOutput,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsInput,
   output: UpdateAccountSettingsOutput,
@@ -4456,7 +4455,7 @@ export const updateMaxRecordSize: API.OperationMethod<
   UpdateMaxRecordSizeInput,
   UpdateMaxRecordSizeResponse,
   UpdateMaxRecordSizeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMaxRecordSizeInput,
   output: UpdateMaxRecordSizeResponse,
@@ -4534,7 +4533,7 @@ export const updateShardCount: API.OperationMethod<
   UpdateShardCountInput,
   UpdateShardCountOutput,
   UpdateShardCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateShardCountInput,
   output: UpdateShardCountOutput,
@@ -4569,7 +4568,7 @@ export const updateStreamMode: API.OperationMethod<
   UpdateStreamModeInput,
   UpdateStreamModeResponse,
   UpdateStreamModeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamModeInput,
   output: UpdateStreamModeResponse,
@@ -4615,7 +4614,7 @@ export const updateStreamWarmThroughput: API.OperationMethod<
   UpdateStreamWarmThroughputInput,
   UpdateStreamWarmThroughputOutput,
   UpdateStreamWarmThroughputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamWarmThroughputInput,
   output: UpdateStreamWarmThroughputOutput,

--- a/packages/aws/src/services/kms.ts
+++ b/packages/aws/src/services/kms.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const ns = T.XmlNamespace("https://trent.amazonaws.com/doc/2014-11-01/");
 const svc = T.AwsApiService({ sdkId: "KMS", serviceShapeName: "TrentService" });
@@ -3213,7 +3212,7 @@ export const cancelKeyDeletion: API.OperationMethod<
   CancelKeyDeletionRequest,
   CancelKeyDeletionResponse,
   CancelKeyDeletionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelKeyDeletionRequest,
   output: CancelKeyDeletionResponse,
@@ -3324,7 +3323,7 @@ export const connectCustomKeyStore: API.OperationMethod<
   ConnectCustomKeyStoreRequest,
   ConnectCustomKeyStoreResponse,
   ConnectCustomKeyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConnectCustomKeyStoreRequest,
   output: ConnectCustomKeyStoreResponse,
@@ -3400,7 +3399,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasRequest,
   CreateAliasResponse,
   CreateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasRequest,
   output: CreateAliasResponse,
@@ -3516,7 +3515,7 @@ export const createCustomKeyStore: API.OperationMethod<
   CreateCustomKeyStoreRequest,
   CreateCustomKeyStoreResponse,
   CreateCustomKeyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomKeyStoreRequest,
   output: CreateCustomKeyStoreResponse,
@@ -3617,7 +3616,7 @@ export const createGrant: API.OperationMethod<
   CreateGrantRequest,
   CreateGrantResponse,
   CreateGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGrantRequest,
   output: CreateGrantResponse,
@@ -3823,7 +3822,7 @@ export const createKey: API.OperationMethod<
   CreateKeyRequest,
   CreateKeyResponse,
   CreateKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyRequest,
   output: CreateKeyResponse,
@@ -3938,7 +3937,7 @@ export const decrypt: API.OperationMethod<
   DecryptRequest,
   DecryptResponse,
   DecryptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecryptRequest,
   output: DecryptResponse,
@@ -4006,7 +4005,7 @@ export const deleteAlias: API.OperationMethod<
   DeleteAliasRequest,
   DeleteAliasResponse,
   DeleteAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAliasRequest,
   output: DeleteAliasResponse,
@@ -4082,7 +4081,7 @@ export const deleteCustomKeyStore: API.OperationMethod<
   DeleteCustomKeyStoreRequest,
   DeleteCustomKeyStoreResponse,
   DeleteCustomKeyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomKeyStoreRequest,
   output: DeleteCustomKeyStoreResponse,
@@ -4146,7 +4145,7 @@ export const deleteImportedKeyMaterial: API.OperationMethod<
   DeleteImportedKeyMaterialRequest,
   DeleteImportedKeyMaterialResponse,
   DeleteImportedKeyMaterialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImportedKeyMaterialRequest,
   output: DeleteImportedKeyMaterialResponse,
@@ -4254,7 +4253,7 @@ export const deriveSharedSecret: API.OperationMethod<
   DeriveSharedSecretRequest,
   DeriveSharedSecretResponse,
   DeriveSharedSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeriveSharedSecretRequest,
   output: DeriveSharedSecretResponse,
@@ -4334,7 +4333,7 @@ export const describeCustomKeyStores: API.PaginatedOperationMethod<
   DescribeCustomKeyStoresRequest,
   DescribeCustomKeyStoresResponse,
   DescribeCustomKeyStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomKeyStoresListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCustomKeyStoresRequest,
@@ -4424,7 +4423,7 @@ export const describeKey: API.OperationMethod<
   DescribeKeyRequest,
   DescribeKeyResponse,
   DescribeKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyRequest,
   output: DescribeKeyResponse,
@@ -4469,7 +4468,7 @@ export const disableKey: API.OperationMethod<
   DisableKeyRequest,
   DisableKeyResponse,
   DisableKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableKeyRequest,
   output: DisableKeyResponse,
@@ -4533,7 +4532,7 @@ export const disableKeyRotation: API.OperationMethod<
   DisableKeyRotationRequest,
   DisableKeyRotationResponse,
   DisableKeyRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableKeyRotationRequest,
   output: DisableKeyRotationResponse,
@@ -4602,7 +4601,7 @@ export const disconnectCustomKeyStore: API.OperationMethod<
   DisconnectCustomKeyStoreRequest,
   DisconnectCustomKeyStoreResponse,
   DisconnectCustomKeyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectCustomKeyStoreRequest,
   output: DisconnectCustomKeyStoreResponse,
@@ -4644,7 +4643,7 @@ export const enableKey: API.OperationMethod<
   EnableKeyRequest,
   EnableKeyResponse,
   EnableKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableKeyRequest,
   output: EnableKeyResponse,
@@ -4729,7 +4728,7 @@ export const enableKeyRotation: API.OperationMethod<
   EnableKeyRotationRequest,
   EnableKeyRotationResponse,
   EnableKeyRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableKeyRotationRequest,
   output: EnableKeyRotationResponse,
@@ -4833,7 +4832,7 @@ export const encrypt: API.OperationMethod<
   EncryptRequest,
   EncryptResponse,
   EncryptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EncryptRequest,
   output: EncryptResponse,
@@ -4957,7 +4956,7 @@ export const generateDataKey: API.OperationMethod<
   GenerateDataKeyRequest,
   GenerateDataKeyResponse,
   GenerateDataKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateDataKeyRequest,
   output: GenerateDataKeyResponse,
@@ -5068,7 +5067,7 @@ export const generateDataKeyPair: API.OperationMethod<
   GenerateDataKeyPairRequest,
   GenerateDataKeyPairResponse,
   GenerateDataKeyPairError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateDataKeyPairRequest,
   output: GenerateDataKeyPairResponse,
@@ -5161,7 +5160,7 @@ export const generateDataKeyPairWithoutPlaintext: API.OperationMethod<
   GenerateDataKeyPairWithoutPlaintextRequest,
   GenerateDataKeyPairWithoutPlaintextResponse,
   GenerateDataKeyPairWithoutPlaintextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateDataKeyPairWithoutPlaintextRequest,
   output: GenerateDataKeyPairWithoutPlaintextResponse,
@@ -5266,7 +5265,7 @@ export const generateDataKeyWithoutPlaintext: API.OperationMethod<
   GenerateDataKeyWithoutPlaintextRequest,
   GenerateDataKeyWithoutPlaintextResponse,
   GenerateDataKeyWithoutPlaintextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateDataKeyWithoutPlaintextRequest,
   output: GenerateDataKeyWithoutPlaintextResponse,
@@ -5334,7 +5333,7 @@ export const generateMac: API.OperationMethod<
   GenerateMacRequest,
   GenerateMacResponse,
   GenerateMacError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMacRequest,
   output: GenerateMacResponse,
@@ -5392,7 +5391,7 @@ export const generateRandom: API.OperationMethod<
   GenerateRandomRequest,
   GenerateRandomResponse,
   GenerateRandomError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateRandomRequest,
   output: GenerateRandomResponse,
@@ -5473,7 +5472,7 @@ export const getKeyLastUsage: API.OperationMethod<
   GetKeyLastUsageRequest,
   GetKeyLastUsageResponse,
   GetKeyLastUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyLastUsageRequest,
   output: GetKeyLastUsageResponse,
@@ -5511,7 +5510,7 @@ export const getKeyPolicy: API.OperationMethod<
   GetKeyPolicyRequest,
   GetKeyPolicyResponse,
   GetKeyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyPolicyRequest,
   output: GetKeyPolicyResponse,
@@ -5594,7 +5593,7 @@ export const getKeyRotationStatus: API.OperationMethod<
   GetKeyRotationStatusRequest,
   GetKeyRotationStatusResponse,
   GetKeyRotationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyRotationStatusRequest,
   output: GetKeyRotationStatusResponse,
@@ -5690,7 +5689,7 @@ export const getParametersForImport: API.OperationMethod<
   GetParametersForImportRequest,
   GetParametersForImportResponse,
   GetParametersForImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParametersForImportRequest,
   output: GetParametersForImportResponse,
@@ -5773,7 +5772,7 @@ export const getPublicKey: API.OperationMethod<
   GetPublicKeyRequest,
   GetPublicKeyResponse,
   GetPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicKeyRequest,
   output: GetPublicKeyResponse,
@@ -5926,7 +5925,7 @@ export const importKeyMaterial: API.OperationMethod<
   ImportKeyMaterialRequest,
   ImportKeyMaterialResponse,
   ImportKeyMaterialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportKeyMaterialRequest,
   output: ImportKeyMaterialResponse,
@@ -5995,7 +5994,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesRequest,
   ListAliasesResponse,
   ListAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AliasListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesRequest,
@@ -6070,7 +6069,7 @@ export const listGrants: API.PaginatedOperationMethod<
   ListGrantsRequest,
   ListGrantsResponse,
   ListGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GrantListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGrantsRequest,
@@ -6124,7 +6123,7 @@ export const listKeyPolicies: API.PaginatedOperationMethod<
   ListKeyPoliciesRequest,
   ListKeyPoliciesResponse,
   ListKeyPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyNameType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeyPoliciesRequest,
@@ -6191,7 +6190,7 @@ export const listKeyRotations: API.PaginatedOperationMethod<
   ListKeyRotationsRequest,
   ListKeyRotationsResponse,
   ListKeyRotationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RotationsListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeyRotationsRequest,
@@ -6244,7 +6243,7 @@ export const listKeys: API.PaginatedOperationMethod<
   ListKeysRequest,
   ListKeysResponse,
   ListKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KeyListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeysRequest,
@@ -6300,7 +6299,7 @@ export const listResourceTags: API.PaginatedOperationMethod<
   ListResourceTagsRequest,
   ListResourceTagsResponse,
   ListResourceTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceTagsRequest,
@@ -6380,7 +6379,7 @@ export const listRetirableGrants: API.PaginatedOperationMethod<
   ListRetirableGrantsRequest,
   ListGrantsResponse,
   ListRetirableGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GrantListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRetirableGrantsRequest,
@@ -6436,7 +6435,7 @@ export const putKeyPolicy: API.OperationMethod<
   PutKeyPolicyRequest,
   PutKeyPolicyResponse,
   PutKeyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutKeyPolicyRequest,
   output: PutKeyPolicyResponse,
@@ -6554,7 +6553,7 @@ export const reEncrypt: API.OperationMethod<
   ReEncryptRequest,
   ReEncryptResponse,
   ReEncryptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReEncryptRequest,
   output: ReEncryptResponse,
@@ -6665,7 +6664,7 @@ export const replicateKey: API.OperationMethod<
   ReplicateKeyRequest,
   ReplicateKeyResponse,
   ReplicateKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplicateKeyRequest,
   output: ReplicateKeyResponse,
@@ -6737,7 +6736,7 @@ export const retireGrant: API.OperationMethod<
   RetireGrantRequest,
   RetireGrantResponse,
   RetireGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetireGrantRequest,
   output: RetireGrantResponse,
@@ -6805,7 +6804,7 @@ export const revokeGrant: API.OperationMethod<
   RevokeGrantRequest,
   RevokeGrantResponse,
   RevokeGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeGrantRequest,
   output: RevokeGrantResponse,
@@ -6895,7 +6894,7 @@ export const rotateKeyOnDemand: API.OperationMethod<
   RotateKeyOnDemandRequest,
   RotateKeyOnDemandResponse,
   RotateKeyOnDemandError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateKeyOnDemandRequest,
   output: RotateKeyOnDemandResponse,
@@ -6982,7 +6981,7 @@ export const scheduleKeyDeletion: API.OperationMethod<
   ScheduleKeyDeletionRequest,
   ScheduleKeyDeletionResponse,
   ScheduleKeyDeletionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScheduleKeyDeletionRequest,
   output: ScheduleKeyDeletionResponse,
@@ -7066,7 +7065,7 @@ export const sign: API.OperationMethod<
   SignRequest,
   SignResponse,
   SignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignRequest,
   output: SignResponse,
@@ -7138,7 +7137,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7200,7 +7199,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7278,7 +7277,7 @@ export const updateAlias: API.OperationMethod<
   UpdateAliasRequest,
   UpdateAliasResponse,
   UpdateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAliasRequest,
   output: UpdateAliasResponse,
@@ -7404,7 +7403,7 @@ export const updateCustomKeyStore: API.OperationMethod<
   UpdateCustomKeyStoreRequest,
   UpdateCustomKeyStoreResponse,
   UpdateCustomKeyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomKeyStoreRequest,
   output: UpdateCustomKeyStoreResponse,
@@ -7462,7 +7461,7 @@ export const updateKeyDescription: API.OperationMethod<
   UpdateKeyDescriptionRequest,
   UpdateKeyDescriptionResponse,
   UpdateKeyDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyDescriptionRequest,
   output: UpdateKeyDescriptionResponse,
@@ -7553,7 +7552,7 @@ export const updatePrimaryRegion: API.OperationMethod<
   UpdatePrimaryRegionRequest,
   UpdatePrimaryRegionResponse,
   UpdatePrimaryRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrimaryRegionRequest,
   output: UpdatePrimaryRegionResponse,
@@ -7630,7 +7629,7 @@ export const verify: API.OperationMethod<
   VerifyRequest,
   VerifyResponse,
   VerifyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyRequest,
   output: VerifyResponse,
@@ -7694,7 +7693,7 @@ export const verifyMac: API.OperationMethod<
   VerifyMacRequest,
   VerifyMacResponse,
   VerifyMacError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyMacRequest,
   output: VerifyMacResponse,

--- a/packages/aws/src/services/lakeformation.ts
+++ b/packages/aws/src/services/lakeformation.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "LakeFormation",
@@ -3203,7 +3202,7 @@ export const addLFTagsToResource: API.OperationMethod<
   AddLFTagsToResourceRequest,
   AddLFTagsToResourceResponse,
   AddLFTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddLFTagsToResourceRequest,
   output: AddLFTagsToResourceResponse,
@@ -3249,7 +3248,7 @@ export const assumeDecoratedRoleWithSAML: API.OperationMethod<
   AssumeDecoratedRoleWithSAMLRequest,
   AssumeDecoratedRoleWithSAMLResponse,
   AssumeDecoratedRoleWithSAMLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeDecoratedRoleWithSAMLRequest,
   output: AssumeDecoratedRoleWithSAMLResponse,
@@ -3276,7 +3275,7 @@ export const batchGrantPermissions: API.OperationMethod<
   BatchGrantPermissionsRequest,
   BatchGrantPermissionsResponse,
   BatchGrantPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGrantPermissionsRequest,
   output: BatchGrantPermissionsResponse,
@@ -3297,7 +3296,7 @@ export const batchRevokePermissions: API.OperationMethod<
   BatchRevokePermissionsRequest,
   BatchRevokePermissionsResponse,
   BatchRevokePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchRevokePermissionsRequest,
   output: BatchRevokePermissionsResponse,
@@ -3323,7 +3322,7 @@ export const cancelTransaction: API.OperationMethod<
   CancelTransactionRequest,
   CancelTransactionResponse,
   CancelTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTransactionRequest,
   output: CancelTransactionResponse,
@@ -3356,7 +3355,7 @@ export const commitTransaction: API.OperationMethod<
   CommitTransactionRequest,
   CommitTransactionResponse,
   CommitTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CommitTransactionRequest,
   output: CommitTransactionResponse,
@@ -3389,7 +3388,7 @@ export const createDataCellsFilter: API.OperationMethod<
   CreateDataCellsFilterRequest,
   CreateDataCellsFilterResponse,
   CreateDataCellsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataCellsFilterRequest,
   output: CreateDataCellsFilterResponse,
@@ -3422,7 +3421,7 @@ export const createLakeFormationIdentityCenterConfiguration: API.OperationMethod
   CreateLakeFormationIdentityCenterConfigurationRequest,
   CreateLakeFormationIdentityCenterConfigurationResponse,
   CreateLakeFormationIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLakeFormationIdentityCenterConfigurationRequest,
   output: CreateLakeFormationIdentityCenterConfigurationResponse,
@@ -3456,7 +3455,7 @@ export const createLakeFormationOptIn: API.OperationMethod<
   CreateLakeFormationOptInRequest,
   CreateLakeFormationOptInResponse,
   CreateLakeFormationOptInError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLakeFormationOptInRequest,
   output: CreateLakeFormationOptInResponse,
@@ -3490,7 +3489,7 @@ export const createLFTag: API.OperationMethod<
   CreateLFTagRequest,
   CreateLFTagResponse,
   CreateLFTagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLFTagRequest,
   output: CreateLFTagResponse,
@@ -3530,7 +3529,7 @@ export const createLFTagExpression: API.OperationMethod<
   CreateLFTagExpressionRequest,
   CreateLFTagExpressionResponse,
   CreateLFTagExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLFTagExpressionRequest,
   output: CreateLFTagExpressionResponse,
@@ -3561,7 +3560,7 @@ export const deleteDataCellsFilter: API.OperationMethod<
   DeleteDataCellsFilterRequest,
   DeleteDataCellsFilterResponse,
   DeleteDataCellsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataCellsFilterRequest,
   output: DeleteDataCellsFilterResponse,
@@ -3592,7 +3591,7 @@ export const deleteLakeFormationIdentityCenterConfiguration: API.OperationMethod
   DeleteLakeFormationIdentityCenterConfigurationRequest,
   DeleteLakeFormationIdentityCenterConfigurationResponse,
   DeleteLakeFormationIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLakeFormationIdentityCenterConfigurationRequest,
   output: DeleteLakeFormationIdentityCenterConfigurationResponse,
@@ -3625,7 +3624,7 @@ export const deleteLakeFormationOptIn: API.OperationMethod<
   DeleteLakeFormationOptInRequest,
   DeleteLakeFormationOptInResponse,
   DeleteLakeFormationOptInError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLakeFormationOptInRequest,
   output: DeleteLakeFormationOptInResponse,
@@ -3663,7 +3662,7 @@ export const deleteLFTag: API.OperationMethod<
   DeleteLFTagRequest,
   DeleteLFTagResponse,
   DeleteLFTagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLFTagRequest,
   output: DeleteLFTagResponse,
@@ -3694,7 +3693,7 @@ export const deleteLFTagExpression: API.OperationMethod<
   DeleteLFTagExpressionRequest,
   DeleteLFTagExpressionResponse,
   DeleteLFTagExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLFTagExpressionRequest,
   output: DeleteLFTagExpressionResponse,
@@ -3732,7 +3731,7 @@ export const deleteObjectsOnCancel: API.OperationMethod<
   DeleteObjectsOnCancelRequest,
   DeleteObjectsOnCancelResponse,
   DeleteObjectsOnCancelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectsOnCancelRequest,
   output: DeleteObjectsOnCancelResponse,
@@ -3767,7 +3766,7 @@ export const deregisterResource: API.OperationMethod<
   DeregisterResourceRequest,
   DeregisterResourceResponse,
   DeregisterResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterResourceRequest,
   output: DeregisterResourceResponse,
@@ -3797,7 +3796,7 @@ export const describeLakeFormationIdentityCenterConfiguration: API.OperationMeth
   DescribeLakeFormationIdentityCenterConfigurationRequest,
   DescribeLakeFormationIdentityCenterConfigurationResponse,
   DescribeLakeFormationIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLakeFormationIdentityCenterConfigurationRequest,
   output: DescribeLakeFormationIdentityCenterConfigurationResponse,
@@ -3826,7 +3825,7 @@ export const describeResource: API.OperationMethod<
   DescribeResourceRequest,
   DescribeResourceResponse,
   DescribeResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceRequest,
   output: DescribeResourceResponse,
@@ -3854,7 +3853,7 @@ export const describeTransaction: API.OperationMethod<
   DescribeTransactionRequest,
   DescribeTransactionResponse,
   DescribeTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTransactionRequest,
   output: DescribeTransactionResponse,
@@ -3887,7 +3886,7 @@ export const extendTransaction: API.OperationMethod<
   ExtendTransactionRequest,
   ExtendTransactionResponse,
   ExtendTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExtendTransactionRequest,
   output: ExtendTransactionResponse,
@@ -3919,7 +3918,7 @@ export const getDataCellsFilter: API.OperationMethod<
   GetDataCellsFilterRequest,
   GetDataCellsFilterResponse,
   GetDataCellsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataCellsFilterRequest,
   output: GetDataCellsFilterResponse,
@@ -3947,7 +3946,7 @@ export const getDataLakePrincipal: API.OperationMethod<
   GetDataLakePrincipalRequest,
   GetDataLakePrincipalResponse,
   GetDataLakePrincipalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakePrincipalRequest,
   output: GetDataLakePrincipalResponse,
@@ -3973,7 +3972,7 @@ export const getDataLakeSettings: API.OperationMethod<
   GetDataLakeSettingsRequest,
   GetDataLakeSettingsResponse,
   GetDataLakeSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakeSettingsRequest,
   output: GetDataLakeSettingsResponse,
@@ -4001,7 +4000,7 @@ export const getEffectivePermissionsForPath: API.PaginatedOperationMethod<
   GetEffectivePermissionsForPathRequest,
   GetEffectivePermissionsForPathResponse,
   GetEffectivePermissionsForPathError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEffectivePermissionsForPathRequest,
@@ -4036,7 +4035,7 @@ export const getLFTag: API.OperationMethod<
   GetLFTagRequest,
   GetLFTagResponse,
   GetLFTagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLFTagRequest,
   output: GetLFTagResponse,
@@ -4066,7 +4065,7 @@ export const getLFTagExpression: API.OperationMethod<
   GetLFTagExpressionRequest,
   GetLFTagExpressionResponse,
   GetLFTagExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLFTagExpressionRequest,
   output: GetLFTagExpressionResponse,
@@ -4094,7 +4093,7 @@ export const getQueryState: API.OperationMethod<
   GetQueryStateRequest,
   GetQueryStateResponse,
   GetQueryStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStateRequest,
   output: GetQueryStateResponse,
@@ -4124,7 +4123,7 @@ export const getQueryStatistics: API.OperationMethod<
   GetQueryStatisticsRequest,
   GetQueryStatisticsResponse,
   GetQueryStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStatisticsRequest,
   output: GetQueryStatisticsResponse,
@@ -4157,7 +4156,7 @@ export const getResourceLFTags: API.OperationMethod<
   GetResourceLFTagsRequest,
   GetResourceLFTagsResponse,
   GetResourceLFTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceLFTagsRequest,
   output: GetResourceLFTagsResponse,
@@ -4190,7 +4189,7 @@ export const getTableObjects: API.PaginatedOperationMethod<
   GetTableObjectsRequest,
   GetTableObjectsResponse,
   GetTableObjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTableObjectsRequest,
@@ -4249,7 +4248,7 @@ export const getTemporaryDataLocationCredentials: API.OperationMethod<
   GetTemporaryDataLocationCredentialsRequest,
   GetTemporaryDataLocationCredentialsResponse,
   GetTemporaryDataLocationCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemporaryDataLocationCredentialsRequest,
   output: GetTemporaryDataLocationCredentialsResponse,
@@ -4282,7 +4281,7 @@ export const getTemporaryGluePartitionCredentials: API.OperationMethod<
   GetTemporaryGluePartitionCredentialsRequest,
   GetTemporaryGluePartitionCredentialsResponse,
   GetTemporaryGluePartitionCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemporaryGluePartitionCredentialsRequest,
   output: GetTemporaryGluePartitionCredentialsResponse,
@@ -4316,7 +4315,7 @@ export const getTemporaryGlueTableCredentials: API.OperationMethod<
   GetTemporaryGlueTableCredentialsRequest,
   GetTemporaryGlueTableCredentialsResponse,
   GetTemporaryGlueTableCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemporaryGlueTableCredentialsRequest,
   output: GetTemporaryGlueTableCredentialsResponse,
@@ -4347,7 +4346,7 @@ export const getWorkUnitResults: API.OperationMethod<
   GetWorkUnitResultsRequest,
   GetWorkUnitResultsResponse,
   GetWorkUnitResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkUnitResultsRequest,
   output: GetWorkUnitResultsResponse,
@@ -4378,7 +4377,7 @@ export const getWorkUnits: API.PaginatedOperationMethod<
   GetWorkUnitsRequest,
   GetWorkUnitsResponse,
   GetWorkUnitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkUnitRange
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetWorkUnitsRequest,
@@ -4417,7 +4416,7 @@ export const grantPermissions: API.OperationMethod<
   GrantPermissionsRequest,
   GrantPermissionsResponse,
   GrantPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GrantPermissionsRequest,
   output: GrantPermissionsResponse,
@@ -4445,7 +4444,7 @@ export const listDataCellsFilter: API.PaginatedOperationMethod<
   ListDataCellsFilterRequest,
   ListDataCellsFilterResponse,
   ListDataCellsFilterError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataCellsFilter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataCellsFilterRequest,
@@ -4482,7 +4481,7 @@ export const listLakeFormationOptIns: API.PaginatedOperationMethod<
   ListLakeFormationOptInsRequest,
   ListLakeFormationOptInsResponse,
   ListLakeFormationOptInsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLakeFormationOptInsRequest,
@@ -4519,7 +4518,7 @@ export const listLFTagExpressions: API.PaginatedOperationMethod<
   ListLFTagExpressionsRequest,
   ListLFTagExpressionsResponse,
   ListLFTagExpressionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LFTagExpression
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLFTagExpressionsRequest,
@@ -4556,7 +4555,7 @@ export const listLFTags: API.PaginatedOperationMethod<
   ListLFTagsRequest,
   ListLFTagsResponse,
   ListLFTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LFTagPair
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLFTagsRequest,
@@ -4598,7 +4597,7 @@ export const listPermissions: API.PaginatedOperationMethod<
   ListPermissionsRequest,
   ListPermissionsResponse,
   ListPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionsRequest,
@@ -4631,7 +4630,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesRequest,
   ListResourcesResponse,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesRequest,
@@ -4664,7 +4663,7 @@ export const listTableStorageOptimizers: API.PaginatedOperationMethod<
   ListTableStorageOptimizersRequest,
   ListTableStorageOptimizersResponse,
   ListTableStorageOptimizersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTableStorageOptimizersRequest,
@@ -4699,7 +4698,7 @@ export const listTransactions: API.PaginatedOperationMethod<
   ListTransactionsRequest,
   ListTransactionsResponse,
   ListTransactionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTransactionsRequest,
@@ -4733,7 +4732,7 @@ export const putDataLakeSettings: API.OperationMethod<
   PutDataLakeSettingsRequest,
   PutDataLakeSettingsResponse,
   PutDataLakeSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataLakeSettingsRequest,
   output: PutDataLakeSettingsResponse,
@@ -4774,7 +4773,7 @@ export const registerResource: API.OperationMethod<
   RegisterResourceRequest,
   RegisterResourceResponse,
   RegisterResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterResourceRequest,
   output: RegisterResourceResponse,
@@ -4808,7 +4807,7 @@ export const removeLFTagsFromResource: API.OperationMethod<
   RemoveLFTagsFromResourceRequest,
   RemoveLFTagsFromResourceResponse,
   RemoveLFTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveLFTagsFromResourceRequest,
   output: RemoveLFTagsFromResourceResponse,
@@ -4839,7 +4838,7 @@ export const revokePermissions: API.OperationMethod<
   RevokePermissionsRequest,
   RevokePermissionsResponse,
   RevokePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokePermissionsRequest,
   output: RevokePermissionsResponse,
@@ -4869,7 +4868,7 @@ export const searchDatabasesByLFTags: API.PaginatedOperationMethod<
   SearchDatabasesByLFTagsRequest,
   SearchDatabasesByLFTagsResponse,
   SearchDatabasesByLFTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaggedDatabase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDatabasesByLFTagsRequest,
@@ -4908,7 +4907,7 @@ export const searchTablesByLFTags: API.PaginatedOperationMethod<
   SearchTablesByLFTagsRequest,
   SearchTablesByLFTagsResponse,
   SearchTablesByLFTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaggedTable
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTablesByLFTagsRequest,
@@ -4947,7 +4946,7 @@ export const startQueryPlanning: API.OperationMethod<
   StartQueryPlanningRequest,
   StartQueryPlanningResponse,
   StartQueryPlanningError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryPlanningRequest,
   output: StartQueryPlanningResponse,
@@ -4974,7 +4973,7 @@ export const startTransaction: API.OperationMethod<
   StartTransactionRequest,
   StartTransactionResponse,
   StartTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTransactionRequest,
   output: StartTransactionResponse,
@@ -4999,7 +4998,7 @@ export const updateDataCellsFilter: API.OperationMethod<
   UpdateDataCellsFilterRequest,
   UpdateDataCellsFilterResponse,
   UpdateDataCellsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataCellsFilterRequest,
   output: UpdateDataCellsFilterResponse,
@@ -5031,7 +5030,7 @@ export const updateLakeFormationIdentityCenterConfiguration: API.OperationMethod
   UpdateLakeFormationIdentityCenterConfigurationRequest,
   UpdateLakeFormationIdentityCenterConfigurationResponse,
   UpdateLakeFormationIdentityCenterConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLakeFormationIdentityCenterConfigurationRequest,
   output: UpdateLakeFormationIdentityCenterConfigurationResponse,
@@ -5063,7 +5062,7 @@ export const updateLFTag: API.OperationMethod<
   UpdateLFTagRequest,
   UpdateLFTagResponse,
   UpdateLFTagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLFTagRequest,
   output: UpdateLFTagResponse,
@@ -5096,7 +5095,7 @@ export const updateLFTagExpression: API.OperationMethod<
   UpdateLFTagExpressionRequest,
   UpdateLFTagExpressionResponse,
   UpdateLFTagExpressionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLFTagExpressionRequest,
   output: UpdateLFTagExpressionResponse,
@@ -5126,7 +5125,7 @@ export const updateResource: API.OperationMethod<
   UpdateResourceRequest,
   UpdateResourceResponse,
   UpdateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceRequest,
   output: UpdateResourceResponse,
@@ -5159,7 +5158,7 @@ export const updateTableObjects: API.OperationMethod<
   UpdateTableObjectsRequest,
   UpdateTableObjectsResponse,
   UpdateTableObjectsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableObjectsRequest,
   output: UpdateTableObjectsResponse,
@@ -5192,7 +5191,7 @@ export const updateTableStorageOptimizer: API.OperationMethod<
   UpdateTableStorageOptimizerRequest,
   UpdateTableStorageOptimizerResponse,
   UpdateTableStorageOptimizerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableStorageOptimizerRequest,
   output: UpdateTableStorageOptimizerResponse,

--- a/packages/aws/src/services/lambda-core.ts
+++ b/packages/aws/src/services/lambda-core.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Lambda Core",
   serviceShapeName: "LambdaCoreApiService",
@@ -534,7 +533,7 @@ export const createNetworkConnector: API.OperationMethod<
   CreateNetworkConnectorRequest,
   CreateNetworkConnectorResponse,
   CreateNetworkConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkConnectorRequest,
   output: CreateNetworkConnectorResponse,
@@ -566,7 +565,7 @@ export const deleteNetworkConnector: API.OperationMethod<
   DeleteNetworkConnectorRequest,
   DeleteNetworkConnectorResponse,
   DeleteNetworkConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkConnectorRequest,
   output: DeleteNetworkConnectorResponse,
@@ -597,7 +596,7 @@ export const getNetworkConnector: API.OperationMethod<
   GetNetworkConnectorRequest,
   GetNetworkConnectorResponse,
   GetNetworkConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkConnectorRequest,
   output: GetNetworkConnectorResponse,
@@ -626,7 +625,7 @@ export const listNetworkConnectors: API.PaginatedOperationMethod<
   ListNetworkConnectorsRequest,
   ListNetworkConnectorsResponse,
   ListNetworkConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkConnectorsRequest,
@@ -663,7 +662,7 @@ export const updateNetworkConnector: API.OperationMethod<
   UpdateNetworkConnectorRequest,
   UpdateNetworkConnectorResponse,
   UpdateNetworkConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkConnectorRequest,
   output: UpdateNetworkConnectorResponse,

--- a/packages/aws/src/services/lambda-microvms.ts
+++ b/packages/aws/src/services/lambda-microvms.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lambda Microvms",
@@ -1681,7 +1680,7 @@ export const createMicrovmAuthToken: API.OperationMethod<
   CreateMicrovmAuthTokenRequest,
   CreateMicrovmAuthTokenResponse,
   CreateMicrovmAuthTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMicrovmAuthTokenRequest,
   output: CreateMicrovmAuthTokenResponse,
@@ -1713,7 +1712,7 @@ export const createMicrovmImage: API.OperationMethod<
   CreateMicrovmImageRequest,
   CreateMicrovmImageResponse,
   CreateMicrovmImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMicrovmImageRequest,
   output: CreateMicrovmImageResponse,
@@ -1745,7 +1744,7 @@ export const createMicrovmShellAuthToken: API.OperationMethod<
   CreateMicrovmShellAuthTokenRequest,
   CreateMicrovmShellAuthTokenResponse,
   CreateMicrovmShellAuthTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMicrovmShellAuthTokenRequest,
   output: CreateMicrovmShellAuthTokenResponse,
@@ -1776,7 +1775,7 @@ export const deleteMicrovmImage: API.OperationMethod<
   DeleteMicrovmImageInput,
   DeleteMicrovmImageOutput,
   DeleteMicrovmImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMicrovmImageInput,
   output: DeleteMicrovmImageOutput,
@@ -1808,7 +1807,7 @@ export const deleteMicrovmImageVersion: API.OperationMethod<
   DeleteMicrovmImageVersionInput,
   DeleteMicrovmImageVersionOutput,
   DeleteMicrovmImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMicrovmImageVersionInput,
   output: DeleteMicrovmImageVersionOutput,
@@ -1839,7 +1838,7 @@ export const getMicrovm: API.OperationMethod<
   GetMicrovmRequest,
   GetMicrovmResponse,
   GetMicrovmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMicrovmRequest,
   output: GetMicrovmResponse,
@@ -1869,7 +1868,7 @@ export const getMicrovmImage: API.OperationMethod<
   GetMicrovmImageInput,
   GetMicrovmImageOutput,
   GetMicrovmImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMicrovmImageInput,
   output: GetMicrovmImageOutput,
@@ -1899,7 +1898,7 @@ export const getMicrovmImageBuild: API.OperationMethod<
   GetMicrovmImageBuildInput,
   GetMicrovmImageBuildOutput,
   GetMicrovmImageBuildError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMicrovmImageBuildInput,
   output: GetMicrovmImageBuildOutput,
@@ -1929,7 +1928,7 @@ export const getMicrovmImageVersion: API.OperationMethod<
   GetMicrovmImageVersionInput,
   GetMicrovmImageVersionOutput,
   GetMicrovmImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMicrovmImageVersionInput,
   output: GetMicrovmImageVersionOutput,
@@ -1958,7 +1957,7 @@ export const listManagedMicrovmImages: API.PaginatedOperationMethod<
   ListManagedMicrovmImagesInput,
   ListManagedMicrovmImagesOutput,
   ListManagedMicrovmImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedMicrovmImageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedMicrovmImagesInput,
@@ -1994,7 +1993,7 @@ export const listManagedMicrovmImageVersions: API.PaginatedOperationMethod<
   ListManagedMicrovmImageVersionsInput,
   ListManagedMicrovmImageVersionsOutput,
   ListManagedMicrovmImageVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedMicrovmImageVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedMicrovmImageVersionsInput,
@@ -2031,7 +2030,7 @@ export const listMicrovmImageBuilds: API.PaginatedOperationMethod<
   ListMicrovmImageBuildsInput,
   ListMicrovmImageBuildsOutput,
   ListMicrovmImageBuildsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MicrovmImageBuildSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrovmImageBuildsInput,
@@ -2067,7 +2066,7 @@ export const listMicrovmImages: API.PaginatedOperationMethod<
   ListMicrovmImagesRequest,
   ListMicrovmImagesResponse,
   ListMicrovmImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MicrovmImageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrovmImagesRequest,
@@ -2103,7 +2102,7 @@ export const listMicrovmImageVersions: API.PaginatedOperationMethod<
   ListMicrovmImageVersionsInput,
   ListMicrovmImageVersionsOutput,
   ListMicrovmImageVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MicrovmImageVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrovmImageVersionsInput,
@@ -2140,7 +2139,7 @@ export const listMicrovms: API.PaginatedOperationMethod<
   ListMicrovmsRequest,
   ListMicrovmsResponse,
   ListMicrovmsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MicrovmItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMicrovmsRequest,
@@ -2176,7 +2175,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -2206,7 +2205,7 @@ export const resumeMicrovm: API.OperationMethod<
   ResumeMicrovmRequest,
   ResumeMicrovmResponse,
   ResumeMicrovmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeMicrovmRequest,
   output: ResumeMicrovmResponse,
@@ -2239,7 +2238,7 @@ export const runMicrovm: API.OperationMethod<
   RunMicrovmRequest,
   RunMicrovmResponse,
   RunMicrovmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RunMicrovmRequest,
   output: RunMicrovmResponse,
@@ -2272,7 +2271,7 @@ export const suspendMicrovm: API.OperationMethod<
   SuspendMicrovmRequest,
   SuspendMicrovmResponse,
   SuspendMicrovmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SuspendMicrovmRequest,
   output: SuspendMicrovmResponse,
@@ -2303,7 +2302,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2334,7 +2333,7 @@ export const terminateMicrovm: API.OperationMethod<
   TerminateMicrovmRequest,
   TerminateMicrovmResponse,
   TerminateMicrovmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateMicrovmRequest,
   output: TerminateMicrovmResponse,
@@ -2365,7 +2364,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2397,7 +2396,7 @@ export const updateMicrovmImage: API.OperationMethod<
   UpdateMicrovmImageRequest,
   UpdateMicrovmImageResponse,
   UpdateMicrovmImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMicrovmImageRequest,
   output: UpdateMicrovmImageResponse,
@@ -2430,7 +2429,7 @@ export const updateMicrovmImageVersion: API.OperationMethod<
   UpdateMicrovmImageVersionRequest,
   UpdateMicrovmImageVersionResponse,
   UpdateMicrovmImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMicrovmImageVersionRequest,
   output: UpdateMicrovmImageVersionResponse,

--- a/packages/aws/src/services/lambda.ts
+++ b/packages/aws/src/services/lambda.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lambda",
@@ -6097,7 +6096,7 @@ export const addLayerVersionPermission: API.OperationMethod<
   AddLayerVersionPermissionRequest,
   AddLayerVersionPermissionResponse,
   AddLayerVersionPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddLayerVersionPermissionRequest,
   output: AddLayerVersionPermissionResponse,
@@ -6140,7 +6139,7 @@ export const addPermission: API.OperationMethod<
   AddPermissionRequest,
   AddPermissionResponse,
   AddPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddPermissionRequest,
   output: AddPermissionResponse,
@@ -6175,7 +6174,7 @@ export const checkpointDurableExecution: API.OperationMethod<
   CheckpointDurableExecutionRequest,
   CheckpointDurableExecutionResponse,
   CheckpointDurableExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckpointDurableExecutionRequest,
   output: CheckpointDurableExecutionResponse,
@@ -6208,7 +6207,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasRequest,
   AliasConfiguration,
   CreateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasRequest,
   output: AliasConfiguration,
@@ -6241,7 +6240,7 @@ export const createCapacityProvider: API.OperationMethod<
   CreateCapacityProviderRequest,
   CreateCapacityProviderResponse,
   CreateCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCapacityProviderRequest,
   output: CreateCapacityProviderResponse,
@@ -6268,7 +6267,7 @@ export const createCodeSigningConfig: API.OperationMethod<
   CreateCodeSigningConfigRequest,
   CreateCodeSigningConfigResponse,
   CreateCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeSigningConfigRequest,
   output: CreateCodeSigningConfigResponse,
@@ -6340,7 +6339,7 @@ export const createEventSourceMapping: API.OperationMethod<
   CreateEventSourceMappingRequest,
   EventSourceMappingConfiguration,
   CreateEventSourceMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSourceMappingRequest,
   output: EventSourceMappingConfiguration,
@@ -6393,7 +6392,7 @@ export const createFunction: API.OperationMethod<
   CreateFunctionRequest,
   FunctionConfiguration,
   CreateFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionRequest,
   output: FunctionConfiguration,
@@ -6430,7 +6429,7 @@ export const createFunctionUrlConfig: API.OperationMethod<
   CreateFunctionUrlConfigRequest,
   CreateFunctionUrlConfigResponse,
   CreateFunctionUrlConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFunctionUrlConfigRequest,
   output: CreateFunctionUrlConfigResponse,
@@ -6463,7 +6462,7 @@ export const deleteAlias: API.OperationMethod<
   DeleteAliasRequest,
   DeleteAliasResponse,
   DeleteAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAliasRequest,
   output: DeleteAliasResponse,
@@ -6494,7 +6493,7 @@ export const deleteCapacityProvider: API.OperationMethod<
   DeleteCapacityProviderRequest,
   DeleteCapacityProviderResponse,
   DeleteCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCapacityProviderRequest,
   output: DeleteCapacityProviderResponse,
@@ -6525,7 +6524,7 @@ export const deleteCodeSigningConfig: API.OperationMethod<
   DeleteCodeSigningConfigRequest,
   DeleteCodeSigningConfigResponse,
   DeleteCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCodeSigningConfigRequest,
   output: DeleteCodeSigningConfigResponse,
@@ -6559,7 +6558,7 @@ export const deleteEventSourceMapping: API.OperationMethod<
   DeleteEventSourceMappingRequest,
   EventSourceMappingConfiguration,
   DeleteEventSourceMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSourceMappingRequest,
   output: EventSourceMappingConfiguration,
@@ -6594,7 +6593,7 @@ export const deleteFunction: API.OperationMethod<
   DeleteFunctionRequest,
   DeleteFunctionResponse,
   DeleteFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionRequest,
   output: DeleteFunctionResponse,
@@ -6625,7 +6624,7 @@ export const deleteFunctionCodeSigningConfig: API.OperationMethod<
   DeleteFunctionCodeSigningConfigRequest,
   DeleteFunctionCodeSigningConfigResponse,
   DeleteFunctionCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionCodeSigningConfigRequest,
   output: DeleteFunctionCodeSigningConfigResponse,
@@ -6658,7 +6657,7 @@ export const deleteFunctionConcurrency: API.OperationMethod<
   DeleteFunctionConcurrencyRequest,
   DeleteFunctionConcurrencyResponse,
   DeleteFunctionConcurrencyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionConcurrencyRequest,
   output: DeleteFunctionConcurrencyResponse,
@@ -6694,7 +6693,7 @@ export const deleteFunctionEventInvokeConfig: API.OperationMethod<
   DeleteFunctionEventInvokeConfigRequest,
   DeleteFunctionEventInvokeConfigResponse,
   DeleteFunctionEventInvokeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionEventInvokeConfigRequest,
   output: DeleteFunctionEventInvokeConfigResponse,
@@ -6728,7 +6727,7 @@ export const deleteFunctionUrlConfig: API.OperationMethod<
   DeleteFunctionUrlConfigRequest,
   DeleteFunctionUrlConfigResponse,
   DeleteFunctionUrlConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionUrlConfigRequest,
   output: DeleteFunctionUrlConfigResponse,
@@ -6761,7 +6760,7 @@ export const deleteLayerVersion: API.OperationMethod<
   DeleteLayerVersionRequest,
   DeleteLayerVersionResponse,
   DeleteLayerVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLayerVersionRequest,
   output: DeleteLayerVersionResponse,
@@ -6794,7 +6793,7 @@ export const deleteProvisionedConcurrencyConfig: API.OperationMethod<
   DeleteProvisionedConcurrencyConfigRequest,
   DeleteProvisionedConcurrencyConfigResponse,
   DeleteProvisionedConcurrencyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisionedConcurrencyConfigRequest,
   output: DeleteProvisionedConcurrencyConfigResponse,
@@ -6823,7 +6822,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsResponse,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsResponse,
@@ -6846,7 +6845,7 @@ export const getAlias: API.OperationMethod<
   GetAliasRequest,
   AliasConfiguration,
   GetAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAliasRequest,
   output: AliasConfiguration,
@@ -6874,7 +6873,7 @@ export const getCapacityProvider: API.OperationMethod<
   GetCapacityProviderRequest,
   GetCapacityProviderResponse,
   GetCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityProviderRequest,
   output: GetCapacityProviderResponse,
@@ -6903,7 +6902,7 @@ export const getCodeSigningConfig: API.OperationMethod<
   GetCodeSigningConfigRequest,
   GetCodeSigningConfigResponse,
   GetCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeSigningConfigRequest,
   output: GetCodeSigningConfigResponse,
@@ -6932,7 +6931,7 @@ export const getDurableExecution: API.OperationMethod<
   GetDurableExecutionRequest,
   GetDurableExecutionResponse,
   GetDurableExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDurableExecutionRequest,
   output: GetDurableExecutionResponse,
@@ -6962,7 +6961,7 @@ export const getDurableExecutionHistory: API.PaginatedOperationMethod<
   GetDurableExecutionHistoryRequest,
   GetDurableExecutionHistoryResponse,
   GetDurableExecutionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDurableExecutionHistoryRequest,
@@ -6998,7 +6997,7 @@ export const getDurableExecutionState: API.PaginatedOperationMethod<
   GetDurableExecutionStateRequest,
   GetDurableExecutionStateResponse,
   GetDurableExecutionStateError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Operation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDurableExecutionStateRequest,
@@ -7032,7 +7031,7 @@ export const getEventSourceMapping: API.OperationMethod<
   GetEventSourceMappingRequest,
   EventSourceMappingConfiguration,
   GetEventSourceMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventSourceMappingRequest,
   output: EventSourceMappingConfiguration,
@@ -7060,7 +7059,7 @@ export const getFunction: API.OperationMethod<
   GetFunctionRequest,
   GetFunctionResponse,
   GetFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionRequest,
   output: GetFunctionResponse,
@@ -7089,7 +7088,7 @@ export const getFunctionCodeSigningConfig: API.OperationMethod<
   GetFunctionCodeSigningConfigRequest,
   GetFunctionCodeSigningConfigResponse,
   GetFunctionCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionCodeSigningConfigRequest,
   output: GetFunctionCodeSigningConfigResponse,
@@ -7120,7 +7119,7 @@ export const getFunctionConcurrency: API.OperationMethod<
   GetFunctionConcurrencyRequest,
   GetFunctionConcurrencyResponse,
   GetFunctionConcurrencyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionConcurrencyRequest,
   output: GetFunctionConcurrencyResponse,
@@ -7152,7 +7151,7 @@ export const getFunctionConfiguration: API.OperationMethod<
   GetFunctionConfigurationRequest,
   FunctionConfiguration,
   GetFunctionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionConfigurationRequest,
   output: FunctionConfiguration,
@@ -7184,7 +7183,7 @@ export const getFunctionEventInvokeConfig: API.OperationMethod<
   GetFunctionEventInvokeConfigRequest,
   FunctionEventInvokeConfig,
   GetFunctionEventInvokeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionEventInvokeConfigRequest,
   output: FunctionEventInvokeConfig,
@@ -7216,7 +7215,7 @@ export const getFunctionRecursionConfig: API.OperationMethod<
   GetFunctionRecursionConfigRequest,
   GetFunctionRecursionConfigResponse,
   GetFunctionRecursionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionRecursionConfigRequest,
   output: GetFunctionRecursionConfigResponse,
@@ -7246,7 +7245,7 @@ export const getFunctionScalingConfig: API.OperationMethod<
   GetFunctionScalingConfigRequest,
   GetFunctionScalingConfigResponse,
   GetFunctionScalingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionScalingConfigRequest,
   output: GetFunctionScalingConfigResponse,
@@ -7274,7 +7273,7 @@ export const getFunctionUrlConfig: API.OperationMethod<
   GetFunctionUrlConfigRequest,
   GetFunctionUrlConfigResponse,
   GetFunctionUrlConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionUrlConfigRequest,
   output: GetFunctionUrlConfigResponse,
@@ -7304,7 +7303,7 @@ export const getLayerVersion: API.OperationMethod<
   GetLayerVersionRequest,
   GetLayerVersionResponse,
   GetLayerVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLayerVersionRequest,
   output: GetLayerVersionResponse,
@@ -7334,7 +7333,7 @@ export const getLayerVersionByArn: API.OperationMethod<
   GetLayerVersionByArnRequest,
   GetLayerVersionResponse,
   GetLayerVersionByArnError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLayerVersionByArnRequest,
   output: GetLayerVersionResponse,
@@ -7364,7 +7363,7 @@ export const getLayerVersionPolicy: API.OperationMethod<
   GetLayerVersionPolicyRequest,
   GetLayerVersionPolicyResponse,
   GetLayerVersionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLayerVersionPolicyRequest,
   output: GetLayerVersionPolicyResponse,
@@ -7394,7 +7393,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -7425,7 +7424,7 @@ export const getProvisionedConcurrencyConfig: API.OperationMethod<
   GetProvisionedConcurrencyConfigRequest,
   GetProvisionedConcurrencyConfigResponse,
   GetProvisionedConcurrencyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProvisionedConcurrencyConfigRequest,
   output: GetProvisionedConcurrencyConfigResponse,
@@ -7456,7 +7455,7 @@ export const getRuntimeManagementConfig: API.OperationMethod<
   GetRuntimeManagementConfigRequest,
   GetRuntimeManagementConfigResponse,
   GetRuntimeManagementConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuntimeManagementConfigRequest,
   output: GetRuntimeManagementConfigResponse,
@@ -7539,7 +7538,7 @@ export const invoke: API.OperationMethod<
   InvocationRequest,
   InvocationResponse,
   InvokeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvocationRequest,
   output: InvocationResponse,
@@ -7639,7 +7638,7 @@ export const invokeAsync: API.OperationMethod<
   InvokeAsyncRequest,
   InvokeAsyncResponse,
   InvokeAsyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeAsyncRequest,
   output: InvokeAsyncResponse,
@@ -7727,7 +7726,7 @@ export const invokeWithResponseStream: API.OperationMethod<
   InvokeWithResponseStreamRequest,
   InvokeWithResponseStreamResponse,
   InvokeWithResponseStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeWithResponseStreamRequest,
   output: InvokeWithResponseStreamResponse,
@@ -7788,7 +7787,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesRequest,
   ListAliasesResponse,
   ListAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AliasConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesRequest,
@@ -7822,7 +7821,7 @@ export const listCapacityProviders: API.PaginatedOperationMethod<
   ListCapacityProvidersRequest,
   ListCapacityProvidersResponse,
   ListCapacityProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityProvider
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCapacityProvidersRequest,
@@ -7854,7 +7853,7 @@ export const listCodeSigningConfigs: API.PaginatedOperationMethod<
   ListCodeSigningConfigsRequest,
   ListCodeSigningConfigsResponse,
   ListCodeSigningConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeSigningConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeSigningConfigsRequest,
@@ -7884,7 +7883,7 @@ export const listDurableExecutionsByFunction: API.PaginatedOperationMethod<
   ListDurableExecutionsByFunctionRequest,
   ListDurableExecutionsByFunctionResponse,
   ListDurableExecutionsByFunctionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Execution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDurableExecutionsByFunctionRequest,
@@ -7919,7 +7918,7 @@ export const listEventSourceMappings: API.PaginatedOperationMethod<
   ListEventSourceMappingsRequest,
   ListEventSourceMappingsResponse,
   ListEventSourceMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSourceMappingConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventSourceMappingsRequest,
@@ -7958,7 +7957,7 @@ export const listFunctionEventInvokeConfigs: API.PaginatedOperationMethod<
   ListFunctionEventInvokeConfigsRequest,
   ListFunctionEventInvokeConfigsResponse,
   ListFunctionEventInvokeConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionEventInvokeConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionEventInvokeConfigsRequest,
@@ -7998,7 +7997,7 @@ export const listFunctions: API.PaginatedOperationMethod<
   ListFunctionsRequest,
   ListFunctionsResponse,
   ListFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionsRequest,
@@ -8031,7 +8030,7 @@ export const listFunctionsByCodeSigningConfig: API.PaginatedOperationMethod<
   ListFunctionsByCodeSigningConfigRequest,
   ListFunctionsByCodeSigningConfigResponse,
   ListFunctionsByCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionsByCodeSigningConfigRequest,
@@ -8065,7 +8064,7 @@ export const listFunctionUrlConfigs: API.PaginatedOperationMethod<
   ListFunctionUrlConfigsRequest,
   ListFunctionUrlConfigsResponse,
   ListFunctionUrlConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionUrlConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionUrlConfigsRequest,
@@ -8100,7 +8099,7 @@ export const listFunctionVersionsByCapacityProvider: API.PaginatedOperationMetho
   ListFunctionVersionsByCapacityProviderRequest,
   ListFunctionVersionsByCapacityProviderResponse,
   ListFunctionVersionsByCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionVersionsByCapacityProviderListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionVersionsByCapacityProviderRequest,
@@ -8134,7 +8133,7 @@ export const listLayers: API.PaginatedOperationMethod<
   ListLayersRequest,
   ListLayersResponse,
   ListLayersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LayersListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLayersRequest,
@@ -8170,7 +8169,7 @@ export const listLayerVersions: API.PaginatedOperationMethod<
   ListLayerVersionsRequest,
   ListLayerVersionsResponse,
   ListLayerVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LayerVersionsListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLayerVersionsRequest,
@@ -8209,7 +8208,7 @@ export const listProvisionedConcurrencyConfigs: API.PaginatedOperationMethod<
   ListProvisionedConcurrencyConfigsRequest,
   ListProvisionedConcurrencyConfigsResponse,
   ListProvisionedConcurrencyConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedConcurrencyConfigListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisionedConcurrencyConfigsRequest,
@@ -8248,7 +8247,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -8278,7 +8277,7 @@ export const listVersionsByFunction: API.PaginatedOperationMethod<
   ListVersionsByFunctionRequest,
   ListVersionsByFunctionResponse,
   ListVersionsByFunctionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FunctionConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVersionsByFunctionRequest,
@@ -8318,7 +8317,7 @@ export const publishLayerVersion: API.OperationMethod<
   PublishLayerVersionRequest,
   PublishLayerVersionResponse,
   PublishLayerVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishLayerVersionRequest,
   output: PublishLayerVersionResponse,
@@ -8359,7 +8358,7 @@ export const publishVersion: API.OperationMethod<
   PublishVersionRequest,
   FunctionConfiguration,
   PublishVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishVersionRequest,
   output: FunctionConfiguration,
@@ -8397,7 +8396,7 @@ export const putFunctionCodeSigningConfig: API.OperationMethod<
   PutFunctionCodeSigningConfigRequest,
   PutFunctionCodeSigningConfigResponse,
   PutFunctionCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionCodeSigningConfigRequest,
   output: PutFunctionCodeSigningConfigResponse,
@@ -8436,7 +8435,7 @@ export const putFunctionConcurrency: API.OperationMethod<
   PutFunctionConcurrencyRequest,
   Concurrency,
   PutFunctionConcurrencyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionConcurrencyRequest,
   output: Concurrency,
@@ -8476,7 +8475,7 @@ export const putFunctionEventInvokeConfig: API.OperationMethod<
   PutFunctionEventInvokeConfigRequest,
   FunctionEventInvokeConfig,
   PutFunctionEventInvokeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionEventInvokeConfigRequest,
   output: FunctionEventInvokeConfig,
@@ -8514,7 +8513,7 @@ export const putFunctionRecursionConfig: API.OperationMethod<
   PutFunctionRecursionConfigRequest,
   PutFunctionRecursionConfigResponse,
   PutFunctionRecursionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionRecursionConfigRequest,
   output: PutFunctionRecursionConfigResponse,
@@ -8546,7 +8545,7 @@ export const putFunctionScalingConfig: API.OperationMethod<
   PutFunctionScalingConfigRequest,
   PutFunctionScalingConfigResponse,
   PutFunctionScalingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionScalingConfigRequest,
   output: PutFunctionScalingConfigResponse,
@@ -8578,7 +8577,7 @@ export const putProvisionedConcurrencyConfig: API.OperationMethod<
   PutProvisionedConcurrencyConfigRequest,
   PutProvisionedConcurrencyConfigResponse,
   PutProvisionedConcurrencyConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProvisionedConcurrencyConfigRequest,
   output: PutProvisionedConcurrencyConfigResponse,
@@ -8610,7 +8609,7 @@ export const putRuntimeManagementConfig: API.OperationMethod<
   PutRuntimeManagementConfigRequest,
   PutRuntimeManagementConfigResponse,
   PutRuntimeManagementConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRuntimeManagementConfigRequest,
   output: PutRuntimeManagementConfigResponse,
@@ -8642,7 +8641,7 @@ export const removeLayerVersionPermission: API.OperationMethod<
   RemoveLayerVersionPermissionRequest,
   RemoveLayerVersionPermissionResponse,
   RemoveLayerVersionPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveLayerVersionPermissionRequest,
   output: RemoveLayerVersionPermissionResponse,
@@ -8675,7 +8674,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionRequest,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionRequest,
   output: RemovePermissionResponse,
@@ -8706,7 +8705,7 @@ export const sendDurableExecutionCallbackFailure: API.OperationMethod<
   SendDurableExecutionCallbackFailureRequest,
   SendDurableExecutionCallbackFailureResponse,
   SendDurableExecutionCallbackFailureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDurableExecutionCallbackFailureRequest,
   output: SendDurableExecutionCallbackFailureResponse,
@@ -8736,7 +8735,7 @@ export const sendDurableExecutionCallbackHeartbeat: API.OperationMethod<
   SendDurableExecutionCallbackHeartbeatRequest,
   SendDurableExecutionCallbackHeartbeatResponse,
   SendDurableExecutionCallbackHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDurableExecutionCallbackHeartbeatRequest,
   output: SendDurableExecutionCallbackHeartbeatResponse,
@@ -8766,7 +8765,7 @@ export const sendDurableExecutionCallbackSuccess: API.OperationMethod<
   SendDurableExecutionCallbackSuccessRequest,
   SendDurableExecutionCallbackSuccessResponse,
   SendDurableExecutionCallbackSuccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDurableExecutionCallbackSuccessRequest,
   output: SendDurableExecutionCallbackSuccessResponse,
@@ -8795,7 +8794,7 @@ export const stopDurableExecution: API.OperationMethod<
   StopDurableExecutionRequest,
   StopDurableExecutionResponse,
   StopDurableExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDurableExecutionRequest,
   output: StopDurableExecutionResponse,
@@ -8826,7 +8825,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8860,7 +8859,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8895,7 +8894,7 @@ export const updateAlias: API.OperationMethod<
   UpdateAliasRequest,
   AliasConfiguration,
   UpdateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAliasRequest,
   output: AliasConfiguration,
@@ -8928,7 +8927,7 @@ export const updateCapacityProvider: API.OperationMethod<
   UpdateCapacityProviderRequest,
   UpdateCapacityProviderResponse,
   UpdateCapacityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCapacityProviderRequest,
   output: UpdateCapacityProviderResponse,
@@ -8956,7 +8955,7 @@ export const updateCodeSigningConfig: API.OperationMethod<
   UpdateCodeSigningConfigRequest,
   UpdateCodeSigningConfigResponse,
   UpdateCodeSigningConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCodeSigningConfigRequest,
   output: UpdateCodeSigningConfigResponse,
@@ -9033,7 +9032,7 @@ export const updateEventSourceMapping: API.OperationMethod<
   UpdateEventSourceMappingRequest,
   EventSourceMappingConfiguration,
   UpdateEventSourceMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventSourceMappingRequest,
   output: EventSourceMappingConfiguration,
@@ -9083,7 +9082,7 @@ export const updateFunctionCode: API.OperationMethod<
   UpdateFunctionCodeRequest,
   FunctionConfiguration,
   UpdateFunctionCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionCodeRequest,
   output: FunctionConfiguration,
@@ -9132,7 +9131,7 @@ export const updateFunctionConfiguration: API.OperationMethod<
   UpdateFunctionConfigurationRequest,
   FunctionConfiguration,
   UpdateFunctionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionConfigurationRequest,
   output: FunctionConfiguration,
@@ -9170,7 +9169,7 @@ export const updateFunctionEventInvokeConfig: API.OperationMethod<
   UpdateFunctionEventInvokeConfigRequest,
   FunctionEventInvokeConfig,
   UpdateFunctionEventInvokeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionEventInvokeConfigRequest,
   output: FunctionEventInvokeConfig,
@@ -9202,7 +9201,7 @@ export const updateFunctionUrlConfig: API.OperationMethod<
   UpdateFunctionUrlConfigRequest,
   UpdateFunctionUrlConfigResponse,
   UpdateFunctionUrlConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFunctionUrlConfigRequest,
   output: UpdateFunctionUrlConfigResponse,

--- a/packages/aws/src/services/launch-wizard.ts
+++ b/packages/aws/src/services/launch-wizard.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Launch Wizard",
   serviceShapeName: "LaunchWizard",
@@ -949,7 +948,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentInput,
   CreateDeploymentOutput,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentInput,
   output: CreateDeploymentOutput,
@@ -977,7 +976,7 @@ export const deleteDeployment: API.OperationMethod<
   DeleteDeploymentInput,
   DeleteDeploymentOutput,
   DeleteDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentInput,
   output: DeleteDeploymentOutput,
@@ -1004,7 +1003,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentInput,
   GetDeploymentOutput,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentInput,
   output: GetDeploymentOutput,
@@ -1029,7 +1028,7 @@ export const getDeploymentPatternVersion: API.OperationMethod<
   GetDeploymentPatternVersionInput,
   GetDeploymentPatternVersionOutput,
   GetDeploymentPatternVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentPatternVersionInput,
   output: GetDeploymentPatternVersionOutput,
@@ -1051,7 +1050,7 @@ export const getWorkload: API.OperationMethod<
   GetWorkloadInput,
   GetWorkloadOutput,
   GetWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadInput,
   output: GetWorkloadOutput,
@@ -1077,7 +1076,7 @@ export const getWorkloadDeploymentPattern: API.OperationMethod<
   GetWorkloadDeploymentPatternInput,
   GetWorkloadDeploymentPatternOutput,
   GetWorkloadDeploymentPatternError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadDeploymentPatternInput,
   output: GetWorkloadDeploymentPatternOutput,
@@ -1103,7 +1102,7 @@ export const listDeploymentEvents: API.PaginatedOperationMethod<
   ListDeploymentEventsInput,
   ListDeploymentEventsOutput,
   ListDeploymentEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentEventDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentEventsInput,
@@ -1136,7 +1135,7 @@ export const listDeploymentPatternVersions: API.PaginatedOperationMethod<
   ListDeploymentPatternVersionsInput,
   ListDeploymentPatternVersionsOutput,
   ListDeploymentPatternVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentPatternVersionDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentPatternVersionsInput,
@@ -1168,7 +1167,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsInput,
   ListDeploymentsOutput,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsInput,
@@ -1197,7 +1196,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1223,7 +1222,7 @@ export const listWorkloadDeploymentPatterns: API.PaginatedOperationMethod<
   ListWorkloadDeploymentPatternsInput,
   ListWorkloadDeploymentPatternsOutput,
   ListWorkloadDeploymentPatternsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadDeploymentPatternDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadDeploymentPatternsInput,
@@ -1255,7 +1254,7 @@ export const listWorkloads: API.PaginatedOperationMethod<
   ListWorkloadsInput,
   ListWorkloadsOutput,
   ListWorkloadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadDataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadsInput,
@@ -1284,7 +1283,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1310,7 +1309,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1337,7 +1336,7 @@ export const updateDeployment: API.OperationMethod<
   UpdateDeploymentInput,
   UpdateDeploymentOutput,
   UpdateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeploymentInput,
   output: UpdateDeploymentOutput,

--- a/packages/aws/src/services/lex-model-building-service.ts
+++ b/packages/aws/src/services/lex-model-building-service.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Lex Model Building Service",
   serviceShapeName: "AWSDeepSenseModelBuildingService",
@@ -2705,7 +2704,7 @@ export const createBotVersion: API.OperationMethod<
   CreateBotVersionRequest,
   CreateBotVersionResponse,
   CreateBotVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotVersionRequest,
   output: CreateBotVersionResponse,
@@ -2751,7 +2750,7 @@ export const createIntentVersion: API.OperationMethod<
   CreateIntentVersionRequest,
   CreateIntentVersionResponse,
   CreateIntentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntentVersionRequest,
   output: CreateIntentVersionResponse,
@@ -2797,7 +2796,7 @@ export const createSlotTypeVersion: API.OperationMethod<
   CreateSlotTypeVersionRequest,
   CreateSlotTypeVersionResponse,
   CreateSlotTypeVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSlotTypeVersionRequest,
   output: CreateSlotTypeVersionResponse,
@@ -2847,7 +2846,7 @@ export const deleteBot: API.OperationMethod<
   DeleteBotRequest,
   DeleteBotResponse,
   DeleteBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotRequest,
   output: DeleteBotResponse,
@@ -2888,7 +2887,7 @@ export const deleteBotAlias: API.OperationMethod<
   DeleteBotAliasRequest,
   DeleteBotAliasResponse,
   DeleteBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotAliasRequest,
   output: DeleteBotAliasResponse,
@@ -2923,7 +2922,7 @@ export const deleteBotChannelAssociation: API.OperationMethod<
   DeleteBotChannelAssociationRequest,
   DeleteBotChannelAssociationResponse,
   DeleteBotChannelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotChannelAssociationRequest,
   output: DeleteBotChannelAssociationResponse,
@@ -2958,7 +2957,7 @@ export const deleteBotVersion: API.OperationMethod<
   DeleteBotVersionRequest,
   DeleteBotVersionResponse,
   DeleteBotVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotVersionRequest,
   output: DeleteBotVersionResponse,
@@ -3007,7 +3006,7 @@ export const deleteIntent: API.OperationMethod<
   DeleteIntentRequest,
   DeleteIntentResponse,
   DeleteIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntentRequest,
   output: DeleteIntentResponse,
@@ -3043,7 +3042,7 @@ export const deleteIntentVersion: API.OperationMethod<
   DeleteIntentVersionRequest,
   DeleteIntentVersionResponse,
   DeleteIntentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntentVersionRequest,
   output: DeleteIntentVersionResponse,
@@ -3092,7 +3091,7 @@ export const deleteSlotType: API.OperationMethod<
   DeleteSlotTypeRequest,
   DeleteSlotTypeResponse,
   DeleteSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlotTypeRequest,
   output: DeleteSlotTypeResponse,
@@ -3128,7 +3127,7 @@ export const deleteSlotTypeVersion: API.OperationMethod<
   DeleteSlotTypeVersionRequest,
   DeleteSlotTypeVersionResponse,
   DeleteSlotTypeVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlotTypeVersionRequest,
   output: DeleteSlotTypeVersionResponse,
@@ -3172,7 +3171,7 @@ export const deleteUtterances: API.OperationMethod<
   DeleteUtterancesRequest,
   DeleteUtterancesResponse,
   DeleteUtterancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUtterancesRequest,
   output: DeleteUtterancesResponse,
@@ -3204,7 +3203,7 @@ export const getBot: API.OperationMethod<
   GetBotRequest,
   GetBotResponse,
   GetBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotRequest,
   output: GetBotResponse,
@@ -3236,7 +3235,7 @@ export const getBotAlias: API.OperationMethod<
   GetBotAliasRequest,
   GetBotAliasResponse,
   GetBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotAliasRequest,
   output: GetBotAliasResponse,
@@ -3266,7 +3265,7 @@ export const getBotAliases: API.PaginatedOperationMethod<
   GetBotAliasesRequest,
   GetBotAliasesResponse,
   GetBotAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBotAliasesRequest,
@@ -3303,7 +3302,7 @@ export const getBotChannelAssociation: API.OperationMethod<
   GetBotChannelAssociationRequest,
   GetBotChannelAssociationResponse,
   GetBotChannelAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotChannelAssociationRequest,
   output: GetBotChannelAssociationResponse,
@@ -3335,7 +3334,7 @@ export const getBotChannelAssociations: API.PaginatedOperationMethod<
   GetBotChannelAssociationsRequest,
   GetBotChannelAssociationsResponse,
   GetBotChannelAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBotChannelAssociationsRequest,
@@ -3379,7 +3378,7 @@ export const getBots: API.PaginatedOperationMethod<
   GetBotsRequest,
   GetBotsResponse,
   GetBotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBotsRequest,
@@ -3426,7 +3425,7 @@ export const getBotVersions: API.PaginatedOperationMethod<
   GetBotVersionsRequest,
   GetBotVersionsResponse,
   GetBotVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBotVersionsRequest,
@@ -3463,7 +3462,7 @@ export const getBuiltinIntent: API.OperationMethod<
   GetBuiltinIntentRequest,
   GetBuiltinIntentResponse,
   GetBuiltinIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBuiltinIntentRequest,
   output: GetBuiltinIntentResponse,
@@ -3494,7 +3493,7 @@ export const getBuiltinIntents: API.PaginatedOperationMethod<
   GetBuiltinIntentsRequest,
   GetBuiltinIntentsResponse,
   GetBuiltinIntentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBuiltinIntentsRequest,
@@ -3533,7 +3532,7 @@ export const getBuiltinSlotTypes: API.PaginatedOperationMethod<
   GetBuiltinSlotTypesRequest,
   GetBuiltinSlotTypesResponse,
   GetBuiltinSlotTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetBuiltinSlotTypesRequest,
@@ -3566,7 +3565,7 @@ export const getExport: API.OperationMethod<
   GetExportRequest,
   GetExportResponse,
   GetExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportRequest,
   output: GetExportResponse,
@@ -3595,7 +3594,7 @@ export const getImport: API.OperationMethod<
   GetImportRequest,
   GetImportResponse,
   GetImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportRequest,
   output: GetImportResponse,
@@ -3627,7 +3626,7 @@ export const getIntent: API.OperationMethod<
   GetIntentRequest,
   GetIntentResponse,
   GetIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntentRequest,
   output: GetIntentResponse,
@@ -3666,7 +3665,7 @@ export const getIntents: API.PaginatedOperationMethod<
   GetIntentsRequest,
   GetIntentsResponse,
   GetIntentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIntentsRequest,
@@ -3713,7 +3712,7 @@ export const getIntentVersions: API.PaginatedOperationMethod<
   GetIntentVersionsRequest,
   GetIntentVersionsResponse,
   GetIntentVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetIntentVersionsRequest,
@@ -3749,7 +3748,7 @@ export const getMigration: API.OperationMethod<
   GetMigrationRequest,
   GetMigrationResponse,
   GetMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMigrationRequest,
   output: GetMigrationResponse,
@@ -3776,7 +3775,7 @@ export const getMigrations: API.PaginatedOperationMethod<
   GetMigrationsRequest,
   GetMigrationsResponse,
   GetMigrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetMigrationsRequest,
@@ -3814,7 +3813,7 @@ export const getSlotType: API.OperationMethod<
   GetSlotTypeRequest,
   GetSlotTypeResponse,
   GetSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSlotTypeRequest,
   output: GetSlotTypeResponse,
@@ -3853,7 +3852,7 @@ export const getSlotTypes: API.PaginatedOperationMethod<
   GetSlotTypesRequest,
   GetSlotTypesResponse,
   GetSlotTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSlotTypesRequest,
@@ -3900,7 +3899,7 @@ export const getSlotTypeVersions: API.PaginatedOperationMethod<
   GetSlotTypeVersionsRequest,
   GetSlotTypeVersionsResponse,
   GetSlotTypeVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSlotTypeVersionsRequest,
@@ -3961,7 +3960,7 @@ export const getUtterancesView: API.OperationMethod<
   GetUtterancesViewRequest,
   GetUtterancesViewResponse,
   GetUtterancesViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUtterancesViewRequest,
   output: GetUtterancesViewResponse,
@@ -3989,7 +3988,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4036,7 +4035,7 @@ export const putBot: API.OperationMethod<
   PutBotRequest,
   PutBotResponse,
   PutBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBotRequest,
   output: PutBotResponse,
@@ -4072,7 +4071,7 @@ export const putBotAlias: API.OperationMethod<
   PutBotAliasRequest,
   PutBotAliasResponse,
   PutBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBotAliasRequest,
   output: PutBotAliasResponse,
@@ -4153,7 +4152,7 @@ export const putIntent: API.OperationMethod<
   PutIntentRequest,
   PutIntentResponse,
   PutIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIntentRequest,
   output: PutIntentResponse,
@@ -4200,7 +4199,7 @@ export const putSlotType: API.OperationMethod<
   PutSlotTypeRequest,
   PutSlotTypeResponse,
   PutSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSlotTypeRequest,
   output: PutSlotTypeResponse,
@@ -4228,7 +4227,7 @@ export const startImport: API.OperationMethod<
   StartImportRequest,
   StartImportResponse,
   StartImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportRequest,
   output: StartImportResponse,
@@ -4260,7 +4259,7 @@ export const startMigration: API.OperationMethod<
   StartMigrationRequest,
   StartMigrationResponse,
   StartMigrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMigrationRequest,
   output: StartMigrationResponse,
@@ -4291,7 +4290,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4321,7 +4320,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/lex-models-v2.ts
+++ b/packages/aws/src/services/lex-models-v2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lex Models V2",
@@ -10190,7 +10189,7 @@ export const batchCreateCustomVocabularyItem: API.OperationMethod<
   BatchCreateCustomVocabularyItemRequest,
   BatchCreateCustomVocabularyItemResponse,
   BatchCreateCustomVocabularyItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateCustomVocabularyItemRequest,
   output: BatchCreateCustomVocabularyItemResponse,
@@ -10221,7 +10220,7 @@ export const batchDeleteCustomVocabularyItem: API.OperationMethod<
   BatchDeleteCustomVocabularyItemRequest,
   BatchDeleteCustomVocabularyItemResponse,
   BatchDeleteCustomVocabularyItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteCustomVocabularyItemRequest,
   output: BatchDeleteCustomVocabularyItemResponse,
@@ -10252,7 +10251,7 @@ export const batchUpdateCustomVocabularyItem: API.OperationMethod<
   BatchUpdateCustomVocabularyItemRequest,
   BatchUpdateCustomVocabularyItemResponse,
   BatchUpdateCustomVocabularyItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateCustomVocabularyItemRequest,
   output: BatchUpdateCustomVocabularyItemResponse,
@@ -10285,7 +10284,7 @@ export const buildBotLocale: API.OperationMethod<
   BuildBotLocaleRequest,
   BuildBotLocaleResponse,
   BuildBotLocaleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BuildBotLocaleRequest,
   output: BuildBotLocaleResponse,
@@ -10317,7 +10316,7 @@ export const createBot: API.OperationMethod<
   CreateBotRequest,
   CreateBotResponse,
   CreateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotRequest,
   output: CreateBotResponse,
@@ -10354,7 +10353,7 @@ export const createBotAlias: API.OperationMethod<
   CreateBotAliasRequest,
   CreateBotAliasResponse,
   CreateBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotAliasRequest,
   output: CreateBotAliasResponse,
@@ -10389,7 +10388,7 @@ export const createBotLocale: API.OperationMethod<
   CreateBotLocaleRequest,
   CreateBotLocaleResponse,
   CreateBotLocaleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotLocaleRequest,
   output: CreateBotLocaleResponse,
@@ -10421,7 +10420,7 @@ export const createBotReplica: API.OperationMethod<
   CreateBotReplicaRequest,
   CreateBotReplicaResponse,
   CreateBotReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotReplicaRequest,
   output: CreateBotReplicaResponse,
@@ -10457,7 +10456,7 @@ export const createBotVersion: API.OperationMethod<
   CreateBotVersionRequest,
   CreateBotVersionResponse,
   CreateBotVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotVersionRequest,
   output: CreateBotVersionResponse,
@@ -10499,7 +10498,7 @@ export const createExport: API.OperationMethod<
   CreateExportRequest,
   CreateExportResponse,
   CreateExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportRequest,
   output: CreateExportResponse,
@@ -10562,7 +10561,7 @@ export const createIntent: API.OperationMethod<
   CreateIntentRequest,
   CreateIntentResponse,
   CreateIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntentRequest,
   output: CreateIntentResponse,
@@ -10595,7 +10594,7 @@ export const createResourcePolicy: API.OperationMethod<
   CreateResourcePolicyRequest,
   CreateResourcePolicyResponse,
   CreateResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourcePolicyRequest,
   output: CreateResourcePolicyResponse,
@@ -10636,7 +10635,7 @@ export const createResourcePolicyStatement: API.OperationMethod<
   CreateResourcePolicyStatementRequest,
   CreateResourcePolicyStatementResponse,
   CreateResourcePolicyStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourcePolicyStatementRequest,
   output: CreateResourcePolicyStatementResponse,
@@ -10673,7 +10672,7 @@ export const createSlot: API.OperationMethod<
   CreateSlotRequest,
   CreateSlotResponse,
   CreateSlotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSlotRequest,
   output: CreateSlotResponse,
@@ -10709,7 +10708,7 @@ export const createSlotType: API.OperationMethod<
   CreateSlotTypeRequest,
   CreateSlotTypeResponse,
   CreateSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSlotTypeRequest,
   output: CreateSlotTypeResponse,
@@ -10741,7 +10740,7 @@ export const createTestSetDiscrepancyReport: API.OperationMethod<
   CreateTestSetDiscrepancyReportRequest,
   CreateTestSetDiscrepancyReportResponse,
   CreateTestSetDiscrepancyReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTestSetDiscrepancyReportRequest,
   output: CreateTestSetDiscrepancyReportResponse,
@@ -10773,7 +10772,7 @@ export const createUploadUrl: API.OperationMethod<
   CreateUploadUrlRequest,
   CreateUploadUrlResponse,
   CreateUploadUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUploadUrlRequest,
   output: CreateUploadUrlResponse,
@@ -10815,7 +10814,7 @@ export const deleteBot: API.OperationMethod<
   DeleteBotRequest,
   DeleteBotResponse,
   DeleteBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotRequest,
   output: DeleteBotResponse,
@@ -10847,7 +10846,7 @@ export const deleteBotAlias: API.OperationMethod<
   DeleteBotAliasRequest,
   DeleteBotAliasResponse,
   DeleteBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotAliasRequest,
   output: DeleteBotAliasResponse,
@@ -10879,7 +10878,7 @@ export const deleteBotAnalyzerRecommendation: API.OperationMethod<
   DeleteBotAnalyzerRecommendationRequest,
   DeleteBotAnalyzerRecommendationResponse,
   DeleteBotAnalyzerRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotAnalyzerRecommendationRequest,
   output: DeleteBotAnalyzerRecommendationResponse,
@@ -10912,7 +10911,7 @@ export const deleteBotLocale: API.OperationMethod<
   DeleteBotLocaleRequest,
   DeleteBotLocaleResponse,
   DeleteBotLocaleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotLocaleRequest,
   output: DeleteBotLocaleResponse,
@@ -10944,7 +10943,7 @@ export const deleteBotReplica: API.OperationMethod<
   DeleteBotReplicaRequest,
   DeleteBotReplicaResponse,
   DeleteBotReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotReplicaRequest,
   output: DeleteBotReplicaResponse,
@@ -10977,7 +10976,7 @@ export const deleteBotVersion: API.OperationMethod<
   DeleteBotVersionRequest,
   DeleteBotVersionResponse,
   DeleteBotVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotVersionRequest,
   output: DeleteBotVersionResponse,
@@ -11010,7 +11009,7 @@ export const deleteCustomVocabulary: API.OperationMethod<
   DeleteCustomVocabularyRequest,
   DeleteCustomVocabularyResponse,
   DeleteCustomVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomVocabularyRequest,
   output: DeleteCustomVocabularyResponse,
@@ -11042,7 +11041,7 @@ export const deleteExport: API.OperationMethod<
   DeleteExportRequest,
   DeleteExportResponse,
   DeleteExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExportRequest,
   output: DeleteExportResponse,
@@ -11073,7 +11072,7 @@ export const deleteImport: API.OperationMethod<
   DeleteImportRequest,
   DeleteImportResponse,
   DeleteImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImportRequest,
   output: DeleteImportResponse,
@@ -11107,7 +11106,7 @@ export const deleteIntent: API.OperationMethod<
   DeleteIntentRequest,
   DeleteIntentResponse,
   DeleteIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntentRequest,
   output: DeleteIntentResponse,
@@ -11138,7 +11137,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -11173,7 +11172,7 @@ export const deleteResourcePolicyStatement: API.OperationMethod<
   DeleteResourcePolicyStatementRequest,
   DeleteResourcePolicyStatementResponse,
   DeleteResourcePolicyStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyStatementRequest,
   output: DeleteResourcePolicyStatementResponse,
@@ -11203,7 +11202,7 @@ export const deleteSlot: API.OperationMethod<
   DeleteSlotRequest,
   DeleteSlotResponse,
   DeleteSlotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlotRequest,
   output: DeleteSlotResponse,
@@ -11240,7 +11239,7 @@ export const deleteSlotType: API.OperationMethod<
   DeleteSlotTypeRequest,
   DeleteSlotTypeResponse,
   DeleteSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlotTypeRequest,
   output: DeleteSlotTypeResponse,
@@ -11272,7 +11271,7 @@ export const deleteTestSet: API.OperationMethod<
   DeleteTestSetRequest,
   DeleteTestSetResponse,
   DeleteTestSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTestSetRequest,
   output: DeleteTestSetResponse,
@@ -11314,7 +11313,7 @@ export const deleteUtterances: API.OperationMethod<
   DeleteUtterancesRequest,
   DeleteUtterancesResponse,
   DeleteUtterancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUtterancesRequest,
   output: DeleteUtterancesResponse,
@@ -11338,7 +11337,7 @@ export const describeBot: API.OperationMethod<
   DescribeBotRequest,
   DescribeBotResponse,
   DescribeBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotRequest,
   output: DescribeBotResponse,
@@ -11368,7 +11367,7 @@ export const describeBotAlias: API.OperationMethod<
   DescribeBotAliasRequest,
   DescribeBotAliasResponse,
   DescribeBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotAliasRequest,
   output: DescribeBotAliasResponse,
@@ -11399,7 +11398,7 @@ export const describeBotAnalyzerRecommendation: API.PaginatedOperationMethod<
   DescribeBotAnalyzerRecommendationRequest,
   DescribeBotAnalyzerRecommendationResponse,
   DescribeBotAnalyzerRecommendationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BotAnalyzerRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBotAnalyzerRecommendationRequest,
@@ -11435,7 +11434,7 @@ export const describeBotLocale: API.OperationMethod<
   DescribeBotLocaleRequest,
   DescribeBotLocaleResponse,
   DescribeBotLocaleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotLocaleRequest,
   output: DescribeBotLocaleResponse,
@@ -11468,7 +11467,7 @@ export const describeBotRecommendation: API.OperationMethod<
   DescribeBotRecommendationRequest,
   DescribeBotRecommendationResponse,
   DescribeBotRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotRecommendationRequest,
   output: DescribeBotRecommendationResponse,
@@ -11497,7 +11496,7 @@ export const describeBotReplica: API.OperationMethod<
   DescribeBotReplicaRequest,
   DescribeBotReplicaResponse,
   DescribeBotReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotReplicaRequest,
   output: DescribeBotReplicaResponse,
@@ -11529,7 +11528,7 @@ export const describeBotResourceGeneration: API.OperationMethod<
   DescribeBotResourceGenerationRequest,
   DescribeBotResourceGenerationResponse,
   DescribeBotResourceGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotResourceGenerationRequest,
   output: DescribeBotResourceGenerationResponse,
@@ -11558,7 +11557,7 @@ export const describeBotVersion: API.OperationMethod<
   DescribeBotVersionRequest,
   DescribeBotVersionResponse,
   DescribeBotVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBotVersionRequest,
   output: DescribeBotVersionResponse,
@@ -11588,7 +11587,7 @@ export const describeCustomVocabularyMetadata: API.OperationMethod<
   DescribeCustomVocabularyMetadataRequest,
   DescribeCustomVocabularyMetadataResponse,
   DescribeCustomVocabularyMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomVocabularyMetadataRequest,
   output: DescribeCustomVocabularyMetadataResponse,
@@ -11617,7 +11616,7 @@ export const describeExport: API.OperationMethod<
   DescribeExportRequest,
   DescribeExportResponse,
   DescribeExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExportRequest,
   output: DescribeExportResponse,
@@ -11645,7 +11644,7 @@ export const describeImport: API.OperationMethod<
   DescribeImportRequest,
   DescribeImportResponse,
   DescribeImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImportRequest,
   output: DescribeImportResponse,
@@ -11674,7 +11673,7 @@ export const describeIntent: API.OperationMethod<
   DescribeIntentRequest,
   DescribeIntentResponse,
   DescribeIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIntentRequest,
   output: DescribeIntentResponse,
@@ -11703,7 +11702,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -11731,7 +11730,7 @@ export const describeSlot: API.OperationMethod<
   DescribeSlotRequest,
   DescribeSlotResponse,
   DescribeSlotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSlotRequest,
   output: DescribeSlotResponse,
@@ -11761,7 +11760,7 @@ export const describeSlotType: API.OperationMethod<
   DescribeSlotTypeRequest,
   DescribeSlotTypeResponse,
   DescribeSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSlotTypeRequest,
   output: DescribeSlotTypeResponse,
@@ -11791,7 +11790,7 @@ export const describeTestExecution: API.OperationMethod<
   DescribeTestExecutionRequest,
   DescribeTestExecutionResponse,
   DescribeTestExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTestExecutionRequest,
   output: DescribeTestExecutionResponse,
@@ -11821,7 +11820,7 @@ export const describeTestSet: API.OperationMethod<
   DescribeTestSetRequest,
   DescribeTestSetResponse,
   DescribeTestSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTestSetRequest,
   output: DescribeTestSetResponse,
@@ -11851,7 +11850,7 @@ export const describeTestSetDiscrepancyReport: API.OperationMethod<
   DescribeTestSetDiscrepancyReportRequest,
   DescribeTestSetDiscrepancyReportResponse,
   DescribeTestSetDiscrepancyReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTestSetDiscrepancyReportRequest,
   output: DescribeTestSetDiscrepancyReportResponse,
@@ -11881,7 +11880,7 @@ export const describeTestSetGeneration: API.OperationMethod<
   DescribeTestSetGenerationRequest,
   DescribeTestSetGenerationResponse,
   DescribeTestSetGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTestSetGenerationRequest,
   output: DescribeTestSetGenerationResponse,
@@ -11913,7 +11912,7 @@ export const generateBotElement: API.OperationMethod<
   GenerateBotElementRequest,
   GenerateBotElementResponse,
   GenerateBotElementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateBotElementRequest,
   output: GenerateBotElementResponse,
@@ -11945,7 +11944,7 @@ export const getTestExecutionArtifactsUrl: API.OperationMethod<
   GetTestExecutionArtifactsUrlRequest,
   GetTestExecutionArtifactsUrlResponse,
   GetTestExecutionArtifactsUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTestExecutionArtifactsUrlRequest,
   output: GetTestExecutionArtifactsUrlResponse,
@@ -11997,7 +11996,7 @@ export const listAggregatedUtterances: API.PaginatedOperationMethod<
   ListAggregatedUtterancesRequest,
   ListAggregatedUtterancesResponse,
   ListAggregatedUtterancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAggregatedUtterancesRequest,
@@ -12032,7 +12031,7 @@ export const listBotAliases: API.PaginatedOperationMethod<
   ListBotAliasesRequest,
   ListBotAliasesResponse,
   ListBotAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotAliasesRequest,
@@ -12067,7 +12066,7 @@ export const listBotAliasReplicas: API.PaginatedOperationMethod<
   ListBotAliasReplicasRequest,
   ListBotAliasReplicasResponse,
   ListBotAliasReplicasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotAliasReplicasRequest,
@@ -12103,7 +12102,7 @@ export const listBotAnalyzerHistory: API.PaginatedOperationMethod<
   ListBotAnalyzerHistoryRequest,
   ListBotAnalyzerHistoryResponse,
   ListBotAnalyzerHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BotAnalyzerHistorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotAnalyzerHistoryRequest,
@@ -12138,7 +12137,7 @@ export const listBotLocales: API.PaginatedOperationMethod<
   ListBotLocalesRequest,
   ListBotLocalesResponse,
   ListBotLocalesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotLocalesRequest,
@@ -12173,7 +12172,7 @@ export const listBotRecommendations: API.PaginatedOperationMethod<
   ListBotRecommendationsRequest,
   ListBotRecommendationsResponse,
   ListBotRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotRecommendationsRequest,
@@ -12207,7 +12206,7 @@ export const listBotReplicas: API.OperationMethod<
   ListBotReplicasRequest,
   ListBotReplicasResponse,
   ListBotReplicasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBotReplicasRequest,
   output: ListBotReplicasResponse,
@@ -12235,7 +12234,7 @@ export const listBotResourceGenerations: API.PaginatedOperationMethod<
   ListBotResourceGenerationsRequest,
   ListBotResourceGenerationsResponse,
   ListBotResourceGenerationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotResourceGenerationsRequest,
@@ -12269,7 +12268,7 @@ export const listBots: API.PaginatedOperationMethod<
   ListBotsRequest,
   ListBotsResponse,
   ListBotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotsRequest,
@@ -12303,7 +12302,7 @@ export const listBotVersionReplicas: API.PaginatedOperationMethod<
   ListBotVersionReplicasRequest,
   ListBotVersionReplicasResponse,
   ListBotVersionReplicasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotVersionReplicasRequest,
@@ -12346,7 +12345,7 @@ export const listBotVersions: API.PaginatedOperationMethod<
   ListBotVersionsRequest,
   ListBotVersionsResponse,
   ListBotVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotVersionsRequest,
@@ -12386,7 +12385,7 @@ export const listBuiltInIntents: API.PaginatedOperationMethod<
   ListBuiltInIntentsRequest,
   ListBuiltInIntentsResponse,
   ListBuiltInIntentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuiltInIntentsRequest,
@@ -12421,7 +12420,7 @@ export const listBuiltInSlotTypes: API.PaginatedOperationMethod<
   ListBuiltInSlotTypesRequest,
   ListBuiltInSlotTypesResponse,
   ListBuiltInSlotTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBuiltInSlotTypesRequest,
@@ -12457,7 +12456,7 @@ export const listCustomVocabularyItems: API.PaginatedOperationMethod<
   ListCustomVocabularyItemsRequest,
   ListCustomVocabularyItemsResponse,
   ListCustomVocabularyItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomVocabularyItemsRequest,
@@ -12492,7 +12491,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsRequest,
   ListExportsResponse,
   ListExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsRequest,
@@ -12521,7 +12520,7 @@ export const listImports: API.PaginatedOperationMethod<
   ListImportsRequest,
   ListImportsResponse,
   ListImportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportsRequest,
@@ -12563,7 +12562,7 @@ export const listIntentMetrics: API.PaginatedOperationMethod<
   ListIntentMetricsRequest,
   ListIntentMetricsResponse,
   ListIntentMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntentMetricsRequest,
@@ -12605,7 +12604,7 @@ export const listIntentPaths: API.OperationMethod<
   ListIntentPathsRequest,
   ListIntentPathsResponse,
   ListIntentPathsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIntentPathsRequest,
   output: ListIntentPathsResponse,
@@ -12635,7 +12634,7 @@ export const listIntents: API.PaginatedOperationMethod<
   ListIntentsRequest,
   ListIntentsResponse,
   ListIntentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntentsRequest,
@@ -12683,7 +12682,7 @@ export const listIntentStageMetrics: API.PaginatedOperationMethod<
   ListIntentStageMetricsRequest,
   ListIntentStageMetricsResponse,
   ListIntentStageMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntentStageMetricsRequest,
@@ -12721,7 +12720,7 @@ export const listRecommendedIntents: API.PaginatedOperationMethod<
   ListRecommendedIntentsRequest,
   ListRecommendedIntentsResponse,
   ListRecommendedIntentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendedIntentsRequest,
@@ -12761,7 +12760,7 @@ export const listSessionAnalyticsData: API.PaginatedOperationMethod<
   ListSessionAnalyticsDataRequest,
   ListSessionAnalyticsDataResponse,
   ListSessionAnalyticsDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionAnalyticsDataRequest,
@@ -12809,7 +12808,7 @@ export const listSessionMetrics: API.PaginatedOperationMethod<
   ListSessionMetricsRequest,
   ListSessionMetricsResponse,
   ListSessionMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionMetricsRequest,
@@ -12844,7 +12843,7 @@ export const listSlots: API.PaginatedOperationMethod<
   ListSlotsRequest,
   ListSlotsResponse,
   ListSlotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSlotsRequest,
@@ -12879,7 +12878,7 @@ export const listSlotTypes: API.PaginatedOperationMethod<
   ListSlotTypesRequest,
   ListSlotTypesResponse,
   ListSlotTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSlotTypesRequest,
@@ -12915,7 +12914,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -12944,7 +12943,7 @@ export const listTestExecutionResultItems: API.PaginatedOperationMethod<
   ListTestExecutionResultItemsRequest,
   ListTestExecutionResultItemsResponse,
   ListTestExecutionResultItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestExecutionResultItemsRequest,
@@ -12979,7 +12978,7 @@ export const listTestExecutions: API.PaginatedOperationMethod<
   ListTestExecutionsRequest,
   ListTestExecutionsResponse,
   ListTestExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestExecutionsRequest,
@@ -13014,7 +13013,7 @@ export const listTestSetRecords: API.PaginatedOperationMethod<
   ListTestSetRecordsRequest,
   ListTestSetRecordsResponse,
   ListTestSetRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestSetRecordsRequest,
@@ -13049,7 +13048,7 @@ export const listTestSets: API.PaginatedOperationMethod<
   ListTestSetsRequest,
   ListTestSetsResponse,
   ListTestSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestSetsRequest,
@@ -13097,7 +13096,7 @@ export const listUtteranceAnalyticsData: API.PaginatedOperationMethod<
   ListUtteranceAnalyticsDataRequest,
   ListUtteranceAnalyticsDataResponse,
   ListUtteranceAnalyticsDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUtteranceAnalyticsDataRequest,
@@ -13150,7 +13149,7 @@ export const listUtteranceMetrics: API.PaginatedOperationMethod<
   ListUtteranceMetricsRequest,
   ListUtteranceMetricsResponse,
   ListUtteranceMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUtteranceMetricsRequest,
@@ -13187,7 +13186,7 @@ export const searchAssociatedTranscripts: API.OperationMethod<
   SearchAssociatedTranscriptsRequest,
   SearchAssociatedTranscriptsResponse,
   SearchAssociatedTranscriptsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchAssociatedTranscriptsRequest,
   output: SearchAssociatedTranscriptsResponse,
@@ -13219,7 +13218,7 @@ export const startBotAnalyzer: API.OperationMethod<
   StartBotAnalyzerRequest,
   StartBotAnalyzerResponse,
   StartBotAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBotAnalyzerRequest,
   output: StartBotAnalyzerResponse,
@@ -13252,7 +13251,7 @@ export const startBotRecommendation: API.OperationMethod<
   StartBotRecommendationRequest,
   StartBotRecommendationResponse,
   StartBotRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBotRecommendationRequest,
   output: StartBotRecommendationResponse,
@@ -13289,7 +13288,7 @@ export const startBotResourceGeneration: API.OperationMethod<
   StartBotResourceGenerationRequest,
   StartBotResourceGenerationResponse,
   StartBotResourceGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBotResourceGenerationRequest,
   output: StartBotResourceGenerationResponse,
@@ -13322,7 +13321,7 @@ export const startImport: API.OperationMethod<
   StartImportRequest,
   StartImportResponse,
   StartImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportRequest,
   output: StartImportResponse,
@@ -13354,7 +13353,7 @@ export const startTestExecution: API.OperationMethod<
   StartTestExecutionRequest,
   StartTestExecutionResponse,
   StartTestExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTestExecutionRequest,
   output: StartTestExecutionResponse,
@@ -13386,7 +13385,7 @@ export const startTestSetGeneration: API.OperationMethod<
   StartTestSetGenerationRequest,
   StartTestSetGenerationResponse,
   StartTestSetGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTestSetGenerationRequest,
   output: StartTestSetGenerationResponse,
@@ -13416,7 +13415,7 @@ export const stopBotAnalyzer: API.OperationMethod<
   StopBotAnalyzerRequest,
   StopBotAnalyzerResponse,
   StopBotAnalyzerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBotAnalyzerRequest,
   output: StopBotAnalyzerResponse,
@@ -13447,7 +13446,7 @@ export const stopBotRecommendation: API.OperationMethod<
   StopBotRecommendationRequest,
   StopBotRecommendationResponse,
   StopBotRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopBotRecommendationRequest,
   output: StopBotRecommendationResponse,
@@ -13480,7 +13479,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -13508,7 +13507,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -13538,7 +13537,7 @@ export const updateBot: API.OperationMethod<
   UpdateBotRequest,
   UpdateBotResponse,
   UpdateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotRequest,
   output: UpdateBotResponse,
@@ -13570,7 +13569,7 @@ export const updateBotAlias: API.OperationMethod<
   UpdateBotAliasRequest,
   UpdateBotAliasResponse,
   UpdateBotAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotAliasRequest,
   output: UpdateBotAliasResponse,
@@ -13602,7 +13601,7 @@ export const updateBotLocale: API.OperationMethod<
   UpdateBotLocaleRequest,
   UpdateBotLocaleResponse,
   UpdateBotLocaleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotLocaleRequest,
   output: UpdateBotLocaleResponse,
@@ -13635,7 +13634,7 @@ export const updateBotRecommendation: API.OperationMethod<
   UpdateBotRecommendationRequest,
   UpdateBotRecommendationResponse,
   UpdateBotRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotRecommendationRequest,
   output: UpdateBotRecommendationResponse,
@@ -13673,7 +13672,7 @@ export const updateExport: API.OperationMethod<
   UpdateExportRequest,
   UpdateExportResponse,
   UpdateExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExportRequest,
   output: UpdateExportResponse,
@@ -13705,7 +13704,7 @@ export const updateIntent: API.OperationMethod<
   UpdateIntentRequest,
   UpdateIntentResponse,
   UpdateIntentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntentRequest,
   output: UpdateIntentResponse,
@@ -13739,7 +13738,7 @@ export const updateResourcePolicy: API.OperationMethod<
   UpdateResourcePolicyRequest,
   UpdateResourcePolicyResponse,
   UpdateResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourcePolicyRequest,
   output: UpdateResourcePolicyResponse,
@@ -13771,7 +13770,7 @@ export const updateSlot: API.OperationMethod<
   UpdateSlotRequest,
   UpdateSlotResponse,
   UpdateSlotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSlotRequest,
   output: UpdateSlotResponse,
@@ -13803,7 +13802,7 @@ export const updateSlotType: API.OperationMethod<
   UpdateSlotTypeRequest,
   UpdateSlotTypeResponse,
   UpdateSlotTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSlotTypeRequest,
   output: UpdateSlotTypeResponse,
@@ -13835,7 +13834,7 @@ export const updateTestSet: API.OperationMethod<
   UpdateTestSetRequest,
   UpdateTestSetResponse,
   UpdateTestSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTestSetRequest,
   output: UpdateTestSetResponse,

--- a/packages/aws/src/services/lex-runtime-service.ts
+++ b/packages/aws/src/services/lex-runtime-service.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lex Runtime Service",
@@ -773,7 +772,7 @@ export const deleteSession: API.OperationMethod<
   DeleteSessionRequest,
   DeleteSessionResponse,
   DeleteSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSessionRequest,
   output: DeleteSessionResponse,
@@ -803,7 +802,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -896,7 +895,7 @@ export const postContent: API.OperationMethod<
   PostContentRequest,
   PostContentResponse,
   PostContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostContentRequest,
   output: PostContentResponse,
@@ -990,7 +989,7 @@ export const postText: API.OperationMethod<
   PostTextRequest,
   PostTextResponse,
   PostTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostTextRequest,
   output: PostTextResponse,
@@ -1031,7 +1030,7 @@ export const putSession: API.OperationMethod<
   PutSessionRequest,
   PutSessionResponse,
   PutSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSessionRequest,
   output: PutSessionResponse,

--- a/packages/aws/src/services/lex-runtime-v2.ts
+++ b/packages/aws/src/services/lex-runtime-v2.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lex Runtime V2",
@@ -1385,7 +1384,7 @@ export const deleteSession: API.OperationMethod<
   DeleteSessionRequest,
   DeleteSessionResponse,
   DeleteSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSessionRequest,
   output: DeleteSessionResponse,
@@ -1426,7 +1425,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -1461,7 +1460,7 @@ export const putSession: API.OperationMethod<
   PutSessionRequest,
   PutSessionResponse,
   PutSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSessionRequest,
   output: PutSessionResponse,
@@ -1522,7 +1521,7 @@ export const recognizeText: API.OperationMethod<
   RecognizeTextRequest,
   RecognizeTextResponse,
   RecognizeTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecognizeTextRequest,
   output: RecognizeTextResponse,
@@ -1606,7 +1605,7 @@ export const recognizeUtterance: API.OperationMethod<
   RecognizeUtteranceRequest,
   RecognizeUtteranceResponse,
   RecognizeUtteranceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecognizeUtteranceRequest,
   output: RecognizeUtteranceResponse,
@@ -1682,7 +1681,7 @@ export const startConversation: API.OperationMethod<
   StartConversationRequest,
   StartConversationResponse,
   StartConversationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConversationRequest,
   output: StartConversationResponse,

--- a/packages/aws/src/services/license-manager-linux-subscriptions.ts
+++ b/packages/aws/src/services/license-manager-linux-subscriptions.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "License Manager Linux Subscriptions",
   serviceShapeName: "LicenseManagerLinuxSubscriptions",
@@ -626,7 +625,7 @@ export const deregisterSubscriptionProvider: API.OperationMethod<
   DeregisterSubscriptionProviderRequest,
   DeregisterSubscriptionProviderResponse,
   DeregisterSubscriptionProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterSubscriptionProviderRequest,
   output: DeregisterSubscriptionProviderResponse,
@@ -654,7 +653,7 @@ export const getRegisteredSubscriptionProvider: API.OperationMethod<
   GetRegisteredSubscriptionProviderRequest,
   GetRegisteredSubscriptionProviderResponse,
   GetRegisteredSubscriptionProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegisteredSubscriptionProviderRequest,
   output: GetRegisteredSubscriptionProviderResponse,
@@ -681,7 +680,7 @@ export const getServiceSettings: API.OperationMethod<
   GetServiceSettingsRequest,
   GetServiceSettingsResponse,
   GetServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSettingsRequest,
   output: GetServiceSettingsResponse,
@@ -704,7 +703,7 @@ export const listLinuxSubscriptionInstances: API.PaginatedOperationMethod<
   ListLinuxSubscriptionInstancesRequest,
   ListLinuxSubscriptionInstancesResponse,
   ListLinuxSubscriptionInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Instance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinuxSubscriptionInstancesRequest,
@@ -735,7 +734,7 @@ export const listLinuxSubscriptions: API.PaginatedOperationMethod<
   ListLinuxSubscriptionsRequest,
   ListLinuxSubscriptionsResponse,
   ListLinuxSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinuxSubscriptionsRequest,
@@ -764,7 +763,7 @@ export const listRegisteredSubscriptionProviders: API.PaginatedOperationMethod<
   ListRegisteredSubscriptionProvidersRequest,
   ListRegisteredSubscriptionProvidersResponse,
   ListRegisteredSubscriptionProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegisteredSubscriptionProvider
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegisteredSubscriptionProvidersRequest,
@@ -794,7 +793,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -820,7 +819,7 @@ export const registerSubscriptionProvider: API.OperationMethod<
   RegisterSubscriptionProviderRequest,
   RegisterSubscriptionProviderResponse,
   RegisterSubscriptionProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterSubscriptionProviderRequest,
   output: RegisterSubscriptionProviderResponse,
@@ -842,7 +841,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -867,7 +866,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -889,7 +888,7 @@ export const updateServiceSettings: API.OperationMethod<
   UpdateServiceSettingsRequest,
   UpdateServiceSettingsResponse,
   UpdateServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSettingsRequest,
   output: UpdateServiceSettingsResponse,

--- a/packages/aws/src/services/license-manager-user-subscriptions.ts
+++ b/packages/aws/src/services/license-manager-user-subscriptions.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "License Manager User Subscriptions",
   serviceShapeName: "LicenseManagerUserSubscriptions",
@@ -1023,7 +1022,7 @@ export const associateUser: API.OperationMethod<
   AssociateUserRequest,
   AssociateUserResponse,
   AssociateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateUserRequest,
   output: AssociateUserResponse,
@@ -1057,7 +1056,7 @@ export const createLicenseServerEndpoint: API.OperationMethod<
   CreateLicenseServerEndpointRequest,
   CreateLicenseServerEndpointResponse,
   CreateLicenseServerEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseServerEndpointRequest,
   output: CreateLicenseServerEndpointResponse,
@@ -1091,7 +1090,7 @@ export const deleteLicenseServerEndpoint: API.OperationMethod<
   DeleteLicenseServerEndpointRequest,
   DeleteLicenseServerEndpointResponse,
   DeleteLicenseServerEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseServerEndpointRequest,
   output: DeleteLicenseServerEndpointResponse,
@@ -1125,7 +1124,7 @@ export const deregisterIdentityProvider: API.OperationMethod<
   DeregisterIdentityProviderRequest,
   DeregisterIdentityProviderResponse,
   DeregisterIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterIdentityProviderRequest,
   output: DeregisterIdentityProviderResponse,
@@ -1159,7 +1158,7 @@ export const disassociateUser: API.OperationMethod<
   DisassociateUserRequest,
   DisassociateUserResponse,
   DisassociateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateUserRequest,
   output: DisassociateUserResponse,
@@ -1193,7 +1192,7 @@ export const listIdentityProviders: API.PaginatedOperationMethod<
   ListIdentityProvidersRequest,
   ListIdentityProvidersResponse,
   ListIdentityProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdentityProviderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentityProvidersRequest,
@@ -1234,7 +1233,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesRequest,
   ListInstancesResponse,
   ListInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesRequest,
@@ -1274,7 +1273,7 @@ export const listLicenseServerEndpoints: API.PaginatedOperationMethod<
   ListLicenseServerEndpointsRequest,
   ListLicenseServerEndpointsResponse,
   ListLicenseServerEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LicenseServerEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLicenseServerEndpointsRequest,
@@ -1314,7 +1313,7 @@ export const listProductSubscriptions: API.PaginatedOperationMethod<
   ListProductSubscriptionsRequest,
   ListProductSubscriptionsResponse,
   ListProductSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProductUserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProductSubscriptionsRequest,
@@ -1351,7 +1350,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1381,7 +1380,7 @@ export const listUserAssociations: API.PaginatedOperationMethod<
   ListUserAssociationsRequest,
   ListUserAssociationsResponse,
   ListUserAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceUserSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserAssociationsRequest,
@@ -1422,7 +1421,7 @@ export const registerIdentityProvider: API.OperationMethod<
   RegisterIdentityProviderRequest,
   RegisterIdentityProviderResponse,
   RegisterIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterIdentityProviderRequest,
   output: RegisterIdentityProviderResponse,
@@ -1458,7 +1457,7 @@ export const startProductSubscription: API.OperationMethod<
   StartProductSubscriptionRequest,
   StartProductSubscriptionResponse,
   StartProductSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProductSubscriptionRequest,
   output: StartProductSubscriptionResponse,
@@ -1492,7 +1491,7 @@ export const stopProductSubscription: API.OperationMethod<
   StopProductSubscriptionRequest,
   StopProductSubscriptionResponse,
   StopProductSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopProductSubscriptionRequest,
   output: StopProductSubscriptionResponse,
@@ -1522,7 +1521,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1547,7 +1546,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1570,7 +1569,7 @@ export const updateIdentityProviderSettings: API.OperationMethod<
   UpdateIdentityProviderSettingsRequest,
   UpdateIdentityProviderSettingsResponse,
   UpdateIdentityProviderSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdentityProviderSettingsRequest,
   output: UpdateIdentityProviderSettingsResponse,

--- a/packages/aws/src/services/license-manager.ts
+++ b/packages/aws/src/services/license-manager.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "https://license-manager.amazonaws.com/doc/2018_08_01",
@@ -3726,7 +3725,7 @@ export const acceptGrant: API.OperationMethod<
   AcceptGrantRequest,
   AcceptGrantResponse,
   AcceptGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptGrantRequest,
   output: AcceptGrantResponse,
@@ -3761,7 +3760,7 @@ export const checkInLicense: API.OperationMethod<
   CheckInLicenseRequest,
   CheckInLicenseResponse,
   CheckInLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckInLicenseRequest,
   output: CheckInLicenseResponse,
@@ -3800,7 +3799,7 @@ export const checkoutBorrowLicense: API.OperationMethod<
   CheckoutBorrowLicenseRequest,
   CheckoutBorrowLicenseResponse,
   CheckoutBorrowLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckoutBorrowLicenseRequest,
   output: CheckoutBorrowLicenseResponse,
@@ -3844,7 +3843,7 @@ export const checkoutLicense: API.OperationMethod<
   CheckoutLicenseRequest,
   CheckoutLicenseResponse,
   CheckoutLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckoutLicenseRequest,
   output: CheckoutLicenseResponse,
@@ -3883,7 +3882,7 @@ export const createGrant: API.OperationMethod<
   CreateGrantRequest,
   CreateGrantResponse,
   CreateGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGrantRequest,
   output: CreateGrantResponse,
@@ -3918,7 +3917,7 @@ export const createGrantVersion: API.OperationMethod<
   CreateGrantVersionRequest,
   CreateGrantVersionResponse,
   CreateGrantVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGrantVersionRequest,
   output: CreateGrantVersionResponse,
@@ -3952,7 +3951,7 @@ export const createLicense: API.OperationMethod<
   CreateLicenseRequest,
   CreateLicenseResponse,
   CreateLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseRequest,
   output: CreateLicenseResponse,
@@ -3985,7 +3984,7 @@ export const createLicenseAssetGroup: API.OperationMethod<
   CreateLicenseAssetGroupRequest,
   CreateLicenseAssetGroupResponse,
   CreateLicenseAssetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseAssetGroupRequest,
   output: CreateLicenseAssetGroupResponse,
@@ -4017,7 +4016,7 @@ export const createLicenseAssetRuleset: API.OperationMethod<
   CreateLicenseAssetRulesetRequest,
   CreateLicenseAssetRulesetResponse,
   CreateLicenseAssetRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseAssetRulesetRequest,
   output: CreateLicenseAssetRulesetResponse,
@@ -4055,7 +4054,7 @@ export const createLicenseConfiguration: API.OperationMethod<
   CreateLicenseConfigurationRequest,
   CreateLicenseConfigurationResponse,
   CreateLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseConfigurationRequest,
   output: CreateLicenseConfigurationResponse,
@@ -4087,7 +4086,7 @@ export const createLicenseConversionTaskForResource: API.OperationMethod<
   CreateLicenseConversionTaskForResourceRequest,
   CreateLicenseConversionTaskForResourceResponse,
   CreateLicenseConversionTaskForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseConversionTaskForResourceRequest,
   output: CreateLicenseConversionTaskForResourceResponse,
@@ -4121,7 +4120,7 @@ export const createLicenseManagerReportGenerator: API.OperationMethod<
   CreateLicenseManagerReportGeneratorRequest,
   CreateLicenseManagerReportGeneratorResponse,
   CreateLicenseManagerReportGeneratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseManagerReportGeneratorRequest,
   output: CreateLicenseManagerReportGeneratorResponse,
@@ -4157,7 +4156,7 @@ export const createLicenseVersion: API.OperationMethod<
   CreateLicenseVersionRequest,
   CreateLicenseVersionResponse,
   CreateLicenseVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLicenseVersionRequest,
   output: CreateLicenseVersionResponse,
@@ -4197,7 +4196,7 @@ export const createToken: API.OperationMethod<
   CreateTokenRequest,
   CreateTokenResponse,
   CreateTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTokenRequest,
   output: CreateTokenResponse,
@@ -4232,7 +4231,7 @@ export const deleteGrant: API.OperationMethod<
   DeleteGrantRequest,
   DeleteGrantResponse,
   DeleteGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGrantRequest,
   output: DeleteGrantResponse,
@@ -4267,7 +4266,7 @@ export const deleteLicense: API.OperationMethod<
   DeleteLicenseRequest,
   DeleteLicenseResponse,
   DeleteLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseRequest,
   output: DeleteLicenseResponse,
@@ -4301,7 +4300,7 @@ export const deleteLicenseAssetGroup: API.OperationMethod<
   DeleteLicenseAssetGroupRequest,
   DeleteLicenseAssetGroupResponse,
   DeleteLicenseAssetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseAssetGroupRequest,
   output: DeleteLicenseAssetGroupResponse,
@@ -4333,7 +4332,7 @@ export const deleteLicenseAssetRuleset: API.OperationMethod<
   DeleteLicenseAssetRulesetRequest,
   DeleteLicenseAssetRulesetResponse,
   DeleteLicenseAssetRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseAssetRulesetRequest,
   output: DeleteLicenseAssetRulesetResponse,
@@ -4367,7 +4366,7 @@ export const deleteLicenseConfiguration: API.OperationMethod<
   DeleteLicenseConfigurationRequest,
   DeleteLicenseConfigurationResponse,
   DeleteLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseConfigurationRequest,
   output: DeleteLicenseConfigurationResponse,
@@ -4404,7 +4403,7 @@ export const deleteLicenseManagerReportGenerator: API.OperationMethod<
   DeleteLicenseManagerReportGeneratorRequest,
   DeleteLicenseManagerReportGeneratorResponse,
   DeleteLicenseManagerReportGeneratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLicenseManagerReportGeneratorRequest,
   output: DeleteLicenseManagerReportGeneratorResponse,
@@ -4439,7 +4438,7 @@ export const deleteToken: API.OperationMethod<
   DeleteTokenRequest,
   DeleteTokenResponse,
   DeleteTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTokenRequest,
   output: DeleteTokenResponse,
@@ -4473,7 +4472,7 @@ export const extendLicenseConsumption: API.OperationMethod<
   ExtendLicenseConsumptionRequest,
   ExtendLicenseConsumptionResponse,
   ExtendLicenseConsumptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExtendLicenseConsumptionRequest,
   output: ExtendLicenseConsumptionResponse,
@@ -4507,7 +4506,7 @@ export const getAccessToken: API.OperationMethod<
   GetAccessTokenRequest,
   GetAccessTokenResponse,
   GetAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessTokenRequest,
   output: GetAccessTokenResponse,
@@ -4541,7 +4540,7 @@ export const getGrant: API.OperationMethod<
   GetGrantRequest,
   GetGrantResponse,
   GetGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGrantRequest,
   output: GetGrantResponse,
@@ -4576,7 +4575,7 @@ export const getLicense: API.OperationMethod<
   GetLicenseRequest,
   GetLicenseResponse,
   GetLicenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseRequest,
   output: GetLicenseResponse,
@@ -4609,7 +4608,7 @@ export const getLicenseAssetGroup: API.OperationMethod<
   GetLicenseAssetGroupRequest,
   GetLicenseAssetGroupResponse,
   GetLicenseAssetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseAssetGroupRequest,
   output: GetLicenseAssetGroupResponse,
@@ -4641,7 +4640,7 @@ export const getLicenseAssetRuleset: API.OperationMethod<
   GetLicenseAssetRulesetRequest,
   GetLicenseAssetRulesetResponse,
   GetLicenseAssetRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseAssetRulesetRequest,
   output: GetLicenseAssetRulesetResponse,
@@ -4673,7 +4672,7 @@ export const getLicenseConfiguration: API.OperationMethod<
   GetLicenseConfigurationRequest,
   GetLicenseConfigurationResponse,
   GetLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseConfigurationRequest,
   output: GetLicenseConfigurationResponse,
@@ -4704,7 +4703,7 @@ export const getLicenseConversionTask: API.OperationMethod<
   GetLicenseConversionTaskRequest,
   GetLicenseConversionTaskResponse,
   GetLicenseConversionTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseConversionTaskRequest,
   output: GetLicenseConversionTaskResponse,
@@ -4737,7 +4736,7 @@ export const getLicenseManagerReportGenerator: API.OperationMethod<
   GetLicenseManagerReportGeneratorRequest,
   GetLicenseManagerReportGeneratorResponse,
   GetLicenseManagerReportGeneratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseManagerReportGeneratorRequest,
   output: GetLicenseManagerReportGeneratorResponse,
@@ -4771,7 +4770,7 @@ export const getLicenseUsage: API.OperationMethod<
   GetLicenseUsageRequest,
   GetLicenseUsageResponse,
   GetLicenseUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLicenseUsageRequest,
   output: GetLicenseUsageResponse,
@@ -4801,7 +4800,7 @@ export const getServiceSettings: API.OperationMethod<
   GetServiceSettingsRequest,
   GetServiceSettingsResponse,
   GetServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSettingsRequest,
   output: GetServiceSettingsResponse,
@@ -4831,7 +4830,7 @@ export const listAssetsForLicenseAssetGroup: API.OperationMethod<
   ListAssetsForLicenseAssetGroupRequest,
   ListAssetsForLicenseAssetGroupResponse,
   ListAssetsForLicenseAssetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAssetsForLicenseAssetGroupRequest,
   output: ListAssetsForLicenseAssetGroupResponse,
@@ -4867,7 +4866,7 @@ export const listAssociationsForLicenseConfiguration: API.OperationMethod<
   ListAssociationsForLicenseConfigurationRequest,
   ListAssociationsForLicenseConfigurationResponse,
   ListAssociationsForLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAssociationsForLicenseConfigurationRequest,
   output: ListAssociationsForLicenseConfigurationResponse,
@@ -4900,7 +4899,7 @@ export const listDistributedGrants: API.OperationMethod<
   ListDistributedGrantsRequest,
   ListDistributedGrantsResponse,
   ListDistributedGrantsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDistributedGrantsRequest,
   output: ListDistributedGrantsResponse,
@@ -4932,7 +4931,7 @@ export const listFailuresForLicenseConfigurationOperations: API.OperationMethod<
   ListFailuresForLicenseConfigurationOperationsRequest,
   ListFailuresForLicenseConfigurationOperationsResponse,
   ListFailuresForLicenseConfigurationOperationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListFailuresForLicenseConfigurationOperationsRequest,
   output: ListFailuresForLicenseConfigurationOperationsResponse,
@@ -4963,7 +4962,7 @@ export const listLicenseAssetGroups: API.OperationMethod<
   ListLicenseAssetGroupsRequest,
   ListLicenseAssetGroupsResponse,
   ListLicenseAssetGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseAssetGroupsRequest,
   output: ListLicenseAssetGroupsResponse,
@@ -4995,7 +4994,7 @@ export const listLicenseAssetRulesets: API.OperationMethod<
   ListLicenseAssetRulesetsRequest,
   ListLicenseAssetRulesetsResponse,
   ListLicenseAssetRulesetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseAssetRulesetsRequest,
   output: ListLicenseAssetRulesetsResponse,
@@ -5027,7 +5026,7 @@ export const listLicenseConfigurations: API.OperationMethod<
   ListLicenseConfigurationsRequest,
   ListLicenseConfigurationsResponse,
   ListLicenseConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseConfigurationsRequest,
   output: ListLicenseConfigurationsResponse,
@@ -5059,7 +5058,7 @@ export const listLicenseConfigurationsForOrganization: API.OperationMethod<
   ListLicenseConfigurationsForOrganizationRequest,
   ListLicenseConfigurationsForOrganizationResponse,
   ListLicenseConfigurationsForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseConfigurationsForOrganizationRequest,
   output: ListLicenseConfigurationsForOrganizationResponse,
@@ -5090,7 +5089,7 @@ export const listLicenseConversionTasks: API.OperationMethod<
   ListLicenseConversionTasksRequest,
   ListLicenseConversionTasksResponse,
   ListLicenseConversionTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseConversionTasksRequest,
   output: ListLicenseConversionTasksResponse,
@@ -5123,7 +5122,7 @@ export const listLicenseManagerReportGenerators: API.OperationMethod<
   ListLicenseManagerReportGeneratorsRequest,
   ListLicenseManagerReportGeneratorsResponse,
   ListLicenseManagerReportGeneratorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseManagerReportGeneratorsRequest,
   output: ListLicenseManagerReportGeneratorsResponse,
@@ -5157,7 +5156,7 @@ export const listLicenses: API.OperationMethod<
   ListLicensesRequest,
   ListLicensesResponse,
   ListLicensesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicensesRequest,
   output: ListLicensesResponse,
@@ -5188,7 +5187,7 @@ export const listLicenseSpecificationsForResource: API.OperationMethod<
   ListLicenseSpecificationsForResourceRequest,
   ListLicenseSpecificationsForResourceResponse,
   ListLicenseSpecificationsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseSpecificationsForResourceRequest,
   output: ListLicenseSpecificationsForResourceResponse,
@@ -5218,7 +5217,7 @@ export const listLicenseVersions: API.OperationMethod<
   ListLicenseVersionsRequest,
   ListLicenseVersionsResponse,
   ListLicenseVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLicenseVersionsRequest,
   output: ListLicenseVersionsResponse,
@@ -5252,7 +5251,7 @@ export const listReceivedGrants: API.OperationMethod<
   ListReceivedGrantsRequest,
   ListReceivedGrantsResponse,
   ListReceivedGrantsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceivedGrantsRequest,
   output: ListReceivedGrantsResponse,
@@ -5286,7 +5285,7 @@ export const listReceivedGrantsForOrganization: API.OperationMethod<
   ListReceivedGrantsForOrganizationRequest,
   ListReceivedGrantsForOrganizationResponse,
   ListReceivedGrantsForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceivedGrantsForOrganizationRequest,
   output: ListReceivedGrantsForOrganizationResponse,
@@ -5320,7 +5319,7 @@ export const listReceivedLicenses: API.OperationMethod<
   ListReceivedLicensesRequest,
   ListReceivedLicensesResponse,
   ListReceivedLicensesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceivedLicensesRequest,
   output: ListReceivedLicensesResponse,
@@ -5354,7 +5353,7 @@ export const listReceivedLicensesForOrganization: API.OperationMethod<
   ListReceivedLicensesForOrganizationRequest,
   ListReceivedLicensesForOrganizationResponse,
   ListReceivedLicensesForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceivedLicensesForOrganizationRequest,
   output: ListReceivedLicensesForOrganizationResponse,
@@ -5388,7 +5387,7 @@ export const listResourceInventory: API.OperationMethod<
   ListResourceInventoryRequest,
   ListResourceInventoryResponse,
   ListResourceInventoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceInventoryRequest,
   output: ListResourceInventoryResponse,
@@ -5422,7 +5421,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5453,7 +5452,7 @@ export const listTokens: API.OperationMethod<
   ListTokensRequest,
   ListTokensResponse,
   ListTokensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTokensRequest,
   output: ListTokensResponse,
@@ -5486,7 +5485,7 @@ export const listUsageForLicenseConfiguration: API.OperationMethod<
   ListUsageForLicenseConfigurationRequest,
   ListUsageForLicenseConfigurationResponse,
   ListUsageForLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUsageForLicenseConfigurationRequest,
   output: ListUsageForLicenseConfigurationResponse,
@@ -5519,7 +5518,7 @@ export const rejectGrant: API.OperationMethod<
   RejectGrantRequest,
   RejectGrantResponse,
   RejectGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectGrantRequest,
   output: RejectGrantResponse,
@@ -5561,7 +5560,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5593,7 +5592,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5625,7 +5624,7 @@ export const updateLicenseAssetGroup: API.OperationMethod<
   UpdateLicenseAssetGroupRequest,
   UpdateLicenseAssetGroupResponse,
   UpdateLicenseAssetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLicenseAssetGroupRequest,
   output: UpdateLicenseAssetGroupResponse,
@@ -5657,7 +5656,7 @@ export const updateLicenseAssetRuleset: API.OperationMethod<
   UpdateLicenseAssetRulesetRequest,
   UpdateLicenseAssetRulesetResponse,
   UpdateLicenseAssetRulesetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLicenseAssetRulesetRequest,
   output: UpdateLicenseAssetRulesetResponse,
@@ -5691,7 +5690,7 @@ export const updateLicenseConfiguration: API.OperationMethod<
   UpdateLicenseConfigurationRequest,
   UpdateLicenseConfigurationResponse,
   UpdateLicenseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLicenseConfigurationRequest,
   output: UpdateLicenseConfigurationResponse,
@@ -5729,7 +5728,7 @@ export const updateLicenseManagerReportGenerator: API.OperationMethod<
   UpdateLicenseManagerReportGeneratorRequest,
   UpdateLicenseManagerReportGeneratorResponse,
   UpdateLicenseManagerReportGeneratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLicenseManagerReportGeneratorRequest,
   output: UpdateLicenseManagerReportGeneratorResponse,
@@ -5769,7 +5768,7 @@ export const updateLicenseSpecificationsForResource: API.OperationMethod<
   UpdateLicenseSpecificationsForResourceRequest,
   UpdateLicenseSpecificationsForResourceResponse,
   UpdateLicenseSpecificationsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLicenseSpecificationsForResourceRequest,
   output: UpdateLicenseSpecificationsForResourceResponse,
@@ -5804,7 +5803,7 @@ export const updateServiceSettings: API.OperationMethod<
   UpdateServiceSettingsRequest,
   UpdateServiceSettingsResponse,
   UpdateServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSettingsRequest,
   output: UpdateServiceSettingsResponse,

--- a/packages/aws/src/services/lightsail.ts
+++ b/packages/aws/src/services/lightsail.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Lightsail",
@@ -8634,7 +8633,7 @@ export const allocateStaticIp: API.OperationMethod<
   AllocateStaticIpRequest,
   AllocateStaticIpResult,
   AllocateStaticIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AllocateStaticIpRequest,
   output: AllocateStaticIpResult,
@@ -8681,7 +8680,7 @@ export const attachCertificateToDistribution: API.OperationMethod<
   AttachCertificateToDistributionRequest,
   AttachCertificateToDistributionResult,
   AttachCertificateToDistributionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachCertificateToDistributionRequest,
   output: AttachCertificateToDistributionResult,
@@ -8720,7 +8719,7 @@ export const attachDisk: API.OperationMethod<
   AttachDiskRequest,
   AttachDiskResult,
   AttachDiskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachDiskRequest,
   output: AttachDiskResult,
@@ -8763,7 +8762,7 @@ export const attachInstancesToLoadBalancer: API.OperationMethod<
   AttachInstancesToLoadBalancerRequest,
   AttachInstancesToLoadBalancerResult,
   AttachInstancesToLoadBalancerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachInstancesToLoadBalancerRequest,
   output: AttachInstancesToLoadBalancerResult,
@@ -8809,7 +8808,7 @@ export const attachLoadBalancerTlsCertificate: API.OperationMethod<
   AttachLoadBalancerTlsCertificateRequest,
   AttachLoadBalancerTlsCertificateResult,
   AttachLoadBalancerTlsCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachLoadBalancerTlsCertificateRequest,
   output: AttachLoadBalancerTlsCertificateResult,
@@ -8845,7 +8844,7 @@ export const attachStaticIp: API.OperationMethod<
   AttachStaticIpRequest,
   AttachStaticIpResult,
   AttachStaticIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachStaticIpRequest,
   output: AttachStaticIpResult,
@@ -8885,7 +8884,7 @@ export const closeInstancePublicPorts: API.OperationMethod<
   CloseInstancePublicPortsRequest,
   CloseInstancePublicPortsResult,
   CloseInstancePublicPortsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloseInstancePublicPortsRequest,
   output: CloseInstancePublicPortsResult,
@@ -8932,7 +8931,7 @@ export const copySnapshot: API.OperationMethod<
   CopySnapshotRequest,
   CopySnapshotResult,
   CopySnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopySnapshotRequest,
   output: CopySnapshotResult,
@@ -8970,7 +8969,7 @@ export const createBucket: API.OperationMethod<
   CreateBucketRequest,
   CreateBucketResult,
   CreateBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketRequest,
   output: CreateBucketResult,
@@ -9012,7 +9011,7 @@ export const createBucketAccessKey: API.OperationMethod<
   CreateBucketAccessKeyRequest,
   CreateBucketAccessKeyResult,
   CreateBucketAccessKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketAccessKeyRequest,
   output: CreateBucketAccessKeyResult,
@@ -9056,7 +9055,7 @@ export const createCertificate: API.OperationMethod<
   CreateCertificateRequest,
   CreateCertificateResult,
   CreateCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCertificateRequest,
   output: CreateCertificateResult,
@@ -9096,7 +9095,7 @@ export const createCloudFormationStack: API.OperationMethod<
   CreateCloudFormationStackRequest,
   CreateCloudFormationStackResult,
   CreateCloudFormationStackError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudFormationStackRequest,
   output: CreateCloudFormationStackResult,
@@ -9139,7 +9138,7 @@ export const createContactMethod: API.OperationMethod<
   CreateContactMethodRequest,
   CreateContactMethodResult,
   CreateContactMethodError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactMethodRequest,
   output: CreateContactMethodResult,
@@ -9176,7 +9175,7 @@ export const createContainerService: API.OperationMethod<
   CreateContainerServiceRequest,
   CreateContainerServiceResult,
   CreateContainerServiceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerServiceRequest,
   output: CreateContainerServiceResult,
@@ -9219,7 +9218,7 @@ export const createContainerServiceDeployment: API.OperationMethod<
   CreateContainerServiceDeploymentRequest,
   CreateContainerServiceDeploymentResult,
   CreateContainerServiceDeploymentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerServiceDeploymentRequest,
   output: CreateContainerServiceDeploymentResult,
@@ -9269,7 +9268,7 @@ export const createContainerServiceRegistryLogin: API.OperationMethod<
   CreateContainerServiceRegistryLoginRequest,
   CreateContainerServiceRegistryLoginResult,
   CreateContainerServiceRegistryLoginError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerServiceRegistryLoginRequest,
   output: CreateContainerServiceRegistryLoginResult,
@@ -9307,7 +9306,7 @@ export const createDisk: API.OperationMethod<
   CreateDiskRequest,
   CreateDiskResult,
   CreateDiskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDiskRequest,
   output: CreateDiskResult,
@@ -9349,7 +9348,7 @@ export const createDiskFromSnapshot: API.OperationMethod<
   CreateDiskFromSnapshotRequest,
   CreateDiskFromSnapshotResult,
   CreateDiskFromSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDiskFromSnapshotRequest,
   output: CreateDiskFromSnapshotResult,
@@ -9406,7 +9405,7 @@ export const createDiskSnapshot: API.OperationMethod<
   CreateDiskSnapshotRequest,
   CreateDiskSnapshotResult,
   CreateDiskSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDiskSnapshotRequest,
   output: CreateDiskSnapshotResult,
@@ -9444,7 +9443,7 @@ export const createDistribution: API.OperationMethod<
   CreateDistributionRequest,
   CreateDistributionResult,
   CreateDistributionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDistributionRequest,
   output: CreateDistributionResult,
@@ -9481,7 +9480,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResult,
   CreateDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResult,
@@ -9523,7 +9522,7 @@ export const createDomainEntry: API.OperationMethod<
   CreateDomainEntryRequest,
   CreateDomainEntryResult,
   CreateDomainEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainEntryRequest,
   output: CreateDomainEntryResult,
@@ -9562,7 +9561,7 @@ export const createGUISessionAccessDetails: API.OperationMethod<
   CreateGUISessionAccessDetailsRequest,
   CreateGUISessionAccessDetailsResult,
   CreateGUISessionAccessDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGUISessionAccessDetailsRequest,
   output: CreateGUISessionAccessDetailsResult,
@@ -9599,7 +9598,7 @@ export const createInstances: API.OperationMethod<
   CreateInstancesRequest,
   CreateInstancesResult,
   CreateInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstancesRequest,
   output: CreateInstancesResult,
@@ -9640,7 +9639,7 @@ export const createInstancesFromSnapshot: API.OperationMethod<
   CreateInstancesFromSnapshotRequest,
   CreateInstancesFromSnapshotResult,
   CreateInstancesFromSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstancesFromSnapshotRequest,
   output: CreateInstancesFromSnapshotResult,
@@ -9680,7 +9679,7 @@ export const createInstanceSnapshot: API.OperationMethod<
   CreateInstanceSnapshotRequest,
   CreateInstanceSnapshotResult,
   CreateInstanceSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceSnapshotRequest,
   output: CreateInstanceSnapshotResult,
@@ -9724,7 +9723,7 @@ export const createKeyPair: API.OperationMethod<
   CreateKeyPairRequest,
   CreateKeyPairResult,
   CreateKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyPairRequest,
   output: CreateKeyPairResult,
@@ -9769,7 +9768,7 @@ export const createLoadBalancer: API.OperationMethod<
   CreateLoadBalancerRequest,
   CreateLoadBalancerResult,
   CreateLoadBalancerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoadBalancerRequest,
   output: CreateLoadBalancerResult,
@@ -9811,7 +9810,7 @@ export const createLoadBalancerTlsCertificate: API.OperationMethod<
   CreateLoadBalancerTlsCertificateRequest,
   CreateLoadBalancerTlsCertificateResult,
   CreateLoadBalancerTlsCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLoadBalancerTlsCertificateRequest,
   output: CreateLoadBalancerTlsCertificateResult,
@@ -9850,7 +9849,7 @@ export const createRelationalDatabase: API.OperationMethod<
   CreateRelationalDatabaseRequest,
   CreateRelationalDatabaseResult,
   CreateRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelationalDatabaseRequest,
   output: CreateRelationalDatabaseResult,
@@ -9894,7 +9893,7 @@ export const createRelationalDatabaseFromSnapshot: API.OperationMethod<
   CreateRelationalDatabaseFromSnapshotRequest,
   CreateRelationalDatabaseFromSnapshotResult,
   CreateRelationalDatabaseFromSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelationalDatabaseFromSnapshotRequest,
   output: CreateRelationalDatabaseFromSnapshotResult,
@@ -9934,7 +9933,7 @@ export const createRelationalDatabaseSnapshot: API.OperationMethod<
   CreateRelationalDatabaseSnapshotRequest,
   CreateRelationalDatabaseSnapshotResult,
   CreateRelationalDatabaseSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelationalDatabaseSnapshotRequest,
   output: CreateRelationalDatabaseSnapshotResult,
@@ -9974,7 +9973,7 @@ export const deleteAlarm: API.OperationMethod<
   DeleteAlarmRequest,
   DeleteAlarmResult,
   DeleteAlarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlarmRequest,
   output: DeleteAlarmResult,
@@ -10008,7 +10007,7 @@ export const deleteAutoSnapshot: API.OperationMethod<
   DeleteAutoSnapshotRequest,
   DeleteAutoSnapshotResult,
   DeleteAutoSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutoSnapshotRequest,
   output: DeleteAutoSnapshotResult,
@@ -10044,7 +10043,7 @@ export const deleteBucket: API.OperationMethod<
   DeleteBucketRequest,
   DeleteBucketResult,
   DeleteBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketRequest,
   output: DeleteBucketResult,
@@ -10081,7 +10080,7 @@ export const deleteBucketAccessKey: API.OperationMethod<
   DeleteBucketAccessKeyRequest,
   DeleteBucketAccessKeyResult,
   DeleteBucketAccessKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketAccessKeyRequest,
   output: DeleteBucketAccessKeyResult,
@@ -10118,7 +10117,7 @@ export const deleteCertificate: API.OperationMethod<
   DeleteCertificateRequest,
   DeleteCertificateResult,
   DeleteCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateRequest,
   output: DeleteCertificateResult,
@@ -10156,7 +10155,7 @@ export const deleteContactMethod: API.OperationMethod<
   DeleteContactMethodRequest,
   DeleteContactMethodResult,
   DeleteContactMethodError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactMethodRequest,
   output: DeleteContactMethodResult,
@@ -10190,7 +10189,7 @@ export const deleteContainerImage: API.OperationMethod<
   DeleteContainerImageRequest,
   DeleteContainerImageResult,
   DeleteContainerImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerImageRequest,
   output: DeleteContainerImageResult,
@@ -10222,7 +10221,7 @@ export const deleteContainerService: API.OperationMethod<
   DeleteContainerServiceRequest,
   DeleteContainerServiceResult,
   DeleteContainerServiceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerServiceRequest,
   output: DeleteContainerServiceResult,
@@ -10263,7 +10262,7 @@ export const deleteDisk: API.OperationMethod<
   DeleteDiskRequest,
   DeleteDiskResult,
   DeleteDiskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDiskRequest,
   output: DeleteDiskResult,
@@ -10309,7 +10308,7 @@ export const deleteDiskSnapshot: API.OperationMethod<
   DeleteDiskSnapshotRequest,
   DeleteDiskSnapshotResult,
   DeleteDiskSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDiskSnapshotRequest,
   output: DeleteDiskSnapshotResult,
@@ -10343,7 +10342,7 @@ export const deleteDistribution: API.OperationMethod<
   DeleteDistributionRequest,
   DeleteDistributionResult,
   DeleteDistributionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDistributionRequest,
   output: DeleteDistributionResult,
@@ -10381,7 +10380,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResult,
   DeleteDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResult,
@@ -10421,7 +10420,7 @@ export const deleteDomainEntry: API.OperationMethod<
   DeleteDomainEntryRequest,
   DeleteDomainEntryResult,
   DeleteDomainEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainEntryRequest,
   output: DeleteDomainEntryResult,
@@ -10461,7 +10460,7 @@ export const deleteInstance: API.OperationMethod<
   DeleteInstanceRequest,
   DeleteInstanceResult,
   DeleteInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceRequest,
   output: DeleteInstanceResult,
@@ -10502,7 +10501,7 @@ export const deleteInstanceSnapshot: API.OperationMethod<
   DeleteInstanceSnapshotRequest,
   DeleteInstanceSnapshotResult,
   DeleteInstanceSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceSnapshotRequest,
   output: DeleteInstanceSnapshotResult,
@@ -10547,7 +10546,7 @@ export const deleteKeyPair: API.OperationMethod<
   DeleteKeyPairRequest,
   DeleteKeyPairResult,
   DeleteKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyPairRequest,
   output: DeleteKeyPairResult,
@@ -10590,7 +10589,7 @@ export const deleteKnownHostKeys: API.OperationMethod<
   DeleteKnownHostKeysRequest,
   DeleteKnownHostKeysResult,
   DeleteKnownHostKeysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnownHostKeysRequest,
   output: DeleteKnownHostKeysResult,
@@ -10632,7 +10631,7 @@ export const deleteLoadBalancer: API.OperationMethod<
   DeleteLoadBalancerRequest,
   DeleteLoadBalancerResult,
   DeleteLoadBalancerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoadBalancerRequest,
   output: DeleteLoadBalancerResult,
@@ -10672,7 +10671,7 @@ export const deleteLoadBalancerTlsCertificate: API.OperationMethod<
   DeleteLoadBalancerTlsCertificateRequest,
   DeleteLoadBalancerTlsCertificateResult,
   DeleteLoadBalancerTlsCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoadBalancerTlsCertificateRequest,
   output: DeleteLoadBalancerTlsCertificateResult,
@@ -10712,7 +10711,7 @@ export const deleteRelationalDatabase: API.OperationMethod<
   DeleteRelationalDatabaseRequest,
   DeleteRelationalDatabaseResult,
   DeleteRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRelationalDatabaseRequest,
   output: DeleteRelationalDatabaseResult,
@@ -10752,7 +10751,7 @@ export const deleteRelationalDatabaseSnapshot: API.OperationMethod<
   DeleteRelationalDatabaseSnapshotRequest,
   DeleteRelationalDatabaseSnapshotResult,
   DeleteRelationalDatabaseSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRelationalDatabaseSnapshotRequest,
   output: DeleteRelationalDatabaseSnapshotResult,
@@ -10790,7 +10789,7 @@ export const detachCertificateFromDistribution: API.OperationMethod<
   DetachCertificateFromDistributionRequest,
   DetachCertificateFromDistributionResult,
   DetachCertificateFromDistributionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachCertificateFromDistributionRequest,
   output: DetachCertificateFromDistributionResult,
@@ -10830,7 +10829,7 @@ export const detachDisk: API.OperationMethod<
   DetachDiskRequest,
   DetachDiskResult,
   DetachDiskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachDiskRequest,
   output: DetachDiskResult,
@@ -10873,7 +10872,7 @@ export const detachInstancesFromLoadBalancer: API.OperationMethod<
   DetachInstancesFromLoadBalancerRequest,
   DetachInstancesFromLoadBalancerResult,
   DetachInstancesFromLoadBalancerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachInstancesFromLoadBalancerRequest,
   output: DetachInstancesFromLoadBalancerResult,
@@ -10909,7 +10908,7 @@ export const detachStaticIp: API.OperationMethod<
   DetachStaticIpRequest,
   DetachStaticIpResult,
   DetachStaticIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachStaticIpRequest,
   output: DetachStaticIpResult,
@@ -10944,7 +10943,7 @@ export const disableAddOn: API.OperationMethod<
   DisableAddOnRequest,
   DisableAddOnResult,
   DisableAddOnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAddOnRequest,
   output: DisableAddOnResult,
@@ -10982,7 +10981,7 @@ export const downloadDefaultKeyPair: API.OperationMethod<
   DownloadDefaultKeyPairRequest,
   DownloadDefaultKeyPairResult,
   DownloadDefaultKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DownloadDefaultKeyPairRequest,
   output: DownloadDefaultKeyPairResult,
@@ -11018,7 +11017,7 @@ export const enableAddOn: API.OperationMethod<
   EnableAddOnRequest,
   EnableAddOnResult,
   EnableAddOnError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAddOnRequest,
   output: EnableAddOnResult,
@@ -11067,7 +11066,7 @@ export const exportSnapshot: API.OperationMethod<
   ExportSnapshotRequest,
   ExportSnapshotResult,
   ExportSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportSnapshotRequest,
   output: ExportSnapshotResult,
@@ -11103,7 +11102,7 @@ export const getActiveNames: API.OperationMethod<
   GetActiveNamesRequest,
   GetActiveNamesResult,
   GetActiveNamesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActiveNamesRequest,
   output: GetActiveNamesResult,
@@ -11145,7 +11144,7 @@ export const getAlarms: API.OperationMethod<
   GetAlarmsRequest,
   GetAlarmsResult,
   GetAlarmsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAlarmsRequest,
   output: GetAlarmsResult,
@@ -11180,7 +11179,7 @@ export const getAutoSnapshots: API.OperationMethod<
   GetAutoSnapshotsRequest,
   GetAutoSnapshotsResult,
   GetAutoSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoSnapshotsRequest,
   output: GetAutoSnapshotsResult,
@@ -11223,7 +11222,7 @@ export const getBlueprints: API.OperationMethod<
   GetBlueprintsRequest,
   GetBlueprintsResult,
   GetBlueprintsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlueprintsRequest,
   output: GetBlueprintsResult,
@@ -11261,7 +11260,7 @@ export const getBucketAccessKeys: API.OperationMethod<
   GetBucketAccessKeysRequest,
   GetBucketAccessKeysResult,
   GetBucketAccessKeysError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketAccessKeysRequest,
   output: GetBucketAccessKeysResult,
@@ -11298,7 +11297,7 @@ export const getBucketBundles: API.OperationMethod<
   GetBucketBundlesRequest,
   GetBucketBundlesResult,
   GetBucketBundlesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketBundlesRequest,
   output: GetBucketBundlesResult,
@@ -11333,7 +11332,7 @@ export const getBucketMetricData: API.OperationMethod<
   GetBucketMetricDataRequest,
   GetBucketMetricDataResult,
   GetBucketMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketMetricDataRequest,
   output: GetBucketMetricDataResult,
@@ -11370,7 +11369,7 @@ export const getBuckets: API.OperationMethod<
   GetBucketsRequest,
   GetBucketsResult,
   GetBucketsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketsRequest,
   output: GetBucketsResult,
@@ -11412,7 +11411,7 @@ export const getBundles: API.OperationMethod<
   GetBundlesRequest,
   GetBundlesResult,
   GetBundlesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBundlesRequest,
   output: GetBundlesResult,
@@ -11450,7 +11449,7 @@ export const getCertificates: API.OperationMethod<
   GetCertificatesRequest,
   GetCertificatesResult,
   GetCertificatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificatesRequest,
   output: GetCertificatesResult,
@@ -11488,7 +11487,7 @@ export const getCloudFormationStackRecords: API.OperationMethod<
   GetCloudFormationStackRecordsRequest,
   GetCloudFormationStackRecordsResult,
   GetCloudFormationStackRecordsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudFormationStackRecordsRequest,
   output: GetCloudFormationStackRecordsResult,
@@ -11529,7 +11528,7 @@ export const getContactMethods: API.OperationMethod<
   GetContactMethodsRequest,
   GetContactMethodsResult,
   GetContactMethodsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactMethodsRequest,
   output: GetContactMethodsResult,
@@ -11561,7 +11560,7 @@ export const getContainerAPIMetadata: API.OperationMethod<
   GetContainerAPIMetadataRequest,
   GetContainerAPIMetadataResult,
   GetContainerAPIMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerAPIMetadataRequest,
   output: GetContainerAPIMetadataResult,
@@ -11596,7 +11595,7 @@ export const getContainerImages: API.OperationMethod<
   GetContainerImagesRequest,
   GetContainerImagesResult,
   GetContainerImagesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerImagesRequest,
   output: GetContainerImagesResult,
@@ -11637,7 +11636,7 @@ export const getContainerLog: API.OperationMethod<
   GetContainerLogRequest,
   GetContainerLogResult,
   GetContainerLogError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerLogRequest,
   output: GetContainerLogResult,
@@ -11680,7 +11679,7 @@ export const getContainerServiceDeployments: API.OperationMethod<
   GetContainerServiceDeploymentsRequest,
   GetContainerServiceDeploymentsResult,
   GetContainerServiceDeploymentsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerServiceDeploymentsRequest,
   output: GetContainerServiceDeploymentsResult,
@@ -11716,7 +11715,7 @@ export const getContainerServiceMetricData: API.OperationMethod<
   GetContainerServiceMetricDataRequest,
   GetContainerServiceMetricDataResult,
   GetContainerServiceMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerServiceMetricDataRequest,
   output: GetContainerServiceMetricDataResult,
@@ -11752,7 +11751,7 @@ export const getContainerServicePowers: API.OperationMethod<
   GetContainerServicePowersRequest,
   GetContainerServicePowersResult,
   GetContainerServicePowersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerServicePowersRequest,
   output: GetContainerServicePowersResult,
@@ -11784,7 +11783,7 @@ export const getContainerServices: API.OperationMethod<
   GetContainerServicesRequest,
   ContainerServicesListResult,
   GetContainerServicesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerServicesRequest,
   output: ContainerServicesListResult,
@@ -11817,7 +11816,7 @@ export const getCostEstimate: API.OperationMethod<
   GetCostEstimateRequest,
   GetCostEstimateResult,
   GetCostEstimateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCostEstimateRequest,
   output: GetCostEstimateResult,
@@ -11851,7 +11850,7 @@ export const getDisk: API.OperationMethod<
   GetDiskRequest,
   GetDiskResult,
   GetDiskError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDiskRequest,
   output: GetDiskResult,
@@ -11887,7 +11886,7 @@ export const getDisks: API.OperationMethod<
   GetDisksRequest,
   GetDisksResult,
   GetDisksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDisksRequest,
   output: GetDisksResult,
@@ -11923,7 +11922,7 @@ export const getDiskSnapshot: API.OperationMethod<
   GetDiskSnapshotRequest,
   GetDiskSnapshotResult,
   GetDiskSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDiskSnapshotRequest,
   output: GetDiskSnapshotResult,
@@ -11960,7 +11959,7 @@ export const getDiskSnapshots: API.OperationMethod<
   GetDiskSnapshotsRequest,
   GetDiskSnapshotsResult,
   GetDiskSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDiskSnapshotsRequest,
   output: GetDiskSnapshotsResult,
@@ -11998,7 +11997,7 @@ export const getDistributionBundles: API.OperationMethod<
   GetDistributionBundlesRequest,
   GetDistributionBundlesResult,
   GetDistributionBundlesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionBundlesRequest,
   output: GetDistributionBundlesResult,
@@ -12031,7 +12030,7 @@ export const getDistributionLatestCacheReset: API.OperationMethod<
   GetDistributionLatestCacheResetRequest,
   GetDistributionLatestCacheResetResult,
   GetDistributionLatestCacheResetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionLatestCacheResetRequest,
   output: GetDistributionLatestCacheResetResult,
@@ -12068,7 +12067,7 @@ export const getDistributionMetricData: API.OperationMethod<
   GetDistributionMetricDataRequest,
   GetDistributionMetricDataResult,
   GetDistributionMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionMetricDataRequest,
   output: GetDistributionMetricDataResult,
@@ -12101,7 +12100,7 @@ export const getDistributions: API.OperationMethod<
   GetDistributionsRequest,
   GetDistributionsResult,
   GetDistributionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDistributionsRequest,
   output: GetDistributionsResult,
@@ -12135,7 +12134,7 @@ export const getDomain: API.OperationMethod<
   GetDomainRequest,
   GetDomainResult,
   GetDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainRequest,
   output: GetDomainResult,
@@ -12171,7 +12170,7 @@ export const getDomains: API.OperationMethod<
   GetDomainsRequest,
   GetDomainsResult,
   GetDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainsRequest,
   output: GetDomainsResult,
@@ -12212,7 +12211,7 @@ export const getExportSnapshotRecords: API.OperationMethod<
   GetExportSnapshotRecordsRequest,
   GetExportSnapshotRecordsResult,
   GetExportSnapshotRecordsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportSnapshotRecordsRequest,
   output: GetExportSnapshotRecordsResult,
@@ -12249,7 +12248,7 @@ export const getInstance: API.OperationMethod<
   GetInstanceRequest,
   GetInstanceResult,
   GetInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceRequest,
   output: GetInstanceResult,
@@ -12290,7 +12289,7 @@ export const getInstanceAccessDetails: API.OperationMethod<
   GetInstanceAccessDetailsRequest,
   GetInstanceAccessDetailsResult,
   GetInstanceAccessDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceAccessDetailsRequest,
   output: GetInstanceAccessDetailsResult,
@@ -12331,7 +12330,7 @@ export const getInstanceMetricData: API.OperationMethod<
   GetInstanceMetricDataRequest,
   GetInstanceMetricDataResult,
   GetInstanceMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceMetricDataRequest,
   output: GetInstanceMetricDataResult,
@@ -12368,7 +12367,7 @@ export const getInstancePortStates: API.OperationMethod<
   GetInstancePortStatesRequest,
   GetInstancePortStatesResult,
   GetInstancePortStatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstancePortStatesRequest,
   output: GetInstancePortStatesResult,
@@ -12405,7 +12404,7 @@ export const getInstances: API.OperationMethod<
   GetInstancesRequest,
   GetInstancesResult,
   GetInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstancesRequest,
   output: GetInstancesResult,
@@ -12441,7 +12440,7 @@ export const getInstanceSnapshot: API.OperationMethod<
   GetInstanceSnapshotRequest,
   GetInstanceSnapshotResult,
   GetInstanceSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceSnapshotRequest,
   output: GetInstanceSnapshotResult,
@@ -12477,7 +12476,7 @@ export const getInstanceSnapshots: API.OperationMethod<
   GetInstanceSnapshotsRequest,
   GetInstanceSnapshotsResult,
   GetInstanceSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceSnapshotsRequest,
   output: GetInstanceSnapshotsResult,
@@ -12513,7 +12512,7 @@ export const getInstanceState: API.OperationMethod<
   GetInstanceStateRequest,
   GetInstanceStateResult,
   GetInstanceStateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceStateRequest,
   output: GetInstanceStateResult,
@@ -12549,7 +12548,7 @@ export const getKeyPair: API.OperationMethod<
   GetKeyPairRequest,
   GetKeyPairResult,
   GetKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyPairRequest,
   output: GetKeyPairResult,
@@ -12585,7 +12584,7 @@ export const getKeyPairs: API.OperationMethod<
   GetKeyPairsRequest,
   GetKeyPairsResult,
   GetKeyPairsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyPairsRequest,
   output: GetKeyPairsResult,
@@ -12621,7 +12620,7 @@ export const getLoadBalancer: API.OperationMethod<
   GetLoadBalancerRequest,
   GetLoadBalancerResult,
   GetLoadBalancerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoadBalancerRequest,
   output: GetLoadBalancerResult,
@@ -12661,7 +12660,7 @@ export const getLoadBalancerMetricData: API.OperationMethod<
   GetLoadBalancerMetricDataRequest,
   GetLoadBalancerMetricDataResult,
   GetLoadBalancerMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoadBalancerMetricDataRequest,
   output: GetLoadBalancerMetricDataResult,
@@ -12697,7 +12696,7 @@ export const getLoadBalancers: API.OperationMethod<
   GetLoadBalancersRequest,
   GetLoadBalancersResult,
   GetLoadBalancersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoadBalancersRequest,
   output: GetLoadBalancersResult,
@@ -12739,7 +12738,7 @@ export const getLoadBalancerTlsCertificates: API.OperationMethod<
   GetLoadBalancerTlsCertificatesRequest,
   GetLoadBalancerTlsCertificatesResult,
   GetLoadBalancerTlsCertificatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoadBalancerTlsCertificatesRequest,
   output: GetLoadBalancerTlsCertificatesResult,
@@ -12777,7 +12776,7 @@ export const getLoadBalancerTlsPolicies: API.OperationMethod<
   GetLoadBalancerTlsPoliciesRequest,
   GetLoadBalancerTlsPoliciesResult,
   GetLoadBalancerTlsPoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoadBalancerTlsPoliciesRequest,
   output: GetLoadBalancerTlsPoliciesResult,
@@ -12812,7 +12811,7 @@ export const getOperation: API.OperationMethod<
   GetOperationRequest,
   GetOperationResult,
   GetOperationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationRequest,
   output: GetOperationResult,
@@ -12852,7 +12851,7 @@ export const getOperations: API.OperationMethod<
   GetOperationsRequest,
   GetOperationsResult,
   GetOperationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationsRequest,
   output: GetOperationsResult,
@@ -12888,7 +12887,7 @@ export const getOperationsForResource: API.OperationMethod<
   GetOperationsForResourceRequest,
   GetOperationsForResourceResult,
   GetOperationsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationsForResourceRequest,
   output: GetOperationsForResourceResult,
@@ -12926,7 +12925,7 @@ export const getRegions: API.OperationMethod<
   GetRegionsRequest,
   GetRegionsResult,
   GetRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegionsRequest,
   output: GetRegionsResult,
@@ -12962,7 +12961,7 @@ export const getRelationalDatabase: API.OperationMethod<
   GetRelationalDatabaseRequest,
   GetRelationalDatabaseResult,
   GetRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseRequest,
   output: GetRelationalDatabaseResult,
@@ -13002,7 +13001,7 @@ export const getRelationalDatabaseBlueprints: API.OperationMethod<
   GetRelationalDatabaseBlueprintsRequest,
   GetRelationalDatabaseBlueprintsResult,
   GetRelationalDatabaseBlueprintsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseBlueprintsRequest,
   output: GetRelationalDatabaseBlueprintsResult,
@@ -13042,7 +13041,7 @@ export const getRelationalDatabaseBundles: API.OperationMethod<
   GetRelationalDatabaseBundlesRequest,
   GetRelationalDatabaseBundlesResult,
   GetRelationalDatabaseBundlesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseBundlesRequest,
   output: GetRelationalDatabaseBundlesResult,
@@ -13078,7 +13077,7 @@ export const getRelationalDatabaseEvents: API.OperationMethod<
   GetRelationalDatabaseEventsRequest,
   GetRelationalDatabaseEventsResult,
   GetRelationalDatabaseEventsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseEventsRequest,
   output: GetRelationalDatabaseEventsResult,
@@ -13114,7 +13113,7 @@ export const getRelationalDatabaseLogEvents: API.OperationMethod<
   GetRelationalDatabaseLogEventsRequest,
   GetRelationalDatabaseLogEventsResult,
   GetRelationalDatabaseLogEventsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseLogEventsRequest,
   output: GetRelationalDatabaseLogEventsResult,
@@ -13150,7 +13149,7 @@ export const getRelationalDatabaseLogStreams: API.OperationMethod<
   GetRelationalDatabaseLogStreamsRequest,
   GetRelationalDatabaseLogStreamsResult,
   GetRelationalDatabaseLogStreamsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseLogStreamsRequest,
   output: GetRelationalDatabaseLogStreamsResult,
@@ -13191,7 +13190,7 @@ export const getRelationalDatabaseMasterUserPassword: API.OperationMethod<
   GetRelationalDatabaseMasterUserPasswordRequest,
   GetRelationalDatabaseMasterUserPasswordResult,
   GetRelationalDatabaseMasterUserPasswordError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseMasterUserPasswordRequest,
   output: GetRelationalDatabaseMasterUserPasswordResult,
@@ -13231,7 +13230,7 @@ export const getRelationalDatabaseMetricData: API.OperationMethod<
   GetRelationalDatabaseMetricDataRequest,
   GetRelationalDatabaseMetricDataResult,
   GetRelationalDatabaseMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseMetricDataRequest,
   output: GetRelationalDatabaseMetricDataResult,
@@ -13272,7 +13271,7 @@ export const getRelationalDatabaseParameters: API.OperationMethod<
   GetRelationalDatabaseParametersRequest,
   GetRelationalDatabaseParametersResult,
   GetRelationalDatabaseParametersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseParametersRequest,
   output: GetRelationalDatabaseParametersResult,
@@ -13308,7 +13307,7 @@ export const getRelationalDatabases: API.OperationMethod<
   GetRelationalDatabasesRequest,
   GetRelationalDatabasesResult,
   GetRelationalDatabasesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabasesRequest,
   output: GetRelationalDatabasesResult,
@@ -13344,7 +13343,7 @@ export const getRelationalDatabaseSnapshot: API.OperationMethod<
   GetRelationalDatabaseSnapshotRequest,
   GetRelationalDatabaseSnapshotResult,
   GetRelationalDatabaseSnapshotError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseSnapshotRequest,
   output: GetRelationalDatabaseSnapshotResult,
@@ -13380,7 +13379,7 @@ export const getRelationalDatabaseSnapshots: API.OperationMethod<
   GetRelationalDatabaseSnapshotsRequest,
   GetRelationalDatabaseSnapshotsResult,
   GetRelationalDatabaseSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationalDatabaseSnapshotsRequest,
   output: GetRelationalDatabaseSnapshotsResult,
@@ -13415,7 +13414,7 @@ export const getSetupHistory: API.OperationMethod<
   GetSetupHistoryRequest,
   GetSetupHistoryResult,
   GetSetupHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSetupHistoryRequest,
   output: GetSetupHistoryResult,
@@ -13449,7 +13448,7 @@ export const getStaticIp: API.OperationMethod<
   GetStaticIpRequest,
   GetStaticIpResult,
   GetStaticIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStaticIpRequest,
   output: GetStaticIpResult,
@@ -13485,7 +13484,7 @@ export const getStaticIps: API.OperationMethod<
   GetStaticIpsRequest,
   GetStaticIpsResult,
   GetStaticIpsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStaticIpsRequest,
   output: GetStaticIpsResult,
@@ -13521,7 +13520,7 @@ export const importKeyPair: API.OperationMethod<
   ImportKeyPairRequest,
   ImportKeyPairResult,
   ImportKeyPairError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportKeyPairRequest,
   output: ImportKeyPairResult,
@@ -13557,7 +13556,7 @@ export const isVpcPeered: API.OperationMethod<
   IsVpcPeeredRequest,
   IsVpcPeeredResult,
   IsVpcPeeredError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IsVpcPeeredRequest,
   output: IsVpcPeeredResult,
@@ -13598,7 +13597,7 @@ export const openInstancePublicPorts: API.OperationMethod<
   OpenInstancePublicPortsRequest,
   OpenInstancePublicPortsResult,
   OpenInstancePublicPortsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OpenInstancePublicPortsRequest,
   output: OpenInstancePublicPortsResult,
@@ -13634,7 +13633,7 @@ export const peerVpc: API.OperationMethod<
   PeerVpcRequest,
   PeerVpcResult,
   PeerVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PeerVpcRequest,
   output: PeerVpcResult,
@@ -13685,7 +13684,7 @@ export const putAlarm: API.OperationMethod<
   PutAlarmRequest,
   PutAlarmResult,
   PutAlarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAlarmRequest,
   output: PutAlarmResult,
@@ -13729,7 +13728,7 @@ export const putInstancePublicPorts: API.OperationMethod<
   PutInstancePublicPortsRequest,
   PutInstancePublicPortsResult,
   PutInstancePublicPortsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInstancePublicPortsRequest,
   output: PutInstancePublicPortsResult,
@@ -13769,7 +13768,7 @@ export const rebootInstance: API.OperationMethod<
   RebootInstanceRequest,
   RebootInstanceResult,
   RebootInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootInstanceRequest,
   output: RebootInstanceResult,
@@ -13809,7 +13808,7 @@ export const rebootRelationalDatabase: API.OperationMethod<
   RebootRelationalDatabaseRequest,
   RebootRelationalDatabaseResult,
   RebootRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootRelationalDatabaseRequest,
   output: RebootRelationalDatabaseResult,
@@ -13848,7 +13847,7 @@ export const registerContainerImage: API.OperationMethod<
   RegisterContainerImageRequest,
   RegisterContainerImageResult,
   RegisterContainerImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterContainerImageRequest,
   output: RegisterContainerImageResult,
@@ -13882,7 +13881,7 @@ export const releaseStaticIp: API.OperationMethod<
   ReleaseStaticIpRequest,
   ReleaseStaticIpResult,
   ReleaseStaticIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseStaticIpRequest,
   output: ReleaseStaticIpResult,
@@ -13920,7 +13919,7 @@ export const resetDistributionCache: API.OperationMethod<
   ResetDistributionCacheRequest,
   ResetDistributionCacheResult,
   ResetDistributionCacheError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDistributionCacheRequest,
   output: ResetDistributionCacheResult,
@@ -13966,7 +13965,7 @@ export const sendContactMethodVerification: API.OperationMethod<
   SendContactMethodVerificationRequest,
   SendContactMethodVerificationResult,
   SendContactMethodVerificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendContactMethodVerificationRequest,
   output: SendContactMethodVerificationResult,
@@ -14005,7 +14004,7 @@ export const setIpAddressType: API.OperationMethod<
   SetIpAddressTypeRequest,
   SetIpAddressTypeResult,
   SetIpAddressTypeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIpAddressTypeRequest,
   output: SetIpAddressTypeResult,
@@ -14043,7 +14042,7 @@ export const setResourceAccessForBucket: API.OperationMethod<
   SetResourceAccessForBucketRequest,
   SetResourceAccessForBucketResult,
   SetResourceAccessForBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetResourceAccessForBucketRequest,
   output: SetResourceAccessForBucketResult,
@@ -14079,7 +14078,7 @@ export const setupInstanceHttps: API.OperationMethod<
   SetupInstanceHttpsRequest,
   SetupInstanceHttpsResult,
   SetupInstanceHttpsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetupInstanceHttpsRequest,
   output: SetupInstanceHttpsResult,
@@ -14113,7 +14112,7 @@ export const startGUISession: API.OperationMethod<
   StartGUISessionRequest,
   StartGUISessionResult,
   StartGUISessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartGUISessionRequest,
   output: StartGUISessionResult,
@@ -14156,7 +14155,7 @@ export const startInstance: API.OperationMethod<
   StartInstanceRequest,
   StartInstanceResult,
   StartInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInstanceRequest,
   output: StartInstanceResult,
@@ -14197,7 +14196,7 @@ export const startRelationalDatabase: API.OperationMethod<
   StartRelationalDatabaseRequest,
   StartRelationalDatabaseResult,
   StartRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRelationalDatabaseRequest,
   output: StartRelationalDatabaseResult,
@@ -14233,7 +14232,7 @@ export const stopGUISession: API.OperationMethod<
   StopGUISessionRequest,
   StopGUISessionResult,
   StopGUISessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopGUISessionRequest,
   output: StopGUISessionResult,
@@ -14275,7 +14274,7 @@ export const stopInstance: API.OperationMethod<
   StopInstanceRequest,
   StopInstanceResult,
   StopInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInstanceRequest,
   output: StopInstanceResult,
@@ -14319,7 +14318,7 @@ export const stopRelationalDatabase: API.OperationMethod<
   StopRelationalDatabaseRequest,
   StopRelationalDatabaseResult,
   StopRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRelationalDatabaseRequest,
   output: StopRelationalDatabaseResult,
@@ -14361,7 +14360,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -14404,7 +14403,7 @@ export const testAlarm: API.OperationMethod<
   TestAlarmRequest,
   TestAlarmResult,
   TestAlarmError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestAlarmRequest,
   output: TestAlarmResult,
@@ -14439,7 +14438,7 @@ export const unpeerVpc: API.OperationMethod<
   UnpeerVpcRequest,
   UnpeerVpcResult,
   UnpeerVpcError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnpeerVpcRequest,
   output: UnpeerVpcResult,
@@ -14480,7 +14479,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -14517,7 +14516,7 @@ export const updateBucket: API.OperationMethod<
   UpdateBucketRequest,
   UpdateBucketResult,
   UpdateBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBucketRequest,
   output: UpdateBucketResult,
@@ -14563,7 +14562,7 @@ export const updateBucketBundle: API.OperationMethod<
   UpdateBucketBundleRequest,
   UpdateBucketBundleResult,
   UpdateBucketBundleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBucketBundleRequest,
   output: UpdateBucketBundleResult,
@@ -14596,7 +14595,7 @@ export const updateContainerService: API.OperationMethod<
   UpdateContainerServiceRequest,
   UpdateContainerServiceResult,
   UpdateContainerServiceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContainerServiceRequest,
   output: UpdateContainerServiceResult,
@@ -14630,7 +14629,7 @@ export const updateDistribution: API.OperationMethod<
   UpdateDistributionRequest,
   UpdateDistributionResult,
   UpdateDistributionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionRequest,
   output: UpdateDistributionResult,
@@ -14673,7 +14672,7 @@ export const updateDistributionBundle: API.OperationMethod<
   UpdateDistributionBundleRequest,
   UpdateDistributionBundleResult,
   UpdateDistributionBundleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDistributionBundleRequest,
   output: UpdateDistributionBundleResult,
@@ -14711,7 +14710,7 @@ export const updateDomainEntry: API.OperationMethod<
   UpdateDomainEntryRequest,
   UpdateDomainEntryResult,
   UpdateDomainEntryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainEntryRequest,
   output: UpdateDomainEntryResult,
@@ -14752,7 +14751,7 @@ export const updateInstanceMetadataOptions: API.OperationMethod<
   UpdateInstanceMetadataOptionsRequest,
   UpdateInstanceMetadataOptionsResult,
   UpdateInstanceMetadataOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceMetadataOptionsRequest,
   output: UpdateInstanceMetadataOptionsResult,
@@ -14793,7 +14792,7 @@ export const updateLoadBalancerAttribute: API.OperationMethod<
   UpdateLoadBalancerAttributeRequest,
   UpdateLoadBalancerAttributeResult,
   UpdateLoadBalancerAttributeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoadBalancerAttributeRequest,
   output: UpdateLoadBalancerAttributeResult,
@@ -14836,7 +14835,7 @@ export const updateRelationalDatabase: API.OperationMethod<
   UpdateRelationalDatabaseRequest,
   UpdateRelationalDatabaseResult,
   UpdateRelationalDatabaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelationalDatabaseRequest,
   output: UpdateRelationalDatabaseResult,
@@ -14883,7 +14882,7 @@ export const updateRelationalDatabaseParameters: API.OperationMethod<
   UpdateRelationalDatabaseParametersRequest,
   UpdateRelationalDatabaseParametersResult,
   UpdateRelationalDatabaseParametersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelationalDatabaseParametersRequest,
   output: UpdateRelationalDatabaseParametersResult,

--- a/packages/aws/src/services/location.ts
+++ b/packages/aws/src/services/location.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Location",
@@ -3828,7 +3827,7 @@ export const associateTrackerConsumer: API.OperationMethod<
   AssociateTrackerConsumerRequest,
   AssociateTrackerConsumerResponse,
   AssociateTrackerConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTrackerConsumerRequest,
   output: AssociateTrackerConsumerResponse,
@@ -3861,7 +3860,7 @@ export const batchDeleteDevicePositionHistory: API.OperationMethod<
   BatchDeleteDevicePositionHistoryRequest,
   BatchDeleteDevicePositionHistoryResponse,
   BatchDeleteDevicePositionHistoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDevicePositionHistoryRequest,
   output: BatchDeleteDevicePositionHistoryResponse,
@@ -3894,7 +3893,7 @@ export const batchDeleteGeofence: API.OperationMethod<
   BatchDeleteGeofenceRequest,
   BatchDeleteGeofenceResponse,
   BatchDeleteGeofenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteGeofenceRequest,
   output: BatchDeleteGeofenceResponse,
@@ -3937,7 +3936,7 @@ export const batchEvaluateGeofences: API.OperationMethod<
   BatchEvaluateGeofencesRequest,
   BatchEvaluateGeofencesResponse,
   BatchEvaluateGeofencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchEvaluateGeofencesRequest,
   output: BatchEvaluateGeofencesResponse,
@@ -3968,7 +3967,7 @@ export const batchGetDevicePosition: API.OperationMethod<
   BatchGetDevicePositionRequest,
   BatchGetDevicePositionResponse,
   BatchGetDevicePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetDevicePositionRequest,
   output: BatchGetDevicePositionResponse,
@@ -3999,7 +3998,7 @@ export const batchPutGeofence: API.OperationMethod<
   BatchPutGeofenceRequest,
   BatchPutGeofenceResponse,
   BatchPutGeofenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutGeofenceRequest,
   output: BatchPutGeofenceResponse,
@@ -4036,7 +4035,7 @@ export const batchUpdateDevicePosition: API.OperationMethod<
   BatchUpdateDevicePositionRequest,
   BatchUpdateDevicePositionResponse,
   BatchUpdateDevicePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateDevicePositionRequest,
   output: BatchUpdateDevicePositionResponse,
@@ -4089,7 +4088,7 @@ export const calculateRoute: API.OperationMethod<
   CalculateRouteRequest,
   CalculateRouteResponse,
   CalculateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CalculateRouteRequest,
   output: CalculateRouteResponse,
@@ -4146,7 +4145,7 @@ export const calculateRouteMatrix: API.OperationMethod<
   CalculateRouteMatrixRequest,
   CalculateRouteMatrixResponse,
   CalculateRouteMatrixError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CalculateRouteMatrixRequest,
   output: CalculateRouteMatrixResponse,
@@ -4179,7 +4178,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -4211,7 +4210,7 @@ export const createGeofenceCollection: API.OperationMethod<
   CreateGeofenceCollectionRequest,
   CreateGeofenceCollectionResponse,
   CreateGeofenceCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGeofenceCollectionRequest,
   output: CreateGeofenceCollectionResponse,
@@ -4246,7 +4245,7 @@ export const createKey: API.OperationMethod<
   CreateKeyRequest,
   CreateKeyResponse,
   CreateKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyRequest,
   output: CreateKeyResponse,
@@ -4293,7 +4292,7 @@ export const createMap: API.OperationMethod<
   CreateMapRequest,
   CreateMapResponse,
   CreateMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMapRequest,
   output: CreateMapResponse,
@@ -4340,7 +4339,7 @@ export const createPlaceIndex: API.OperationMethod<
   CreatePlaceIndexRequest,
   CreatePlaceIndexResponse,
   CreatePlaceIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlaceIndexRequest,
   output: CreatePlaceIndexResponse,
@@ -4389,7 +4388,7 @@ export const createRouteCalculator: API.OperationMethod<
   CreateRouteCalculatorRequest,
   CreateRouteCalculatorResponse,
   CreateRouteCalculatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteCalculatorRequest,
   output: CreateRouteCalculatorResponse,
@@ -4422,7 +4421,7 @@ export const createTracker: API.OperationMethod<
   CreateTrackerRequest,
   CreateTrackerResponse,
   CreateTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrackerRequest,
   output: CreateTrackerResponse,
@@ -4456,7 +4455,7 @@ export const deleteGeofenceCollection: API.OperationMethod<
   DeleteGeofenceCollectionRequest,
   DeleteGeofenceCollectionResponse,
   DeleteGeofenceCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGeofenceCollectionRequest,
   output: DeleteGeofenceCollectionResponse,
@@ -4489,7 +4488,7 @@ export const deleteKey: API.OperationMethod<
   DeleteKeyRequest,
   DeleteKeyResponse,
   DeleteKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyRequest,
   output: DeleteKeyResponse,
@@ -4534,7 +4533,7 @@ export const deleteMap: API.OperationMethod<
   DeleteMapRequest,
   DeleteMapResponse,
   DeleteMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMapRequest,
   output: DeleteMapResponse,
@@ -4579,7 +4578,7 @@ export const deletePlaceIndex: API.OperationMethod<
   DeletePlaceIndexRequest,
   DeletePlaceIndexResponse,
   DeletePlaceIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlaceIndexRequest,
   output: DeletePlaceIndexResponse,
@@ -4624,7 +4623,7 @@ export const deleteRouteCalculator: API.OperationMethod<
   DeleteRouteCalculatorRequest,
   DeleteRouteCalculatorResponse,
   DeleteRouteCalculatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteCalculatorRequest,
   output: DeleteRouteCalculatorResponse,
@@ -4657,7 +4656,7 @@ export const deleteTracker: API.OperationMethod<
   DeleteTrackerRequest,
   DeleteTrackerResponse,
   DeleteTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrackerRequest,
   output: DeleteTrackerResponse,
@@ -4688,7 +4687,7 @@ export const describeGeofenceCollection: API.OperationMethod<
   DescribeGeofenceCollectionRequest,
   DescribeGeofenceCollectionResponse,
   DescribeGeofenceCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGeofenceCollectionRequest,
   output: DescribeGeofenceCollectionResponse,
@@ -4721,7 +4720,7 @@ export const describeKey: API.OperationMethod<
   DescribeKeyRequest,
   DescribeKeyResponse,
   DescribeKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyRequest,
   output: DescribeKeyResponse,
@@ -4764,7 +4763,7 @@ export const describeMap: API.OperationMethod<
   DescribeMapRequest,
   DescribeMapResponse,
   DescribeMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMapRequest,
   output: DescribeMapResponse,
@@ -4807,7 +4806,7 @@ export const describePlaceIndex: API.OperationMethod<
   DescribePlaceIndexRequest,
   DescribePlaceIndexResponse,
   DescribePlaceIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePlaceIndexRequest,
   output: DescribePlaceIndexResponse,
@@ -4850,7 +4849,7 @@ export const describeRouteCalculator: API.OperationMethod<
   DescribeRouteCalculatorRequest,
   DescribeRouteCalculatorResponse,
   DescribeRouteCalculatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRouteCalculatorRequest,
   output: DescribeRouteCalculatorResponse,
@@ -4881,7 +4880,7 @@ export const describeTracker: API.OperationMethod<
   DescribeTrackerRequest,
   DescribeTrackerResponse,
   DescribeTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrackerRequest,
   output: DescribeTrackerResponse,
@@ -4914,7 +4913,7 @@ export const disassociateTrackerConsumer: API.OperationMethod<
   DisassociateTrackerConsumerRequest,
   DisassociateTrackerConsumerResponse,
   DisassociateTrackerConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTrackerConsumerRequest,
   output: DisassociateTrackerConsumerResponse,
@@ -4953,7 +4952,7 @@ export const forecastGeofenceEvents: API.PaginatedOperationMethod<
   ForecastGeofenceEventsRequest,
   ForecastGeofenceEventsResponse,
   ForecastGeofenceEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ForecastedEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ForecastGeofenceEventsRequest,
@@ -4993,7 +4992,7 @@ export const getDevicePosition: API.OperationMethod<
   GetDevicePositionRequest,
   GetDevicePositionResponse,
   GetDevicePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDevicePositionRequest,
   output: GetDevicePositionResponse,
@@ -5026,7 +5025,7 @@ export const getDevicePositionHistory: API.PaginatedOperationMethod<
   GetDevicePositionHistoryRequest,
   GetDevicePositionHistoryResponse,
   GetDevicePositionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DevicePosition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDevicePositionHistoryRequest,
@@ -5066,7 +5065,7 @@ export const getGeofence: API.OperationMethod<
   GetGeofenceRequest,
   GetGeofenceResponse,
   GetGeofenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeofenceRequest,
   output: GetGeofenceResponse,
@@ -5099,7 +5098,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -5142,7 +5141,7 @@ export const getMapGlyphs: API.OperationMethod<
   GetMapGlyphsRequest,
   GetMapGlyphsResponse,
   GetMapGlyphsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMapGlyphsRequest,
   output: GetMapGlyphsResponse,
@@ -5185,7 +5184,7 @@ export const getMapSprites: API.OperationMethod<
   GetMapSpritesRequest,
   GetMapSpritesResponse,
   GetMapSpritesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMapSpritesRequest,
   output: GetMapSpritesResponse,
@@ -5230,7 +5229,7 @@ export const getMapStyleDescriptor: API.OperationMethod<
   GetMapStyleDescriptorRequest,
   GetMapStyleDescriptorResponse,
   GetMapStyleDescriptorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMapStyleDescriptorRequest,
   output: GetMapStyleDescriptorResponse,
@@ -5275,7 +5274,7 @@ export const getMapTile: API.OperationMethod<
   GetMapTileRequest,
   GetMapTileResponse,
   GetMapTileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMapTileRequest,
   output: GetMapTileResponse,
@@ -5328,7 +5327,7 @@ export const getPlace: API.OperationMethod<
   GetPlaceRequest,
   GetPlaceResponse,
   GetPlaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlaceRequest,
   output: GetPlaceResponse,
@@ -5358,7 +5357,7 @@ export const listDevicePositions: API.PaginatedOperationMethod<
   ListDevicePositionsRequest,
   ListDevicePositionsResponse,
   ListDevicePositionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListDevicePositionsResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicePositionsRequest,
@@ -5394,7 +5393,7 @@ export const listGeofenceCollections: API.PaginatedOperationMethod<
   ListGeofenceCollectionsRequest,
   ListGeofenceCollectionsResponse,
   ListGeofenceCollectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListGeofenceCollectionsResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGeofenceCollectionsRequest,
@@ -5431,7 +5430,7 @@ export const listGeofences: API.PaginatedOperationMethod<
   ListGeofencesRequest,
   ListGeofencesResponse,
   ListGeofencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListGeofenceResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGeofencesRequest,
@@ -5470,7 +5469,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListJobsResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -5508,7 +5507,7 @@ export const listKeys: API.PaginatedOperationMethod<
   ListKeysRequest,
   ListKeysResponse,
   ListKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListKeysResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeysRequest,
@@ -5556,7 +5555,7 @@ export const listMaps: API.PaginatedOperationMethod<
   ListMapsRequest,
   ListMapsResponse,
   ListMapsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListMapsResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMapsRequest,
@@ -5604,7 +5603,7 @@ export const listPlaceIndexes: API.PaginatedOperationMethod<
   ListPlaceIndexesRequest,
   ListPlaceIndexesResponse,
   ListPlaceIndexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListPlaceIndexesResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlaceIndexesRequest,
@@ -5652,7 +5651,7 @@ export const listRouteCalculators: API.PaginatedOperationMethod<
   ListRouteCalculatorsRequest,
   ListRouteCalculatorsResponse,
   ListRouteCalculatorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListRouteCalculatorsResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRouteCalculatorsRequest,
@@ -5689,7 +5688,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5720,7 +5719,7 @@ export const listTrackerConsumers: API.PaginatedOperationMethod<
   ListTrackerConsumersRequest,
   ListTrackerConsumersResponse,
   ListTrackerConsumersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Arn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrackerConsumersRequest,
@@ -5757,7 +5756,7 @@ export const listTrackers: API.PaginatedOperationMethod<
   ListTrackersRequest,
   ListTrackersResponse,
   ListTrackersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListTrackersResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrackersRequest,
@@ -5795,7 +5794,7 @@ export const putGeofence: API.OperationMethod<
   PutGeofenceRequest,
   PutGeofenceResponse,
   PutGeofenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGeofenceRequest,
   output: PutGeofenceResponse,
@@ -5837,7 +5836,7 @@ export const searchPlaceIndexForPosition: API.OperationMethod<
   SearchPlaceIndexForPositionRequest,
   SearchPlaceIndexForPositionResponse,
   SearchPlaceIndexForPositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchPlaceIndexForPositionRequest,
   output: SearchPlaceIndexForPositionResponse,
@@ -5882,7 +5881,7 @@ export const searchPlaceIndexForSuggestions: API.OperationMethod<
   SearchPlaceIndexForSuggestionsRequest,
   SearchPlaceIndexForSuggestionsResponse,
   SearchPlaceIndexForSuggestionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchPlaceIndexForSuggestionsRequest,
   output: SearchPlaceIndexForSuggestionsResponse,
@@ -5929,7 +5928,7 @@ export const searchPlaceIndexForText: API.OperationMethod<
   SearchPlaceIndexForTextRequest,
   SearchPlaceIndexForTextResponse,
   SearchPlaceIndexForTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchPlaceIndexForTextRequest,
   output: SearchPlaceIndexForTextResponse,
@@ -5961,7 +5960,7 @@ export const startJob: API.OperationMethod<
   StartJobRequest,
   StartJobResponse,
   StartJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobRequest,
   output: StartJobResponse,
@@ -5997,7 +5996,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6028,7 +6027,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6059,7 +6058,7 @@ export const updateGeofenceCollection: API.OperationMethod<
   UpdateGeofenceCollectionRequest,
   UpdateGeofenceCollectionResponse,
   UpdateGeofenceCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGeofenceCollectionRequest,
   output: UpdateGeofenceCollectionResponse,
@@ -6090,7 +6089,7 @@ export const updateKey: API.OperationMethod<
   UpdateKeyRequest,
   UpdateKeyResponse,
   UpdateKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyRequest,
   output: UpdateKeyResponse,
@@ -6133,7 +6132,7 @@ export const updateMap: API.OperationMethod<
   UpdateMapRequest,
   UpdateMapResponse,
   UpdateMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMapRequest,
   output: UpdateMapResponse,
@@ -6176,7 +6175,7 @@ export const updatePlaceIndex: API.OperationMethod<
   UpdatePlaceIndexRequest,
   UpdatePlaceIndexResponse,
   UpdatePlaceIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePlaceIndexRequest,
   output: UpdatePlaceIndexResponse,
@@ -6219,7 +6218,7 @@ export const updateRouteCalculator: API.OperationMethod<
   UpdateRouteCalculatorRequest,
   UpdateRouteCalculatorResponse,
   UpdateRouteCalculatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouteCalculatorRequest,
   output: UpdateRouteCalculatorResponse,
@@ -6250,7 +6249,7 @@ export const updateTracker: API.OperationMethod<
   UpdateTrackerRequest,
   UpdateTrackerResponse,
   UpdateTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrackerRequest,
   output: UpdateTrackerResponse,
@@ -6283,7 +6282,7 @@ export const verifyDevicePosition: API.OperationMethod<
   VerifyDevicePositionRequest,
   VerifyDevicePositionResponse,
   VerifyDevicePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyDevicePositionRequest,
   output: VerifyDevicePositionResponse,

--- a/packages/aws/src/services/lookoutequipment.ts
+++ b/packages/aws/src/services/lookoutequipment.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "LookoutEquipment",
   serviceShapeName: "AWSLookoutEquipmentFrontendService",
@@ -2610,7 +2609,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -2647,7 +2646,7 @@ export const createInferenceScheduler: API.OperationMethod<
   CreateInferenceSchedulerRequest,
   CreateInferenceSchedulerResponse,
   CreateInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInferenceSchedulerRequest,
   output: CreateInferenceSchedulerResponse,
@@ -2681,7 +2680,7 @@ export const createLabel: API.OperationMethod<
   CreateLabelRequest,
   CreateLabelResponse,
   CreateLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLabelRequest,
   output: CreateLabelResponse,
@@ -2714,7 +2713,7 @@ export const createLabelGroup: API.OperationMethod<
   CreateLabelGroupRequest,
   CreateLabelGroupResponse,
   CreateLabelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLabelGroupRequest,
   output: CreateLabelGroupResponse,
@@ -2757,7 +2756,7 @@ export const createModel: API.OperationMethod<
   CreateModelRequest,
   CreateModelResponse,
   CreateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelRequest,
   output: CreateModelResponse,
@@ -2790,7 +2789,7 @@ export const createRetrainingScheduler: API.OperationMethod<
   CreateRetrainingSchedulerRequest,
   CreateRetrainingSchedulerResponse,
   CreateRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRetrainingSchedulerRequest,
   output: CreateRetrainingSchedulerResponse,
@@ -2826,7 +2825,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -2859,7 +2858,7 @@ export const deleteInferenceScheduler: API.OperationMethod<
   DeleteInferenceSchedulerRequest,
   DeleteInferenceSchedulerResponse,
   DeleteInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInferenceSchedulerRequest,
   output: DeleteInferenceSchedulerResponse,
@@ -2891,7 +2890,7 @@ export const deleteLabel: API.OperationMethod<
   DeleteLabelRequest,
   DeleteLabelResponse,
   DeleteLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLabelRequest,
   output: DeleteLabelResponse,
@@ -2923,7 +2922,7 @@ export const deleteLabelGroup: API.OperationMethod<
   DeleteLabelGroupRequest,
   DeleteLabelGroupResponse,
   DeleteLabelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLabelGroupRequest,
   output: DeleteLabelGroupResponse,
@@ -2956,7 +2955,7 @@ export const deleteModel: API.OperationMethod<
   DeleteModelRequest,
   DeleteModelResponse,
   DeleteModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelRequest,
   output: DeleteModelResponse,
@@ -2988,7 +2987,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -3021,7 +3020,7 @@ export const deleteRetrainingScheduler: API.OperationMethod<
   DeleteRetrainingSchedulerRequest,
   DeleteRetrainingSchedulerResponse,
   DeleteRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRetrainingSchedulerRequest,
   output: DeleteRetrainingSchedulerResponse,
@@ -3053,7 +3052,7 @@ export const describeDataIngestionJob: API.OperationMethod<
   DescribeDataIngestionJobRequest,
   DescribeDataIngestionJobResponse,
   DescribeDataIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataIngestionJobRequest,
   output: DescribeDataIngestionJobResponse,
@@ -3084,7 +3083,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -3115,7 +3114,7 @@ export const describeInferenceScheduler: API.OperationMethod<
   DescribeInferenceSchedulerRequest,
   DescribeInferenceSchedulerResponse,
   DescribeInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInferenceSchedulerRequest,
   output: DescribeInferenceSchedulerResponse,
@@ -3145,7 +3144,7 @@ export const describeLabel: API.OperationMethod<
   DescribeLabelRequest,
   DescribeLabelResponse,
   DescribeLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLabelRequest,
   output: DescribeLabelResponse,
@@ -3175,7 +3174,7 @@ export const describeLabelGroup: API.OperationMethod<
   DescribeLabelGroupRequest,
   DescribeLabelGroupResponse,
   DescribeLabelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLabelGroupRequest,
   output: DescribeLabelGroupResponse,
@@ -3207,7 +3206,7 @@ export const describeModel: API.OperationMethod<
   DescribeModelRequest,
   DescribeModelResponse,
   DescribeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelRequest,
   output: DescribeModelResponse,
@@ -3237,7 +3236,7 @@ export const describeModelVersion: API.OperationMethod<
   DescribeModelVersionRequest,
   DescribeModelVersionResponse,
   DescribeModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelVersionRequest,
   output: DescribeModelVersionResponse,
@@ -3267,7 +3266,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -3298,7 +3297,7 @@ export const describeRetrainingScheduler: API.OperationMethod<
   DescribeRetrainingSchedulerRequest,
   DescribeRetrainingSchedulerResponse,
   DescribeRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRetrainingSchedulerRequest,
   output: DescribeRetrainingSchedulerResponse,
@@ -3330,7 +3329,7 @@ export const importDataset: API.OperationMethod<
   ImportDatasetRequest,
   ImportDatasetResponse,
   ImportDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportDatasetRequest,
   output: ImportDatasetResponse,
@@ -3364,7 +3363,7 @@ export const importModelVersion: API.OperationMethod<
   ImportModelVersionRequest,
   ImportModelVersionResponse,
   ImportModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportModelVersionRequest,
   output: ImportModelVersionResponse,
@@ -3396,7 +3395,7 @@ export const listDataIngestionJobs: API.PaginatedOperationMethod<
   ListDataIngestionJobsRequest,
   ListDataIngestionJobsResponse,
   ListDataIngestionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIngestionJobsRequest,
@@ -3430,7 +3429,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -3465,7 +3464,7 @@ export const listInferenceEvents: API.PaginatedOperationMethod<
   ListInferenceEventsRequest,
   ListInferenceEventsResponse,
   ListInferenceEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceEventsRequest,
@@ -3502,7 +3501,7 @@ export const listInferenceExecutions: API.PaginatedOperationMethod<
   ListInferenceExecutionsRequest,
   ListInferenceExecutionsResponse,
   ListInferenceExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceExecutionsRequest,
@@ -3537,7 +3536,7 @@ export const listInferenceSchedulers: API.PaginatedOperationMethod<
   ListInferenceSchedulersRequest,
   ListInferenceSchedulersResponse,
   ListInferenceSchedulersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceSchedulersRequest,
@@ -3571,7 +3570,7 @@ export const listLabelGroups: API.PaginatedOperationMethod<
   ListLabelGroupsRequest,
   ListLabelGroupsResponse,
   ListLabelGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLabelGroupsRequest,
@@ -3605,7 +3604,7 @@ export const listLabels: API.PaginatedOperationMethod<
   ListLabelsRequest,
   ListLabelsResponse,
   ListLabelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLabelsRequest,
@@ -3640,7 +3639,7 @@ export const listModels: API.PaginatedOperationMethod<
   ListModelsRequest,
   ListModelsResponse,
   ListModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelsRequest,
@@ -3677,7 +3676,7 @@ export const listModelVersions: API.PaginatedOperationMethod<
   ListModelVersionsRequest,
   ListModelVersionsResponse,
   ListModelVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelVersionsRequest,
@@ -3713,7 +3712,7 @@ export const listRetrainingSchedulers: API.PaginatedOperationMethod<
   ListRetrainingSchedulersRequest,
   ListRetrainingSchedulersResponse,
   ListRetrainingSchedulersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRetrainingSchedulersRequest,
@@ -3750,7 +3749,7 @@ export const listSensorStatistics: API.PaginatedOperationMethod<
   ListSensorStatisticsRequest,
   ListSensorStatisticsResponse,
   ListSensorStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSensorStatisticsRequest,
@@ -3786,7 +3785,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3818,7 +3817,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -3852,7 +3851,7 @@ export const startDataIngestionJob: API.OperationMethod<
   StartDataIngestionJobRequest,
   StartDataIngestionJobResponse,
   StartDataIngestionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataIngestionJobRequest,
   output: StartDataIngestionJobResponse,
@@ -3885,7 +3884,7 @@ export const startInferenceScheduler: API.OperationMethod<
   StartInferenceSchedulerRequest,
   StartInferenceSchedulerResponse,
   StartInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInferenceSchedulerRequest,
   output: StartInferenceSchedulerResponse,
@@ -3917,7 +3916,7 @@ export const startRetrainingScheduler: API.OperationMethod<
   StartRetrainingSchedulerRequest,
   StartRetrainingSchedulerResponse,
   StartRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRetrainingSchedulerRequest,
   output: StartRetrainingSchedulerResponse,
@@ -3949,7 +3948,7 @@ export const stopInferenceScheduler: API.OperationMethod<
   StopInferenceSchedulerRequest,
   StopInferenceSchedulerResponse,
   StopInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInferenceSchedulerRequest,
   output: StopInferenceSchedulerResponse,
@@ -3981,7 +3980,7 @@ export const stopRetrainingScheduler: API.OperationMethod<
   StopRetrainingSchedulerRequest,
   StopRetrainingSchedulerResponse,
   StopRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRetrainingSchedulerRequest,
   output: StopRetrainingSchedulerResponse,
@@ -4017,7 +4016,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4048,7 +4047,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4079,7 +4078,7 @@ export const updateActiveModelVersion: API.OperationMethod<
   UpdateActiveModelVersionRequest,
   UpdateActiveModelVersionResponse,
   UpdateActiveModelVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActiveModelVersionRequest,
   output: UpdateActiveModelVersionResponse,
@@ -4111,7 +4110,7 @@ export const updateInferenceScheduler: API.OperationMethod<
   UpdateInferenceSchedulerRequest,
   UpdateInferenceSchedulerResponse,
   UpdateInferenceSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInferenceSchedulerRequest,
   output: UpdateInferenceSchedulerResponse,
@@ -4143,7 +4142,7 @@ export const updateLabelGroup: API.OperationMethod<
   UpdateLabelGroupRequest,
   UpdateLabelGroupResponse,
   UpdateLabelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLabelGroupRequest,
   output: UpdateLabelGroupResponse,
@@ -4175,7 +4174,7 @@ export const updateModel: API.OperationMethod<
   UpdateModelRequest,
   UpdateModelResponse,
   UpdateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelRequest,
   output: UpdateModelResponse,
@@ -4207,7 +4206,7 @@ export const updateRetrainingScheduler: API.OperationMethod<
   UpdateRetrainingSchedulerRequest,
   UpdateRetrainingSchedulerResponse,
   UpdateRetrainingSchedulerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRetrainingSchedulerRequest,
   output: UpdateRetrainingSchedulerResponse,

--- a/packages/aws/src/services/m2.ts
+++ b/packages/aws/src/services/m2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "m2",
   serviceShapeName: "AwsSupernovaControlPlaneService",
@@ -2380,7 +2379,7 @@ export const cancelBatchJobExecution: API.OperationMethod<
   CancelBatchJobExecutionRequest,
   CancelBatchJobExecutionResponse,
   CancelBatchJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelBatchJobExecutionRequest,
   output: CancelBatchJobExecutionResponse,
@@ -2413,7 +2412,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -2446,7 +2445,7 @@ export const createDataSetExportTask: API.OperationMethod<
   CreateDataSetExportTaskRequest,
   CreateDataSetExportTaskResponse,
   CreateDataSetExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSetExportTaskRequest,
   output: CreateDataSetExportTaskResponse,
@@ -2480,7 +2479,7 @@ export const createDataSetImportTask: API.OperationMethod<
   CreateDataSetImportTaskRequest,
   CreateDataSetImportTaskResponse,
   CreateDataSetImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSetImportTaskRequest,
   output: CreateDataSetImportTaskResponse,
@@ -2515,7 +2514,7 @@ export const createDeployment: API.OperationMethod<
   CreateDeploymentRequest,
   CreateDeploymentResponse,
   CreateDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeploymentRequest,
   output: CreateDeploymentResponse,
@@ -2548,7 +2547,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   CreateEnvironmentResponse,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: CreateEnvironmentResponse,
@@ -2579,7 +2578,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -2613,7 +2612,7 @@ export const deleteApplicationFromEnvironment: API.OperationMethod<
   DeleteApplicationFromEnvironmentRequest,
   DeleteApplicationFromEnvironmentResponse,
   DeleteApplicationFromEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationFromEnvironmentRequest,
   output: DeleteApplicationFromEnvironmentResponse,
@@ -2646,7 +2645,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -2676,7 +2675,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -2706,7 +2705,7 @@ export const getApplicationVersion: API.OperationMethod<
   GetApplicationVersionRequest,
   GetApplicationVersionResponse,
   GetApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationVersionRequest,
   output: GetApplicationVersionResponse,
@@ -2736,7 +2735,7 @@ export const getBatchJobExecution: API.OperationMethod<
   GetBatchJobExecutionRequest,
   GetBatchJobExecutionResponse,
   GetBatchJobExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBatchJobExecutionRequest,
   output: GetBatchJobExecutionResponse,
@@ -2769,7 +2768,7 @@ export const getDataSetDetails: API.OperationMethod<
   GetDataSetDetailsRequest,
   GetDataSetDetailsResponse,
   GetDataSetDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSetDetailsRequest,
   output: GetDataSetDetailsResponse,
@@ -2802,7 +2801,7 @@ export const getDataSetExportTask: API.OperationMethod<
   GetDataSetExportTaskRequest,
   GetDataSetExportTaskResponse,
   GetDataSetExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSetExportTaskRequest,
   output: GetDataSetExportTaskResponse,
@@ -2832,7 +2831,7 @@ export const getDataSetImportTask: API.OperationMethod<
   GetDataSetImportTaskRequest,
   GetDataSetImportTaskResponse,
   GetDataSetImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSetImportTaskRequest,
   output: GetDataSetImportTaskResponse,
@@ -2862,7 +2861,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentRequest,
   GetDeploymentResponse,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentRequest,
   output: GetDeploymentResponse,
@@ -2892,7 +2891,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -2920,7 +2919,7 @@ export const getSignedBluinsightsUrl: API.OperationMethod<
   GetSignedBluinsightsUrlRequest,
   GetSignedBluinsightsUrlResponse,
   GetSignedBluinsightsUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSignedBluinsightsUrlRequest,
   output: GetSignedBluinsightsUrlResponse,
@@ -2945,7 +2944,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -2981,7 +2980,7 @@ export const listApplicationVersions: API.PaginatedOperationMethod<
   ListApplicationVersionsRequest,
   ListApplicationVersionsResponse,
   ListApplicationVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationVersionsRequest,
@@ -3020,7 +3019,7 @@ export const listBatchJobDefinitions: API.PaginatedOperationMethod<
   ListBatchJobDefinitionsRequest,
   ListBatchJobDefinitionsResponse,
   ListBatchJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchJobDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchJobDefinitionsRequest,
@@ -3058,7 +3057,7 @@ export const listBatchJobExecutions: API.PaginatedOperationMethod<
   ListBatchJobExecutionsRequest,
   ListBatchJobExecutionsResponse,
   ListBatchJobExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchJobExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchJobExecutionsRequest,
@@ -3096,7 +3095,7 @@ export const listBatchJobRestartPoints: API.OperationMethod<
   ListBatchJobRestartPointsRequest,
   ListBatchJobRestartPointsResponse,
   ListBatchJobRestartPointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBatchJobRestartPointsRequest,
   output: ListBatchJobRestartPointsResponse,
@@ -3127,7 +3126,7 @@ export const listDataSetExportHistory: API.PaginatedOperationMethod<
   ListDataSetExportHistoryRequest,
   ListDataSetExportHistoryResponse,
   ListDataSetExportHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetExportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetExportHistoryRequest,
@@ -3164,7 +3163,7 @@ export const listDataSetImportHistory: API.PaginatedOperationMethod<
   ListDataSetImportHistoryRequest,
   ListDataSetImportHistoryResponse,
   ListDataSetImportHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetImportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetImportHistoryRequest,
@@ -3206,7 +3205,7 @@ export const listDataSets: API.PaginatedOperationMethod<
   ListDataSetsRequest,
   ListDataSetsResponse,
   ListDataSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetsRequest,
@@ -3248,7 +3247,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsRequest,
   ListDeploymentsResponse,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsRequest,
@@ -3284,7 +3283,7 @@ export const listEngineVersions: API.PaginatedOperationMethod<
   ListEngineVersionsRequest,
   ListEngineVersionsResponse,
   ListEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngineVersionsSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngineVersionsRequest,
@@ -3319,7 +3318,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -3355,7 +3354,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3386,7 +3385,7 @@ export const startApplication: API.OperationMethod<
   StartApplicationRequest,
   StartApplicationResponse,
   StartApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationRequest,
   output: StartApplicationResponse,
@@ -3419,7 +3418,7 @@ export const startBatchJob: API.OperationMethod<
   StartBatchJobRequest,
   StartBatchJobResponse,
   StartBatchJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartBatchJobRequest,
   output: StartBatchJobResponse,
@@ -3451,7 +3450,7 @@ export const stopApplication: API.OperationMethod<
   StopApplicationRequest,
   StopApplicationResponse,
   StopApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopApplicationRequest,
   output: StopApplicationResponse,
@@ -3483,7 +3482,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3514,7 +3513,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3545,7 +3544,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -3578,7 +3577,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentRequest,
   UpdateEnvironmentResponse,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentRequest,
   output: UpdateEnvironmentResponse,

--- a/packages/aws/src/services/machine-learning.ts
+++ b/packages/aws/src/services/machine-learning.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "http://machinelearning.amazonaws.com/doc/2014-12-12/",
@@ -1768,7 +1767,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -1805,7 +1804,7 @@ export const createBatchPrediction: API.OperationMethod<
   CreateBatchPredictionInput,
   CreateBatchPredictionOutput,
   CreateBatchPredictionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchPredictionInput,
   output: CreateBatchPredictionOutput,
@@ -1839,7 +1838,7 @@ export const createDataSourceFromRDS: API.OperationMethod<
   CreateDataSourceFromRDSInput,
   CreateDataSourceFromRDSOutput,
   CreateDataSourceFromRDSError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceFromRDSInput,
   output: CreateDataSourceFromRDSOutput,
@@ -1894,7 +1893,7 @@ export const createDataSourceFromRedshift: API.OperationMethod<
   CreateDataSourceFromRedshiftInput,
   CreateDataSourceFromRedshiftOutput,
   CreateDataSourceFromRedshiftError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceFromRedshiftInput,
   output: CreateDataSourceFromRedshiftOutput,
@@ -1950,7 +1949,7 @@ export const createDataSourceFromS3: API.OperationMethod<
   CreateDataSourceFromS3Input,
   CreateDataSourceFromS3Output,
   CreateDataSourceFromS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceFromS3Input,
   output: CreateDataSourceFromS3Output,
@@ -1985,7 +1984,7 @@ export const createEvaluation: API.OperationMethod<
   CreateEvaluationInput,
   CreateEvaluationOutput,
   CreateEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEvaluationInput,
   output: CreateEvaluationOutput,
@@ -2030,7 +2029,7 @@ export const createMLModel: API.OperationMethod<
   CreateMLModelInput,
   CreateMLModelOutput,
   CreateMLModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMLModelInput,
   output: CreateMLModelOutput,
@@ -2056,7 +2055,7 @@ export const createRealtimeEndpoint: API.OperationMethod<
   CreateRealtimeEndpointInput,
   CreateRealtimeEndpointOutput,
   CreateRealtimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRealtimeEndpointInput,
   output: CreateRealtimeEndpointOutput,
@@ -2087,7 +2086,7 @@ export const deleteBatchPrediction: API.OperationMethod<
   DeleteBatchPredictionInput,
   DeleteBatchPredictionOutput,
   DeleteBatchPredictionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBatchPredictionInput,
   output: DeleteBatchPredictionOutput,
@@ -2117,7 +2116,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceInput,
   DeleteDataSourceOutput,
   DeleteDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceInput,
   output: DeleteDataSourceOutput,
@@ -2148,7 +2147,7 @@ export const deleteEvaluation: API.OperationMethod<
   DeleteEvaluationInput,
   DeleteEvaluationOutput,
   DeleteEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEvaluationInput,
   output: DeleteEvaluationOutput,
@@ -2179,7 +2178,7 @@ export const deleteMLModel: API.OperationMethod<
   DeleteMLModelInput,
   DeleteMLModelOutput,
   DeleteMLModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMLModelInput,
   output: DeleteMLModelOutput,
@@ -2205,7 +2204,7 @@ export const deleteRealtimeEndpoint: API.OperationMethod<
   DeleteRealtimeEndpointInput,
   DeleteRealtimeEndpointOutput,
   DeleteRealtimeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRealtimeEndpointInput,
   output: DeleteRealtimeEndpointOutput,
@@ -2234,7 +2233,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsInput,
   DeleteTagsOutput,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsInput,
   output: DeleteTagsOutput,
@@ -2260,7 +2259,7 @@ export const describeBatchPredictions: API.PaginatedOperationMethod<
   DescribeBatchPredictionsInput,
   DescribeBatchPredictionsOutput,
   DescribeBatchPredictionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchPrediction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBatchPredictionsInput,
@@ -2288,7 +2287,7 @@ export const describeDataSources: API.PaginatedOperationMethod<
   DescribeDataSourcesInput,
   DescribeDataSourcesOutput,
   DescribeDataSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataSourcesInput,
@@ -2316,7 +2315,7 @@ export const describeEvaluations: API.PaginatedOperationMethod<
   DescribeEvaluationsInput,
   DescribeEvaluationsOutput,
   DescribeEvaluationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Evaluation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEvaluationsInput,
@@ -2344,7 +2343,7 @@ export const describeMLModels: API.PaginatedOperationMethod<
   DescribeMLModelsInput,
   DescribeMLModelsOutput,
   DescribeMLModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MLModel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMLModelsInput,
@@ -2373,7 +2372,7 @@ export const describeTags: API.OperationMethod<
   DescribeTagsInput,
   DescribeTagsOutput,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagsInput,
   output: DescribeTagsOutput,
@@ -2400,7 +2399,7 @@ export const getBatchPrediction: API.OperationMethod<
   GetBatchPredictionInput,
   GetBatchPredictionOutput,
   GetBatchPredictionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBatchPredictionInput,
   output: GetBatchPredictionOutput,
@@ -2429,7 +2428,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceInput,
   GetDataSourceOutput,
   GetDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceInput,
   output: GetDataSourceOutput,
@@ -2455,7 +2454,7 @@ export const getEvaluation: API.OperationMethod<
   GetEvaluationInput,
   GetEvaluationOutput,
   GetEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEvaluationInput,
   output: GetEvaluationOutput,
@@ -2483,7 +2482,7 @@ export const getMLModel: API.OperationMethod<
   GetMLModelInput,
   GetMLModelOutput,
   GetMLModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLModelInput,
   output: GetMLModelOutput,
@@ -2514,7 +2513,7 @@ export const predict: API.OperationMethod<
   PredictInput,
   PredictOutput,
   PredictError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PredictInput,
   output: PredictOutput,
@@ -2544,7 +2543,7 @@ export const updateBatchPrediction: API.OperationMethod<
   UpdateBatchPredictionInput,
   UpdateBatchPredictionOutput,
   UpdateBatchPredictionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBatchPredictionInput,
   output: UpdateBatchPredictionOutput,
@@ -2572,7 +2571,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceInput,
   UpdateDataSourceOutput,
   UpdateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceInput,
   output: UpdateDataSourceOutput,
@@ -2600,7 +2599,7 @@ export const updateEvaluation: API.OperationMethod<
   UpdateEvaluationInput,
   UpdateEvaluationOutput,
   UpdateEvaluationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEvaluationInput,
   output: UpdateEvaluationOutput,
@@ -2628,7 +2627,7 @@ export const updateMLModel: API.OperationMethod<
   UpdateMLModelInput,
   UpdateMLModelOutput,
   UpdateMLModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMLModelInput,
   output: UpdateMLModelOutput,

--- a/packages/aws/src/services/macie2.ts
+++ b/packages/aws/src/services/macie2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Macie2", serviceShapeName: "Macie2" });
 const auth = T.AwsAuthSigv4({ name: "macie2" });
@@ -5337,7 +5336,7 @@ export const acceptInvitation: API.OperationMethod<
   AcceptInvitationRequest,
   AcceptInvitationResponse,
   AcceptInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInvitationRequest,
   output: AcceptInvitationResponse,
@@ -5371,7 +5370,7 @@ export const batchGetCustomDataIdentifiers: API.OperationMethod<
   BatchGetCustomDataIdentifiersRequest,
   BatchGetCustomDataIdentifiersResponse,
   BatchGetCustomDataIdentifiersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCustomDataIdentifiersRequest,
   output: BatchGetCustomDataIdentifiersResponse,
@@ -5403,7 +5402,7 @@ export const batchUpdateAutomatedDiscoveryAccounts: API.OperationMethod<
   BatchUpdateAutomatedDiscoveryAccountsRequest,
   BatchUpdateAutomatedDiscoveryAccountsResponse,
   BatchUpdateAutomatedDiscoveryAccountsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateAutomatedDiscoveryAccountsRequest,
   output: BatchUpdateAutomatedDiscoveryAccountsResponse,
@@ -5436,7 +5435,7 @@ export const createAllowList: API.OperationMethod<
   CreateAllowListRequest,
   CreateAllowListResponse,
   CreateAllowListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAllowListRequest,
   output: CreateAllowListResponse,
@@ -5472,7 +5471,7 @@ export const createClassificationJob: API.OperationMethod<
   CreateClassificationJobRequest,
   CreateClassificationJobResponse,
   CreateClassificationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClassificationJobRequest,
   output: CreateClassificationJobResponse,
@@ -5508,7 +5507,7 @@ export const createCustomDataIdentifier: API.OperationMethod<
   CreateCustomDataIdentifierRequest,
   CreateCustomDataIdentifierResponse,
   CreateCustomDataIdentifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomDataIdentifierRequest,
   output: CreateCustomDataIdentifierResponse,
@@ -5544,7 +5543,7 @@ export const createFindingsFilter: API.OperationMethod<
   CreateFindingsFilterRequest,
   CreateFindingsFilterResponse,
   CreateFindingsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFindingsFilterRequest,
   output: CreateFindingsFilterResponse,
@@ -5579,7 +5578,7 @@ export const createInvitations: API.OperationMethod<
   CreateInvitationsRequest,
   CreateInvitationsResponse,
   CreateInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInvitationsRequest,
   output: CreateInvitationsResponse,
@@ -5613,7 +5612,7 @@ export const createMember: API.OperationMethod<
   CreateMemberRequest,
   CreateMemberResponse,
   CreateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMemberRequest,
   output: CreateMemberResponse,
@@ -5647,7 +5646,7 @@ export const createSampleFindings: API.OperationMethod<
   CreateSampleFindingsRequest,
   CreateSampleFindingsResponse,
   CreateSampleFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSampleFindingsRequest,
   output: CreateSampleFindingsResponse,
@@ -5681,7 +5680,7 @@ export const declineInvitations: API.OperationMethod<
   DeclineInvitationsRequest,
   DeclineInvitationsResponse,
   DeclineInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeclineInvitationsRequest,
   output: DeclineInvitationsResponse,
@@ -5713,7 +5712,7 @@ export const deleteAllowList: API.OperationMethod<
   DeleteAllowListRequest,
   DeleteAllowListResponse,
   DeleteAllowListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAllowListRequest,
   output: DeleteAllowListResponse,
@@ -5745,7 +5744,7 @@ export const deleteCustomDataIdentifier: API.OperationMethod<
   DeleteCustomDataIdentifierRequest,
   DeleteCustomDataIdentifierResponse,
   DeleteCustomDataIdentifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomDataIdentifierRequest,
   output: DeleteCustomDataIdentifierResponse,
@@ -5779,7 +5778,7 @@ export const deleteFindingsFilter: API.OperationMethod<
   DeleteFindingsFilterRequest,
   DeleteFindingsFilterResponse,
   DeleteFindingsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFindingsFilterRequest,
   output: DeleteFindingsFilterResponse,
@@ -5813,7 +5812,7 @@ export const deleteInvitations: API.OperationMethod<
   DeleteInvitationsRequest,
   DeleteInvitationsResponse,
   DeleteInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvitationsRequest,
   output: DeleteInvitationsResponse,
@@ -5847,7 +5846,7 @@ export const deleteMember: API.OperationMethod<
   DeleteMemberRequest,
   DeleteMemberResponse,
   DeleteMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMemberRequest,
   output: DeleteMemberResponse,
@@ -5881,7 +5880,7 @@ export const describeBuckets: API.PaginatedOperationMethod<
   DescribeBucketsRequest,
   DescribeBucketsResponse,
   DescribeBucketsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BucketMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBucketsRequest,
@@ -5922,7 +5921,7 @@ export const describeClassificationJob: API.OperationMethod<
   DescribeClassificationJobRequest,
   DescribeClassificationJobResponse,
   DescribeClassificationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClassificationJobRequest,
   output: DescribeClassificationJobResponse,
@@ -5956,7 +5955,7 @@ export const describeOrganizationConfiguration: API.OperationMethod<
   DescribeOrganizationConfigurationRequest,
   DescribeOrganizationConfigurationResponse,
   DescribeOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationConfigurationRequest,
   output: DescribeOrganizationConfigurationResponse,
@@ -5990,7 +5989,7 @@ export const disableMacie: API.OperationMethod<
   DisableMacieRequest,
   DisableMacieResponse,
   DisableMacieError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableMacieRequest,
   output: DisableMacieResponse,
@@ -6024,7 +6023,7 @@ export const disableOrganizationAdminAccount: API.OperationMethod<
   DisableOrganizationAdminAccountRequest,
   DisableOrganizationAdminAccountResponse,
   DisableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationAdminAccountRequest,
   output: DisableOrganizationAdminAccountResponse,
@@ -6058,7 +6057,7 @@ export const disassociateFromAdministratorAccount: API.OperationMethod<
   DisassociateFromAdministratorAccountRequest,
   DisassociateFromAdministratorAccountResponse,
   DisassociateFromAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromAdministratorAccountRequest,
   output: DisassociateFromAdministratorAccountResponse,
@@ -6092,7 +6091,7 @@ export const disassociateFromMasterAccount: API.OperationMethod<
   DisassociateFromMasterAccountRequest,
   DisassociateFromMasterAccountResponse,
   DisassociateFromMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromMasterAccountRequest,
   output: DisassociateFromMasterAccountResponse,
@@ -6126,7 +6125,7 @@ export const disassociateMember: API.OperationMethod<
   DisassociateMemberRequest,
   DisassociateMemberResponse,
   DisassociateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberRequest,
   output: DisassociateMemberResponse,
@@ -6160,7 +6159,7 @@ export const enableMacie: API.OperationMethod<
   EnableMacieRequest,
   EnableMacieResponse,
   EnableMacieError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableMacieRequest,
   output: EnableMacieResponse,
@@ -6194,7 +6193,7 @@ export const enableOrganizationAdminAccount: API.OperationMethod<
   EnableOrganizationAdminAccountRequest,
   EnableOrganizationAdminAccountResponse,
   EnableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationAdminAccountRequest,
   output: EnableOrganizationAdminAccountResponse,
@@ -6228,7 +6227,7 @@ export const getAdministratorAccount: API.OperationMethod<
   GetAdministratorAccountRequest,
   GetAdministratorAccountResponse,
   GetAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdministratorAccountRequest,
   output: GetAdministratorAccountResponse,
@@ -6260,7 +6259,7 @@ export const getAllowList: API.OperationMethod<
   GetAllowListRequest,
   GetAllowListResponse,
   GetAllowListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAllowListRequest,
   output: GetAllowListResponse,
@@ -6289,7 +6288,7 @@ export const getAutomatedDiscoveryConfiguration: API.OperationMethod<
   GetAutomatedDiscoveryConfigurationRequest,
   GetAutomatedDiscoveryConfigurationResponse,
   GetAutomatedDiscoveryConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomatedDiscoveryConfigurationRequest,
   output: GetAutomatedDiscoveryConfigurationResponse,
@@ -6320,7 +6319,7 @@ export const getBucketStatistics: API.OperationMethod<
   GetBucketStatisticsRequest,
   GetBucketStatisticsResponse,
   GetBucketStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketStatisticsRequest,
   output: GetBucketStatisticsResponse,
@@ -6354,7 +6353,7 @@ export const getClassificationExportConfiguration: API.OperationMethod<
   GetClassificationExportConfigurationRequest,
   GetClassificationExportConfigurationResponse,
   GetClassificationExportConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClassificationExportConfigurationRequest,
   output: GetClassificationExportConfigurationResponse,
@@ -6386,7 +6385,7 @@ export const getClassificationScope: API.OperationMethod<
   GetClassificationScopeRequest,
   GetClassificationScopeResponse,
   GetClassificationScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClassificationScopeRequest,
   output: GetClassificationScopeResponse,
@@ -6418,7 +6417,7 @@ export const getCustomDataIdentifier: API.OperationMethod<
   GetCustomDataIdentifierRequest,
   GetCustomDataIdentifierResponse,
   GetCustomDataIdentifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomDataIdentifierRequest,
   output: GetCustomDataIdentifierResponse,
@@ -6452,7 +6451,7 @@ export const getFindings: API.OperationMethod<
   GetFindingsRequest,
   GetFindingsResponse,
   GetFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsRequest,
   output: GetFindingsResponse,
@@ -6486,7 +6485,7 @@ export const getFindingsFilter: API.OperationMethod<
   GetFindingsFilterRequest,
   GetFindingsFilterResponse,
   GetFindingsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsFilterRequest,
   output: GetFindingsFilterResponse,
@@ -6520,7 +6519,7 @@ export const getFindingsPublicationConfiguration: API.OperationMethod<
   GetFindingsPublicationConfigurationRequest,
   GetFindingsPublicationConfigurationResponse,
   GetFindingsPublicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingsPublicationConfigurationRequest,
   output: GetFindingsPublicationConfigurationResponse,
@@ -6554,7 +6553,7 @@ export const getFindingStatistics: API.OperationMethod<
   GetFindingStatisticsRequest,
   GetFindingStatisticsResponse,
   GetFindingStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingStatisticsRequest,
   output: GetFindingStatisticsResponse,
@@ -6588,7 +6587,7 @@ export const getInvitationsCount: API.OperationMethod<
   GetInvitationsCountRequest,
   GetInvitationsCountResponse,
   GetInvitationsCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvitationsCountRequest,
   output: GetInvitationsCountResponse,
@@ -6622,7 +6621,7 @@ export const getMacieSession: API.OperationMethod<
   GetMacieSessionRequest,
   GetMacieSessionResponse,
   GetMacieSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMacieSessionRequest,
   output: GetMacieSessionResponse,
@@ -6656,7 +6655,7 @@ export const getMasterAccount: API.OperationMethod<
   GetMasterAccountRequest,
   GetMasterAccountResponse,
   GetMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMasterAccountRequest,
   output: GetMasterAccountResponse,
@@ -6690,7 +6689,7 @@ export const getMember: API.OperationMethod<
   GetMemberRequest,
   GetMemberResponse,
   GetMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemberRequest,
   output: GetMemberResponse,
@@ -6723,7 +6722,7 @@ export const getResourceProfile: API.OperationMethod<
   GetResourceProfileRequest,
   GetResourceProfileResponse,
   GetResourceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceProfileRequest,
   output: GetResourceProfileResponse,
@@ -6753,7 +6752,7 @@ export const getRevealConfiguration: API.OperationMethod<
   GetRevealConfigurationRequest,
   GetRevealConfigurationResponse,
   GetRevealConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevealConfigurationRequest,
   output: GetRevealConfigurationResponse,
@@ -6783,7 +6782,7 @@ export const getSensitiveDataOccurrences: API.OperationMethod<
   GetSensitiveDataOccurrencesRequest,
   GetSensitiveDataOccurrencesResponse,
   GetSensitiveDataOccurrencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSensitiveDataOccurrencesRequest,
   output: GetSensitiveDataOccurrencesResponse,
@@ -6813,7 +6812,7 @@ export const getSensitiveDataOccurrencesAvailability: API.OperationMethod<
   GetSensitiveDataOccurrencesAvailabilityRequest,
   GetSensitiveDataOccurrencesAvailabilityResponse,
   GetSensitiveDataOccurrencesAvailabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSensitiveDataOccurrencesAvailabilityRequest,
   output: GetSensitiveDataOccurrencesAvailabilityResponse,
@@ -6842,7 +6841,7 @@ export const getSensitivityInspectionTemplate: API.OperationMethod<
   GetSensitivityInspectionTemplateRequest,
   GetSensitivityInspectionTemplateResponse,
   GetSensitivityInspectionTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSensitivityInspectionTemplateRequest,
   output: GetSensitivityInspectionTemplateResponse,
@@ -6874,7 +6873,7 @@ export const getUsageStatistics: API.PaginatedOperationMethod<
   GetUsageStatisticsRequest,
   GetUsageStatisticsResponse,
   GetUsageStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsageRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUsageStatisticsRequest,
@@ -6915,7 +6914,7 @@ export const getUsageTotals: API.OperationMethod<
   GetUsageTotalsRequest,
   GetUsageTotalsResponse,
   GetUsageTotalsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsageTotalsRequest,
   output: GetUsageTotalsResponse,
@@ -6946,7 +6945,7 @@ export const listAllowLists: API.PaginatedOperationMethod<
   ListAllowListsRequest,
   ListAllowListsResponse,
   ListAllowListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AllowListSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAllowListsRequest,
@@ -6982,7 +6981,7 @@ export const listAutomatedDiscoveryAccounts: API.PaginatedOperationMethod<
   ListAutomatedDiscoveryAccountsRequest,
   ListAutomatedDiscoveryAccountsResponse,
   ListAutomatedDiscoveryAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutomatedDiscoveryAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutomatedDiscoveryAccountsRequest,
@@ -7021,7 +7020,7 @@ export const listClassificationJobs: API.PaginatedOperationMethod<
   ListClassificationJobsRequest,
   ListClassificationJobsResponse,
   ListClassificationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClassificationJobsRequest,
@@ -7059,7 +7058,7 @@ export const listClassificationScopes: API.PaginatedOperationMethod<
   ListClassificationScopesRequest,
   ListClassificationScopesResponse,
   ListClassificationScopesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClassificationScopeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClassificationScopesRequest,
@@ -7096,7 +7095,7 @@ export const listCustomDataIdentifiers: API.PaginatedOperationMethod<
   ListCustomDataIdentifiersRequest,
   ListCustomDataIdentifiersResponse,
   ListCustomDataIdentifiersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomDataIdentifierSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomDataIdentifiersRequest,
@@ -7137,7 +7136,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsRequest,
   ListFindingsResponse,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsRequest,
@@ -7178,7 +7177,7 @@ export const listFindingsFilters: API.PaginatedOperationMethod<
   ListFindingsFiltersRequest,
   ListFindingsFiltersResponse,
   ListFindingsFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingsFilterListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsFiltersRequest,
@@ -7219,7 +7218,7 @@ export const listInvitations: API.PaginatedOperationMethod<
   ListInvitationsRequest,
   ListInvitationsResponse,
   ListInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Invitation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvitationsRequest,
@@ -7252,7 +7251,7 @@ export const listManagedDataIdentifiers: API.PaginatedOperationMethod<
   ListManagedDataIdentifiersRequest,
   ListManagedDataIdentifiersResponse,
   ListManagedDataIdentifiersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedDataIdentifierSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedDataIdentifiersRequest,
@@ -7284,7 +7283,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersRequest,
   ListMembersResponse,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Member
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersRequest,
@@ -7325,7 +7324,7 @@ export const listOrganizationAdminAccounts: API.PaginatedOperationMethod<
   ListOrganizationAdminAccountsRequest,
   ListOrganizationAdminAccountsResponse,
   ListOrganizationAdminAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdminAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationAdminAccountsRequest,
@@ -7364,7 +7363,7 @@ export const listResourceProfileArtifacts: API.PaginatedOperationMethod<
   ListResourceProfileArtifactsRequest,
   ListResourceProfileArtifactsResponse,
   ListResourceProfileArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceProfileArtifact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceProfileArtifactsRequest,
@@ -7401,7 +7400,7 @@ export const listResourceProfileDetections: API.PaginatedOperationMethod<
   ListResourceProfileDetectionsRequest,
   ListResourceProfileDetectionsResponse,
   ListResourceProfileDetectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Detection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceProfileDetectionsRequest,
@@ -7439,7 +7438,7 @@ export const listSensitivityInspectionTemplates: API.PaginatedOperationMethod<
   ListSensitivityInspectionTemplatesRequest,
   ListSensitivityInspectionTemplatesResponse,
   ListSensitivityInspectionTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SensitivityInspectionTemplatesEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSensitivityInspectionTemplatesRequest,
@@ -7470,7 +7469,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -7496,7 +7495,7 @@ export const putClassificationExportConfiguration: API.OperationMethod<
   PutClassificationExportConfigurationRequest,
   PutClassificationExportConfigurationResponse,
   PutClassificationExportConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutClassificationExportConfigurationRequest,
   output: PutClassificationExportConfigurationResponse,
@@ -7530,7 +7529,7 @@ export const putFindingsPublicationConfiguration: API.OperationMethod<
   PutFindingsPublicationConfigurationRequest,
   PutFindingsPublicationConfigurationResponse,
   PutFindingsPublicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFindingsPublicationConfigurationRequest,
   output: PutFindingsPublicationConfigurationResponse,
@@ -7564,7 +7563,7 @@ export const searchResources: API.PaginatedOperationMethod<
   SearchResourcesRequest,
   SearchResourcesResponse,
   SearchResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MatchingResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchResourcesRequest,
@@ -7597,7 +7596,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7623,7 +7622,7 @@ export const testCustomDataIdentifier: API.OperationMethod<
   TestCustomDataIdentifierRequest,
   TestCustomDataIdentifierResponse,
   TestCustomDataIdentifierError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestCustomDataIdentifierRequest,
   output: TestCustomDataIdentifierResponse,
@@ -7649,7 +7648,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7673,7 +7672,7 @@ export const updateAllowList: API.OperationMethod<
   UpdateAllowListRequest,
   UpdateAllowListResponse,
   UpdateAllowListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAllowListRequest,
   output: UpdateAllowListResponse,
@@ -7702,7 +7701,7 @@ export const updateAutomatedDiscoveryConfiguration: API.OperationMethod<
   UpdateAutomatedDiscoveryConfigurationRequest,
   UpdateAutomatedDiscoveryConfigurationResponse,
   UpdateAutomatedDiscoveryConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomatedDiscoveryConfigurationRequest,
   output: UpdateAutomatedDiscoveryConfigurationResponse,
@@ -7733,7 +7732,7 @@ export const updateClassificationJob: API.OperationMethod<
   UpdateClassificationJobRequest,
   UpdateClassificationJobResponse,
   UpdateClassificationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClassificationJobRequest,
   output: UpdateClassificationJobResponse,
@@ -7765,7 +7764,7 @@ export const updateClassificationScope: API.OperationMethod<
   UpdateClassificationScopeRequest,
   UpdateClassificationScopeResponse,
   UpdateClassificationScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClassificationScopeRequest,
   output: UpdateClassificationScopeResponse,
@@ -7797,7 +7796,7 @@ export const updateFindingsFilter: API.OperationMethod<
   UpdateFindingsFilterRequest,
   UpdateFindingsFilterResponse,
   UpdateFindingsFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingsFilterRequest,
   output: UpdateFindingsFilterResponse,
@@ -7831,7 +7830,7 @@ export const updateMacieSession: API.OperationMethod<
   UpdateMacieSessionRequest,
   UpdateMacieSessionResponse,
   UpdateMacieSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMacieSessionRequest,
   output: UpdateMacieSessionResponse,
@@ -7865,7 +7864,7 @@ export const updateMemberSession: API.OperationMethod<
   UpdateMemberSessionRequest,
   UpdateMemberSessionResponse,
   UpdateMemberSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMemberSessionRequest,
   output: UpdateMemberSessionResponse,
@@ -7899,7 +7898,7 @@ export const updateOrganizationConfiguration: API.OperationMethod<
   UpdateOrganizationConfigurationRequest,
   UpdateOrganizationConfigurationResponse,
   UpdateOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationConfigurationRequest,
   output: UpdateOrganizationConfigurationResponse,
@@ -7932,7 +7931,7 @@ export const updateResourceProfile: API.OperationMethod<
   UpdateResourceProfileRequest,
   UpdateResourceProfileResponse,
   UpdateResourceProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceProfileRequest,
   output: UpdateResourceProfileResponse,
@@ -7964,7 +7963,7 @@ export const updateResourceProfileDetections: API.OperationMethod<
   UpdateResourceProfileDetectionsRequest,
   UpdateResourceProfileDetectionsResponse,
   UpdateResourceProfileDetectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceProfileDetectionsRequest,
   output: UpdateResourceProfileDetectionsResponse,
@@ -7994,7 +7993,7 @@ export const updateRevealConfiguration: API.OperationMethod<
   UpdateRevealConfigurationRequest,
   UpdateRevealConfigurationResponse,
   UpdateRevealConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRevealConfigurationRequest,
   output: UpdateRevealConfigurationResponse,
@@ -8023,7 +8022,7 @@ export const updateSensitivityInspectionTemplate: API.OperationMethod<
   UpdateSensitivityInspectionTemplateRequest,
   UpdateSensitivityInspectionTemplateResponse,
   UpdateSensitivityInspectionTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSensitivityInspectionTemplateRequest,
   output: UpdateSensitivityInspectionTemplateResponse,

--- a/packages/aws/src/services/mailmanager.ts
+++ b/packages/aws/src/services/mailmanager.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MailManager",
@@ -3284,7 +3283,7 @@ export const createAddonInstance: API.OperationMethod<
   CreateAddonInstanceRequest,
   CreateAddonInstanceResponse,
   CreateAddonInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddonInstanceRequest,
   output: CreateAddonInstanceResponse,
@@ -3312,7 +3311,7 @@ export const createAddonSubscription: API.OperationMethod<
   CreateAddonSubscriptionRequest,
   CreateAddonSubscriptionResponse,
   CreateAddonSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddonSubscriptionRequest,
   output: CreateAddonSubscriptionResponse,
@@ -3341,7 +3340,7 @@ export const createAddressList: API.OperationMethod<
   CreateAddressListRequest,
   CreateAddressListResponse,
   CreateAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddressListRequest,
   output: CreateAddressListResponse,
@@ -3370,7 +3369,7 @@ export const createAddressListImportJob: API.OperationMethod<
   CreateAddressListImportJobRequest,
   CreateAddressListImportJobResponse,
   CreateAddressListImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddressListImportJobRequest,
   output: CreateAddressListImportJobResponse,
@@ -3399,7 +3398,7 @@ export const createArchive: API.OperationMethod<
   CreateArchiveRequest,
   CreateArchiveResponse,
   CreateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateArchiveRequest,
   output: CreateArchiveResponse,
@@ -3427,7 +3426,7 @@ export const createIngressPoint: API.OperationMethod<
   CreateIngressPointRequest,
   CreateIngressPointResponse,
   CreateIngressPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIngressPointRequest,
   output: CreateIngressPointResponse,
@@ -3453,7 +3452,7 @@ export const createRelay: API.OperationMethod<
   CreateRelayRequest,
   CreateRelayResponse,
   CreateRelayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelayRequest,
   output: CreateRelayResponse,
@@ -3479,7 +3478,7 @@ export const createRuleSet: API.OperationMethod<
   CreateRuleSetRequest,
   CreateRuleSetResponse,
   CreateRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleSetRequest,
   output: CreateRuleSetResponse,
@@ -3505,7 +3504,7 @@ export const createTrafficPolicy: API.OperationMethod<
   CreateTrafficPolicyRequest,
   CreateTrafficPolicyResponse,
   CreateTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficPolicyRequest,
   output: CreateTrafficPolicyResponse,
@@ -3530,7 +3529,7 @@ export const deleteAddonInstance: API.OperationMethod<
   DeleteAddonInstanceRequest,
   DeleteAddonInstanceResponse,
   DeleteAddonInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAddonInstanceRequest,
   output: DeleteAddonInstanceResponse,
@@ -3551,7 +3550,7 @@ export const deleteAddonSubscription: API.OperationMethod<
   DeleteAddonSubscriptionRequest,
   DeleteAddonSubscriptionResponse,
   DeleteAddonSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAddonSubscriptionRequest,
   output: DeleteAddonSubscriptionResponse,
@@ -3574,7 +3573,7 @@ export const deleteAddressList: API.OperationMethod<
   DeleteAddressListRequest,
   DeleteAddressListResponse,
   DeleteAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAddressListRequest,
   output: DeleteAddressListResponse,
@@ -3602,7 +3601,7 @@ export const deleteArchive: API.OperationMethod<
   DeleteArchiveRequest,
   DeleteArchiveResponse,
   DeleteArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArchiveRequest,
   output: DeleteArchiveResponse,
@@ -3629,7 +3628,7 @@ export const deleteIngressPoint: API.OperationMethod<
   DeleteIngressPointRequest,
   DeleteIngressPointResponse,
   DeleteIngressPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIngressPointRequest,
   output: DeleteIngressPointResponse,
@@ -3651,7 +3650,7 @@ export const deleteRelay: API.OperationMethod<
   DeleteRelayRequest,
   DeleteRelayResponse,
   DeleteRelayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRelayRequest,
   output: DeleteRelayResponse,
@@ -3672,7 +3671,7 @@ export const deleteRuleSet: API.OperationMethod<
   DeleteRuleSetRequest,
   DeleteRuleSetResponse,
   DeleteRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleSetRequest,
   output: DeleteRuleSetResponse,
@@ -3694,7 +3693,7 @@ export const deleteTrafficPolicy: API.OperationMethod<
   DeleteTrafficPolicyRequest,
   DeleteTrafficPolicyResponse,
   DeleteTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficPolicyRequest,
   output: DeleteTrafficPolicyResponse,
@@ -3718,7 +3717,7 @@ export const deregisterMemberFromAddressList: API.OperationMethod<
   DeregisterMemberFromAddressListRequest,
   DeregisterMemberFromAddressListResponse,
   DeregisterMemberFromAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterMemberFromAddressListRequest,
   output: DeregisterMemberFromAddressListResponse,
@@ -3745,7 +3744,7 @@ export const getAddonInstance: API.OperationMethod<
   GetAddonInstanceRequest,
   GetAddonInstanceResponse,
   GetAddonInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAddonInstanceRequest,
   output: GetAddonInstanceResponse,
@@ -3766,7 +3765,7 @@ export const getAddonSubscription: API.OperationMethod<
   GetAddonSubscriptionRequest,
   GetAddonSubscriptionResponse,
   GetAddonSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAddonSubscriptionRequest,
   output: GetAddonSubscriptionResponse,
@@ -3789,7 +3788,7 @@ export const getAddressList: API.OperationMethod<
   GetAddressListRequest,
   GetAddressListResponse,
   GetAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAddressListRequest,
   output: GetAddressListResponse,
@@ -3817,7 +3816,7 @@ export const getAddressListImportJob: API.OperationMethod<
   GetAddressListImportJobRequest,
   GetAddressListImportJobResponse,
   GetAddressListImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAddressListImportJobRequest,
   output: GetAddressListImportJobResponse,
@@ -3845,7 +3844,7 @@ export const getArchive: API.OperationMethod<
   GetArchiveRequest,
   GetArchiveResponse,
   GetArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveRequest,
   output: GetArchiveResponse,
@@ -3872,7 +3871,7 @@ export const getArchiveExport: API.OperationMethod<
   GetArchiveExportRequest,
   GetArchiveExportResponse,
   GetArchiveExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveExportRequest,
   output: GetArchiveExportResponse,
@@ -3894,7 +3893,7 @@ export const getArchiveMessage: API.OperationMethod<
   GetArchiveMessageRequest,
   GetArchiveMessageResponse,
   GetArchiveMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveMessageRequest,
   output: GetArchiveMessageResponse,
@@ -3916,7 +3915,7 @@ export const getArchiveMessageContent: API.OperationMethod<
   GetArchiveMessageContentRequest,
   GetArchiveMessageContentResponse,
   GetArchiveMessageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveMessageContentRequest,
   output: GetArchiveMessageContentResponse,
@@ -3938,7 +3937,7 @@ export const getArchiveSearch: API.OperationMethod<
   GetArchiveSearchRequest,
   GetArchiveSearchResponse,
   GetArchiveSearchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveSearchRequest,
   output: GetArchiveSearchResponse,
@@ -3961,7 +3960,7 @@ export const getArchiveSearchResults: API.OperationMethod<
   GetArchiveSearchResultsRequest,
   GetArchiveSearchResultsResponse,
   GetArchiveSearchResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchiveSearchResultsRequest,
   output: GetArchiveSearchResultsResponse,
@@ -3987,7 +3986,7 @@ export const getIngressPoint: API.OperationMethod<
   GetIngressPointRequest,
   GetIngressPointResponse,
   GetIngressPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIngressPointRequest,
   output: GetIngressPointResponse,
@@ -4010,7 +4009,7 @@ export const getMemberOfAddressList: API.OperationMethod<
   GetMemberOfAddressListRequest,
   GetMemberOfAddressListResponse,
   GetMemberOfAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemberOfAddressListRequest,
   output: GetMemberOfAddressListResponse,
@@ -4036,7 +4035,7 @@ export const getRelay: API.OperationMethod<
   GetRelayRequest,
   GetRelayResponse,
   GetRelayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelayRequest,
   output: GetRelayResponse,
@@ -4057,7 +4056,7 @@ export const getRuleSet: API.OperationMethod<
   GetRuleSetRequest,
   GetRuleSetResponse,
   GetRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleSetRequest,
   output: GetRuleSetResponse,
@@ -4078,7 +4077,7 @@ export const getTrafficPolicy: API.OperationMethod<
   GetTrafficPolicyRequest,
   GetTrafficPolicyResponse,
   GetTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrafficPolicyRequest,
   output: GetTrafficPolicyResponse,
@@ -4096,7 +4095,7 @@ export const listAddonInstances: API.PaginatedOperationMethod<
   ListAddonInstancesRequest,
   ListAddonInstancesResponse,
   ListAddonInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddonInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAddonInstancesRequest,
@@ -4121,7 +4120,7 @@ export const listAddonSubscriptions: API.PaginatedOperationMethod<
   ListAddonSubscriptionsRequest,
   ListAddonSubscriptionsResponse,
   ListAddonSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddonSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAddonSubscriptionsRequest,
@@ -4151,7 +4150,7 @@ export const listAddressListImportJobs: API.PaginatedOperationMethod<
   ListAddressListImportJobsRequest,
   ListAddressListImportJobsResponse,
   ListAddressListImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAddressListImportJobsRequest,
@@ -4185,7 +4184,7 @@ export const listAddressLists: API.PaginatedOperationMethod<
   ListAddressListsRequest,
   ListAddressListsResponse,
   ListAddressListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AddressList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAddressListsRequest,
@@ -4215,7 +4214,7 @@ export const listArchiveExports: API.PaginatedOperationMethod<
   ListArchiveExportsRequest,
   ListArchiveExportsResponse,
   ListArchiveExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArchiveExportsRequest,
@@ -4249,7 +4248,7 @@ export const listArchives: API.PaginatedOperationMethod<
   ListArchivesRequest,
   ListArchivesResponse,
   ListArchivesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Archive
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArchivesRequest,
@@ -4279,7 +4278,7 @@ export const listArchiveSearches: API.PaginatedOperationMethod<
   ListArchiveSearchesRequest,
   ListArchiveSearchesResponse,
   ListArchiveSearchesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArchiveSearchesRequest,
@@ -4309,7 +4308,7 @@ export const listIngressPoints: API.PaginatedOperationMethod<
   ListIngressPointsRequest,
   ListIngressPointsResponse,
   ListIngressPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IngressPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngressPointsRequest,
@@ -4339,7 +4338,7 @@ export const listMembersOfAddressList: API.PaginatedOperationMethod<
   ListMembersOfAddressListRequest,
   ListMembersOfAddressListResponse,
   ListMembersOfAddressListError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SavedAddress
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersOfAddressListRequest,
@@ -4369,7 +4368,7 @@ export const listRelays: API.PaginatedOperationMethod<
   ListRelaysRequest,
   ListRelaysResponse,
   ListRelaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Relay
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRelaysRequest,
@@ -4394,7 +4393,7 @@ export const listRuleSets: API.PaginatedOperationMethod<
   ListRuleSetsRequest,
   ListRuleSetsResponse,
   ListRuleSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleSet
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRuleSetsRequest,
@@ -4422,7 +4421,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4440,7 +4439,7 @@ export const listTrafficPolicies: API.PaginatedOperationMethod<
   ListTrafficPoliciesRequest,
   ListTrafficPoliciesResponse,
   ListTrafficPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrafficPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrafficPoliciesRequest,
@@ -4472,7 +4471,7 @@ export const registerMemberToAddressList: API.OperationMethod<
   RegisterMemberToAddressListRequest,
   RegisterMemberToAddressListResponse,
   RegisterMemberToAddressListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterMemberToAddressListRequest,
   output: RegisterMemberToAddressListResponse,
@@ -4504,7 +4503,7 @@ export const startAddressListImportJob: API.OperationMethod<
   StartAddressListImportJobRequest,
   StartAddressListImportJobResponse,
   StartAddressListImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAddressListImportJobRequest,
   output: StartAddressListImportJobResponse,
@@ -4535,7 +4534,7 @@ export const startArchiveExport: API.OperationMethod<
   StartArchiveExportRequest,
   StartArchiveExportResponse,
   StartArchiveExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartArchiveExportRequest,
   output: StartArchiveExportResponse,
@@ -4566,7 +4565,7 @@ export const startArchiveSearch: API.OperationMethod<
   StartArchiveSearchRequest,
   StartArchiveSearchResponse,
   StartArchiveSearchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartArchiveSearchRequest,
   output: StartArchiveSearchResponse,
@@ -4597,7 +4596,7 @@ export const stopAddressListImportJob: API.OperationMethod<
   StopAddressListImportJobRequest,
   StopAddressListImportJobResponse,
   StopAddressListImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAddressListImportJobRequest,
   output: StopAddressListImportJobResponse,
@@ -4625,7 +4624,7 @@ export const stopArchiveExport: API.OperationMethod<
   StopArchiveExportRequest,
   StopArchiveExportResponse,
   StopArchiveExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopArchiveExportRequest,
   output: StopArchiveExportResponse,
@@ -4647,7 +4646,7 @@ export const stopArchiveSearch: API.OperationMethod<
   StopArchiveSearchRequest,
   StopArchiveSearchResponse,
   StopArchiveSearchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopArchiveSearchRequest,
   output: StopArchiveSearchResponse,
@@ -4670,7 +4669,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4697,7 +4696,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4722,7 +4721,7 @@ export const updateArchive: API.OperationMethod<
   UpdateArchiveRequest,
   UpdateArchiveResponse,
   UpdateArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateArchiveRequest,
   output: UpdateArchiveResponse,
@@ -4751,7 +4750,7 @@ export const updateIngressPoint: API.OperationMethod<
   UpdateIngressPointRequest,
   UpdateIngressPointResponse,
   UpdateIngressPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIngressPointRequest,
   output: UpdateIngressPointResponse,
@@ -4773,7 +4772,7 @@ export const updateRelay: API.OperationMethod<
   UpdateRelayRequest,
   UpdateRelayResponse,
   UpdateRelayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelayRequest,
   output: UpdateRelayResponse,
@@ -4795,7 +4794,7 @@ export const updateRuleSet: API.OperationMethod<
   UpdateRuleSetRequest,
   UpdateRuleSetResponse,
   UpdateRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleSetRequest,
   output: UpdateRuleSetResponse,
@@ -4817,7 +4816,7 @@ export const updateTrafficPolicy: API.OperationMethod<
   UpdateTrafficPolicyRequest,
   UpdateTrafficPolicyResponse,
   UpdateTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrafficPolicyRequest,
   output: UpdateTrafficPolicyResponse,

--- a/packages/aws/src/services/managedblockchain-query.ts
+++ b/packages/aws/src/services/managedblockchain-query.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ManagedBlockchain Query",
   serviceShapeName: "TietonChainQueryService",
@@ -872,7 +871,7 @@ export const batchGetTokenBalance: API.OperationMethod<
   BatchGetTokenBalanceInput,
   BatchGetTokenBalanceOutput,
   BatchGetTokenBalanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTokenBalanceInput,
   output: BatchGetTokenBalanceOutput,
@@ -910,7 +909,7 @@ export const getAssetContract: API.OperationMethod<
   GetAssetContractInput,
   GetAssetContractOutput,
   GetAssetContractError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssetContractInput,
   output: GetAssetContractOutput,
@@ -945,7 +944,7 @@ export const getTokenBalance: API.OperationMethod<
   GetTokenBalanceInput,
   GetTokenBalanceOutput,
   GetTokenBalanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTokenBalanceInput,
   output: GetTokenBalanceOutput,
@@ -981,7 +980,7 @@ export const getTransaction: API.OperationMethod<
   GetTransactionInput,
   GetTransactionOutput,
   GetTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransactionInput,
   output: GetTransactionOutput,
@@ -1016,7 +1015,7 @@ export const listAssetContracts: API.PaginatedOperationMethod<
   ListAssetContractsInput,
   ListAssetContractsOutput,
   ListAssetContractsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetContract
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetContractsInput,
@@ -1055,7 +1054,7 @@ export const listFilteredTransactionEvents: API.PaginatedOperationMethod<
   ListFilteredTransactionEventsInput,
   ListFilteredTransactionEventsOutput,
   ListFilteredTransactionEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransactionEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFilteredTransactionEventsInput,
@@ -1102,7 +1101,7 @@ export const listTokenBalances: API.PaginatedOperationMethod<
   ListTokenBalancesInput,
   ListTokenBalancesOutput,
   ListTokenBalancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TokenBalance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTokenBalancesInput,
@@ -1143,7 +1142,7 @@ export const listTransactionEvents: API.PaginatedOperationMethod<
   ListTransactionEventsInput,
   ListTransactionEventsOutput,
   ListTransactionEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransactionEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTransactionEventsInput,
@@ -1180,7 +1179,7 @@ export const listTransactions: API.PaginatedOperationMethod<
   ListTransactionsInput,
   ListTransactionsOutput,
   ListTransactionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransactionOutputItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTransactionsInput,

--- a/packages/aws/src/services/managedblockchain.ts
+++ b/packages/aws/src/services/managedblockchain.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "ManagedBlockchain",
@@ -1746,7 +1745,7 @@ export const createAccessor: API.OperationMethod<
   CreateAccessorInput,
   CreateAccessorOutput,
   CreateAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessorInput,
   output: CreateAccessorOutput,
@@ -1784,7 +1783,7 @@ export const createMember: API.OperationMethod<
   CreateMemberInput,
   CreateMemberOutput,
   CreateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMemberInput,
   output: CreateMemberOutput,
@@ -1822,7 +1821,7 @@ export const createNetwork: API.OperationMethod<
   CreateNetworkInput,
   CreateNetworkOutput,
   CreateNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkInput,
   output: CreateNetworkOutput,
@@ -1860,7 +1859,7 @@ export const createNode: API.OperationMethod<
   CreateNodeInput,
   CreateNodeOutput,
   CreateNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNodeInput,
   output: CreateNodeOutput,
@@ -1898,7 +1897,7 @@ export const createProposal: API.OperationMethod<
   CreateProposalInput,
   CreateProposalOutput,
   CreateProposalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProposalInput,
   output: CreateProposalOutput,
@@ -1936,7 +1935,7 @@ export const deleteAccessor: API.OperationMethod<
   DeleteAccessorInput,
   DeleteAccessorOutput,
   DeleteAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessorInput,
   output: DeleteAccessorOutput,
@@ -1969,7 +1968,7 @@ export const deleteMember: API.OperationMethod<
   DeleteMemberInput,
   DeleteMemberOutput,
   DeleteMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMemberInput,
   output: DeleteMemberOutput,
@@ -2003,7 +2002,7 @@ export const deleteNode: API.OperationMethod<
   DeleteNodeInput,
   DeleteNodeOutput,
   DeleteNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNodeInput,
   output: DeleteNodeOutput,
@@ -2035,7 +2034,7 @@ export const getAccessor: API.OperationMethod<
   GetAccessorInput,
   GetAccessorOutput,
   GetAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessorInput,
   output: GetAccessorOutput,
@@ -2067,7 +2066,7 @@ export const getMember: API.OperationMethod<
   GetMemberInput,
   GetMemberOutput,
   GetMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMemberInput,
   output: GetMemberOutput,
@@ -2099,7 +2098,7 @@ export const getNetwork: API.OperationMethod<
   GetNetworkInput,
   GetNetworkOutput,
   GetNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkInput,
   output: GetNetworkOutput,
@@ -2131,7 +2130,7 @@ export const getNode: API.OperationMethod<
   GetNodeInput,
   GetNodeOutput,
   GetNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNodeInput,
   output: GetNodeOutput,
@@ -2163,7 +2162,7 @@ export const getProposal: API.OperationMethod<
   GetProposalInput,
   GetProposalOutput,
   GetProposalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProposalInput,
   output: GetProposalOutput,
@@ -2193,7 +2192,7 @@ export const listAccessors: API.PaginatedOperationMethod<
   ListAccessorsInput,
   ListAccessorsOutput,
   ListAccessorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessorsInput,
@@ -2232,7 +2231,7 @@ export const listInvitations: API.PaginatedOperationMethod<
   ListInvitationsInput,
   ListInvitationsOutput,
   ListInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvitationsInput,
@@ -2270,7 +2269,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersInput,
   ListMembersOutput,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersInput,
@@ -2306,7 +2305,7 @@ export const listNetworks: API.PaginatedOperationMethod<
   ListNetworksInput,
   ListNetworksOutput,
   ListNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworksInput,
@@ -2342,7 +2341,7 @@ export const listNodes: API.PaginatedOperationMethod<
   ListNodesInput,
   ListNodesOutput,
   ListNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesInput,
@@ -2379,7 +2378,7 @@ export const listProposals: API.PaginatedOperationMethod<
   ListProposalsInput,
   ListProposalsOutput,
   ListProposalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProposalsInput,
@@ -2416,7 +2415,7 @@ export const listProposalVotes: API.PaginatedOperationMethod<
   ListProposalVotesInput,
   ListProposalVotesOutput,
   ListProposalVotesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProposalVotesInput,
@@ -2452,7 +2451,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2484,7 +2483,7 @@ export const rejectInvitation: API.OperationMethod<
   RejectInvitationInput,
   RejectInvitationOutput,
   RejectInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectInvitationInput,
   output: RejectInvitationOutput,
@@ -2521,7 +2520,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2552,7 +2551,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2583,7 +2582,7 @@ export const updateMember: API.OperationMethod<
   UpdateMemberInput,
   UpdateMemberOutput,
   UpdateMemberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMemberInput,
   output: UpdateMemberOutput,
@@ -2615,7 +2614,7 @@ export const updateNode: API.OperationMethod<
   UpdateNodeInput,
   UpdateNodeOutput,
   UpdateNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNodeInput,
   output: UpdateNodeOutput,
@@ -2648,7 +2647,7 @@ export const voteOnProposal: API.OperationMethod<
   VoteOnProposalInput,
   VoteOnProposalOutput,
   VoteOnProposalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VoteOnProposalInput,
   output: VoteOnProposalOutput,

--- a/packages/aws/src/services/marketplace-agreement.ts
+++ b/packages/aws/src/services/marketplace-agreement.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Agreement",
@@ -2388,7 +2387,7 @@ export const acceptAgreementCancellationRequest: API.OperationMethod<
   AcceptAgreementCancellationRequestInput,
   AcceptAgreementCancellationRequestOutput,
   AcceptAgreementCancellationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAgreementCancellationRequestInput,
   output: AcceptAgreementCancellationRequestOutput,
@@ -2422,7 +2421,7 @@ export const acceptAgreementPaymentRequest: API.OperationMethod<
   AcceptAgreementPaymentRequestInput,
   AcceptAgreementPaymentRequestOutput,
   AcceptAgreementPaymentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAgreementPaymentRequestInput,
   output: AcceptAgreementPaymentRequestOutput,
@@ -2454,7 +2453,7 @@ export const acceptAgreementRequest: API.OperationMethod<
   AcceptAgreementRequestInput,
   AcceptAgreementRequestOutput,
   AcceptAgreementRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAgreementRequestInput,
   output: AcceptAgreementRequestOutput,
@@ -2487,7 +2486,7 @@ export const batchCreateBillingAdjustmentRequest: API.OperationMethod<
   BatchCreateBillingAdjustmentRequestInput,
   BatchCreateBillingAdjustmentRequestOutput,
   BatchCreateBillingAdjustmentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateBillingAdjustmentRequestInput,
   output: BatchCreateBillingAdjustmentRequestOutput,
@@ -2518,7 +2517,7 @@ export const cancelAgreement: API.OperationMethod<
   CancelAgreementInput,
   CancelAgreementOutput,
   CancelAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAgreementInput,
   output: CancelAgreementOutput,
@@ -2552,7 +2551,7 @@ export const cancelAgreementCancellationRequest: API.OperationMethod<
   CancelAgreementCancellationRequestInput,
   CancelAgreementCancellationRequestOutput,
   CancelAgreementCancellationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAgreementCancellationRequestInput,
   output: CancelAgreementCancellationRequestOutput,
@@ -2586,7 +2585,7 @@ export const cancelAgreementPaymentRequest: API.OperationMethod<
   CancelAgreementPaymentRequestInput,
   CancelAgreementPaymentRequestOutput,
   CancelAgreementPaymentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAgreementPaymentRequestInput,
   output: CancelAgreementPaymentRequestOutput,
@@ -2619,7 +2618,7 @@ export const createAgreementRequest: API.OperationMethod<
   CreateAgreementRequestInput,
   CreateAgreementRequestOutput,
   CreateAgreementRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgreementRequestInput,
   output: CreateAgreementRequestOutput,
@@ -2651,7 +2650,7 @@ export const describeAgreement: API.OperationMethod<
   DescribeAgreementInput,
   DescribeAgreementOutput,
   DescribeAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgreementInput,
   output: DescribeAgreementOutput,
@@ -2681,7 +2680,7 @@ export const getAgreementCancellationRequest: API.OperationMethod<
   GetAgreementCancellationRequestInput,
   GetAgreementCancellationRequestOutput,
   GetAgreementCancellationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgreementCancellationRequestInput,
   output: GetAgreementCancellationRequestOutput,
@@ -2711,7 +2710,7 @@ export const getAgreementEntitlements: API.PaginatedOperationMethod<
   GetAgreementEntitlementsInput,
   GetAgreementEntitlementsOutput,
   GetAgreementEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgreementEntitlement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAgreementEntitlementsInput,
@@ -2750,7 +2749,7 @@ export const getAgreementPaymentRequest: API.OperationMethod<
   GetAgreementPaymentRequestInput,
   GetAgreementPaymentRequestOutput,
   GetAgreementPaymentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAgreementPaymentRequestInput,
   output: GetAgreementPaymentRequestOutput,
@@ -2790,7 +2789,7 @@ export const getAgreementTerms: API.PaginatedOperationMethod<
   GetAgreementTermsInput,
   GetAgreementTermsOutput,
   GetAgreementTermsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AcceptedTerm
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAgreementTermsInput,
@@ -2827,7 +2826,7 @@ export const getBillingAdjustmentRequest: API.OperationMethod<
   GetBillingAdjustmentRequestInput,
   GetBillingAdjustmentRequestOutput,
   GetBillingAdjustmentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBillingAdjustmentRequestInput,
   output: GetBillingAdjustmentRequestOutput,
@@ -2858,7 +2857,7 @@ export const listAgreementCancellationRequests: API.PaginatedOperationMethod<
   ListAgreementCancellationRequestsInput,
   ListAgreementCancellationRequestsOutput,
   ListAgreementCancellationRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgreementCancellationRequestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgreementCancellationRequestsInput,
@@ -2893,7 +2892,7 @@ export const listAgreementCharges: API.PaginatedOperationMethod<
   ListAgreementChargesInput,
   ListAgreementChargesOutput,
   ListAgreementChargesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Charge
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgreementChargesInput,
@@ -2931,7 +2930,7 @@ export const listAgreementInvoiceLineItems: API.PaginatedOperationMethod<
   ListAgreementInvoiceLineItemsInput,
   ListAgreementInvoiceLineItemsOutput,
   ListAgreementInvoiceLineItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgreementInvoiceLineItemGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgreementInvoiceLineItemsInput,
@@ -2969,7 +2968,7 @@ export const listAgreementPaymentRequests: API.PaginatedOperationMethod<
   ListAgreementPaymentRequestsInput,
   ListAgreementPaymentRequestsOutput,
   ListAgreementPaymentRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PaymentRequestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgreementPaymentRequestsInput,
@@ -3004,7 +3003,7 @@ export const listBillingAdjustmentRequests: API.PaginatedOperationMethod<
   ListBillingAdjustmentRequestsInput,
   ListBillingAdjustmentRequestsOutput,
   ListBillingAdjustmentRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingAdjustmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBillingAdjustmentRequestsInput,
@@ -3043,7 +3042,7 @@ export const rejectAgreementCancellationRequest: API.OperationMethod<
   RejectAgreementCancellationRequestInput,
   RejectAgreementCancellationRequestOutput,
   RejectAgreementCancellationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectAgreementCancellationRequestInput,
   output: RejectAgreementCancellationRequestOutput,
@@ -3077,7 +3076,7 @@ export const rejectAgreementPaymentRequest: API.OperationMethod<
   RejectAgreementPaymentRequestInput,
   RejectAgreementPaymentRequestOutput,
   RejectAgreementPaymentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectAgreementPaymentRequestInput,
   output: RejectAgreementPaymentRequestOutput,
@@ -3221,7 +3220,7 @@ export const searchAgreements: API.PaginatedOperationMethod<
   SearchAgreementsInput,
   SearchAgreementsOutput,
   SearchAgreementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgreementViewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAgreementsInput,
@@ -3258,7 +3257,7 @@ export const sendAgreementCancellationRequest: API.OperationMethod<
   SendAgreementCancellationRequestInput,
   SendAgreementCancellationRequestOutput,
   SendAgreementCancellationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendAgreementCancellationRequestInput,
   output: SendAgreementCancellationRequestOutput,
@@ -3292,7 +3291,7 @@ export const sendAgreementPaymentRequest: API.OperationMethod<
   SendAgreementPaymentRequestInput,
   SendAgreementPaymentRequestOutput,
   SendAgreementPaymentRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendAgreementPaymentRequestInput,
   output: SendAgreementPaymentRequestOutput,
@@ -3324,7 +3323,7 @@ export const updatePurchaseOrders: API.OperationMethod<
   UpdatePurchaseOrdersInput,
   UpdatePurchaseOrdersOutput,
   UpdatePurchaseOrdersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePurchaseOrdersInput,
   output: UpdatePurchaseOrdersOutput,

--- a/packages/aws/src/services/marketplace-catalog.ts
+++ b/packages/aws/src/services/marketplace-catalog.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Catalog",
   serviceShapeName: "AWSMPSeymour",
@@ -2414,7 +2413,7 @@ export const batchDescribeEntities: API.OperationMethod<
   BatchDescribeEntitiesRequest,
   BatchDescribeEntitiesResponse,
   BatchDescribeEntitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDescribeEntitiesRequest,
   output: BatchDescribeEntitiesResponse,
@@ -2447,7 +2446,7 @@ export const cancelChangeSet: API.OperationMethod<
   CancelChangeSetRequest,
   CancelChangeSetResponse,
   CancelChangeSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelChangeSetRequest,
   output: CancelChangeSetResponse,
@@ -2479,7 +2478,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -2509,7 +2508,7 @@ export const describeChangeSet: API.OperationMethod<
   DescribeChangeSetRequest,
   DescribeChangeSetResponse,
   DescribeChangeSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChangeSetRequest,
   output: DescribeChangeSetResponse,
@@ -2540,7 +2539,7 @@ export const describeEntity: API.OperationMethod<
   DescribeEntityRequest,
   DescribeEntityResponse,
   DescribeEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntityRequest,
   output: DescribeEntityResponse,
@@ -2572,7 +2571,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -2607,7 +2606,7 @@ export const listChangeSets: API.PaginatedOperationMethod<
   ListChangeSetsRequest,
   ListChangeSetsResponse,
   ListChangeSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChangeSetSummaryListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChangeSetsRequest,
@@ -2643,7 +2642,7 @@ export const listEntities: API.PaginatedOperationMethod<
   ListEntitiesRequest,
   ListEntitiesResponse,
   ListEntitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EntitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitiesRequest,
@@ -2680,7 +2679,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2711,7 +2710,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -2760,7 +2759,7 @@ export const startChangeSet: API.OperationMethod<
   StartChangeSetRequest,
   StartChangeSetResponse,
   StartChangeSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartChangeSetRequest,
   output: StartChangeSetResponse,
@@ -2792,7 +2791,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2822,7 +2821,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/marketplace-commerce-analytics.ts
+++ b/packages/aws/src/services/marketplace-commerce-analytics.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Commerce Analytics",
   serviceShapeName: "MarketplaceCommerceAnalytics20150701",
@@ -219,7 +218,7 @@ export const generateDataSet: API.OperationMethod<
   GenerateDataSetRequest,
   GenerateDataSetResult,
   GenerateDataSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateDataSetRequest,
   output: GenerateDataSetResult,
@@ -246,7 +245,7 @@ export const startSupportDataExport: API.OperationMethod<
   StartSupportDataExportRequest,
   StartSupportDataExportResult,
   StartSupportDataExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSupportDataExportRequest,
   output: StartSupportDataExportResult,

--- a/packages/aws/src/services/marketplace-deployment.ts
+++ b/packages/aws/src/services/marketplace-deployment.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Deployment",
@@ -300,7 +299,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -332,7 +331,7 @@ export const putDeploymentParameter: API.OperationMethod<
   PutDeploymentParameterRequest,
   PutDeploymentParameterResponse,
   PutDeploymentParameterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeploymentParameterRequest,
   output: PutDeploymentParameterResponse,
@@ -365,7 +364,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -397,7 +396,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/marketplace-discovery.ts
+++ b/packages/aws/src/services/marketplace-discovery.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Discovery",
   serviceShapeName: "AWSMarketplaceDiscovery",
@@ -2150,7 +2149,7 @@ export const getListing: API.OperationMethod<
   GetListingInput,
   GetListingOutput,
   GetListingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetListingInput,
   output: GetListingOutput,
@@ -2168,7 +2167,7 @@ export const getOffer: API.OperationMethod<
   GetOfferInput,
   GetOfferOutput,
   GetOfferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOfferInput,
   output: GetOfferOutput,
@@ -2186,7 +2185,7 @@ export const getOfferSet: API.OperationMethod<
   GetOfferSetInput,
   GetOfferSetOutput,
   GetOfferSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOfferSetInput,
   output: GetOfferSetOutput,
@@ -2204,7 +2203,7 @@ export const getOfferTerms: API.PaginatedOperationMethod<
   GetOfferTermsInput,
   GetOfferTermsOutput,
   GetOfferTermsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OfferTerm
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOfferTermsInput,
@@ -2228,7 +2227,7 @@ export const getProduct: API.OperationMethod<
   GetProductInput,
   GetProductOutput,
   GetProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProductInput,
   output: GetProductOutput,
@@ -2248,7 +2247,7 @@ export const listFulfillmentOptions: API.PaginatedOperationMethod<
   ListFulfillmentOptionsInput,
   ListFulfillmentOptionsOutput,
   ListFulfillmentOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FulfillmentOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFulfillmentOptionsInput,
@@ -2275,7 +2274,7 @@ export const listPurchaseOptions: API.PaginatedOperationMethod<
   ListPurchaseOptionsInput,
   ListPurchaseOptionsOutput,
   ListPurchaseOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PurchaseOptionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPurchaseOptionsInput,
@@ -2299,7 +2298,7 @@ export const searchFacets: API.PaginatedOperationMethod<
   SearchFacetsInput,
   SearchFacetsOutput,
   SearchFacetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchFacetsInput,
@@ -2323,7 +2322,7 @@ export const searchListings: API.PaginatedOperationMethod<
   SearchListingsInput,
   SearchListingsOutput,
   SearchListingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchListingsInput,

--- a/packages/aws/src/services/marketplace-entitlement-service.ts
+++ b/packages/aws/src/services/marketplace-entitlement-service.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Entitlement Service",
   serviceShapeName: "AWSMPEntitlementService",
@@ -235,7 +234,7 @@ export const getEntitlements: API.PaginatedOperationMethod<
   GetEntitlementsRequest,
   GetEntitlementsResult,
   GetEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEntitlementsRequest,

--- a/packages/aws/src/services/marketplace-metering.ts
+++ b/packages/aws/src/services/marketplace-metering.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Metering",
   serviceShapeName: "AWSMPMeteringService",
@@ -454,7 +453,7 @@ export const batchMeterUsage: API.OperationMethod<
   BatchMeterUsageRequest,
   BatchMeterUsageResult,
   BatchMeterUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchMeterUsageRequest,
   output: BatchMeterUsageResult,
@@ -533,7 +532,7 @@ export const meterUsage: API.OperationMethod<
   MeterUsageRequest,
   MeterUsageResult,
   MeterUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MeterUsageRequest,
   output: MeterUsageResult,
@@ -610,7 +609,7 @@ export const registerUsage: API.OperationMethod<
   RegisterUsageRequest,
   RegisterUsageResult,
   RegisterUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterUsageRequest,
   output: RegisterUsageResult,
@@ -658,7 +657,7 @@ export const resolveCustomer: API.OperationMethod<
   ResolveCustomerRequest,
   ResolveCustomerResult,
   ResolveCustomerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResolveCustomerRequest,
   output: ResolveCustomerResult,

--- a/packages/aws/src/services/marketplace-reporting.ts
+++ b/packages/aws/src/services/marketplace-reporting.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Marketplace Reporting",
   serviceShapeName: "AWSMarketplaceReporting",
@@ -170,7 +169,7 @@ export const getBuyerDashboard: API.OperationMethod<
   GetBuyerDashboardInput,
   GetBuyerDashboardOutput,
   GetBuyerDashboardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBuyerDashboardInput,
   output: GetBuyerDashboardOutput,

--- a/packages/aws/src/services/mediaconnect.ts
+++ b/packages/aws/src/services/mediaconnect.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaConnect",
   serviceShapeName: "MediaConnect",
@@ -8367,7 +8366,7 @@ export const addBridgeOutputs: API.OperationMethod<
   AddBridgeOutputsRequest,
   AddBridgeOutputsResponse,
   AddBridgeOutputsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddBridgeOutputsRequest,
   output: AddBridgeOutputsResponse,
@@ -8401,7 +8400,7 @@ export const addBridgeSources: API.OperationMethod<
   AddBridgeSourcesRequest,
   AddBridgeSourcesResponse,
   AddBridgeSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddBridgeSourcesRequest,
   output: AddBridgeSourcesResponse,
@@ -8434,7 +8433,7 @@ export const addFlowMediaStreams: API.OperationMethod<
   AddFlowMediaStreamsRequest,
   AddFlowMediaStreamsResponse,
   AddFlowMediaStreamsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddFlowMediaStreamsRequest,
   output: AddFlowMediaStreamsResponse,
@@ -8467,7 +8466,7 @@ export const addFlowOutputs: API.OperationMethod<
   AddFlowOutputsRequest,
   AddFlowOutputsResponse,
   AddFlowOutputsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddFlowOutputsRequest,
   output: AddFlowOutputsResponse,
@@ -8500,7 +8499,7 @@ export const addFlowSources: API.OperationMethod<
   AddFlowSourcesRequest,
   AddFlowSourcesResponse,
   AddFlowSourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddFlowSourcesRequest,
   output: AddFlowSourcesResponse,
@@ -8532,7 +8531,7 @@ export const addFlowVpcInterfaces: API.OperationMethod<
   AddFlowVpcInterfacesRequest,
   AddFlowVpcInterfacesResponse,
   AddFlowVpcInterfacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddFlowVpcInterfacesRequest,
   output: AddFlowVpcInterfacesResponse,
@@ -8563,7 +8562,7 @@ export const batchGetRouterInput: API.OperationMethod<
   BatchGetRouterInputRequest,
   BatchGetRouterInputResponse,
   BatchGetRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRouterInputRequest,
   output: BatchGetRouterInputResponse,
@@ -8593,7 +8592,7 @@ export const batchGetRouterNetworkInterface: API.OperationMethod<
   BatchGetRouterNetworkInterfaceRequest,
   BatchGetRouterNetworkInterfaceResponse,
   BatchGetRouterNetworkInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRouterNetworkInterfaceRequest,
   output: BatchGetRouterNetworkInterfaceResponse,
@@ -8623,7 +8622,7 @@ export const batchGetRouterOutput: API.OperationMethod<
   BatchGetRouterOutputRequest,
   BatchGetRouterOutputResponse,
   BatchGetRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRouterOutputRequest,
   output: BatchGetRouterOutputResponse,
@@ -8655,7 +8654,7 @@ export const createBridge: API.OperationMethod<
   CreateBridgeRequest,
   CreateBridgeResponse,
   CreateBridgeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBridgeRequest,
   output: CreateBridgeResponse,
@@ -8688,7 +8687,7 @@ export const createFlow: API.OperationMethod<
   CreateFlowRequest,
   CreateFlowResponse,
   CreateFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowRequest,
   output: CreateFlowResponse,
@@ -8721,7 +8720,7 @@ export const createGateway: API.OperationMethod<
   CreateGatewayRequest,
   CreateGatewayResponse,
   CreateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGatewayRequest,
   output: CreateGatewayResponse,
@@ -8755,7 +8754,7 @@ export const createRouterInput: API.OperationMethod<
   CreateRouterInputRequest,
   CreateRouterInputResponse,
   CreateRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouterInputRequest,
   output: CreateRouterInputResponse,
@@ -8789,7 +8788,7 @@ export const createRouterNetworkInterface: API.OperationMethod<
   CreateRouterNetworkInterfaceRequest,
   CreateRouterNetworkInterfaceResponse,
   CreateRouterNetworkInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouterNetworkInterfaceRequest,
   output: CreateRouterNetworkInterfaceResponse,
@@ -8823,7 +8822,7 @@ export const createRouterOutput: API.OperationMethod<
   CreateRouterOutputRequest,
   CreateRouterOutputResponse,
   CreateRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouterOutputRequest,
   output: CreateRouterOutputResponse,
@@ -8857,7 +8856,7 @@ export const deleteBridge: API.OperationMethod<
   DeleteBridgeRequest,
   DeleteBridgeResponse,
   DeleteBridgeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBridgeRequest,
   output: DeleteBridgeResponse,
@@ -8890,7 +8889,7 @@ export const deleteFlow: API.OperationMethod<
   DeleteFlowRequest,
   DeleteFlowResponse,
   DeleteFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowRequest,
   output: DeleteFlowResponse,
@@ -8923,7 +8922,7 @@ export const deleteGateway: API.OperationMethod<
   DeleteGatewayRequest,
   DeleteGatewayResponse,
   DeleteGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayRequest,
   output: DeleteGatewayResponse,
@@ -8957,7 +8956,7 @@ export const deleteRouterInput: API.OperationMethod<
   DeleteRouterInputRequest,
   DeleteRouterInputResponse,
   DeleteRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouterInputRequest,
   output: DeleteRouterInputResponse,
@@ -8991,7 +8990,7 @@ export const deleteRouterNetworkInterface: API.OperationMethod<
   DeleteRouterNetworkInterfaceRequest,
   DeleteRouterNetworkInterfaceResponse,
   DeleteRouterNetworkInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouterNetworkInterfaceRequest,
   output: DeleteRouterNetworkInterfaceResponse,
@@ -9025,7 +9024,7 @@ export const deleteRouterOutput: API.OperationMethod<
   DeleteRouterOutputRequest,
   DeleteRouterOutputResponse,
   DeleteRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouterOutputRequest,
   output: DeleteRouterOutputResponse,
@@ -9059,7 +9058,7 @@ export const deregisterGatewayInstance: API.OperationMethod<
   DeregisterGatewayInstanceRequest,
   DeregisterGatewayInstanceResponse,
   DeregisterGatewayInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterGatewayInstanceRequest,
   output: DeregisterGatewayInstanceResponse,
@@ -9093,7 +9092,7 @@ export const describeBridge: API.OperationMethod<
   DescribeBridgeRequest,
   DescribeBridgeResponse,
   DescribeBridgeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBridgeRequest,
   output: DescribeBridgeResponse,
@@ -9126,7 +9125,7 @@ export const describeFlow: API.OperationMethod<
   DescribeFlowRequest,
   DescribeFlowResponse,
   DescribeFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowRequest,
   output: DescribeFlowResponse,
@@ -9158,7 +9157,7 @@ export const describeFlowSourceMetadata: API.OperationMethod<
   DescribeFlowSourceMetadataRequest,
   DescribeFlowSourceMetadataResponse,
   DescribeFlowSourceMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowSourceMetadataRequest,
   output: DescribeFlowSourceMetadataResponse,
@@ -9190,7 +9189,7 @@ export const describeFlowSourceThumbnail: API.OperationMethod<
   DescribeFlowSourceThumbnailRequest,
   DescribeFlowSourceThumbnailResponse,
   DescribeFlowSourceThumbnailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowSourceThumbnailRequest,
   output: DescribeFlowSourceThumbnailResponse,
@@ -9223,7 +9222,7 @@ export const describeGateway: API.OperationMethod<
   DescribeGatewayRequest,
   DescribeGatewayResponse,
   DescribeGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayRequest,
   output: DescribeGatewayResponse,
@@ -9257,7 +9256,7 @@ export const describeGatewayInstance: API.OperationMethod<
   DescribeGatewayInstanceRequest,
   DescribeGatewayInstanceResponse,
   DescribeGatewayInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayInstanceRequest,
   output: DescribeGatewayInstanceResponse,
@@ -9289,7 +9288,7 @@ export const describeOffering: API.OperationMethod<
   DescribeOfferingRequest,
   DescribeOfferingResponse,
   DescribeOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOfferingRequest,
   output: DescribeOfferingResponse,
@@ -9319,7 +9318,7 @@ export const describeReservation: API.OperationMethod<
   DescribeReservationRequest,
   DescribeReservationResponse,
   DescribeReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReservationRequest,
   output: DescribeReservationResponse,
@@ -9351,7 +9350,7 @@ export const getRouterInput: API.OperationMethod<
   GetRouterInputRequest,
   GetRouterInputResponse,
   GetRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouterInputRequest,
   output: GetRouterInputResponse,
@@ -9384,7 +9383,7 @@ export const getRouterInputSourceMetadata: API.OperationMethod<
   GetRouterInputSourceMetadataRequest,
   GetRouterInputSourceMetadataResponse,
   GetRouterInputSourceMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouterInputSourceMetadataRequest,
   output: GetRouterInputSourceMetadataResponse,
@@ -9416,7 +9415,7 @@ export const getRouterInputThumbnail: API.OperationMethod<
   GetRouterInputThumbnailRequest,
   GetRouterInputThumbnailResponse,
   GetRouterInputThumbnailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouterInputThumbnailRequest,
   output: GetRouterInputThumbnailResponse,
@@ -9449,7 +9448,7 @@ export const getRouterNetworkInterface: API.OperationMethod<
   GetRouterNetworkInterfaceRequest,
   GetRouterNetworkInterfaceResponse,
   GetRouterNetworkInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouterNetworkInterfaceRequest,
   output: GetRouterNetworkInterfaceResponse,
@@ -9483,7 +9482,7 @@ export const getRouterOutput: API.OperationMethod<
   GetRouterOutputRequest,
   GetRouterOutputResponse,
   GetRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouterOutputRequest,
   output: GetRouterOutputResponse,
@@ -9517,7 +9516,7 @@ export const grantFlowEntitlements: API.OperationMethod<
   GrantFlowEntitlementsRequest,
   GrantFlowEntitlementsResponse,
   GrantFlowEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GrantFlowEntitlementsRequest,
   output: GrantFlowEntitlementsResponse,
@@ -9549,7 +9548,7 @@ export const listBridges: API.PaginatedOperationMethod<
   ListBridgesRequest,
   ListBridgesResponse,
   ListBridgesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedBridge
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBridgesRequest,
@@ -9585,7 +9584,7 @@ export const listEntitlements: API.PaginatedOperationMethod<
   ListEntitlementsRequest,
   ListEntitlementsResponse,
   ListEntitlementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedEntitlement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEntitlementsRequest,
@@ -9620,7 +9619,7 @@ export const listFlows: API.PaginatedOperationMethod<
   ListFlowsRequest,
   ListFlowsResponse,
   ListFlowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedFlow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowsRequest,
@@ -9656,7 +9655,7 @@ export const listGatewayInstances: API.PaginatedOperationMethod<
   ListGatewayInstancesRequest,
   ListGatewayInstancesResponse,
   ListGatewayInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedGatewayInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewayInstancesRequest,
@@ -9693,7 +9692,7 @@ export const listGateways: API.PaginatedOperationMethod<
   ListGatewaysRequest,
   ListGatewaysResponse,
   ListGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedGateway
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewaysRequest,
@@ -9729,7 +9728,7 @@ export const listOfferings: API.PaginatedOperationMethod<
   ListOfferingsRequest,
   ListOfferingsResponse,
   ListOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Offering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOfferingsRequest,
@@ -9764,7 +9763,7 @@ export const listReservations: API.PaginatedOperationMethod<
   ListReservationsRequest,
   ListReservationsResponse,
   ListReservationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Reservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReservationsRequest,
@@ -9800,7 +9799,7 @@ export const listRouterInputs: API.PaginatedOperationMethod<
   ListRouterInputsRequest,
   ListRouterInputsResponse,
   ListRouterInputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedRouterInput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRouterInputsRequest,
@@ -9837,7 +9836,7 @@ export const listRouterNetworkInterfaces: API.PaginatedOperationMethod<
   ListRouterNetworkInterfacesRequest,
   ListRouterNetworkInterfacesResponse,
   ListRouterNetworkInterfacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedRouterNetworkInterface
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRouterNetworkInterfacesRequest,
@@ -9874,7 +9873,7 @@ export const listRouterOutputs: API.PaginatedOperationMethod<
   ListRouterOutputsRequest,
   ListRouterOutputsResponse,
   ListRouterOutputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedRouterOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRouterOutputsRequest,
@@ -9909,7 +9908,7 @@ export const listTagsForGlobalResource: API.OperationMethod<
   ListTagsForGlobalResourceRequest,
   ListTagsForGlobalResourceResponse,
   ListTagsForGlobalResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForGlobalResourceRequest,
   output: ListTagsForGlobalResourceResponse,
@@ -9935,7 +9934,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -9964,7 +9963,7 @@ export const purchaseOffering: API.OperationMethod<
   PurchaseOfferingRequest,
   PurchaseOfferingResponse,
   PurchaseOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseOfferingRequest,
   output: PurchaseOfferingResponse,
@@ -9997,7 +9996,7 @@ export const removeBridgeOutput: API.OperationMethod<
   RemoveBridgeOutputRequest,
   RemoveBridgeOutputResponse,
   RemoveBridgeOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveBridgeOutputRequest,
   output: RemoveBridgeOutputResponse,
@@ -10031,7 +10030,7 @@ export const removeBridgeSource: API.OperationMethod<
   RemoveBridgeSourceRequest,
   RemoveBridgeSourceResponse,
   RemoveBridgeSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveBridgeSourceRequest,
   output: RemoveBridgeSourceResponse,
@@ -10064,7 +10063,7 @@ export const removeFlowMediaStream: API.OperationMethod<
   RemoveFlowMediaStreamRequest,
   RemoveFlowMediaStreamResponse,
   RemoveFlowMediaStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFlowMediaStreamRequest,
   output: RemoveFlowMediaStreamResponse,
@@ -10096,7 +10095,7 @@ export const removeFlowOutput: API.OperationMethod<
   RemoveFlowOutputRequest,
   RemoveFlowOutputResponse,
   RemoveFlowOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFlowOutputRequest,
   output: RemoveFlowOutputResponse,
@@ -10128,7 +10127,7 @@ export const removeFlowSource: API.OperationMethod<
   RemoveFlowSourceRequest,
   RemoveFlowSourceResponse,
   RemoveFlowSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFlowSourceRequest,
   output: RemoveFlowSourceResponse,
@@ -10160,7 +10159,7 @@ export const removeFlowVpcInterface: API.OperationMethod<
   RemoveFlowVpcInterfaceRequest,
   RemoveFlowVpcInterfaceResponse,
   RemoveFlowVpcInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFlowVpcInterfaceRequest,
   output: RemoveFlowVpcInterfaceResponse,
@@ -10193,7 +10192,7 @@ export const restartRouterInput: API.OperationMethod<
   RestartRouterInputRequest,
   RestartRouterInputResponse,
   RestartRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestartRouterInputRequest,
   output: RestartRouterInputResponse,
@@ -10227,7 +10226,7 @@ export const restartRouterOutput: API.OperationMethod<
   RestartRouterOutputRequest,
   RestartRouterOutputResponse,
   RestartRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestartRouterOutputRequest,
   output: RestartRouterOutputResponse,
@@ -10260,7 +10259,7 @@ export const revokeFlowEntitlement: API.OperationMethod<
   RevokeFlowEntitlementRequest,
   RevokeFlowEntitlementResponse,
   RevokeFlowEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeFlowEntitlementRequest,
   output: RevokeFlowEntitlementResponse,
@@ -10292,7 +10291,7 @@ export const startFlow: API.OperationMethod<
   StartFlowRequest,
   StartFlowResponse,
   StartFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlowRequest,
   output: StartFlowResponse,
@@ -10325,7 +10324,7 @@ export const startRouterInput: API.OperationMethod<
   StartRouterInputRequest,
   StartRouterInputResponse,
   StartRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRouterInputRequest,
   output: StartRouterInputResponse,
@@ -10359,7 +10358,7 @@ export const startRouterOutput: API.OperationMethod<
   StartRouterOutputRequest,
   StartRouterOutputResponse,
   StartRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRouterOutputRequest,
   output: StartRouterOutputResponse,
@@ -10392,7 +10391,7 @@ export const stopFlow: API.OperationMethod<
   StopFlowRequest,
   StopFlowResponse,
   StopFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopFlowRequest,
   output: StopFlowResponse,
@@ -10425,7 +10424,7 @@ export const stopRouterInput: API.OperationMethod<
   StopRouterInputRequest,
   StopRouterInputResponse,
   StopRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRouterInputRequest,
   output: StopRouterInputResponse,
@@ -10459,7 +10458,7 @@ export const stopRouterOutput: API.OperationMethod<
   StopRouterOutputRequest,
   StopRouterOutputResponse,
   StopRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRouterOutputRequest,
   output: StopRouterOutputResponse,
@@ -10489,7 +10488,7 @@ export const tagGlobalResource: API.OperationMethod<
   TagGlobalResourceRequest,
   TagGlobalResourceResponse,
   TagGlobalResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagGlobalResourceRequest,
   output: TagGlobalResourceResponse,
@@ -10515,7 +10514,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10545,7 +10544,7 @@ export const takeRouterInput: API.OperationMethod<
   TakeRouterInputRequest,
   TakeRouterInputResponse,
   TakeRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TakeRouterInputRequest,
   output: TakeRouterInputResponse,
@@ -10575,7 +10574,7 @@ export const untagGlobalResource: API.OperationMethod<
   UntagGlobalResourceRequest,
   UntagGlobalResourceResponse,
   UntagGlobalResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagGlobalResourceRequest,
   output: UntagGlobalResourceResponse,
@@ -10601,7 +10600,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10631,7 +10630,7 @@ export const updateBridge: API.OperationMethod<
   UpdateBridgeRequest,
   UpdateBridgeResponse,
   UpdateBridgeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBridgeRequest,
   output: UpdateBridgeResponse,
@@ -10665,7 +10664,7 @@ export const updateBridgeOutput: API.OperationMethod<
   UpdateBridgeOutputRequest,
   UpdateBridgeOutputResponse,
   UpdateBridgeOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBridgeOutputRequest,
   output: UpdateBridgeOutputResponse,
@@ -10699,7 +10698,7 @@ export const updateBridgeSource: API.OperationMethod<
   UpdateBridgeSourceRequest,
   UpdateBridgeSourceResponse,
   UpdateBridgeSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBridgeSourceRequest,
   output: UpdateBridgeSourceResponse,
@@ -10733,7 +10732,7 @@ export const updateBridgeState: API.OperationMethod<
   UpdateBridgeStateRequest,
   UpdateBridgeStateResponse,
   UpdateBridgeStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBridgeStateRequest,
   output: UpdateBridgeStateResponse,
@@ -10780,7 +10779,7 @@ export const updateFlow: API.OperationMethod<
   UpdateFlowRequest,
   UpdateFlowResponse,
   UpdateFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowRequest,
   output: UpdateFlowResponse,
@@ -10812,7 +10811,7 @@ export const updateFlowEntitlement: API.OperationMethod<
   UpdateFlowEntitlementRequest,
   UpdateFlowEntitlementResponse,
   UpdateFlowEntitlementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowEntitlementRequest,
   output: UpdateFlowEntitlementResponse,
@@ -10844,7 +10843,7 @@ export const updateFlowMediaStream: API.OperationMethod<
   UpdateFlowMediaStreamRequest,
   UpdateFlowMediaStreamResponse,
   UpdateFlowMediaStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowMediaStreamRequest,
   output: UpdateFlowMediaStreamResponse,
@@ -10876,7 +10875,7 @@ export const updateFlowOutput: API.OperationMethod<
   UpdateFlowOutputRequest,
   UpdateFlowOutputResponse,
   UpdateFlowOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowOutputRequest,
   output: UpdateFlowOutputResponse,
@@ -10922,7 +10921,7 @@ export const updateFlowSource: API.OperationMethod<
   UpdateFlowSourceRequest,
   UpdateFlowSourceResponse,
   UpdateFlowSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowSourceRequest,
   output: UpdateFlowSourceResponse,
@@ -10955,7 +10954,7 @@ export const updateGatewayInstance: API.OperationMethod<
   UpdateGatewayInstanceRequest,
   UpdateGatewayInstanceResponse,
   UpdateGatewayInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayInstanceRequest,
   output: UpdateGatewayInstanceResponse,
@@ -10989,7 +10988,7 @@ export const updateRouterInput: API.OperationMethod<
   UpdateRouterInputRequest,
   UpdateRouterInputResponse,
   UpdateRouterInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouterInputRequest,
   output: UpdateRouterInputResponse,
@@ -11022,7 +11021,7 @@ export const updateRouterNetworkInterface: API.OperationMethod<
   UpdateRouterNetworkInterfaceRequest,
   UpdateRouterNetworkInterfaceResponse,
   UpdateRouterNetworkInterfaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouterNetworkInterfaceRequest,
   output: UpdateRouterNetworkInterfaceResponse,
@@ -11055,7 +11054,7 @@ export const updateRouterOutput: API.OperationMethod<
   UpdateRouterOutputRequest,
   UpdateRouterOutputResponse,
   UpdateRouterOutputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouterOutputRequest,
   output: UpdateRouterOutputResponse,

--- a/packages/aws/src/services/mediaconvert.ts
+++ b/packages/aws/src/services/mediaconvert.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaConvert",
@@ -11064,7 +11063,7 @@ export const associateCertificate: API.OperationMethod<
   AssociateCertificateRequest,
   AssociateCertificateResponse,
   AssociateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCertificateRequest,
   output: AssociateCertificateResponse,
@@ -11098,7 +11097,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResponse,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResponse,
@@ -11132,7 +11131,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -11166,7 +11165,7 @@ export const createJobTemplate: API.OperationMethod<
   CreateJobTemplateRequest,
   CreateJobTemplateResponse,
   CreateJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobTemplateRequest,
   output: CreateJobTemplateResponse,
@@ -11200,7 +11199,7 @@ export const createPreset: API.OperationMethod<
   CreatePresetRequest,
   CreatePresetResponse,
   CreatePresetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresetRequest,
   output: CreatePresetResponse,
@@ -11234,7 +11233,7 @@ export const createQueue: API.OperationMethod<
   CreateQueueRequest,
   CreateQueueResponse,
   CreateQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueRequest,
   output: CreateQueueResponse,
@@ -11268,7 +11267,7 @@ export const createResourceShare: API.OperationMethod<
   CreateResourceShareRequest,
   CreateResourceShareResponse,
   CreateResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceShareRequest,
   output: CreateResourceShareResponse,
@@ -11302,7 +11301,7 @@ export const deleteJobTemplate: API.OperationMethod<
   DeleteJobTemplateRequest,
   DeleteJobTemplateResponse,
   DeleteJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobTemplateRequest,
   output: DeleteJobTemplateResponse,
@@ -11336,7 +11335,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -11370,7 +11369,7 @@ export const deletePreset: API.OperationMethod<
   DeletePresetRequest,
   DeletePresetResponse,
   DeletePresetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePresetRequest,
   output: DeletePresetResponse,
@@ -11404,7 +11403,7 @@ export const deleteQueue: API.OperationMethod<
   DeleteQueueRequest,
   DeleteQueueResponse,
   DeleteQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueRequest,
   output: DeleteQueueResponse,
@@ -11438,7 +11437,7 @@ export const describeEndpoints: API.PaginatedOperationMethod<
   DescribeEndpointsRequest,
   DescribeEndpointsResponse,
   DescribeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Endpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointsRequest,
@@ -11479,7 +11478,7 @@ export const disassociateCertificate: API.OperationMethod<
   DisassociateCertificateRequest,
   DisassociateCertificateResponse,
   DisassociateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCertificateRequest,
   output: DisassociateCertificateResponse,
@@ -11513,7 +11512,7 @@ export const getJob: API.OperationMethod<
   GetJobRequest,
   GetJobResponse,
   GetJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobRequest,
   output: GetJobResponse,
@@ -11547,7 +11546,7 @@ export const getJobsQueryResults: API.OperationMethod<
   GetJobsQueryResultsRequest,
   GetJobsQueryResultsResponse,
   GetJobsQueryResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobsQueryResultsRequest,
   output: GetJobsQueryResultsResponse,
@@ -11581,7 +11580,7 @@ export const getJobTemplate: API.OperationMethod<
   GetJobTemplateRequest,
   GetJobTemplateResponse,
   GetJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobTemplateRequest,
   output: GetJobTemplateResponse,
@@ -11615,7 +11614,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -11649,7 +11648,7 @@ export const getPreset: API.OperationMethod<
   GetPresetRequest,
   GetPresetResponse,
   GetPresetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPresetRequest,
   output: GetPresetResponse,
@@ -11683,7 +11682,7 @@ export const getQueue: API.OperationMethod<
   GetQueueRequest,
   GetQueueResponse,
   GetQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueRequest,
   output: GetQueueResponse,
@@ -11717,7 +11716,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -11758,7 +11757,7 @@ export const listJobTemplates: API.PaginatedOperationMethod<
   ListJobTemplatesRequest,
   ListJobTemplatesResponse,
   ListJobTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobTemplatesRequest,
@@ -11799,7 +11798,7 @@ export const listPresets: API.PaginatedOperationMethod<
   ListPresetsRequest,
   ListPresetsResponse,
   ListPresetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Preset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPresetsRequest,
@@ -11840,7 +11839,7 @@ export const listQueues: API.PaginatedOperationMethod<
   ListQueuesRequest,
   ListQueuesResponse,
   ListQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Queue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuesRequest,
@@ -11881,7 +11880,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -11915,7 +11914,7 @@ export const listVersions: API.PaginatedOperationMethod<
   ListVersionsRequest,
   ListVersionsResponse,
   ListVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVersionsRequest,
@@ -11956,7 +11955,7 @@ export const probe: API.OperationMethod<
   ProbeRequest,
   ProbeResponse,
   ProbeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProbeRequest,
   output: ProbeResponse,
@@ -11990,7 +11989,7 @@ export const putPolicy: API.OperationMethod<
   PutPolicyRequest,
   PutPolicyResponse,
   PutPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPolicyRequest,
   output: PutPolicyResponse,
@@ -12024,7 +12023,7 @@ export const searchJobs: API.PaginatedOperationMethod<
   SearchJobsRequest,
   SearchJobsResponse,
   SearchJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchJobsRequest,
@@ -12065,7 +12064,7 @@ export const startJobsQuery: API.OperationMethod<
   StartJobsQueryRequest,
   StartJobsQueryResponse,
   StartJobsQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartJobsQueryRequest,
   output: StartJobsQueryResponse,
@@ -12099,7 +12098,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -12133,7 +12132,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -12167,7 +12166,7 @@ export const updateJobTemplate: API.OperationMethod<
   UpdateJobTemplateRequest,
   UpdateJobTemplateResponse,
   UpdateJobTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobTemplateRequest,
   output: UpdateJobTemplateResponse,
@@ -12201,7 +12200,7 @@ export const updatePreset: API.OperationMethod<
   UpdatePresetRequest,
   UpdatePresetResponse,
   UpdatePresetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePresetRequest,
   output: UpdatePresetResponse,
@@ -12235,7 +12234,7 @@ export const updateQueue: API.OperationMethod<
   UpdateQueueRequest,
   UpdateQueueResponse,
   UpdateQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueRequest,
   output: UpdateQueueResponse,

--- a/packages/aws/src/services/medialive.ts
+++ b/packages/aws/src/services/medialive.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaLive",
@@ -20236,7 +20235,7 @@ export const acceptInputDeviceTransfer: API.OperationMethod<
   AcceptInputDeviceTransferRequest,
   AcceptInputDeviceTransferResponse,
   AcceptInputDeviceTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInputDeviceTransferRequest,
   output: AcceptInputDeviceTransferResponse,
@@ -20273,7 +20272,7 @@ export const batchDelete: API.OperationMethod<
   BatchDeleteRequest,
   BatchDeleteResponse,
   BatchDeleteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteRequest,
   output: BatchDeleteResponse,
@@ -20309,7 +20308,7 @@ export const batchStart: API.OperationMethod<
   BatchStartRequest,
   BatchStartResponse,
   BatchStartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStartRequest,
   output: BatchStartResponse,
@@ -20345,7 +20344,7 @@ export const batchStop: API.OperationMethod<
   BatchStopRequest,
   BatchStopResponse,
   BatchStopError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchStopRequest,
   output: BatchStopResponse,
@@ -20381,7 +20380,7 @@ export const batchUpdateSchedule: API.OperationMethod<
   BatchUpdateScheduleRequest,
   BatchUpdateScheduleResponse,
   BatchUpdateScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateScheduleRequest,
   output: BatchUpdateScheduleResponse,
@@ -20418,7 +20417,7 @@ export const cancelInputDeviceTransfer: API.OperationMethod<
   CancelInputDeviceTransferRequest,
   CancelInputDeviceTransferResponse,
   CancelInputDeviceTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelInputDeviceTransferRequest,
   output: CancelInputDeviceTransferResponse,
@@ -20455,7 +20454,7 @@ export const claimDevice: API.OperationMethod<
   ClaimDeviceRequest,
   ClaimDeviceResponse,
   ClaimDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ClaimDeviceRequest,
   output: ClaimDeviceResponse,
@@ -20492,7 +20491,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -20528,7 +20527,7 @@ export const createChannelPlacementGroup: API.OperationMethod<
   CreateChannelPlacementGroupRequest,
   CreateChannelPlacementGroupResponse,
   CreateChannelPlacementGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelPlacementGroupRequest,
   output: CreateChannelPlacementGroupResponse,
@@ -20561,7 +20560,7 @@ export const createCloudWatchAlarmTemplate: API.OperationMethod<
   CreateCloudWatchAlarmTemplateRequest,
   CreateCloudWatchAlarmTemplateResponse,
   CreateCloudWatchAlarmTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudWatchAlarmTemplateRequest,
   output: CreateCloudWatchAlarmTemplateResponse,
@@ -20593,7 +20592,7 @@ export const createCloudWatchAlarmTemplateGroup: API.OperationMethod<
   CreateCloudWatchAlarmTemplateGroupRequest,
   CreateCloudWatchAlarmTemplateGroupResponse,
   CreateCloudWatchAlarmTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudWatchAlarmTemplateGroupRequest,
   output: CreateCloudWatchAlarmTemplateGroupResponse,
@@ -20626,7 +20625,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -20659,7 +20658,7 @@ export const createEventBridgeRuleTemplate: API.OperationMethod<
   CreateEventBridgeRuleTemplateRequest,
   CreateEventBridgeRuleTemplateResponse,
   CreateEventBridgeRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventBridgeRuleTemplateRequest,
   output: CreateEventBridgeRuleTemplateResponse,
@@ -20691,7 +20690,7 @@ export const createEventBridgeRuleTemplateGroup: API.OperationMethod<
   CreateEventBridgeRuleTemplateGroupRequest,
   CreateEventBridgeRuleTemplateGroupResponse,
   CreateEventBridgeRuleTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventBridgeRuleTemplateGroupRequest,
   output: CreateEventBridgeRuleTemplateGroupResponse,
@@ -20723,7 +20722,7 @@ export const createInput: API.OperationMethod<
   CreateInputRequest,
   CreateInputResponse,
   CreateInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInputRequest,
   output: CreateInputResponse,
@@ -20755,7 +20754,7 @@ export const createInputSecurityGroup: API.OperationMethod<
   CreateInputSecurityGroupRequest,
   CreateInputSecurityGroupResponse,
   CreateInputSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInputSecurityGroupRequest,
   output: CreateInputSecurityGroupResponse,
@@ -20789,7 +20788,7 @@ export const createMultiplex: API.OperationMethod<
   CreateMultiplexRequest,
   CreateMultiplexResponse,
   CreateMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultiplexRequest,
   output: CreateMultiplexResponse,
@@ -20825,7 +20824,7 @@ export const createMultiplexProgram: API.OperationMethod<
   CreateMultiplexProgramRequest,
   CreateMultiplexProgramResponse,
   CreateMultiplexProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultiplexProgramRequest,
   output: CreateMultiplexProgramResponse,
@@ -20860,7 +20859,7 @@ export const createNetwork: API.OperationMethod<
   CreateNetworkRequest,
   CreateNetworkResponse,
   CreateNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkRequest,
   output: CreateNetworkResponse,
@@ -20894,7 +20893,7 @@ export const createNode: API.OperationMethod<
   CreateNodeRequest,
   CreateNodeResponse,
   CreateNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNodeRequest,
   output: CreateNodeResponse,
@@ -20928,7 +20927,7 @@ export const createNodeRegistrationScript: API.OperationMethod<
   CreateNodeRegistrationScriptRequest,
   CreateNodeRegistrationScriptResponse,
   CreateNodeRegistrationScriptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNodeRegistrationScriptRequest,
   output: CreateNodeRegistrationScriptResponse,
@@ -20961,7 +20960,7 @@ export const createPartnerInput: API.OperationMethod<
   CreatePartnerInputRequest,
   CreatePartnerInputResponse,
   CreatePartnerInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerInputRequest,
   output: CreatePartnerInputResponse,
@@ -20994,7 +20993,7 @@ export const createSdiSource: API.OperationMethod<
   CreateSdiSourceRequest,
   CreateSdiSourceResponse,
   CreateSdiSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSdiSourceRequest,
   output: CreateSdiSourceResponse,
@@ -21027,7 +21026,7 @@ export const createSignalMap: API.OperationMethod<
   CreateSignalMapRequest,
   CreateSignalMapResponse,
   CreateSignalMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSignalMapRequest,
   output: CreateSignalMapResponse,
@@ -21057,7 +21056,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResponse,
@@ -21089,7 +21088,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -21125,7 +21124,7 @@ export const deleteChannelPlacementGroup: API.OperationMethod<
   DeleteChannelPlacementGroupRequest,
   DeleteChannelPlacementGroupResponse,
   DeleteChannelPlacementGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelPlacementGroupRequest,
   output: DeleteChannelPlacementGroupResponse,
@@ -21159,7 +21158,7 @@ export const deleteCloudWatchAlarmTemplate: API.OperationMethod<
   DeleteCloudWatchAlarmTemplateRequest,
   DeleteCloudWatchAlarmTemplateResponse,
   DeleteCloudWatchAlarmTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudWatchAlarmTemplateRequest,
   output: DeleteCloudWatchAlarmTemplateResponse,
@@ -21191,7 +21190,7 @@ export const deleteCloudWatchAlarmTemplateGroup: API.OperationMethod<
   DeleteCloudWatchAlarmTemplateGroupRequest,
   DeleteCloudWatchAlarmTemplateGroupResponse,
   DeleteCloudWatchAlarmTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudWatchAlarmTemplateGroupRequest,
   output: DeleteCloudWatchAlarmTemplateGroupResponse,
@@ -21225,7 +21224,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -21259,7 +21258,7 @@ export const deleteEventBridgeRuleTemplate: API.OperationMethod<
   DeleteEventBridgeRuleTemplateRequest,
   DeleteEventBridgeRuleTemplateResponse,
   DeleteEventBridgeRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventBridgeRuleTemplateRequest,
   output: DeleteEventBridgeRuleTemplateResponse,
@@ -21291,7 +21290,7 @@ export const deleteEventBridgeRuleTemplateGroup: API.OperationMethod<
   DeleteEventBridgeRuleTemplateGroupRequest,
   DeleteEventBridgeRuleTemplateGroupResponse,
   DeleteEventBridgeRuleTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventBridgeRuleTemplateGroupRequest,
   output: DeleteEventBridgeRuleTemplateGroupResponse,
@@ -21325,7 +21324,7 @@ export const deleteInput: API.OperationMethod<
   DeleteInputRequest,
   DeleteInputResponse,
   DeleteInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInputRequest,
   output: DeleteInputResponse,
@@ -21360,7 +21359,7 @@ export const deleteInputSecurityGroup: API.OperationMethod<
   DeleteInputSecurityGroupRequest,
   DeleteInputSecurityGroupResponse,
   DeleteInputSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInputSecurityGroupRequest,
   output: DeleteInputSecurityGroupResponse,
@@ -21395,7 +21394,7 @@ export const deleteMultiplex: API.OperationMethod<
   DeleteMultiplexRequest,
   DeleteMultiplexResponse,
   DeleteMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMultiplexRequest,
   output: DeleteMultiplexResponse,
@@ -21431,7 +21430,7 @@ export const deleteMultiplexProgram: API.OperationMethod<
   DeleteMultiplexProgramRequest,
   DeleteMultiplexProgramResponse,
   DeleteMultiplexProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMultiplexProgramRequest,
   output: DeleteMultiplexProgramResponse,
@@ -21467,7 +21466,7 @@ export const deleteNetwork: API.OperationMethod<
   DeleteNetworkRequest,
   DeleteNetworkResponse,
   DeleteNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkRequest,
   output: DeleteNetworkResponse,
@@ -21503,7 +21502,7 @@ export const deleteNode: API.OperationMethod<
   DeleteNodeRequest,
   DeleteNodeResponse,
   DeleteNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNodeRequest,
   output: DeleteNodeResponse,
@@ -21539,7 +21538,7 @@ export const deleteReservation: API.OperationMethod<
   DeleteReservationRequest,
   DeleteReservationResponse,
   DeleteReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReservationRequest,
   output: DeleteReservationResponse,
@@ -21574,7 +21573,7 @@ export const deleteSchedule: API.OperationMethod<
   DeleteScheduleRequest,
   DeleteScheduleResponse,
   DeleteScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduleRequest,
   output: DeleteScheduleResponse,
@@ -21609,7 +21608,7 @@ export const deleteSdiSource: API.OperationMethod<
   DeleteSdiSourceRequest,
   DeleteSdiSourceResponse,
   DeleteSdiSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSdiSourceRequest,
   output: DeleteSdiSourceResponse,
@@ -21643,7 +21642,7 @@ export const deleteSignalMap: API.OperationMethod<
   DeleteSignalMapRequest,
   DeleteSignalMapResponse,
   DeleteSignalMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSignalMapRequest,
   output: DeleteSignalMapResponse,
@@ -21673,7 +21672,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResponse,
@@ -21703,7 +21702,7 @@ export const describeAccountConfiguration: API.OperationMethod<
   DescribeAccountConfigurationRequest,
   DescribeAccountConfigurationResponse,
   DescribeAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountConfigurationRequest,
   output: DescribeAccountConfigurationResponse,
@@ -21736,7 +21735,7 @@ export const describeChannel: API.OperationMethod<
   DescribeChannelRequest,
   DescribeChannelResponse,
   DescribeChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelRequest,
   output: DescribeChannelResponse,
@@ -21770,7 +21769,7 @@ export const describeChannelPlacementGroup: API.OperationMethod<
   DescribeChannelPlacementGroupRequest,
   DescribeChannelPlacementGroupResponse,
   DescribeChannelPlacementGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelPlacementGroupRequest,
   output: DescribeChannelPlacementGroupResponse,
@@ -21804,7 +21803,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResponse,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResponse,
@@ -21838,7 +21837,7 @@ export const describeInput: API.OperationMethod<
   DescribeInputRequest,
   DescribeInputResponse,
   DescribeInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInputRequest,
   output: DescribeInputResponse,
@@ -21872,7 +21871,7 @@ export const describeInputDevice: API.OperationMethod<
   DescribeInputDeviceRequest,
   DescribeInputDeviceResponse,
   DescribeInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInputDeviceRequest,
   output: DescribeInputDeviceResponse,
@@ -21906,7 +21905,7 @@ export const describeInputDeviceThumbnail: API.OperationMethod<
   DescribeInputDeviceThumbnailRequest,
   DescribeInputDeviceThumbnailResponse,
   DescribeInputDeviceThumbnailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInputDeviceThumbnailRequest,
   output: DescribeInputDeviceThumbnailResponse,
@@ -21940,7 +21939,7 @@ export const describeInputSecurityGroup: API.OperationMethod<
   DescribeInputSecurityGroupRequest,
   DescribeInputSecurityGroupResponse,
   DescribeInputSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInputSecurityGroupRequest,
   output: DescribeInputSecurityGroupResponse,
@@ -21974,7 +21973,7 @@ export const describeMultiplex: API.OperationMethod<
   DescribeMultiplexRequest,
   DescribeMultiplexResponse,
   DescribeMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMultiplexRequest,
   output: DescribeMultiplexResponse,
@@ -22008,7 +22007,7 @@ export const describeMultiplexProgram: API.OperationMethod<
   DescribeMultiplexProgramRequest,
   DescribeMultiplexProgramResponse,
   DescribeMultiplexProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMultiplexProgramRequest,
   output: DescribeMultiplexProgramResponse,
@@ -22042,7 +22041,7 @@ export const describeNetwork: API.OperationMethod<
   DescribeNetworkRequest,
   DescribeNetworkResponse,
   DescribeNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNetworkRequest,
   output: DescribeNetworkResponse,
@@ -22076,7 +22075,7 @@ export const describeNode: API.OperationMethod<
   DescribeNodeRequest,
   DescribeNodeResponse,
   DescribeNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNodeRequest,
   output: DescribeNodeResponse,
@@ -22110,7 +22109,7 @@ export const describeOffering: API.OperationMethod<
   DescribeOfferingRequest,
   DescribeOfferingResponse,
   DescribeOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOfferingRequest,
   output: DescribeOfferingResponse,
@@ -22144,7 +22143,7 @@ export const describeReservation: API.OperationMethod<
   DescribeReservationRequest,
   DescribeReservationResponse,
   DescribeReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReservationRequest,
   output: DescribeReservationResponse,
@@ -22178,7 +22177,7 @@ export const describeSchedule: API.PaginatedOperationMethod<
   DescribeScheduleRequest,
   DescribeScheduleResponse,
   DescribeScheduleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduleAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduleRequest,
@@ -22219,7 +22218,7 @@ export const describeSdiSource: API.OperationMethod<
   DescribeSdiSourceRequest,
   DescribeSdiSourceResponse,
   DescribeSdiSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSdiSourceRequest,
   output: DescribeSdiSourceResponse,
@@ -22254,7 +22253,7 @@ export const describeThumbnails: API.OperationMethod<
   DescribeThumbnailsRequest,
   DescribeThumbnailsResponse,
   DescribeThumbnailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThumbnailsRequest,
   output: DescribeThumbnailsResponse,
@@ -22287,7 +22286,7 @@ export const getCloudWatchAlarmTemplate: API.OperationMethod<
   GetCloudWatchAlarmTemplateRequest,
   GetCloudWatchAlarmTemplateResponse,
   GetCloudWatchAlarmTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudWatchAlarmTemplateRequest,
   output: GetCloudWatchAlarmTemplateResponse,
@@ -22317,7 +22316,7 @@ export const getCloudWatchAlarmTemplateGroup: API.OperationMethod<
   GetCloudWatchAlarmTemplateGroupRequest,
   GetCloudWatchAlarmTemplateGroupResponse,
   GetCloudWatchAlarmTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudWatchAlarmTemplateGroupRequest,
   output: GetCloudWatchAlarmTemplateGroupResponse,
@@ -22347,7 +22346,7 @@ export const getEventBridgeRuleTemplate: API.OperationMethod<
   GetEventBridgeRuleTemplateRequest,
   GetEventBridgeRuleTemplateResponse,
   GetEventBridgeRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventBridgeRuleTemplateRequest,
   output: GetEventBridgeRuleTemplateResponse,
@@ -22377,7 +22376,7 @@ export const getEventBridgeRuleTemplateGroup: API.OperationMethod<
   GetEventBridgeRuleTemplateGroupRequest,
   GetEventBridgeRuleTemplateGroupResponse,
   GetEventBridgeRuleTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventBridgeRuleTemplateGroupRequest,
   output: GetEventBridgeRuleTemplateGroupResponse,
@@ -22407,7 +22406,7 @@ export const getSignalMap: API.OperationMethod<
   GetSignalMapRequest,
   GetSignalMapResponse,
   GetSignalMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSignalMapRequest,
   output: GetSignalMapResponse,
@@ -22439,7 +22438,7 @@ export const listAlerts: API.PaginatedOperationMethod<
   ListAlertsRequest,
   ListAlertsResponse,
   ListAlertsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelAlert
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAlertsRequest,
@@ -22479,7 +22478,7 @@ export const listChannelPlacementGroups: API.PaginatedOperationMethod<
   ListChannelPlacementGroupsRequest,
   ListChannelPlacementGroupsResponse,
   ListChannelPlacementGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeChannelPlacementGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelPlacementGroupsRequest,
@@ -22518,7 +22517,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -22556,7 +22555,7 @@ export const listCloudWatchAlarmTemplateGroups: API.PaginatedOperationMethod<
   ListCloudWatchAlarmTemplateGroupsRequest,
   ListCloudWatchAlarmTemplateGroupsResponse,
   ListCloudWatchAlarmTemplateGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CloudWatchAlarmTemplateGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudWatchAlarmTemplateGroupsRequest,
@@ -22593,7 +22592,7 @@ export const listCloudWatchAlarmTemplates: API.PaginatedOperationMethod<
   ListCloudWatchAlarmTemplatesRequest,
   ListCloudWatchAlarmTemplatesResponse,
   ListCloudWatchAlarmTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CloudWatchAlarmTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudWatchAlarmTemplatesRequest,
@@ -22632,7 +22631,7 @@ export const listClusterAlerts: API.PaginatedOperationMethod<
   ListClusterAlertsRequest,
   ListClusterAlertsResponse,
   ListClusterAlertsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterAlert
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterAlertsRequest,
@@ -22672,7 +22671,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -22710,7 +22709,7 @@ export const listEventBridgeRuleTemplateGroups: API.PaginatedOperationMethod<
   ListEventBridgeRuleTemplateGroupsRequest,
   ListEventBridgeRuleTemplateGroupsResponse,
   ListEventBridgeRuleTemplateGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventBridgeRuleTemplateGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventBridgeRuleTemplateGroupsRequest,
@@ -22747,7 +22746,7 @@ export const listEventBridgeRuleTemplates: API.PaginatedOperationMethod<
   ListEventBridgeRuleTemplatesRequest,
   ListEventBridgeRuleTemplatesResponse,
   ListEventBridgeRuleTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventBridgeRuleTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventBridgeRuleTemplatesRequest,
@@ -22785,7 +22784,7 @@ export const listInputDevices: API.PaginatedOperationMethod<
   ListInputDevicesRequest,
   ListInputDevicesResponse,
   ListInputDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InputDeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInputDevicesRequest,
@@ -22825,7 +22824,7 @@ export const listInputDeviceTransfers: API.PaginatedOperationMethod<
   ListInputDeviceTransfersRequest,
   ListInputDeviceTransfersResponse,
   ListInputDeviceTransfersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransferringInputDeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInputDeviceTransfersRequest,
@@ -22865,7 +22864,7 @@ export const listInputs: API.PaginatedOperationMethod<
   ListInputsRequest,
   ListInputsResponse,
   ListInputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Input
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInputsRequest,
@@ -22904,7 +22903,7 @@ export const listInputSecurityGroups: API.PaginatedOperationMethod<
   ListInputSecurityGroupsRequest,
   ListInputSecurityGroupsResponse,
   ListInputSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InputSecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInputSecurityGroupsRequest,
@@ -22944,7 +22943,7 @@ export const listMultiplexAlerts: API.PaginatedOperationMethod<
   ListMultiplexAlertsRequest,
   ListMultiplexAlertsResponse,
   ListMultiplexAlertsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultiplexAlert
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultiplexAlertsRequest,
@@ -22984,7 +22983,7 @@ export const listMultiplexes: API.PaginatedOperationMethod<
   ListMultiplexesRequest,
   ListMultiplexesResponse,
   ListMultiplexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultiplexSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultiplexesRequest,
@@ -23024,7 +23023,7 @@ export const listMultiplexPrograms: API.PaginatedOperationMethod<
   ListMultiplexProgramsRequest,
   ListMultiplexProgramsResponse,
   ListMultiplexProgramsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultiplexProgramSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultiplexProgramsRequest,
@@ -23064,7 +23063,7 @@ export const listNetworks: API.PaginatedOperationMethod<
   ListNetworksRequest,
   ListNetworksResponse,
   ListNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeNetworkSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworksRequest,
@@ -23103,7 +23102,7 @@ export const listNodes: API.PaginatedOperationMethod<
   ListNodesRequest,
   ListNodesResponse,
   ListNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeNodeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesRequest,
@@ -23142,7 +23141,7 @@ export const listOfferings: API.PaginatedOperationMethod<
   ListOfferingsRequest,
   ListOfferingsResponse,
   ListOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Offering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOfferingsRequest,
@@ -23181,7 +23180,7 @@ export const listReservations: API.PaginatedOperationMethod<
   ListReservationsRequest,
   ListReservationsResponse,
   ListReservationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Reservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReservationsRequest,
@@ -23220,7 +23219,7 @@ export const listSdiSources: API.PaginatedOperationMethod<
   ListSdiSourcesRequest,
   ListSdiSourcesResponse,
   ListSdiSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SdiSourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSdiSourcesRequest,
@@ -23258,7 +23257,7 @@ export const listSignalMaps: API.PaginatedOperationMethod<
   ListSignalMapsRequest,
   ListSignalMapsResponse,
   ListSignalMapsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SignalMapSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSignalMapsRequest,
@@ -23294,7 +23293,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -23326,7 +23325,7 @@ export const listVersions: API.OperationMethod<
   ListVersionsRequest,
   ListVersionsResponse,
   ListVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVersionsRequest,
   output: ListVersionsResponse,
@@ -23362,7 +23361,7 @@ export const purchaseOffering: API.OperationMethod<
   PurchaseOfferingRequest,
   PurchaseOfferingResponse,
   PurchaseOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseOfferingRequest,
   output: PurchaseOfferingResponse,
@@ -23398,7 +23397,7 @@ export const rebootInputDevice: API.OperationMethod<
   RebootInputDeviceRequest,
   RebootInputDeviceResponse,
   RebootInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootInputDeviceRequest,
   output: RebootInputDeviceResponse,
@@ -23435,7 +23434,7 @@ export const rejectInputDeviceTransfer: API.OperationMethod<
   RejectInputDeviceTransferRequest,
   RejectInputDeviceTransferResponse,
   RejectInputDeviceTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectInputDeviceTransferRequest,
   output: RejectInputDeviceTransferResponse,
@@ -23472,7 +23471,7 @@ export const restartChannelPipelines: API.OperationMethod<
   RestartChannelPipelinesRequest,
   RestartChannelPipelinesResponse,
   RestartChannelPipelinesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestartChannelPipelinesRequest,
   output: RestartChannelPipelinesResponse,
@@ -23508,7 +23507,7 @@ export const startChannel: API.OperationMethod<
   StartChannelRequest,
   StartChannelResponse,
   StartChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartChannelRequest,
   output: StartChannelResponse,
@@ -23542,7 +23541,7 @@ export const startDeleteMonitorDeployment: API.OperationMethod<
   StartDeleteMonitorDeploymentRequest,
   StartDeleteMonitorDeploymentResponse,
   StartDeleteMonitorDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeleteMonitorDeploymentRequest,
   output: StartDeleteMonitorDeploymentResponse,
@@ -23576,7 +23575,7 @@ export const startInputDevice: API.OperationMethod<
   StartInputDeviceRequest,
   StartInputDeviceResponse,
   StartInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInputDeviceRequest,
   output: StartInputDeviceResponse,
@@ -23612,7 +23611,7 @@ export const startInputDeviceMaintenanceWindow: API.OperationMethod<
   StartInputDeviceMaintenanceWindowRequest,
   StartInputDeviceMaintenanceWindowResponse,
   StartInputDeviceMaintenanceWindowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInputDeviceMaintenanceWindowRequest,
   output: StartInputDeviceMaintenanceWindowResponse,
@@ -23646,7 +23645,7 @@ export const startMonitorDeployment: API.OperationMethod<
   StartMonitorDeploymentRequest,
   StartMonitorDeploymentResponse,
   StartMonitorDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMonitorDeploymentRequest,
   output: StartMonitorDeploymentResponse,
@@ -23680,7 +23679,7 @@ export const startMultiplex: API.OperationMethod<
   StartMultiplexRequest,
   StartMultiplexResponse,
   StartMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMultiplexRequest,
   output: StartMultiplexResponse,
@@ -23714,7 +23713,7 @@ export const startUpdateSignalMap: API.OperationMethod<
   StartUpdateSignalMapRequest,
   StartUpdateSignalMapResponse,
   StartUpdateSignalMapError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartUpdateSignalMapRequest,
   output: StartUpdateSignalMapResponse,
@@ -23748,7 +23747,7 @@ export const stopChannel: API.OperationMethod<
   StopChannelRequest,
   StopChannelResponse,
   StopChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopChannelRequest,
   output: StopChannelResponse,
@@ -23784,7 +23783,7 @@ export const stopInputDevice: API.OperationMethod<
   StopInputDeviceRequest,
   StopInputDeviceResponse,
   StopInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInputDeviceRequest,
   output: StopInputDeviceResponse,
@@ -23820,7 +23819,7 @@ export const stopMultiplex: API.OperationMethod<
   StopMultiplexRequest,
   StopMultiplexResponse,
   StopMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMultiplexRequest,
   output: StopMultiplexResponse,
@@ -23857,7 +23856,7 @@ export const transferInputDevice: API.OperationMethod<
   TransferInputDeviceRequest,
   TransferInputDeviceResponse,
   TransferInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransferInputDeviceRequest,
   output: TransferInputDeviceResponse,
@@ -23893,7 +23892,7 @@ export const updateAccountConfiguration: API.OperationMethod<
   UpdateAccountConfigurationRequest,
   UpdateAccountConfigurationResponse,
   UpdateAccountConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountConfigurationRequest,
   output: UpdateAccountConfigurationResponse,
@@ -23927,7 +23926,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -23963,7 +23962,7 @@ export const updateChannelClass: API.OperationMethod<
   UpdateChannelClassRequest,
   UpdateChannelClassResponse,
   UpdateChannelClassError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelClassRequest,
   output: UpdateChannelClassResponse,
@@ -24000,7 +23999,7 @@ export const updateChannelPlacementGroup: API.OperationMethod<
   UpdateChannelPlacementGroupRequest,
   UpdateChannelPlacementGroupResponse,
   UpdateChannelPlacementGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelPlacementGroupRequest,
   output: UpdateChannelPlacementGroupResponse,
@@ -24034,7 +24033,7 @@ export const updateCloudWatchAlarmTemplate: API.OperationMethod<
   UpdateCloudWatchAlarmTemplateRequest,
   UpdateCloudWatchAlarmTemplateResponse,
   UpdateCloudWatchAlarmTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCloudWatchAlarmTemplateRequest,
   output: UpdateCloudWatchAlarmTemplateResponse,
@@ -24066,7 +24065,7 @@ export const updateCloudWatchAlarmTemplateGroup: API.OperationMethod<
   UpdateCloudWatchAlarmTemplateGroupRequest,
   UpdateCloudWatchAlarmTemplateGroupResponse,
   UpdateCloudWatchAlarmTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCloudWatchAlarmTemplateGroupRequest,
   output: UpdateCloudWatchAlarmTemplateGroupResponse,
@@ -24099,7 +24098,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -24132,7 +24131,7 @@ export const updateEventBridgeRuleTemplate: API.OperationMethod<
   UpdateEventBridgeRuleTemplateRequest,
   UpdateEventBridgeRuleTemplateResponse,
   UpdateEventBridgeRuleTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventBridgeRuleTemplateRequest,
   output: UpdateEventBridgeRuleTemplateResponse,
@@ -24164,7 +24163,7 @@ export const updateEventBridgeRuleTemplateGroup: API.OperationMethod<
   UpdateEventBridgeRuleTemplateGroupRequest,
   UpdateEventBridgeRuleTemplateGroupResponse,
   UpdateEventBridgeRuleTemplateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventBridgeRuleTemplateGroupRequest,
   output: UpdateEventBridgeRuleTemplateGroupResponse,
@@ -24197,7 +24196,7 @@ export const updateInput: API.OperationMethod<
   UpdateInputRequest,
   UpdateInputResponse,
   UpdateInputError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInputRequest,
   output: UpdateInputResponse,
@@ -24232,7 +24231,7 @@ export const updateInputDevice: API.OperationMethod<
   UpdateInputDeviceRequest,
   UpdateInputDeviceResponse,
   UpdateInputDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInputDeviceRequest,
   output: UpdateInputDeviceResponse,
@@ -24267,7 +24266,7 @@ export const updateInputSecurityGroup: API.OperationMethod<
   UpdateInputSecurityGroupRequest,
   UpdateInputSecurityGroupResponse,
   UpdateInputSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInputSecurityGroupRequest,
   output: UpdateInputSecurityGroupResponse,
@@ -24302,7 +24301,7 @@ export const updateMultiplex: API.OperationMethod<
   UpdateMultiplexRequest,
   UpdateMultiplexResponse,
   UpdateMultiplexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMultiplexRequest,
   output: UpdateMultiplexResponse,
@@ -24338,7 +24337,7 @@ export const updateMultiplexProgram: API.OperationMethod<
   UpdateMultiplexProgramRequest,
   UpdateMultiplexProgramResponse,
   UpdateMultiplexProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMultiplexProgramRequest,
   output: UpdateMultiplexProgramResponse,
@@ -24373,7 +24372,7 @@ export const updateNetwork: API.OperationMethod<
   UpdateNetworkRequest,
   UpdateNetworkResponse,
   UpdateNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkRequest,
   output: UpdateNetworkResponse,
@@ -24407,7 +24406,7 @@ export const updateNode: API.OperationMethod<
   UpdateNodeRequest,
   UpdateNodeResponse,
   UpdateNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNodeRequest,
   output: UpdateNodeResponse,
@@ -24442,7 +24441,7 @@ export const updateNodeState: API.OperationMethod<
   UpdateNodeStateRequest,
   UpdateNodeStateResponse,
   UpdateNodeStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNodeStateRequest,
   output: UpdateNodeStateResponse,
@@ -24478,7 +24477,7 @@ export const updateReservation: API.OperationMethod<
   UpdateReservationRequest,
   UpdateReservationResponse,
   UpdateReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReservationRequest,
   output: UpdateReservationResponse,
@@ -24513,7 +24512,7 @@ export const updateSdiSource: API.OperationMethod<
   UpdateSdiSourceRequest,
   UpdateSdiSourceResponse,
   UpdateSdiSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSdiSourceRequest,
   output: UpdateSdiSourceResponse,

--- a/packages/aws/src/services/mediapackage-vod.ts
+++ b/packages/aws/src/services/mediapackage-vod.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaPackage Vod",
   serviceShapeName: "MediaPackageVod",
@@ -1596,7 +1595,7 @@ export const configureLogs: API.OperationMethod<
   ConfigureLogsRequest,
   ConfigureLogsResponse,
   ConfigureLogsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureLogsRequest,
   output: ConfigureLogsResponse,
@@ -1628,7 +1627,7 @@ export const createAsset: API.OperationMethod<
   CreateAssetRequest,
   CreateAssetResponse,
   CreateAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssetRequest,
   output: CreateAssetResponse,
@@ -1660,7 +1659,7 @@ export const createPackagingConfiguration: API.OperationMethod<
   CreatePackagingConfigurationRequest,
   CreatePackagingConfigurationResponse,
   CreatePackagingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackagingConfigurationRequest,
   output: CreatePackagingConfigurationResponse,
@@ -1692,7 +1691,7 @@ export const createPackagingGroup: API.OperationMethod<
   CreatePackagingGroupRequest,
   CreatePackagingGroupResponse,
   CreatePackagingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackagingGroupRequest,
   output: CreatePackagingGroupResponse,
@@ -1724,7 +1723,7 @@ export const deleteAsset: API.OperationMethod<
   DeleteAssetRequest,
   DeleteAssetResponse,
   DeleteAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssetRequest,
   output: DeleteAssetResponse,
@@ -1756,7 +1755,7 @@ export const deletePackagingConfiguration: API.OperationMethod<
   DeletePackagingConfigurationRequest,
   DeletePackagingConfigurationResponse,
   DeletePackagingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackagingConfigurationRequest,
   output: DeletePackagingConfigurationResponse,
@@ -1788,7 +1787,7 @@ export const deletePackagingGroup: API.OperationMethod<
   DeletePackagingGroupRequest,
   DeletePackagingGroupResponse,
   DeletePackagingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackagingGroupRequest,
   output: DeletePackagingGroupResponse,
@@ -1820,7 +1819,7 @@ export const describeAsset: API.OperationMethod<
   DescribeAssetRequest,
   DescribeAssetResponse,
   DescribeAssetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetRequest,
   output: DescribeAssetResponse,
@@ -1852,7 +1851,7 @@ export const describePackagingConfiguration: API.OperationMethod<
   DescribePackagingConfigurationRequest,
   DescribePackagingConfigurationResponse,
   DescribePackagingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackagingConfigurationRequest,
   output: DescribePackagingConfigurationResponse,
@@ -1884,7 +1883,7 @@ export const describePackagingGroup: API.OperationMethod<
   DescribePackagingGroupRequest,
   DescribePackagingGroupResponse,
   DescribePackagingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackagingGroupRequest,
   output: DescribePackagingGroupResponse,
@@ -1916,7 +1915,7 @@ export const listAssets: API.PaginatedOperationMethod<
   ListAssetsRequest,
   ListAssetsResponse,
   ListAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetShallow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetsRequest,
@@ -1955,7 +1954,7 @@ export const listPackagingConfigurations: API.PaginatedOperationMethod<
   ListPackagingConfigurationsRequest,
   ListPackagingConfigurationsResponse,
   ListPackagingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackagingConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagingConfigurationsRequest,
@@ -1994,7 +1993,7 @@ export const listPackagingGroups: API.PaginatedOperationMethod<
   ListPackagingGroupsRequest,
   ListPackagingGroupsResponse,
   ListPackagingGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PackagingGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagingGroupsRequest,
@@ -2026,7 +2025,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2044,7 +2043,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2062,7 +2061,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2087,7 +2086,7 @@ export const updatePackagingGroup: API.OperationMethod<
   UpdatePackagingGroupRequest,
   UpdatePackagingGroupResponse,
   UpdatePackagingGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackagingGroupRequest,
   output: UpdatePackagingGroupResponse,

--- a/packages/aws/src/services/mediapackage.ts
+++ b/packages/aws/src/services/mediapackage.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaPackage",
@@ -2158,7 +2157,7 @@ export const configureLogs: API.OperationMethod<
   ConfigureLogsRequest,
   ConfigureLogsResponse,
   ConfigureLogsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureLogsRequest,
   output: ConfigureLogsResponse,
@@ -2190,7 +2189,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -2222,7 +2221,7 @@ export const createHarvestJob: API.OperationMethod<
   CreateHarvestJobRequest,
   CreateHarvestJobResponse,
   CreateHarvestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHarvestJobRequest,
   output: CreateHarvestJobResponse,
@@ -2254,7 +2253,7 @@ export const createOriginEndpoint: API.OperationMethod<
   CreateOriginEndpointRequest,
   CreateOriginEndpointResponse,
   CreateOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOriginEndpointRequest,
   output: CreateOriginEndpointResponse,
@@ -2286,7 +2285,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -2318,7 +2317,7 @@ export const deleteOriginEndpoint: API.OperationMethod<
   DeleteOriginEndpointRequest,
   DeleteOriginEndpointResponse,
   DeleteOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOriginEndpointRequest,
   output: DeleteOriginEndpointResponse,
@@ -2350,7 +2349,7 @@ export const describeChannel: API.OperationMethod<
   DescribeChannelRequest,
   DescribeChannelResponse,
   DescribeChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelRequest,
   output: DescribeChannelResponse,
@@ -2382,7 +2381,7 @@ export const describeHarvestJob: API.OperationMethod<
   DescribeHarvestJobRequest,
   DescribeHarvestJobResponse,
   DescribeHarvestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHarvestJobRequest,
   output: DescribeHarvestJobResponse,
@@ -2414,7 +2413,7 @@ export const describeOriginEndpoint: API.OperationMethod<
   DescribeOriginEndpointRequest,
   DescribeOriginEndpointResponse,
   DescribeOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOriginEndpointRequest,
   output: DescribeOriginEndpointResponse,
@@ -2446,7 +2445,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Channel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -2485,7 +2484,7 @@ export const listHarvestJobs: API.PaginatedOperationMethod<
   ListHarvestJobsRequest,
   ListHarvestJobsResponse,
   ListHarvestJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HarvestJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHarvestJobsRequest,
@@ -2524,7 +2523,7 @@ export const listOriginEndpoints: API.PaginatedOperationMethod<
   ListOriginEndpointsRequest,
   ListOriginEndpointsResponse,
   ListOriginEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OriginEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOriginEndpointsRequest,
@@ -2556,7 +2555,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2581,7 +2580,7 @@ export const rotateChannelCredentials: API.OperationMethod<
   RotateChannelCredentialsRequest,
   RotateChannelCredentialsResponse,
   RotateChannelCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateChannelCredentialsRequest,
   output: RotateChannelCredentialsResponse,
@@ -2613,7 +2612,7 @@ export const rotateIngestEndpointCredentials: API.OperationMethod<
   RotateIngestEndpointCredentialsRequest,
   RotateIngestEndpointCredentialsResponse,
   RotateIngestEndpointCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateIngestEndpointCredentialsRequest,
   output: RotateIngestEndpointCredentialsResponse,
@@ -2638,7 +2637,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2656,7 +2655,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2681,7 +2680,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -2713,7 +2712,7 @@ export const updateOriginEndpoint: API.OperationMethod<
   UpdateOriginEndpointRequest,
   UpdateOriginEndpointResponse,
   UpdateOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOriginEndpointRequest,
   output: UpdateOriginEndpointResponse,

--- a/packages/aws/src/services/mediapackagev2.ts
+++ b/packages/aws/src/services/mediapackagev2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaPackageV2",
   serviceShapeName: "mediapackagev2",
@@ -2721,7 +2720,7 @@ export const cancelHarvestJob: API.OperationMethod<
   CancelHarvestJobRequest,
   CancelHarvestJobResponse,
   CancelHarvestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelHarvestJobRequest,
   output: CancelHarvestJobResponse,
@@ -2754,7 +2753,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -2788,7 +2787,7 @@ export const createChannelGroup: API.OperationMethod<
   CreateChannelGroupRequest,
   CreateChannelGroupResponse,
   CreateChannelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelGroupRequest,
   output: CreateChannelGroupResponse,
@@ -2822,7 +2821,7 @@ export const createHarvestJob: API.OperationMethod<
   CreateHarvestJobRequest,
   CreateHarvestJobResponse,
   CreateHarvestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHarvestJobRequest,
   output: CreateHarvestJobResponse,
@@ -2856,7 +2855,7 @@ export const createOriginEndpoint: API.OperationMethod<
   CreateOriginEndpointRequest,
   CreateOriginEndpointResponse,
   CreateOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOriginEndpointRequest,
   output: CreateOriginEndpointResponse,
@@ -2888,7 +2887,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -2918,7 +2917,7 @@ export const deleteChannelGroup: API.OperationMethod<
   DeleteChannelGroupRequest,
   DeleteChannelGroupResponse,
   DeleteChannelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelGroupRequest,
   output: DeleteChannelGroupResponse,
@@ -2948,7 +2947,7 @@ export const deleteChannelPolicy: API.OperationMethod<
   DeleteChannelPolicyRequest,
   DeleteChannelPolicyResponse,
   DeleteChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelPolicyRequest,
   output: DeleteChannelPolicyResponse,
@@ -2977,7 +2976,7 @@ export const deleteOriginEndpoint: API.OperationMethod<
   DeleteOriginEndpointRequest,
   DeleteOriginEndpointResponse,
   DeleteOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOriginEndpointRequest,
   output: DeleteOriginEndpointResponse,
@@ -3006,7 +3005,7 @@ export const deleteOriginEndpointPolicy: API.OperationMethod<
   DeleteOriginEndpointPolicyRequest,
   DeleteOriginEndpointPolicyResponse,
   DeleteOriginEndpointPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOriginEndpointPolicyRequest,
   output: DeleteOriginEndpointPolicyResponse,
@@ -3036,7 +3035,7 @@ export const getChannel: API.OperationMethod<
   GetChannelRequest,
   GetChannelResponse,
   GetChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelRequest,
   output: GetChannelResponse,
@@ -3066,7 +3065,7 @@ export const getChannelGroup: API.OperationMethod<
   GetChannelGroupRequest,
   GetChannelGroupResponse,
   GetChannelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelGroupRequest,
   output: GetChannelGroupResponse,
@@ -3096,7 +3095,7 @@ export const getChannelPolicy: API.OperationMethod<
   GetChannelPolicyRequest,
   GetChannelPolicyResponse,
   GetChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelPolicyRequest,
   output: GetChannelPolicyResponse,
@@ -3126,7 +3125,7 @@ export const getHarvestJob: API.OperationMethod<
   GetHarvestJobRequest,
   GetHarvestJobResponse,
   GetHarvestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHarvestJobRequest,
   output: GetHarvestJobResponse,
@@ -3156,7 +3155,7 @@ export const getOriginEndpoint: API.OperationMethod<
   GetOriginEndpointRequest,
   GetOriginEndpointResponse,
   GetOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginEndpointRequest,
   output: GetOriginEndpointResponse,
@@ -3186,7 +3185,7 @@ export const getOriginEndpointPolicy: API.OperationMethod<
   GetOriginEndpointPolicyRequest,
   GetOriginEndpointPolicyResponse,
   GetOriginEndpointPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOriginEndpointPolicyRequest,
   output: GetOriginEndpointPolicyResponse,
@@ -3215,7 +3214,7 @@ export const listChannelGroups: API.PaginatedOperationMethod<
   ListChannelGroupsRequest,
   ListChannelGroupsResponse,
   ListChannelGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelGroupListConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelGroupsRequest,
@@ -3251,7 +3250,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelListConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -3288,7 +3287,7 @@ export const listHarvestJobs: API.PaginatedOperationMethod<
   ListHarvestJobsRequest,
   ListHarvestJobsResponse,
   ListHarvestJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HarvestJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHarvestJobsRequest,
@@ -3325,7 +3324,7 @@ export const listOriginEndpoints: API.PaginatedOperationMethod<
   ListOriginEndpointsRequest,
   ListOriginEndpointsResponse,
   ListOriginEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OriginEndpointListConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOriginEndpointsRequest,
@@ -3356,7 +3355,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3381,7 +3380,7 @@ export const putChannelPolicy: API.OperationMethod<
   PutChannelPolicyRequest,
   PutChannelPolicyResponse,
   PutChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutChannelPolicyRequest,
   output: PutChannelPolicyResponse,
@@ -3413,7 +3412,7 @@ export const putOriginEndpointPolicy: API.OperationMethod<
   PutOriginEndpointPolicyRequest,
   PutOriginEndpointPolicyResponse,
   PutOriginEndpointPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOriginEndpointPolicyRequest,
   output: PutOriginEndpointPolicyResponse,
@@ -3447,7 +3446,7 @@ export const resetChannelState: API.OperationMethod<
   ResetChannelStateRequest,
   ResetChannelStateResponse,
   ResetChannelStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetChannelStateRequest,
   output: ResetChannelStateResponse,
@@ -3481,7 +3480,7 @@ export const resetOriginEndpointState: API.OperationMethod<
   ResetOriginEndpointStateRequest,
   ResetOriginEndpointStateResponse,
   ResetOriginEndpointStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetOriginEndpointStateRequest,
   output: ResetOriginEndpointStateResponse,
@@ -3508,7 +3507,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3526,7 +3525,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3553,7 +3552,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -3587,7 +3586,7 @@ export const updateChannelGroup: API.OperationMethod<
   UpdateChannelGroupRequest,
   UpdateChannelGroupResponse,
   UpdateChannelGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelGroupRequest,
   output: UpdateChannelGroupResponse,
@@ -3622,7 +3621,7 @@ export const updateOriginEndpoint: API.OperationMethod<
   UpdateOriginEndpointRequest,
   UpdateOriginEndpointResponse,
   UpdateOriginEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOriginEndpointRequest,
   output: UpdateOriginEndpointResponse,

--- a/packages/aws/src/services/mediastore-data.ts
+++ b/packages/aws/src/services/mediastore-data.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace(
   "https://object.mediastore.amazonaws.com/doc/2017-09-01",
 );
@@ -359,7 +358,7 @@ export const deleteObject: API.OperationMethod<
   DeleteObjectRequest,
   DeleteObjectResponse,
   DeleteObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectRequest,
   output: DeleteObjectResponse,
@@ -385,7 +384,7 @@ export const describeObject: API.OperationMethod<
   DescribeObjectRequest,
   DescribeObjectResponse,
   DescribeObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeObjectRequest,
   output: DescribeObjectResponse,
@@ -412,7 +411,7 @@ export const getObject: API.OperationMethod<
   GetObjectRequest,
   GetObjectResponse,
   GetObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectRequest,
   output: GetObjectResponse,
@@ -439,7 +438,7 @@ export const listItems: API.PaginatedOperationMethod<
   ListItemsRequest,
   ListItemsResponse,
   ListItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListItemsRequest,
@@ -466,7 +465,7 @@ export const putObject: API.OperationMethod<
   PutObjectRequest,
   PutObjectResponse,
   PutObjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectRequest,
   output: PutObjectResponse,

--- a/packages/aws/src/services/mediastore.ts
+++ b/packages/aws/src/services/mediastore.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("https://mediastore.amazonaws.com/doc/2017-09-01");
 const svc = T.AwsApiService({
   sdkId: "MediaStore",
@@ -768,7 +767,7 @@ export const createContainer: API.OperationMethod<
   CreateContainerInput,
   CreateContainerOutput,
   CreateContainerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContainerInput,
   output: CreateContainerOutput,
@@ -796,7 +795,7 @@ export const deleteContainer: API.OperationMethod<
   DeleteContainerInput,
   DeleteContainerOutput,
   DeleteContainerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerInput,
   output: DeleteContainerOutput,
@@ -823,7 +822,7 @@ export const deleteContainerPolicy: API.OperationMethod<
   DeleteContainerPolicyInput,
   DeleteContainerPolicyOutput,
   DeleteContainerPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContainerPolicyInput,
   output: DeleteContainerPolicyOutput,
@@ -856,7 +855,7 @@ export const deleteCorsPolicy: API.OperationMethod<
   DeleteCorsPolicyInput,
   DeleteCorsPolicyOutput,
   DeleteCorsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCorsPolicyInput,
   output: DeleteCorsPolicyOutput,
@@ -884,7 +883,7 @@ export const deleteLifecyclePolicy: API.OperationMethod<
   DeleteLifecyclePolicyInput,
   DeleteLifecyclePolicyOutput,
   DeleteLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecyclePolicyInput,
   output: DeleteLifecyclePolicyOutput,
@@ -912,7 +911,7 @@ export const deleteMetricPolicy: API.OperationMethod<
   DeleteMetricPolicyInput,
   DeleteMetricPolicyOutput,
   DeleteMetricPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMetricPolicyInput,
   output: DeleteMetricPolicyOutput,
@@ -944,7 +943,7 @@ export const describeContainer: API.OperationMethod<
   DescribeContainerInput,
   DescribeContainerOutput,
   DescribeContainerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContainerInput,
   output: DescribeContainerOutput,
@@ -969,7 +968,7 @@ export const getContainerPolicy: API.OperationMethod<
   GetContainerPolicyInput,
   GetContainerPolicyOutput,
   GetContainerPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContainerPolicyInput,
   output: GetContainerPolicyOutput,
@@ -1002,7 +1001,7 @@ export const getCorsPolicy: API.OperationMethod<
   GetCorsPolicyInput,
   GetCorsPolicyOutput,
   GetCorsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCorsPolicyInput,
   output: GetCorsPolicyOutput,
@@ -1030,7 +1029,7 @@ export const getLifecyclePolicy: API.OperationMethod<
   GetLifecyclePolicyInput,
   GetLifecyclePolicyOutput,
   GetLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLifecyclePolicyInput,
   output: GetLifecyclePolicyOutput,
@@ -1058,7 +1057,7 @@ export const getMetricPolicy: API.OperationMethod<
   GetMetricPolicyInput,
   GetMetricPolicyOutput,
   GetMetricPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMetricPolicyInput,
   output: GetMetricPolicyOutput,
@@ -1091,7 +1090,7 @@ export const listContainers: API.PaginatedOperationMethod<
   ListContainersInput,
   ListContainersOutput,
   ListContainersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContainersInput,
@@ -1119,7 +1118,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1152,7 +1151,7 @@ export const putContainerPolicy: API.OperationMethod<
   PutContainerPolicyInput,
   PutContainerPolicyOutput,
   PutContainerPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutContainerPolicyInput,
   output: PutContainerPolicyOutput,
@@ -1190,7 +1189,7 @@ export const putCorsPolicy: API.OperationMethod<
   PutCorsPolicyInput,
   PutCorsPolicyOutput,
   PutCorsPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCorsPolicyInput,
   output: PutCorsPolicyOutput,
@@ -1218,7 +1217,7 @@ export const putLifecyclePolicy: API.OperationMethod<
   PutLifecyclePolicyInput,
   PutLifecyclePolicyOutput,
   PutLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLifecyclePolicyInput,
   output: PutLifecyclePolicyOutput,
@@ -1244,7 +1243,7 @@ export const putMetricPolicy: API.OperationMethod<
   PutMetricPolicyInput,
   PutMetricPolicyOutput,
   PutMetricPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMetricPolicyInput,
   output: PutMetricPolicyOutput,
@@ -1270,7 +1269,7 @@ export const startAccessLogging: API.OperationMethod<
   StartAccessLoggingInput,
   StartAccessLoggingOutput,
   StartAccessLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAccessLoggingInput,
   output: StartAccessLoggingOutput,
@@ -1296,7 +1295,7 @@ export const stopAccessLogging: API.OperationMethod<
   StopAccessLoggingInput,
   StopAccessLoggingOutput,
   StopAccessLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAccessLoggingInput,
   output: StopAccessLoggingOutput,
@@ -1324,7 +1323,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1350,7 +1349,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,

--- a/packages/aws/src/services/mediatailor.ts
+++ b/packages/aws/src/services/mediatailor.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MediaTailor",
   serviceShapeName: "MediaTailor",
@@ -3516,7 +3515,7 @@ export const configureLogsForChannel: API.OperationMethod<
   ConfigureLogsForChannelRequest,
   ConfigureLogsForChannelResponse,
   ConfigureLogsForChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureLogsForChannelRequest,
   output: ConfigureLogsForChannelResponse,
@@ -3534,7 +3533,7 @@ export const configureLogsForPlaybackConfiguration: API.OperationMethod<
   ConfigureLogsForPlaybackConfigurationRequest,
   ConfigureLogsForPlaybackConfigurationResponse,
   ConfigureLogsForPlaybackConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfigureLogsForPlaybackConfigurationRequest,
   output: ConfigureLogsForPlaybackConfigurationResponse,
@@ -3552,7 +3551,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelRequest,
   CreateChannelResponse,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelRequest,
   output: CreateChannelResponse,
@@ -3570,7 +3569,7 @@ export const createLiveSource: API.OperationMethod<
   CreateLiveSourceRequest,
   CreateLiveSourceResponse,
   CreateLiveSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLiveSourceRequest,
   output: CreateLiveSourceResponse,
@@ -3591,7 +3590,7 @@ export const createPrefetchSchedule: API.OperationMethod<
   CreatePrefetchScheduleRequest,
   CreatePrefetchScheduleResponse,
   CreatePrefetchScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrefetchScheduleRequest,
   output: CreatePrefetchScheduleResponse,
@@ -3612,7 +3611,7 @@ export const createProgram: API.OperationMethod<
   CreateProgramRequest,
   CreateProgramResponse,
   CreateProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProgramRequest,
   output: CreateProgramResponse,
@@ -3630,7 +3629,7 @@ export const createSourceLocation: API.OperationMethod<
   CreateSourceLocationRequest,
   CreateSourceLocationResponse,
   CreateSourceLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSourceLocationRequest,
   output: CreateSourceLocationResponse,
@@ -3648,7 +3647,7 @@ export const createVodSource: API.OperationMethod<
   CreateVodSourceRequest,
   CreateVodSourceResponse,
   CreateVodSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVodSourceRequest,
   output: CreateVodSourceResponse,
@@ -3666,7 +3665,7 @@ export const deleteChannel: API.OperationMethod<
   DeleteChannelRequest,
   DeleteChannelResponse,
   DeleteChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelRequest,
   output: DeleteChannelResponse,
@@ -3684,7 +3683,7 @@ export const deleteChannelPolicy: API.OperationMethod<
   DeleteChannelPolicyRequest,
   DeleteChannelPolicyResponse,
   DeleteChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChannelPolicyRequest,
   output: DeleteChannelPolicyResponse,
@@ -3702,7 +3701,7 @@ export const deleteFunction: API.OperationMethod<
   DeleteFunctionRequest,
   DeleteFunctionResponse,
   DeleteFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFunctionRequest,
   output: DeleteFunctionResponse,
@@ -3720,7 +3719,7 @@ export const deleteLiveSource: API.OperationMethod<
   DeleteLiveSourceRequest,
   DeleteLiveSourceResponse,
   DeleteLiveSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLiveSourceRequest,
   output: DeleteLiveSourceResponse,
@@ -3738,7 +3737,7 @@ export const deletePlaybackConfiguration: API.OperationMethod<
   DeletePlaybackConfigurationRequest,
   DeletePlaybackConfigurationResponse,
   DeletePlaybackConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlaybackConfigurationRequest,
   output: DeletePlaybackConfigurationResponse,
@@ -3759,7 +3758,7 @@ export const deletePrefetchSchedule: API.OperationMethod<
   DeletePrefetchScheduleRequest,
   DeletePrefetchScheduleResponse,
   DeletePrefetchScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrefetchScheduleRequest,
   output: DeletePrefetchScheduleResponse,
@@ -3780,7 +3779,7 @@ export const deleteProgram: API.OperationMethod<
   DeleteProgramRequest,
   DeleteProgramResponse,
   DeleteProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProgramRequest,
   output: DeleteProgramResponse,
@@ -3798,7 +3797,7 @@ export const deleteSourceLocation: API.OperationMethod<
   DeleteSourceLocationRequest,
   DeleteSourceLocationResponse,
   DeleteSourceLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceLocationRequest,
   output: DeleteSourceLocationResponse,
@@ -3816,7 +3815,7 @@ export const deleteVodSource: API.OperationMethod<
   DeleteVodSourceRequest,
   DeleteVodSourceResponse,
   DeleteVodSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVodSourceRequest,
   output: DeleteVodSourceResponse,
@@ -3834,7 +3833,7 @@ export const describeChannel: API.OperationMethod<
   DescribeChannelRequest,
   DescribeChannelResponse,
   DescribeChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChannelRequest,
   output: DescribeChannelResponse,
@@ -3852,7 +3851,7 @@ export const describeLiveSource: API.OperationMethod<
   DescribeLiveSourceRequest,
   DescribeLiveSourceResponse,
   DescribeLiveSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLiveSourceRequest,
   output: DescribeLiveSourceResponse,
@@ -3873,7 +3872,7 @@ export const describeProgram: API.OperationMethod<
   DescribeProgramRequest,
   DescribeProgramResponse,
   DescribeProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProgramRequest,
   output: DescribeProgramResponse,
@@ -3891,7 +3890,7 @@ export const describeSourceLocation: API.OperationMethod<
   DescribeSourceLocationRequest,
   DescribeSourceLocationResponse,
   DescribeSourceLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSourceLocationRequest,
   output: DescribeSourceLocationResponse,
@@ -3909,7 +3908,7 @@ export const describeVodSource: API.OperationMethod<
   DescribeVodSourceRequest,
   DescribeVodSourceResponse,
   DescribeVodSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVodSourceRequest,
   output: DescribeVodSourceResponse,
@@ -3927,7 +3926,7 @@ export const getChannelPolicy: API.OperationMethod<
   GetChannelPolicyRequest,
   GetChannelPolicyResponse,
   GetChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelPolicyRequest,
   output: GetChannelPolicyResponse,
@@ -3948,7 +3947,7 @@ export const getChannelSchedule: API.PaginatedOperationMethod<
   GetChannelScheduleRequest,
   GetChannelScheduleResponse,
   GetChannelScheduleError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduleEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetChannelScheduleRequest,
@@ -3973,7 +3972,7 @@ export const getFunction: API.OperationMethod<
   GetFunctionRequest,
   GetFunctionResponse,
   GetFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFunctionRequest,
   output: GetFunctionResponse,
@@ -3993,7 +3992,7 @@ export const getPlaybackConfiguration: API.OperationMethod<
   GetPlaybackConfigurationRequest,
   GetPlaybackConfigurationResponse,
   GetPlaybackConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlaybackConfigurationRequest,
   output: GetPlaybackConfigurationResponse,
@@ -4014,7 +4013,7 @@ export const getPrefetchSchedule: API.OperationMethod<
   GetPrefetchScheduleRequest,
   GetPrefetchScheduleResponse,
   GetPrefetchScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPrefetchScheduleRequest,
   output: GetPrefetchScheduleResponse,
@@ -4032,7 +4031,7 @@ export const listAlerts: API.PaginatedOperationMethod<
   ListAlertsRequest,
   ListAlertsResponse,
   ListAlertsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Alert
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAlertsRequest,
@@ -4057,7 +4056,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Channel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -4082,7 +4081,7 @@ export const listFunctions: API.PaginatedOperationMethod<
   ListFunctionsRequest,
   ListFunctionsResponse,
   ListFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Function
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFunctionsRequest,
@@ -4107,7 +4106,7 @@ export const listLiveSources: API.PaginatedOperationMethod<
   ListLiveSourcesRequest,
   ListLiveSourcesResponse,
   ListLiveSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LiveSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLiveSourcesRequest,
@@ -4132,7 +4131,7 @@ export const listPlaybackConfigurations: API.PaginatedOperationMethod<
   ListPlaybackConfigurationsRequest,
   ListPlaybackConfigurationsResponse,
   ListPlaybackConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PlaybackConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlaybackConfigurationsRequest,
@@ -4160,7 +4159,7 @@ export const listPrefetchSchedules: API.PaginatedOperationMethod<
   ListPrefetchSchedulesRequest,
   ListPrefetchSchedulesResponse,
   ListPrefetchSchedulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrefetchSchedule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrefetchSchedulesRequest,
@@ -4185,7 +4184,7 @@ export const listSourceLocations: API.PaginatedOperationMethod<
   ListSourceLocationsRequest,
   ListSourceLocationsResponse,
   ListSourceLocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceLocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceLocationsRequest,
@@ -4210,7 +4209,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4228,7 +4227,7 @@ export const listVodSources: API.PaginatedOperationMethod<
   ListVodSourcesRequest,
   ListVodSourcesResponse,
   ListVodSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VodSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVodSourcesRequest,
@@ -4253,7 +4252,7 @@ export const putChannelPolicy: API.OperationMethod<
   PutChannelPolicyRequest,
   PutChannelPolicyResponse,
   PutChannelPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutChannelPolicyRequest,
   output: PutChannelPolicyResponse,
@@ -4271,7 +4270,7 @@ export const putFunction: API.OperationMethod<
   PutFunctionRequest,
   PutFunctionResponse,
   PutFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFunctionRequest,
   output: PutFunctionResponse,
@@ -4289,7 +4288,7 @@ export const putPlaybackConfiguration: API.OperationMethod<
   PutPlaybackConfigurationRequest,
   PutPlaybackConfigurationResponse,
   PutPlaybackConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPlaybackConfigurationRequest,
   output: PutPlaybackConfigurationResponse,
@@ -4310,7 +4309,7 @@ export const startChannel: API.OperationMethod<
   StartChannelRequest,
   StartChannelResponse,
   StartChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartChannelRequest,
   output: StartChannelResponse,
@@ -4331,7 +4330,7 @@ export const stopChannel: API.OperationMethod<
   StopChannelRequest,
   StopChannelResponse,
   StopChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopChannelRequest,
   output: StopChannelResponse,
@@ -4349,7 +4348,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4367,7 +4366,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4385,7 +4384,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelRequest,
   UpdateChannelResponse,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelRequest,
   output: UpdateChannelResponse,
@@ -4403,7 +4402,7 @@ export const updateLiveSource: API.OperationMethod<
   UpdateLiveSourceRequest,
   UpdateLiveSourceResponse,
   UpdateLiveSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLiveSourceRequest,
   output: UpdateLiveSourceResponse,
@@ -4424,7 +4423,7 @@ export const updateProgram: API.OperationMethod<
   UpdateProgramRequest,
   UpdateProgramResponse,
   UpdateProgramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProgramRequest,
   output: UpdateProgramResponse,
@@ -4442,7 +4441,7 @@ export const updateSourceLocation: API.OperationMethod<
   UpdateSourceLocationRequest,
   UpdateSourceLocationResponse,
   UpdateSourceLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSourceLocationRequest,
   output: UpdateSourceLocationResponse,
@@ -4460,7 +4459,7 @@ export const updateVodSource: API.OperationMethod<
   UpdateVodSourceRequest,
   UpdateVodSourceResponse,
   UpdateVodSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVodSourceRequest,
   output: UpdateVodSourceResponse,

--- a/packages/aws/src/services/medical-imaging.ts
+++ b/packages/aws/src/services/medical-imaging.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Medical Imaging",
@@ -1465,7 +1464,7 @@ export const copyImageSet: API.OperationMethod<
   CopyImageSetRequest,
   CopyImageSetResponse,
   CopyImageSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyImageSetRequest,
   output: CopyImageSetResponse,
@@ -1500,7 +1499,7 @@ export const createDatastore: API.OperationMethod<
   CreateDatastoreRequest,
   CreateDatastoreResponse,
   CreateDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatastoreRequest,
   output: CreateDatastoreResponse,
@@ -1535,7 +1534,7 @@ export const deleteDatastore: API.OperationMethod<
   DeleteDatastoreRequest,
   DeleteDatastoreResponse,
   DeleteDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatastoreRequest,
   output: DeleteDatastoreResponse,
@@ -1567,7 +1566,7 @@ export const deleteImageSet: API.OperationMethod<
   DeleteImageSetRequest,
   DeleteImageSetResponse,
   DeleteImageSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageSetRequest,
   output: DeleteImageSetResponse,
@@ -1599,7 +1598,7 @@ export const getDatastore: API.OperationMethod<
   GetDatastoreRequest,
   GetDatastoreResponse,
   GetDatastoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatastoreRequest,
   output: GetDatastoreResponse,
@@ -1632,7 +1631,7 @@ export const getDICOMImportJob: API.OperationMethod<
   GetDICOMImportJobRequest,
   GetDICOMImportJobResponse,
   GetDICOMImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDICOMImportJobRequest,
   output: GetDICOMImportJobResponse,
@@ -1666,7 +1665,7 @@ export const getImageFrame: API.OperationMethod<
   GetImageFrameRequest,
   GetImageFrameResponse,
   GetImageFrameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageFrameRequest,
   output: GetImageFrameResponse,
@@ -1701,7 +1700,7 @@ export const getImageSet: API.OperationMethod<
   GetImageSetRequest,
   GetImageSetResponse,
   GetImageSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageSetRequest,
   output: GetImageSetResponse,
@@ -1734,7 +1733,7 @@ export const getImageSetMetadata: API.OperationMethod<
   GetImageSetMetadataRequest,
   GetImageSetMetadataResponse,
   GetImageSetMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImageSetMetadataRequest,
   output: GetImageSetMetadataResponse,
@@ -1765,7 +1764,7 @@ export const listDatastores: API.PaginatedOperationMethod<
   ListDatastoresRequest,
   ListDatastoresResponse,
   ListDatastoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatastoreSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatastoresRequest,
@@ -1802,7 +1801,7 @@ export const listDICOMImportJobs: API.PaginatedOperationMethod<
   ListDICOMImportJobsRequest,
   ListDICOMImportJobsResponse,
   ListDICOMImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DICOMImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDICOMImportJobsRequest,
@@ -1841,7 +1840,7 @@ export const listImageSetVersions: API.PaginatedOperationMethod<
   ListImageSetVersionsRequest,
   ListImageSetVersionsResponse,
   ListImageSetVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageSetProperties
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageSetVersionsRequest,
@@ -1880,7 +1879,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1915,7 +1914,7 @@ export const searchImageSets: API.PaginatedOperationMethod<
   SearchImageSetsRequest,
   SearchImageSetsResponse,
   SearchImageSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageSetsMetadataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchImageSetsRequest,
@@ -1956,7 +1955,7 @@ export const startDICOMImportJob: API.OperationMethod<
   StartDICOMImportJobRequest,
   StartDICOMImportJobResponse,
   StartDICOMImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDICOMImportJobRequest,
   output: StartDICOMImportJobResponse,
@@ -1988,7 +1987,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2018,7 +2017,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2050,7 +2049,7 @@ export const updateImageSetMetadata: API.OperationMethod<
   UpdateImageSetMetadataRequest,
   UpdateImageSetMetadataResponse,
   UpdateImageSetMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImageSetMetadataRequest,
   output: UpdateImageSetMetadataResponse,

--- a/packages/aws/src/services/memorydb.ts
+++ b/packages/aws/src/services/memorydb.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://memorydb.amazonaws.com/doc/2021-01-01/");
 const svc = T.AwsApiService({
@@ -3182,7 +3181,7 @@ export const batchUpdateCluster: API.OperationMethod<
   BatchUpdateClusterRequest,
   BatchUpdateClusterResponse,
   BatchUpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateClusterRequest,
   output: BatchUpdateClusterResponse,
@@ -3213,7 +3212,7 @@ export const copySnapshot: API.OperationMethod<
   CopySnapshotRequest,
   CopySnapshotResponse,
   CopySnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopySnapshotRequest,
   output: CopySnapshotResponse,
@@ -3248,7 +3247,7 @@ export const createACL: API.OperationMethod<
   CreateACLRequest,
   CreateACLResponse,
   CreateACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateACLRequest,
   output: CreateACLResponse,
@@ -3293,7 +3292,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -3337,7 +3336,7 @@ export const createMultiRegionCluster: API.OperationMethod<
   CreateMultiRegionClusterRequest,
   CreateMultiRegionClusterResponse,
   CreateMultiRegionClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultiRegionClusterRequest,
   output: CreateMultiRegionClusterResponse,
@@ -3371,7 +3370,7 @@ export const createParameterGroup: API.OperationMethod<
   CreateParameterGroupRequest,
   CreateParameterGroupResponse,
   CreateParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParameterGroupRequest,
   output: CreateParameterGroupResponse,
@@ -3406,7 +3405,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotRequest,
   CreateSnapshotResponse,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotRequest,
   output: CreateSnapshotResponse,
@@ -3444,7 +3443,7 @@ export const createSubnetGroup: API.OperationMethod<
   CreateSubnetGroupRequest,
   CreateSubnetGroupResponse,
   CreateSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubnetGroupRequest,
   output: CreateSubnetGroupResponse,
@@ -3477,7 +3476,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -3506,7 +3505,7 @@ export const deleteACL: API.OperationMethod<
   DeleteACLRequest,
   DeleteACLResponse,
   DeleteACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteACLRequest,
   output: DeleteACLResponse,
@@ -3538,7 +3537,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -3567,7 +3566,7 @@ export const deleteMultiRegionCluster: API.OperationMethod<
   DeleteMultiRegionClusterRequest,
   DeleteMultiRegionClusterResponse,
   DeleteMultiRegionClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMultiRegionClusterRequest,
   output: DeleteMultiRegionClusterResponse,
@@ -3596,7 +3595,7 @@ export const deleteParameterGroup: API.OperationMethod<
   DeleteParameterGroupRequest,
   DeleteParameterGroupResponse,
   DeleteParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteParameterGroupRequest,
   output: DeleteParameterGroupResponse,
@@ -3626,7 +3625,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
   DeleteSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotRequest,
   output: DeleteSnapshotResponse,
@@ -3654,7 +3653,7 @@ export const deleteSubnetGroup: API.OperationMethod<
   DeleteSubnetGroupRequest,
   DeleteSubnetGroupResponse,
   DeleteSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubnetGroupRequest,
   output: DeleteSubnetGroupResponse,
@@ -3680,7 +3679,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -3705,7 +3704,7 @@ export const describeACLs: API.PaginatedOperationMethod<
   DescribeACLsRequest,
   DescribeACLsResponse,
   DescribeACLsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ACL
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeACLsRequest,
@@ -3735,7 +3734,7 @@ export const describeClusters: API.PaginatedOperationMethod<
   DescribeClustersRequest,
   DescribeClustersResponse,
   DescribeClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Cluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClustersRequest,
@@ -3769,7 +3768,7 @@ export const describeEngineVersions: API.PaginatedOperationMethod<
   DescribeEngineVersionsRequest,
   DescribeEngineVersionsResponse,
   DescribeEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngineVersionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineVersionsRequest,
@@ -3804,7 +3803,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsRequest,
   DescribeEventsResponse,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsRequest,
@@ -3838,7 +3837,7 @@ export const describeMultiRegionClusters: API.PaginatedOperationMethod<
   DescribeMultiRegionClustersRequest,
   DescribeMultiRegionClustersResponse,
   DescribeMultiRegionClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultiRegionCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMultiRegionClustersRequest,
@@ -3873,7 +3872,7 @@ export const describeMultiRegionParameterGroups: API.OperationMethod<
   DescribeMultiRegionParameterGroupsRequest,
   DescribeMultiRegionParameterGroupsResponse,
   DescribeMultiRegionParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMultiRegionParameterGroupsRequest,
   output: DescribeMultiRegionParameterGroupsResponse,
@@ -3901,7 +3900,7 @@ export const describeMultiRegionParameters: API.OperationMethod<
   DescribeMultiRegionParametersRequest,
   DescribeMultiRegionParametersResponse,
   DescribeMultiRegionParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMultiRegionParametersRequest,
   output: DescribeMultiRegionParametersResponse,
@@ -3929,7 +3928,7 @@ export const describeParameterGroups: API.PaginatedOperationMethod<
   DescribeParameterGroupsRequest,
   DescribeParameterGroupsResponse,
   DescribeParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeParameterGroupsRequest,
@@ -3964,7 +3963,7 @@ export const describeParameters: API.PaginatedOperationMethod<
   DescribeParametersRequest,
   DescribeParametersResponse,
   DescribeParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeParametersRequest,
@@ -3999,7 +3998,7 @@ export const describeReservedNodes: API.PaginatedOperationMethod<
   DescribeReservedNodesRequest,
   DescribeReservedNodesResponse,
   DescribeReservedNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNode
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedNodesRequest,
@@ -4034,7 +4033,7 @@ export const describeReservedNodesOfferings: API.PaginatedOperationMethod<
   DescribeReservedNodesOfferingsRequest,
   DescribeReservedNodesOfferingsResponse,
   DescribeReservedNodesOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNodesOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedNodesOfferingsRequest,
@@ -4067,7 +4066,7 @@ export const describeServiceUpdates: API.PaginatedOperationMethod<
   DescribeServiceUpdatesRequest,
   DescribeServiceUpdatesResponse,
   DescribeServiceUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceUpdate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServiceUpdatesRequest,
@@ -4101,7 +4100,7 @@ export const describeSnapshots: API.PaginatedOperationMethod<
   DescribeSnapshotsRequest,
   DescribeSnapshotsResponse,
   DescribeSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotsRequest,
@@ -4134,7 +4133,7 @@ export const describeSubnetGroups: API.PaginatedOperationMethod<
   DescribeSubnetGroupsRequest,
   DescribeSubnetGroupsResponse,
   DescribeSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSubnetGroupsRequest,
@@ -4162,7 +4161,7 @@ export const describeUsers: API.PaginatedOperationMethod<
   DescribeUsersRequest,
   DescribeUsersResponse,
   DescribeUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUsersRequest,
@@ -4197,7 +4196,7 @@ export const failoverShard: API.OperationMethod<
   FailoverShardRequest,
   FailoverShardResponse,
   FailoverShardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverShardRequest,
   output: FailoverShardResponse,
@@ -4228,7 +4227,7 @@ export const listAllowedMultiRegionClusterUpdates: API.OperationMethod<
   ListAllowedMultiRegionClusterUpdatesRequest,
   ListAllowedMultiRegionClusterUpdatesResponse,
   ListAllowedMultiRegionClusterUpdatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAllowedMultiRegionClusterUpdatesRequest,
   output: ListAllowedMultiRegionClusterUpdatesResponse,
@@ -4257,7 +4256,7 @@ export const listAllowedNodeTypeUpdates: API.OperationMethod<
   ListAllowedNodeTypeUpdatesRequest,
   ListAllowedNodeTypeUpdatesResponse,
   ListAllowedNodeTypeUpdatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAllowedNodeTypeUpdatesRequest,
   output: ListAllowedNodeTypeUpdatesResponse,
@@ -4294,7 +4293,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -4332,7 +4331,7 @@ export const purchaseReservedNodesOffering: API.OperationMethod<
   PurchaseReservedNodesOfferingRequest,
   PurchaseReservedNodesOfferingResponse,
   PurchaseReservedNodesOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedNodesOfferingRequest,
   output: PurchaseReservedNodesOfferingResponse,
@@ -4364,7 +4363,7 @@ export const resetParameterGroup: API.OperationMethod<
   ResetParameterGroupRequest,
   ResetParameterGroupResponse,
   ResetParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetParameterGroupRequest,
   output: ResetParameterGroupResponse,
@@ -4410,7 +4409,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4464,7 +4463,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4504,7 +4503,7 @@ export const updateACL: API.OperationMethod<
   UpdateACLRequest,
   UpdateACLResponse,
   UpdateACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateACLRequest,
   output: UpdateACLResponse,
@@ -4547,7 +4546,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -4588,7 +4587,7 @@ export const updateMultiRegionCluster: API.OperationMethod<
   UpdateMultiRegionClusterRequest,
   UpdateMultiRegionClusterResponse,
   UpdateMultiRegionClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMultiRegionClusterRequest,
   output: UpdateMultiRegionClusterResponse,
@@ -4618,7 +4617,7 @@ export const updateParameterGroup: API.OperationMethod<
   UpdateParameterGroupRequest,
   UpdateParameterGroupResponse,
   UpdateParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateParameterGroupRequest,
   output: UpdateParameterGroupResponse,
@@ -4649,7 +4648,7 @@ export const updateSubnetGroup: API.OperationMethod<
   UpdateSubnetGroupRequest,
   UpdateSubnetGroupResponse,
   UpdateSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubnetGroupRequest,
   output: UpdateSubnetGroupResponse,
@@ -4679,7 +4678,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/mgn.ts
+++ b/packages/aws/src/services/mgn.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "mgn",
   serviceShapeName: "ApplicationMigrationService",
@@ -5693,7 +5692,7 @@ export const archiveApplication: API.OperationMethod<
   ArchiveApplicationRequest,
   Application,
   ArchiveApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ArchiveApplicationRequest,
   output: Application,
@@ -5721,7 +5720,7 @@ export const archiveWave: API.OperationMethod<
   ArchiveWaveRequest,
   Wave,
   ArchiveWaveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ArchiveWaveRequest,
   output: Wave,
@@ -5749,7 +5748,7 @@ export const associateApplications: API.OperationMethod<
   AssociateApplicationsRequest,
   AssociateApplicationsResponse,
   AssociateApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateApplicationsRequest,
   output: AssociateApplicationsResponse,
@@ -5777,7 +5776,7 @@ export const associateSourceServers: API.OperationMethod<
   AssociateSourceServersRequest,
   AssociateSourceServersResponse,
   AssociateSourceServersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceServersRequest,
   output: AssociateSourceServersResponse,
@@ -5805,7 +5804,7 @@ export const changeServerLifeCycleState: API.OperationMethod<
   ChangeServerLifeCycleStateRequest,
   SourceServer,
   ChangeServerLifeCycleStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeServerLifeCycleStateRequest,
   output: SourceServer,
@@ -5832,7 +5831,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   Application,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: Application,
@@ -5857,7 +5856,7 @@ export const createConnector: API.OperationMethod<
   CreateConnectorRequest,
   Connector,
   CreateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorRequest,
   output: Connector,
@@ -5879,7 +5878,7 @@ export const createLaunchConfigurationTemplate: API.OperationMethod<
   CreateLaunchConfigurationTemplateRequest,
   LaunchConfigurationTemplate,
   CreateLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLaunchConfigurationTemplateRequest,
   output: LaunchConfigurationTemplate,
@@ -5904,7 +5903,7 @@ export const createNetworkMigrationDefinition: API.OperationMethod<
   CreateNetworkMigrationDefinitionRequest,
   NetworkMigrationDefinition,
   CreateNetworkMigrationDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkMigrationDefinitionRequest,
   output: NetworkMigrationDefinition,
@@ -5926,7 +5925,7 @@ export const createReplicationConfigurationTemplate: API.OperationMethod<
   CreateReplicationConfigurationTemplateRequest,
   ReplicationConfigurationTemplate,
   CreateReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationConfigurationTemplateRequest,
   output: ReplicationConfigurationTemplate,
@@ -5952,7 +5951,7 @@ export const createWave: API.OperationMethod<
   CreateWaveRequest,
   Wave,
   CreateWaveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWaveRequest,
   output: Wave,
@@ -5978,7 +5977,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -6004,7 +6003,7 @@ export const deleteConnector: API.OperationMethod<
   DeleteConnectorRequest,
   DeleteConnectorResponse,
   DeleteConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorRequest,
   output: DeleteConnectorResponse,
@@ -6030,7 +6029,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -6056,7 +6055,7 @@ export const deleteLaunchConfigurationTemplate: API.OperationMethod<
   DeleteLaunchConfigurationTemplateRequest,
   DeleteLaunchConfigurationTemplateResponse,
   DeleteLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLaunchConfigurationTemplateRequest,
   output: DeleteLaunchConfigurationTemplateResponse,
@@ -6082,7 +6081,7 @@ export const deleteNetworkMigrationDefinition: API.OperationMethod<
   DeleteNetworkMigrationDefinitionRequest,
   DeleteNetworkMigrationDefinitionResponse,
   DeleteNetworkMigrationDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkMigrationDefinitionRequest,
   output: DeleteNetworkMigrationDefinitionResponse,
@@ -6104,7 +6103,7 @@ export const deleteReplicationConfigurationTemplate: API.OperationMethod<
   DeleteReplicationConfigurationTemplateRequest,
   DeleteReplicationConfigurationTemplateResponse,
   DeleteReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationConfigurationTemplateRequest,
   output: DeleteReplicationConfigurationTemplateResponse,
@@ -6130,7 +6129,7 @@ export const deleteSourceServer: API.OperationMethod<
   DeleteSourceServerRequest,
   DeleteSourceServerResponse,
   DeleteSourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSourceServerRequest,
   output: DeleteSourceServerResponse,
@@ -6156,7 +6155,7 @@ export const deleteVcenterClient: API.OperationMethod<
   DeleteVcenterClientRequest,
   DeleteVcenterClientResponse,
   DeleteVcenterClientError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVcenterClientRequest,
   output: DeleteVcenterClientResponse,
@@ -6182,7 +6181,7 @@ export const deleteWave: API.OperationMethod<
   DeleteWaveRequest,
   DeleteWaveResponse,
   DeleteWaveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWaveRequest,
   output: DeleteWaveResponse,
@@ -6207,7 +6206,7 @@ export const describeJobLogItems: API.PaginatedOperationMethod<
   DescribeJobLogItemsRequest,
   DescribeJobLogItemsResponse,
   DescribeJobLogItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobLog
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobLogItemsRequest,
@@ -6235,7 +6234,7 @@ export const describeJobs: API.PaginatedOperationMethod<
   DescribeJobsRequest,
   DescribeJobsResponse,
   DescribeJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Job
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeJobsRequest,
@@ -6264,7 +6263,7 @@ export const describeLaunchConfigurationTemplates: API.PaginatedOperationMethod<
   DescribeLaunchConfigurationTemplatesRequest,
   DescribeLaunchConfigurationTemplatesResponse,
   DescribeLaunchConfigurationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LaunchConfigurationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeLaunchConfigurationTemplatesRequest,
@@ -6297,7 +6296,7 @@ export const describeReplicationConfigurationTemplates: API.PaginatedOperationMe
   DescribeReplicationConfigurationTemplatesRequest,
   DescribeReplicationConfigurationTemplatesResponse,
   DescribeReplicationConfigurationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReplicationConfigurationTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReplicationConfigurationTemplatesRequest,
@@ -6329,7 +6328,7 @@ export const describeSourceServers: API.PaginatedOperationMethod<
   DescribeSourceServersRequest,
   DescribeSourceServersResponse,
   DescribeSourceServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSourceServersRequest,
@@ -6358,7 +6357,7 @@ export const describeVcenterClients: API.PaginatedOperationMethod<
   DescribeVcenterClientsRequest,
   DescribeVcenterClientsResponse,
   DescribeVcenterClientsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VcenterClient
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVcenterClientsRequest,
@@ -6391,7 +6390,7 @@ export const disassociateApplications: API.OperationMethod<
   DisassociateApplicationsRequest,
   DisassociateApplicationsResponse,
   DisassociateApplicationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateApplicationsRequest,
   output: DisassociateApplicationsResponse,
@@ -6417,7 +6416,7 @@ export const disassociateSourceServers: API.OperationMethod<
   DisassociateSourceServersRequest,
   DisassociateSourceServersResponse,
   DisassociateSourceServersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSourceServersRequest,
   output: DisassociateSourceServersResponse,
@@ -6443,7 +6442,7 @@ export const disconnectFromService: API.OperationMethod<
   DisconnectFromServiceRequest,
   SourceServer,
   DisconnectFromServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisconnectFromServiceRequest,
   output: SourceServer,
@@ -6470,7 +6469,7 @@ export const finalizeCutover: API.OperationMethod<
   FinalizeCutoverRequest,
   SourceServer,
   FinalizeCutoverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FinalizeCutoverRequest,
   output: SourceServer,
@@ -6496,7 +6495,7 @@ export const getLaunchConfiguration: API.OperationMethod<
   GetLaunchConfigurationRequest,
   LaunchConfiguration,
   GetLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLaunchConfigurationRequest,
   output: LaunchConfiguration,
@@ -6517,7 +6516,7 @@ export const getNetworkMigrationDefinition: API.OperationMethod<
   GetNetworkMigrationDefinitionRequest,
   NetworkMigrationDefinition,
   GetNetworkMigrationDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkMigrationDefinitionRequest,
   output: NetworkMigrationDefinition,
@@ -6539,7 +6538,7 @@ export const getNetworkMigrationMapperSegmentConstruct: API.OperationMethod<
   GetNetworkMigrationMapperSegmentConstructRequest,
   GetNetworkMigrationMapperSegmentConstructResponse,
   GetNetworkMigrationMapperSegmentConstructError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkMigrationMapperSegmentConstructRequest,
   output: GetNetworkMigrationMapperSegmentConstructResponse,
@@ -6564,7 +6563,7 @@ export const getReplicationConfiguration: API.OperationMethod<
   GetReplicationConfigurationRequest,
   ReplicationConfiguration,
   GetReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReplicationConfigurationRequest,
   output: ReplicationConfiguration,
@@ -6585,7 +6584,7 @@ export const initializeService: API.OperationMethod<
   InitializeServiceRequest,
   InitializeServiceResponse,
   InitializeServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitializeServiceRequest,
   output: InitializeServiceResponse,
@@ -6605,7 +6604,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Application
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -6633,7 +6632,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Connector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -6661,7 +6660,7 @@ export const listExportErrors: API.PaginatedOperationMethod<
   ListExportErrorsRequest,
   ListExportErrorsResponse,
   ListExportErrorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportTaskError
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportErrorsRequest,
@@ -6686,7 +6685,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsRequest,
   ListExportsResponse,
   ListExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsRequest,
@@ -6714,7 +6713,7 @@ export const listImportErrors: API.PaginatedOperationMethod<
   ListImportErrorsRequest,
   ListImportErrorsResponse,
   ListImportErrorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportTaskError
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportErrorsRequest,
@@ -6739,7 +6738,7 @@ export const listImportFileEnrichments: API.PaginatedOperationMethod<
   ListImportFileEnrichmentsRequest,
   ListImportFileEnrichmentsResponse,
   ListImportFileEnrichmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportFileEnrichment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportFileEnrichmentsRequest,
@@ -6767,7 +6766,7 @@ export const listImports: API.PaginatedOperationMethod<
   ListImportsRequest,
   ListImportsResponse,
   ListImportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportsRequest,
@@ -6795,7 +6794,7 @@ export const listManagedAccounts: API.PaginatedOperationMethod<
   ListManagedAccountsRequest,
   ListManagedAccountsResponse,
   ListManagedAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedAccountsRequest,
@@ -6825,7 +6824,7 @@ export const listNetworkMigrationAnalyses: API.PaginatedOperationMethod<
   ListNetworkMigrationAnalysesRequest,
   ListNetworkMigrationAnalysesResponse,
   ListNetworkMigrationAnalysesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationAnalysisJobDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationAnalysesRequest,
@@ -6860,7 +6859,7 @@ export const listNetworkMigrationAnalysisResults: API.PaginatedOperationMethod<
   ListNetworkMigrationAnalysisResultsRequest,
   ListNetworkMigrationAnalysisResultsResponse,
   ListNetworkMigrationAnalysisResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationAnalysisResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationAnalysisResultsRequest,
@@ -6895,7 +6894,7 @@ export const listNetworkMigrationCodeGenerations: API.PaginatedOperationMethod<
   ListNetworkMigrationCodeGenerationsRequest,
   ListNetworkMigrationCodeGenerationsResponse,
   ListNetworkMigrationCodeGenerationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationCodeGenerationJobDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationCodeGenerationsRequest,
@@ -6930,7 +6929,7 @@ export const listNetworkMigrationCodeGenerationSegments: API.PaginatedOperationM
   ListNetworkMigrationCodeGenerationSegmentsRequest,
   ListNetworkMigrationCodeGenerationSegmentsResponse,
   ListNetworkMigrationCodeGenerationSegmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationCodeGenerationSegment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationCodeGenerationSegmentsRequest,
@@ -6962,7 +6961,7 @@ export const listNetworkMigrationDefinitions: API.PaginatedOperationMethod<
   ListNetworkMigrationDefinitionsRequest,
   ListNetworkMigrationDefinitionsResponse,
   ListNetworkMigrationDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationDefinitionsRequest,
@@ -6992,7 +6991,7 @@ export const listNetworkMigrationDeployedStacks: API.PaginatedOperationMethod<
   ListNetworkMigrationDeployedStacksRequest,
   ListNetworkMigrationDeployedStacksResponse,
   ListNetworkMigrationDeployedStacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationDeployedStackDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationDeployedStacksRequest,
@@ -7027,7 +7026,7 @@ export const listNetworkMigrationDeployments: API.PaginatedOperationMethod<
   ListNetworkMigrationDeploymentsRequest,
   ListNetworkMigrationDeployerJobResponse,
   ListNetworkMigrationDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationDeployerJobDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationDeploymentsRequest,
@@ -7060,7 +7059,7 @@ export const listNetworkMigrationExecutions: API.PaginatedOperationMethod<
   ListNetworkMigrationExecutionsRequest,
   ListNetworkMigrationExecutionsResponse,
   ListNetworkMigrationExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationExecutionsRequest,
@@ -7090,7 +7089,7 @@ export const listNetworkMigrationMapperSegmentConstructs: API.PaginatedOperation
   ListNetworkMigrationMapperSegmentConstructsRequest,
   ListNetworkMigrationMapperSegmentConstructsResponse,
   ListNetworkMigrationMapperSegmentConstructsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationMapperSegmentConstruct
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationMapperSegmentConstructsRequest,
@@ -7125,7 +7124,7 @@ export const listNetworkMigrationMapperSegments: API.PaginatedOperationMethod<
   ListNetworkMigrationMapperSegmentsRequest,
   ListNetworkMigrationMapperSegmentsResponse,
   ListNetworkMigrationMapperSegmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationMapperSegment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationMapperSegmentsRequest,
@@ -7160,7 +7159,7 @@ export const listNetworkMigrationMappings: API.PaginatedOperationMethod<
   ListNetworkMigrationMappingsRequest,
   ListNetworkMigrationMappingsResponse,
   ListNetworkMigrationMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationMappingJobDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationMappingsRequest,
@@ -7195,7 +7194,7 @@ export const listNetworkMigrationMappingUpdates: API.PaginatedOperationMethod<
   ListNetworkMigrationMappingUpdatesRequest,
   ListNetworkMigrationMappingUpdatesResponse,
   ListNetworkMigrationMappingUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkMigrationMappingUpdateJobDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkMigrationMappingUpdatesRequest,
@@ -7228,7 +7227,7 @@ export const listSourceServerActions: API.PaginatedOperationMethod<
   ListSourceServerActionsRequest,
   ListSourceServerActionsResponse,
   ListSourceServerActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceServerActionDocument
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceServerActionsRequest,
@@ -7259,7 +7258,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -7286,7 +7285,7 @@ export const listTemplateActions: API.PaginatedOperationMethod<
   ListTemplateActionsRequest,
   ListTemplateActionsResponse,
   ListTemplateActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateActionDocument
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateActionsRequest,
@@ -7311,7 +7310,7 @@ export const listWaves: API.PaginatedOperationMethod<
   ListWavesRequest,
   ListWavesResponse,
   ListWavesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Wave
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWavesRequest,
@@ -7340,7 +7339,7 @@ export const markAsArchived: API.OperationMethod<
   MarkAsArchivedRequest,
   SourceServer,
   MarkAsArchivedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MarkAsArchivedRequest,
   output: SourceServer,
@@ -7368,7 +7367,7 @@ export const pauseReplication: API.OperationMethod<
   PauseReplicationRequest,
   SourceServer,
   PauseReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseReplicationRequest,
   output: SourceServer,
@@ -7397,7 +7396,7 @@ export const putSourceServerAction: API.OperationMethod<
   PutSourceServerActionRequest,
   SourceServerActionDocument,
   PutSourceServerActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSourceServerActionRequest,
   output: SourceServerActionDocument,
@@ -7425,7 +7424,7 @@ export const putTemplateAction: API.OperationMethod<
   PutTemplateActionRequest,
   TemplateActionDocument,
   PutTemplateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTemplateActionRequest,
   output: TemplateActionDocument,
@@ -7452,7 +7451,7 @@ export const removeSourceServerAction: API.OperationMethod<
   RemoveSourceServerActionRequest,
   RemoveSourceServerActionResponse,
   RemoveSourceServerActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveSourceServerActionRequest,
   output: RemoveSourceServerActionResponse,
@@ -7478,7 +7477,7 @@ export const removeTemplateAction: API.OperationMethod<
   RemoveTemplateActionRequest,
   RemoveTemplateActionResponse,
   RemoveTemplateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTemplateActionRequest,
   output: RemoveTemplateActionResponse,
@@ -7506,7 +7505,7 @@ export const resumeReplication: API.OperationMethod<
   ResumeReplicationRequest,
   SourceServer,
   ResumeReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeReplicationRequest,
   output: SourceServer,
@@ -7534,7 +7533,7 @@ export const retryDataReplication: API.OperationMethod<
   RetryDataReplicationRequest,
   SourceServer,
   RetryDataReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryDataReplicationRequest,
   output: SourceServer,
@@ -7560,7 +7559,7 @@ export const startCutover: API.OperationMethod<
   StartCutoverRequest,
   StartCutoverResponse,
   StartCutoverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCutoverRequest,
   output: StartCutoverResponse,
@@ -7586,7 +7585,7 @@ export const startExport: API.OperationMethod<
   StartExportRequest,
   StartExportResponse,
   StartExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExportRequest,
   output: StartExportResponse,
@@ -7614,7 +7613,7 @@ export const startImport: API.OperationMethod<
   StartImportRequest,
   StartImportResponse,
   StartImportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportRequest,
   output: StartImportResponse,
@@ -7644,7 +7643,7 @@ export const startImportFileEnrichment: API.OperationMethod<
   StartImportFileEnrichmentRequest,
   StartImportFileEnrichmentResponse,
   StartImportFileEnrichmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportFileEnrichmentRequest,
   output: StartImportFileEnrichmentResponse,
@@ -7675,7 +7674,7 @@ export const startNetworkMigrationAnalysis: API.OperationMethod<
   StartNetworkMigrationAnalysisRequest,
   StartNetworkMigrationAnalysisResponse,
   StartNetworkMigrationAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkMigrationAnalysisRequest,
   output: StartNetworkMigrationAnalysisResponse,
@@ -7707,7 +7706,7 @@ export const startNetworkMigrationCodeGeneration: API.OperationMethod<
   StartNetworkMigrationCodeGenerationRequest,
   StartNetworkMigrationCodeGenerationResponse,
   StartNetworkMigrationCodeGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkMigrationCodeGenerationRequest,
   output: StartNetworkMigrationCodeGenerationResponse,
@@ -7739,7 +7738,7 @@ export const startNetworkMigrationDeployment: API.OperationMethod<
   StartNetworkMigrationDeploymentRequest,
   StartNetworkMigrationDeployerJobResponse,
   StartNetworkMigrationDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkMigrationDeploymentRequest,
   output: StartNetworkMigrationDeployerJobResponse,
@@ -7771,7 +7770,7 @@ export const startNetworkMigrationMapping: API.OperationMethod<
   StartNetworkMigrationMappingRequest,
   StartNetworkMigrationMappingResponse,
   StartNetworkMigrationMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkMigrationMappingRequest,
   output: StartNetworkMigrationMappingResponse,
@@ -7803,7 +7802,7 @@ export const startNetworkMigrationMappingUpdate: API.OperationMethod<
   StartNetworkMigrationMappingUpdateRequest,
   StartNetworkMigrationMappingUpdateResponse,
   StartNetworkMigrationMappingUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNetworkMigrationMappingUpdateRequest,
   output: StartNetworkMigrationMappingUpdateResponse,
@@ -7834,7 +7833,7 @@ export const startReplication: API.OperationMethod<
   StartReplicationRequest,
   SourceServer,
   StartReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReplicationRequest,
   output: SourceServer,
@@ -7862,7 +7861,7 @@ export const startTest: API.OperationMethod<
   StartTestRequest,
   StartTestResponse,
   StartTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTestRequest,
   output: StartTestResponse,
@@ -7890,7 +7889,7 @@ export const stopReplication: API.OperationMethod<
   StopReplicationRequest,
   SourceServer,
   StopReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopReplicationRequest,
   output: SourceServer,
@@ -7920,7 +7919,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7948,7 +7947,7 @@ export const terminateTargetInstances: API.OperationMethod<
   TerminateTargetInstancesRequest,
   TerminateTargetInstancesResponse,
   TerminateTargetInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateTargetInstancesRequest,
   output: TerminateTargetInstancesResponse,
@@ -7974,7 +7973,7 @@ export const unarchiveApplication: API.OperationMethod<
   UnarchiveApplicationRequest,
   Application,
   UnarchiveApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnarchiveApplicationRequest,
   output: Application,
@@ -8000,7 +7999,7 @@ export const unarchiveWave: API.OperationMethod<
   UnarchiveWaveRequest,
   Wave,
   UnarchiveWaveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnarchiveWaveRequest,
   output: Wave,
@@ -8028,7 +8027,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8056,7 +8055,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   Application,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: Application,
@@ -8082,7 +8081,7 @@ export const updateConnector: API.OperationMethod<
   UpdateConnectorRequest,
   Connector,
   UpdateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorRequest,
   output: Connector,
@@ -8111,7 +8110,7 @@ export const updateLaunchConfiguration: API.OperationMethod<
   UpdateLaunchConfigurationRequest,
   LaunchConfiguration,
   UpdateLaunchConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLaunchConfigurationRequest,
   output: LaunchConfiguration,
@@ -8139,7 +8138,7 @@ export const updateLaunchConfigurationTemplate: API.OperationMethod<
   UpdateLaunchConfigurationTemplateRequest,
   LaunchConfigurationTemplate,
   UpdateLaunchConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLaunchConfigurationTemplateRequest,
   output: LaunchConfigurationTemplate,
@@ -8166,7 +8165,7 @@ export const updateNetworkMigrationDefinition: API.OperationMethod<
   UpdateNetworkMigrationDefinitionRequest,
   NetworkMigrationDefinition,
   UpdateNetworkMigrationDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkMigrationDefinitionRequest,
   output: NetworkMigrationDefinition,
@@ -8192,7 +8191,7 @@ export const updateNetworkMigrationMapperSegment: API.OperationMethod<
   UpdateNetworkMigrationMapperSegmentRequest,
   NetworkMigrationMapperSegment,
   UpdateNetworkMigrationMapperSegmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkMigrationMapperSegmentRequest,
   output: NetworkMigrationMapperSegment,
@@ -8220,7 +8219,7 @@ export const updateReplicationConfiguration: API.OperationMethod<
   UpdateReplicationConfigurationRequest,
   ReplicationConfiguration,
   UpdateReplicationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationConfigurationRequest,
   output: ReplicationConfiguration,
@@ -8249,7 +8248,7 @@ export const updateReplicationConfigurationTemplate: API.OperationMethod<
   UpdateReplicationConfigurationTemplateRequest,
   ReplicationConfigurationTemplate,
   UpdateReplicationConfigurationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationConfigurationTemplateRequest,
   output: ReplicationConfigurationTemplate,
@@ -8276,7 +8275,7 @@ export const updateSourceServer: API.OperationMethod<
   UpdateSourceServerRequest,
   SourceServer,
   UpdateSourceServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSourceServerRequest,
   output: SourceServer,
@@ -8305,7 +8304,7 @@ export const updateSourceServerReplicationType: API.OperationMethod<
   UpdateSourceServerReplicationTypeRequest,
   SourceServer,
   UpdateSourceServerReplicationTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSourceServerReplicationTypeRequest,
   output: SourceServer,
@@ -8332,7 +8331,7 @@ export const updateWave: API.OperationMethod<
   UpdateWaveRequest,
   Wave,
   UpdateWaveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWaveRequest,
   output: Wave,

--- a/packages/aws/src/services/migration-hub-refactor-spaces.ts
+++ b/packages/aws/src/services/migration-hub-refactor-spaces.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Migration Hub Refactor Spaces",
   serviceShapeName: "RefactorSpaces",
@@ -1697,7 +1696,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1741,7 +1740,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   CreateEnvironmentResponse,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: CreateEnvironmentResponse,
@@ -1842,7 +1841,7 @@ export const createRoute: API.OperationMethod<
   CreateRouteRequest,
   CreateRouteResponse,
   CreateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRouteRequest,
   output: CreateRouteResponse,
@@ -1884,7 +1883,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -1918,7 +1917,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1951,7 +1950,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -1982,7 +1981,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -2013,7 +2012,7 @@ export const deleteRoute: API.OperationMethod<
   DeleteRouteRequest,
   DeleteRouteResponse,
   DeleteRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRouteRequest,
   output: DeleteRouteResponse,
@@ -2045,7 +2044,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -2076,7 +2075,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -2106,7 +2105,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -2136,7 +2135,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -2166,7 +2165,7 @@ export const getRoute: API.OperationMethod<
   GetRouteRequest,
   GetRouteResponse,
   GetRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteRequest,
   output: GetRouteResponse,
@@ -2196,7 +2195,7 @@ export const getService: API.OperationMethod<
   GetServiceRequest,
   GetServiceResponse,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRequest,
   output: GetServiceResponse,
@@ -2228,7 +2227,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -2268,7 +2267,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -2306,7 +2305,7 @@ export const listEnvironmentVpcs: API.PaginatedOperationMethod<
   ListEnvironmentVpcsRequest,
   ListEnvironmentVpcsResponse,
   ListEnvironmentVpcsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentVpc
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentVpcsRequest,
@@ -2345,7 +2344,7 @@ export const listRoutes: API.PaginatedOperationMethod<
   ListRoutesRequest,
   ListRoutesResponse,
   ListRoutesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RouteSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutesRequest,
@@ -2386,7 +2385,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -2424,7 +2423,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2456,7 +2455,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -2490,7 +2489,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2518,7 +2517,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2546,7 +2545,7 @@ export const updateRoute: API.OperationMethod<
   UpdateRouteRequest,
   UpdateRouteResponse,
   UpdateRouteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRouteRequest,
   output: UpdateRouteResponse,

--- a/packages/aws/src/services/migration-hub.ts
+++ b/packages/aws/src/services/migration-hub.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Migration Hub",
   serviceShapeName: "AWSMigrationHub",
@@ -906,7 +905,7 @@ export const associateCreatedArtifact: API.OperationMethod<
   AssociateCreatedArtifactRequest,
   AssociateCreatedArtifactResult,
   AssociateCreatedArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCreatedArtifactRequest,
   output: AssociateCreatedArtifactResult,
@@ -946,7 +945,7 @@ export const associateDiscoveredResource: API.OperationMethod<
   AssociateDiscoveredResourceRequest,
   AssociateDiscoveredResourceResult,
   AssociateDiscoveredResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDiscoveredResourceRequest,
   output: AssociateDiscoveredResourceResult,
@@ -985,7 +984,7 @@ export const associateSourceResource: API.OperationMethod<
   AssociateSourceResourceRequest,
   AssociateSourceResourceResult,
   AssociateSourceResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSourceResourceRequest,
   output: AssociateSourceResourceResult,
@@ -1025,7 +1024,7 @@ export const createProgressUpdateStream: API.OperationMethod<
   CreateProgressUpdateStreamRequest,
   CreateProgressUpdateStreamResult,
   CreateProgressUpdateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProgressUpdateStreamRequest,
   output: CreateProgressUpdateStreamResult,
@@ -1084,7 +1083,7 @@ export const deleteProgressUpdateStream: API.OperationMethod<
   DeleteProgressUpdateStreamRequest,
   DeleteProgressUpdateStreamResult,
   DeleteProgressUpdateStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProgressUpdateStreamRequest,
   output: DeleteProgressUpdateStreamResult,
@@ -1121,7 +1120,7 @@ export const describeApplicationState: API.OperationMethod<
   DescribeApplicationStateRequest,
   DescribeApplicationStateResult,
   DescribeApplicationStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationStateRequest,
   output: DescribeApplicationStateResult,
@@ -1156,7 +1155,7 @@ export const describeMigrationTask: API.OperationMethod<
   DescribeMigrationTaskRequest,
   DescribeMigrationTaskResult,
   DescribeMigrationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMigrationTaskRequest,
   output: DescribeMigrationTaskResult,
@@ -1203,7 +1202,7 @@ export const disassociateCreatedArtifact: API.OperationMethod<
   DisassociateCreatedArtifactRequest,
   DisassociateCreatedArtifactResult,
   DisassociateCreatedArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCreatedArtifactRequest,
   output: DisassociateCreatedArtifactResult,
@@ -1242,7 +1241,7 @@ export const disassociateDiscoveredResource: API.OperationMethod<
   DisassociateDiscoveredResourceRequest,
   DisassociateDiscoveredResourceResult,
   DisassociateDiscoveredResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDiscoveredResourceRequest,
   output: DisassociateDiscoveredResourceResult,
@@ -1279,7 +1278,7 @@ export const disassociateSourceResource: API.OperationMethod<
   DisassociateSourceResourceRequest,
   DisassociateSourceResourceResult,
   DisassociateSourceResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSourceResourceRequest,
   output: DisassociateSourceResourceResult,
@@ -1320,7 +1319,7 @@ export const importMigrationTask: API.OperationMethod<
   ImportMigrationTaskRequest,
   ImportMigrationTaskResult,
   ImportMigrationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportMigrationTaskRequest,
   output: ImportMigrationTaskResult,
@@ -1357,7 +1356,7 @@ export const listApplicationStates: API.PaginatedOperationMethod<
   ListApplicationStatesRequest,
   ListApplicationStatesResult,
   ListApplicationStatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationState
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationStatesRequest,
@@ -1406,7 +1405,7 @@ export const listCreatedArtifacts: API.PaginatedOperationMethod<
   ListCreatedArtifactsRequest,
   ListCreatedArtifactsResult,
   ListCreatedArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CreatedArtifact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCreatedArtifactsRequest,
@@ -1447,7 +1446,7 @@ export const listDiscoveredResources: API.PaginatedOperationMethod<
   ListDiscoveredResourcesRequest,
   ListDiscoveredResourcesResult,
   ListDiscoveredResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DiscoveredResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDiscoveredResourcesRequest,
@@ -1497,7 +1496,7 @@ export const listMigrationTasks: API.PaginatedOperationMethod<
   ListMigrationTasksRequest,
   ListMigrationTasksResult,
   ListMigrationTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MigrationTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMigrationTasksRequest,
@@ -1539,7 +1538,7 @@ export const listMigrationTaskUpdates: API.PaginatedOperationMethod<
   ListMigrationTaskUpdatesRequest,
   ListMigrationTaskUpdatesResult,
   ListMigrationTaskUpdatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MigrationTaskUpdate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMigrationTaskUpdatesRequest,
@@ -1578,7 +1577,7 @@ export const listProgressUpdateStreams: API.PaginatedOperationMethod<
   ListProgressUpdateStreamsRequest,
   ListProgressUpdateStreamsResult,
   ListProgressUpdateStreamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProgressUpdateStreamSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProgressUpdateStreamsRequest,
@@ -1618,7 +1617,7 @@ export const listSourceResources: API.PaginatedOperationMethod<
   ListSourceResourcesRequest,
   ListSourceResourcesResult,
   ListSourceResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceResourcesRequest,
@@ -1664,7 +1663,7 @@ export const notifyApplicationState: API.OperationMethod<
   NotifyApplicationStateRequest,
   NotifyApplicationStateResult,
   NotifyApplicationStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyApplicationStateRequest,
   output: NotifyApplicationStateResult,
@@ -1713,7 +1712,7 @@ export const notifyMigrationTaskState: API.OperationMethod<
   NotifyMigrationTaskStateRequest,
   NotifyMigrationTaskStateResult,
   NotifyMigrationTaskStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyMigrationTaskStateRequest,
   output: NotifyMigrationTaskStateResult,
@@ -1768,7 +1767,7 @@ export const putResourceAttributes: API.OperationMethod<
   PutResourceAttributesRequest,
   PutResourceAttributesResult,
   PutResourceAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourceAttributesRequest,
   output: PutResourceAttributesResult,

--- a/packages/aws/src/services/migrationhub-config.ts
+++ b/packages/aws/src/services/migrationhub-config.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MigrationHub Config",
   serviceShapeName: "AWSMigrationHubMultiAccountService",
@@ -258,7 +257,7 @@ export const createHomeRegionControl: API.OperationMethod<
   CreateHomeRegionControlRequest,
   CreateHomeRegionControlResult,
   CreateHomeRegionControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHomeRegionControlRequest,
   output: CreateHomeRegionControlResult,
@@ -289,7 +288,7 @@ export const deleteHomeRegionControl: API.OperationMethod<
   DeleteHomeRegionControlRequest,
   DeleteHomeRegionControlResult,
   DeleteHomeRegionControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHomeRegionControlRequest,
   output: DeleteHomeRegionControlResult,
@@ -320,7 +319,7 @@ export const describeHomeRegionControls: API.PaginatedOperationMethod<
   DescribeHomeRegionControlsRequest,
   DescribeHomeRegionControlsResult,
   DescribeHomeRegionControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHomeRegionControlsRequest,
@@ -360,7 +359,7 @@ export const getHomeRegion: API.OperationMethod<
   GetHomeRegionRequest,
   GetHomeRegionResult,
   GetHomeRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHomeRegionRequest,
   output: GetHomeRegionResult,

--- a/packages/aws/src/services/migrationhuborchestrator.ts
+++ b/packages/aws/src/services/migrationhuborchestrator.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MigrationHubOrchestrator",
   serviceShapeName: "AWSMigrationHubOrchestrator",
@@ -1860,7 +1859,7 @@ export const createTemplate: API.OperationMethod<
   CreateTemplateRequest,
   CreateTemplateResponse,
   CreateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateRequest,
   output: CreateTemplateResponse,
@@ -1889,7 +1888,7 @@ export const createWorkflow: API.OperationMethod<
   CreateMigrationWorkflowRequest,
   CreateMigrationWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMigrationWorkflowRequest,
   output: CreateMigrationWorkflowResponse,
@@ -1917,7 +1916,7 @@ export const createWorkflowStep: API.OperationMethod<
   CreateWorkflowStepRequest,
   CreateWorkflowStepResponse,
   CreateWorkflowStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowStepRequest,
   output: CreateWorkflowStepResponse,
@@ -1945,7 +1944,7 @@ export const createWorkflowStepGroup: API.OperationMethod<
   CreateWorkflowStepGroupRequest,
   CreateWorkflowStepGroupResponse,
   CreateWorkflowStepGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowStepGroupRequest,
   output: CreateWorkflowStepGroupResponse,
@@ -1974,7 +1973,7 @@ export const deleteTemplate: API.OperationMethod<
   DeleteTemplateRequest,
   DeleteTemplateResponse,
   DeleteTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateRequest,
   output: DeleteTemplateResponse,
@@ -2005,7 +2004,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteMigrationWorkflowRequest,
   DeleteMigrationWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMigrationWorkflowRequest,
   output: DeleteMigrationWorkflowResponse,
@@ -2036,7 +2035,7 @@ export const deleteWorkflowStep: API.OperationMethod<
   DeleteWorkflowStepRequest,
   DeleteWorkflowStepResponse,
   DeleteWorkflowStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowStepRequest,
   output: DeleteWorkflowStepResponse,
@@ -2066,7 +2065,7 @@ export const deleteWorkflowStepGroup: API.OperationMethod<
   DeleteWorkflowStepGroupRequest,
   DeleteWorkflowStepGroupResponse,
   DeleteWorkflowStepGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowStepGroupRequest,
   output: DeleteWorkflowStepGroupResponse,
@@ -2095,7 +2094,7 @@ export const getTemplate: API.OperationMethod<
   GetMigrationWorkflowTemplateRequest,
   GetMigrationWorkflowTemplateResponse,
   GetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMigrationWorkflowTemplateRequest,
   output: GetMigrationWorkflowTemplateResponse,
@@ -2124,7 +2123,7 @@ export const getTemplateStep: API.OperationMethod<
   GetTemplateStepRequest,
   GetTemplateStepResponse,
   GetTemplateStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateStepRequest,
   output: GetTemplateStepResponse,
@@ -2154,7 +2153,7 @@ export const getTemplateStepGroup: API.OperationMethod<
   GetTemplateStepGroupRequest,
   GetTemplateStepGroupResponse,
   GetTemplateStepGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateStepGroupRequest,
   output: GetTemplateStepGroupResponse,
@@ -2184,7 +2183,7 @@ export const getWorkflow: API.OperationMethod<
   GetMigrationWorkflowRequest,
   GetMigrationWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMigrationWorkflowRequest,
   output: GetMigrationWorkflowResponse,
@@ -2213,7 +2212,7 @@ export const getWorkflowStep: API.OperationMethod<
   GetWorkflowStepRequest,
   GetWorkflowStepResponse,
   GetWorkflowStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowStepRequest,
   output: GetWorkflowStepResponse,
@@ -2242,7 +2241,7 @@ export const getWorkflowStepGroup: API.OperationMethod<
   GetWorkflowStepGroupRequest,
   GetWorkflowStepGroupResponse,
   GetWorkflowStepGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowStepGroupRequest,
   output: GetWorkflowStepGroupResponse,
@@ -2270,7 +2269,7 @@ export const listPlugins: API.PaginatedOperationMethod<
   ListPluginsRequest,
   ListPluginsResponse,
   ListPluginsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PluginSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPluginsRequest,
@@ -2298,7 +2297,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2320,7 +2319,7 @@ export const listTemplates: API.PaginatedOperationMethod<
   ListMigrationWorkflowTemplatesRequest,
   ListMigrationWorkflowTemplatesResponse,
   ListTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMigrationWorkflowTemplatesRequest,
@@ -2350,7 +2349,7 @@ export const listTemplateStepGroups: API.PaginatedOperationMethod<
   ListTemplateStepGroupsRequest,
   ListTemplateStepGroupsResponse,
   ListTemplateStepGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateStepGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateStepGroupsRequest,
@@ -2386,7 +2385,7 @@ export const listTemplateSteps: API.PaginatedOperationMethod<
   ListTemplateStepsRequest,
   ListTemplateStepsResponse,
   ListTemplateStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateStepSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateStepsRequest,
@@ -2423,7 +2422,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListMigrationWorkflowsRequest,
   ListMigrationWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MigrationWorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMigrationWorkflowsRequest,
@@ -2460,7 +2459,7 @@ export const listWorkflowStepGroups: API.PaginatedOperationMethod<
   ListWorkflowStepGroupsRequest,
   ListWorkflowStepGroupsResponse,
   ListWorkflowStepGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowStepGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowStepGroupsRequest,
@@ -2496,7 +2495,7 @@ export const listWorkflowSteps: API.PaginatedOperationMethod<
   ListWorkflowStepsRequest,
   ListWorkflowStepsResponse,
   ListWorkflowStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowStepSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowStepsRequest,
@@ -2531,7 +2530,7 @@ export const retryWorkflowStep: API.OperationMethod<
   RetryWorkflowStepRequest,
   RetryWorkflowStepResponse,
   RetryWorkflowStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryWorkflowStepRequest,
   output: RetryWorkflowStepResponse,
@@ -2560,7 +2559,7 @@ export const startWorkflow: API.OperationMethod<
   StartMigrationWorkflowRequest,
   StartMigrationWorkflowResponse,
   StartWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMigrationWorkflowRequest,
   output: StartMigrationWorkflowResponse,
@@ -2590,7 +2589,7 @@ export const stopWorkflow: API.OperationMethod<
   StopMigrationWorkflowRequest,
   StopMigrationWorkflowResponse,
   StopWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMigrationWorkflowRequest,
   output: StopMigrationWorkflowResponse,
@@ -2617,7 +2616,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2638,7 +2637,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2662,7 +2661,7 @@ export const updateTemplate: API.OperationMethod<
   UpdateTemplateRequest,
   UpdateTemplateResponse,
   UpdateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateRequest,
   output: UpdateTemplateResponse,
@@ -2692,7 +2691,7 @@ export const updateWorkflow: API.OperationMethod<
   UpdateMigrationWorkflowRequest,
   UpdateMigrationWorkflowResponse,
   UpdateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMigrationWorkflowRequest,
   output: UpdateMigrationWorkflowResponse,
@@ -2721,7 +2720,7 @@ export const updateWorkflowStep: API.OperationMethod<
   UpdateWorkflowStepRequest,
   UpdateWorkflowStepResponse,
   UpdateWorkflowStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowStepRequest,
   output: UpdateWorkflowStepResponse,
@@ -2750,7 +2749,7 @@ export const updateWorkflowStepGroup: API.OperationMethod<
   UpdateWorkflowStepGroupRequest,
   UpdateWorkflowStepGroupResponse,
   UpdateWorkflowStepGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowStepGroupRequest,
   output: UpdateWorkflowStepGroupResponse,

--- a/packages/aws/src/services/migrationhubstrategy.ts
+++ b/packages/aws/src/services/migrationhubstrategy.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MigrationHubStrategy",
@@ -1805,7 +1804,7 @@ export const getApplicationComponentDetails: API.OperationMethod<
   GetApplicationComponentDetailsRequest,
   GetApplicationComponentDetailsResponse,
   GetApplicationComponentDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationComponentDetailsRequest,
   output: GetApplicationComponentDetailsResponse,
@@ -1832,7 +1831,7 @@ export const getApplicationComponentStrategies: API.OperationMethod<
   GetApplicationComponentStrategiesRequest,
   GetApplicationComponentStrategiesResponse,
   GetApplicationComponentStrategiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationComponentStrategiesRequest,
   output: GetApplicationComponentStrategiesResponse,
@@ -1859,7 +1858,7 @@ export const getAssessment: API.OperationMethod<
   GetAssessmentRequest,
   GetAssessmentResponse,
   GetAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssessmentRequest,
   output: GetAssessmentResponse,
@@ -1888,7 +1887,7 @@ export const getImportFileTask: API.OperationMethod<
   GetImportFileTaskRequest,
   GetImportFileTaskResponse,
   GetImportFileTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportFileTaskRequest,
   output: GetImportFileTaskResponse,
@@ -1917,7 +1916,7 @@ export const getLatestAssessmentId: API.OperationMethod<
   GetLatestAssessmentIdRequest,
   GetLatestAssessmentIdResponse,
   GetLatestAssessmentIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLatestAssessmentIdRequest,
   output: GetLatestAssessmentIdResponse,
@@ -1945,7 +1944,7 @@ export const getPortfolioPreferences: API.OperationMethod<
   GetPortfolioPreferencesRequest,
   GetPortfolioPreferencesResponse,
   GetPortfolioPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortfolioPreferencesRequest,
   output: GetPortfolioPreferencesResponse,
@@ -1973,7 +1972,7 @@ export const getPortfolioSummary: API.OperationMethod<
   GetPortfolioSummaryRequest,
   GetPortfolioSummaryResponse,
   GetPortfolioSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortfolioSummaryRequest,
   output: GetPortfolioSummaryResponse,
@@ -1997,7 +1996,7 @@ export const getRecommendationReportDetails: API.OperationMethod<
   GetRecommendationReportDetailsRequest,
   GetRecommendationReportDetailsResponse,
   GetRecommendationReportDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationReportDetailsRequest,
   output: GetRecommendationReportDetailsResponse,
@@ -2027,7 +2026,7 @@ export const getServerDetails: API.PaginatedOperationMethod<
   GetServerDetailsRequest,
   GetServerDetailsResponse,
   GetServerDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedApplication
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetServerDetailsRequest,
@@ -2064,7 +2063,7 @@ export const getServerStrategies: API.OperationMethod<
   GetServerStrategiesRequest,
   GetServerStrategiesResponse,
   GetServerStrategiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServerStrategiesRequest,
   output: GetServerStrategiesResponse,
@@ -2093,7 +2092,7 @@ export const listAnalyzableServers: API.PaginatedOperationMethod<
   ListAnalyzableServersRequest,
   ListAnalyzableServersResponse,
   ListAnalyzableServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalyzableServerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalyzableServersRequest,
@@ -2128,7 +2127,7 @@ export const listApplicationComponents: API.PaginatedOperationMethod<
   ListApplicationComponentsRequest,
   ListApplicationComponentsResponse,
   ListApplicationComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationComponentDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationComponentsRequest,
@@ -2163,7 +2162,7 @@ export const listCollectors: API.PaginatedOperationMethod<
   ListCollectorsRequest,
   ListCollectorsResponse,
   ListCollectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Collector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollectorsRequest,
@@ -2198,7 +2197,7 @@ export const listImportFileTask: API.PaginatedOperationMethod<
   ListImportFileTaskRequest,
   ListImportFileTaskResponse,
   ListImportFileTaskError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportFileTaskInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportFileTaskRequest,
@@ -2233,7 +2232,7 @@ export const listServers: API.PaginatedOperationMethod<
   ListServersRequest,
   ListServersResponse,
   ListServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServersRequest,
@@ -2269,7 +2268,7 @@ export const putPortfolioPreferences: API.OperationMethod<
   PutPortfolioPreferencesRequest,
   PutPortfolioPreferencesResponse,
   PutPortfolioPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPortfolioPreferencesRequest,
   output: PutPortfolioPreferencesResponse,
@@ -2298,7 +2297,7 @@ export const startAssessment: API.OperationMethod<
   StartAssessmentRequest,
   StartAssessmentResponse,
   StartAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssessmentRequest,
   output: StartAssessmentResponse,
@@ -2327,7 +2326,7 @@ export const startImportFileTask: API.OperationMethod<
   StartImportFileTaskRequest,
   StartImportFileTaskResponse,
   StartImportFileTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportFileTaskRequest,
   output: StartImportFileTaskResponse,
@@ -2357,7 +2356,7 @@ export const startRecommendationReportGeneration: API.OperationMethod<
   StartRecommendationReportGenerationRequest,
   StartRecommendationReportGenerationResponse,
   StartRecommendationReportGenerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecommendationReportGenerationRequest,
   output: StartRecommendationReportGenerationResponse,
@@ -2386,7 +2385,7 @@ export const stopAssessment: API.OperationMethod<
   StopAssessmentRequest,
   StopAssessmentResponse,
   StopAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAssessmentRequest,
   output: StopAssessmentResponse,
@@ -2414,7 +2413,7 @@ export const updateApplicationComponentConfig: API.OperationMethod<
   UpdateApplicationComponentConfigRequest,
   UpdateApplicationComponentConfigResponse,
   UpdateApplicationComponentConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationComponentConfigRequest,
   output: UpdateApplicationComponentConfigResponse,
@@ -2442,7 +2441,7 @@ export const updateServerConfig: API.OperationMethod<
   UpdateServerConfigRequest,
   UpdateServerConfigResponse,
   UpdateServerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServerConfigRequest,
   output: UpdateServerConfigResponse,

--- a/packages/aws/src/services/mpa.ts
+++ b/packages/aws/src/services/mpa.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "MPA",
@@ -1524,7 +1523,7 @@ export const cancelSession: API.OperationMethod<
   CancelSessionRequest,
   CancelSessionResponse,
   CancelSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSessionRequest,
   output: CancelSessionResponse,
@@ -1556,7 +1555,7 @@ export const createApprovalTeam: API.OperationMethod<
   CreateApprovalTeamRequest,
   CreateApprovalTeamResponse,
   CreateApprovalTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApprovalTeamRequest,
   output: CreateApprovalTeamResponse,
@@ -1587,7 +1586,7 @@ export const createIdentitySource: API.OperationMethod<
   CreateIdentitySourceRequest,
   CreateIdentitySourceResponse,
   CreateIdentitySourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentitySourceRequest,
   output: CreateIdentitySourceResponse,
@@ -1617,7 +1616,7 @@ export const deleteIdentitySource: API.OperationMethod<
   DeleteIdentitySourceRequest,
   DeleteIdentitySourceResponse,
   DeleteIdentitySourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentitySourceRequest,
   output: DeleteIdentitySourceResponse,
@@ -1650,7 +1649,7 @@ export const deleteInactiveApprovalTeamVersion: API.OperationMethod<
   DeleteInactiveApprovalTeamVersionRequest,
   DeleteInactiveApprovalTeamVersionResponse,
   DeleteInactiveApprovalTeamVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInactiveApprovalTeamVersionRequest,
   output: DeleteInactiveApprovalTeamVersionResponse,
@@ -1681,7 +1680,7 @@ export const getApprovalTeam: API.OperationMethod<
   GetApprovalTeamRequest,
   GetApprovalTeamResponse,
   GetApprovalTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApprovalTeamRequest,
   output: GetApprovalTeamResponse,
@@ -1711,7 +1710,7 @@ export const getIdentitySource: API.OperationMethod<
   GetIdentitySourceRequest,
   GetIdentitySourceResponse,
   GetIdentitySourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentitySourceRequest,
   output: GetIdentitySourceResponse,
@@ -1741,7 +1740,7 @@ export const getPolicyVersion: API.OperationMethod<
   GetPolicyVersionRequest,
   GetPolicyVersionResponse,
   GetPolicyVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyVersionRequest,
   output: GetPolicyVersionResponse,
@@ -1771,7 +1770,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1801,7 +1800,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -1830,7 +1829,7 @@ export const listApprovalTeams: API.PaginatedOperationMethod<
   ListApprovalTeamsRequest,
   ListApprovalTeamsResponse,
   ListApprovalTeamsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListApprovalTeamsResponseApprovalTeam
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApprovalTeamsRequest,
@@ -1865,7 +1864,7 @@ export const listIdentitySources: API.PaginatedOperationMethod<
   ListIdentitySourcesRequest,
   ListIdentitySourcesResponse,
   ListIdentitySourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdentitySourceForList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentitySourcesRequest,
@@ -1900,7 +1899,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Policy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -1936,7 +1935,7 @@ export const listPolicyVersions: API.PaginatedOperationMethod<
   ListPolicyVersionsRequest,
   ListPolicyVersionsResponse,
   ListPolicyVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyVersionsRequest,
@@ -1973,7 +1972,7 @@ export const listResourcePolicies: API.PaginatedOperationMethod<
   ListResourcePoliciesRequest,
   ListResourcePoliciesResponse,
   ListResourcePoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListResourcePoliciesResponseResourcePolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcePoliciesRequest,
@@ -2010,7 +2009,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSessionsResponseSession
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -2047,7 +2046,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2082,7 +2081,7 @@ export const startActiveApprovalTeamDeletion: API.OperationMethod<
   StartActiveApprovalTeamDeletionRequest,
   StartActiveApprovalTeamDeletionResponse,
   StartActiveApprovalTeamDeletionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartActiveApprovalTeamDeletionRequest,
   output: StartActiveApprovalTeamDeletionResponse,
@@ -2113,7 +2112,7 @@ export const startApprovalTeamBaseline: API.OperationMethod<
   StartApprovalTeamBaselineRequest,
   StartApprovalTeamBaselineResponse,
   StartApprovalTeamBaselineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApprovalTeamBaselineRequest,
   output: StartApprovalTeamBaselineResponse,
@@ -2144,7 +2143,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2175,7 +2174,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2211,7 +2210,7 @@ export const updateApprovalTeam: API.OperationMethod<
   UpdateApprovalTeamRequest,
   UpdateApprovalTeamResponse,
   UpdateApprovalTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApprovalTeamRequest,
   output: UpdateApprovalTeamResponse,

--- a/packages/aws/src/services/mq.ts
+++ b/packages/aws/src/services/mq.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "mq", serviceShapeName: "mq" });
 const auth = T.AwsAuthSigv4({ name: "mq" });
@@ -2219,7 +2218,7 @@ export const createBroker: API.OperationMethod<
   CreateBrokerRequest,
   CreateBrokerResponse,
   CreateBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBrokerRequest,
   output: CreateBrokerResponse,
@@ -2248,7 +2247,7 @@ export const createConfiguration: API.OperationMethod<
   CreateConfigurationRequest,
   CreateConfigurationResponse,
   CreateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationRequest,
   output: CreateConfigurationResponse,
@@ -2276,7 +2275,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResponse,
@@ -2307,7 +2306,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -2336,7 +2335,7 @@ export const deleteBroker: API.OperationMethod<
   DeleteBrokerRequest,
   DeleteBrokerResponse,
   DeleteBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrokerRequest,
   output: DeleteBrokerResponse,
@@ -2365,7 +2364,7 @@ export const deleteConfiguration: API.OperationMethod<
   DeleteConfigurationRequest,
   DeleteConfigurationResponse,
   DeleteConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationRequest,
   output: DeleteConfigurationResponse,
@@ -2394,7 +2393,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResponse,
@@ -2422,7 +2421,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -2450,7 +2449,7 @@ export const describeBroker: API.OperationMethod<
   DescribeBrokerRequest,
   DescribeBrokerResponse,
   DescribeBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrokerRequest,
   output: DescribeBrokerResponse,
@@ -2477,7 +2476,7 @@ export const describeBrokerEngineTypes: API.OperationMethod<
   DescribeBrokerEngineTypesRequest,
   DescribeBrokerEngineTypesResponse,
   DescribeBrokerEngineTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrokerEngineTypesRequest,
   output: DescribeBrokerEngineTypesResponse,
@@ -2503,7 +2502,7 @@ export const describeBrokerInstanceOptions: API.OperationMethod<
   DescribeBrokerInstanceOptionsRequest,
   DescribeBrokerInstanceOptionsResponse,
   DescribeBrokerInstanceOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrokerInstanceOptionsRequest,
   output: DescribeBrokerInstanceOptionsResponse,
@@ -2530,7 +2529,7 @@ export const describeConfiguration: API.OperationMethod<
   DescribeConfigurationRequest,
   DescribeConfigurationResponse,
   DescribeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRequest,
   output: DescribeConfigurationResponse,
@@ -2558,7 +2557,7 @@ export const describeConfigurationRevision: API.OperationMethod<
   DescribeConfigurationRevisionRequest,
   DescribeConfigurationRevisionResponse,
   DescribeConfigurationRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationRevisionRequest,
   output: DescribeConfigurationRevisionResponse,
@@ -2586,7 +2585,7 @@ export const describeSharedResources: API.PaginatedOperationMethod<
   DescribeSharedResourcesRequest,
   DescribeSharedResourcesResponse,
   DescribeSharedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SharedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSharedResourcesRequest,
@@ -2621,7 +2620,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -2648,7 +2647,7 @@ export const listBrokers: API.PaginatedOperationMethod<
   ListBrokersRequest,
   ListBrokersResponse,
   ListBrokersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BrokerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBrokersRequest,
@@ -2682,7 +2681,7 @@ export const listConfigurationRevisions: API.OperationMethod<
   ListConfigurationRevisionsRequest,
   ListConfigurationRevisionsResponse,
   ListConfigurationRevisionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConfigurationRevisionsRequest,
   output: ListConfigurationRevisionsResponse,
@@ -2709,7 +2708,7 @@ export const listConfigurations: API.OperationMethod<
   ListConfigurationsRequest,
   ListConfigurationsResponse,
   ListConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConfigurationsRequest,
   output: ListConfigurationsResponse,
@@ -2736,7 +2735,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -2764,7 +2763,7 @@ export const listUsers: API.OperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUsersRequest,
   output: ListUsersResponse,
@@ -2792,7 +2791,7 @@ export const promote: API.OperationMethod<
   PromoteRequest,
   PromoteResponse,
   PromoteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromoteRequest,
   output: PromoteResponse,
@@ -2820,7 +2819,7 @@ export const rebootBroker: API.OperationMethod<
   RebootBrokerRequest,
   RebootBrokerResponse,
   RebootBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootBrokerRequest,
   output: RebootBrokerResponse,
@@ -2849,7 +2848,7 @@ export const updateBroker: API.OperationMethod<
   UpdateBrokerRequest,
   UpdateBrokerResponse,
   UpdateBrokerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrokerRequest,
   output: UpdateBrokerResponse,
@@ -2879,7 +2878,7 @@ export const updateConfiguration: API.OperationMethod<
   UpdateConfigurationRequest,
   UpdateConfigurationResponse,
   UpdateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationRequest,
   output: UpdateConfigurationResponse,
@@ -2909,7 +2908,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/mturk.ts
+++ b/packages/aws/src/services/mturk.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://requester.mturk.com/2017-01-17/");
 const svc = T.AwsApiService({
   sdkId: "MTurk",
@@ -1906,7 +1905,7 @@ export const acceptQualificationRequest: API.OperationMethod<
   AcceptQualificationRequestRequest,
   AcceptQualificationRequestResponse,
   AcceptQualificationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptQualificationRequestRequest,
   output: AcceptQualificationRequestResponse,
@@ -1940,7 +1939,7 @@ export const approveAssignment: API.OperationMethod<
   ApproveAssignmentRequest,
   ApproveAssignmentResponse,
   ApproveAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApproveAssignmentRequest,
   output: ApproveAssignmentResponse,
@@ -1973,7 +1972,7 @@ export const associateQualificationWithWorker: API.OperationMethod<
   AssociateQualificationWithWorkerRequest,
   AssociateQualificationWithWorkerResponse,
   AssociateQualificationWithWorkerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateQualificationWithWorkerRequest,
   output: AssociateQualificationWithWorkerResponse,
@@ -2007,7 +2006,7 @@ export const createAdditionalAssignmentsForHIT: API.OperationMethod<
   CreateAdditionalAssignmentsForHITRequest,
   CreateAdditionalAssignmentsForHITResponse,
   CreateAdditionalAssignmentsForHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAdditionalAssignmentsForHITRequest,
   output: CreateAdditionalAssignmentsForHITResponse,
@@ -2038,7 +2037,7 @@ export const createHIT: API.OperationMethod<
   CreateHITRequest,
   CreateHITResponse,
   CreateHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHITRequest,
   output: CreateHITResponse,
@@ -2059,7 +2058,7 @@ export const createHITType: API.OperationMethod<
   CreateHITTypeRequest,
   CreateHITTypeResponse,
   CreateHITTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHITTypeRequest,
   output: CreateHITTypeResponse,
@@ -2091,7 +2090,7 @@ export const createHITWithHITType: API.OperationMethod<
   CreateHITWithHITTypeRequest,
   CreateHITWithHITTypeResponse,
   CreateHITWithHITTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHITWithHITTypeRequest,
   output: CreateHITWithHITTypeResponse,
@@ -2116,7 +2115,7 @@ export const createQualificationType: API.OperationMethod<
   CreateQualificationTypeRequest,
   CreateQualificationTypeResponse,
   CreateQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQualificationTypeRequest,
   output: CreateQualificationTypeResponse,
@@ -2134,7 +2133,7 @@ export const createWorkerBlock: API.OperationMethod<
   CreateWorkerBlockRequest,
   CreateWorkerBlockResponse,
   CreateWorkerBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkerBlockRequest,
   output: CreateWorkerBlockResponse,
@@ -2168,7 +2167,7 @@ export const deleteHIT: API.OperationMethod<
   DeleteHITRequest,
   DeleteHITResponse,
   DeleteHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHITRequest,
   output: DeleteHITResponse,
@@ -2205,7 +2204,7 @@ export const deleteQualificationType: API.OperationMethod<
   DeleteQualificationTypeRequest,
   DeleteQualificationTypeResponse,
   DeleteQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQualificationTypeRequest,
   output: DeleteQualificationTypeResponse,
@@ -2223,7 +2222,7 @@ export const deleteWorkerBlock: API.OperationMethod<
   DeleteWorkerBlockRequest,
   DeleteWorkerBlockResponse,
   DeleteWorkerBlockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkerBlockRequest,
   output: DeleteWorkerBlockResponse,
@@ -2248,7 +2247,7 @@ export const disassociateQualificationFromWorker: API.OperationMethod<
   DisassociateQualificationFromWorkerRequest,
   DisassociateQualificationFromWorkerResponse,
   DisassociateQualificationFromWorkerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateQualificationFromWorkerRequest,
   output: DisassociateQualificationFromWorkerResponse,
@@ -2268,7 +2267,7 @@ export const getAccountBalance: API.OperationMethod<
   GetAccountBalanceRequest,
   GetAccountBalanceResponse,
   GetAccountBalanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountBalanceRequest,
   output: GetAccountBalanceResponse,
@@ -2286,7 +2285,7 @@ export const getAssignment: API.OperationMethod<
   GetAssignmentRequest,
   GetAssignmentResponse,
   GetAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssignmentRequest,
   output: GetAssignmentResponse,
@@ -2318,7 +2317,7 @@ export const getFileUploadURL: API.OperationMethod<
   GetFileUploadURLRequest,
   GetFileUploadURLResponse,
   GetFileUploadURLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFileUploadURLRequest,
   output: GetFileUploadURLResponse,
@@ -2336,7 +2335,7 @@ export const getHIT: API.OperationMethod<
   GetHITRequest,
   GetHITResponse,
   GetHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHITRequest,
   output: GetHITResponse,
@@ -2368,7 +2367,7 @@ export const getQualificationScore: API.OperationMethod<
   GetQualificationScoreRequest,
   GetQualificationScoreResponse,
   GetQualificationScoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQualificationScoreRequest,
   output: GetQualificationScoreResponse,
@@ -2389,7 +2388,7 @@ export const getQualificationType: API.OperationMethod<
   GetQualificationTypeRequest,
   GetQualificationTypeResponse,
   GetQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQualificationTypeRequest,
   output: GetQualificationTypeResponse,
@@ -2434,7 +2433,7 @@ export const listAssignmentsForHIT: API.PaginatedOperationMethod<
   ListAssignmentsForHITRequest,
   ListAssignmentsForHITResponse,
   ListAssignmentsForHITError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssignmentsForHITRequest,
@@ -2461,7 +2460,7 @@ export const listBonusPayments: API.PaginatedOperationMethod<
   ListBonusPaymentsRequest,
   ListBonusPaymentsResponse,
   ListBonusPaymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBonusPaymentsRequest,
@@ -2489,7 +2488,7 @@ export const listHITs: API.PaginatedOperationMethod<
   ListHITsRequest,
   ListHITsResponse,
   ListHITsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHITsRequest,
@@ -2519,7 +2518,7 @@ export const listHITsForQualificationType: API.PaginatedOperationMethod<
   ListHITsForQualificationTypeRequest,
   ListHITsForQualificationTypeResponse,
   ListHITsForQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHITsForQualificationTypeRequest,
@@ -2551,7 +2550,7 @@ export const listQualificationRequests: API.PaginatedOperationMethod<
   ListQualificationRequestsRequest,
   ListQualificationRequestsResponse,
   ListQualificationRequestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQualificationRequestsRequest,
@@ -2581,7 +2580,7 @@ export const listQualificationTypes: API.PaginatedOperationMethod<
   ListQualificationTypesRequest,
   ListQualificationTypesResponse,
   ListQualificationTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQualificationTypesRequest,
@@ -2609,7 +2608,7 @@ export const listReviewableHITs: API.PaginatedOperationMethod<
   ListReviewableHITsRequest,
   ListReviewableHITsResponse,
   ListReviewableHITsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReviewableHITsRequest,
@@ -2640,7 +2639,7 @@ export const listReviewPolicyResultsForHIT: API.PaginatedOperationMethod<
   ListReviewPolicyResultsForHITRequest,
   ListReviewPolicyResultsForHITResponse,
   ListReviewPolicyResultsForHITError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReviewPolicyResultsForHITRequest,
@@ -2664,7 +2663,7 @@ export const listWorkerBlocks: API.PaginatedOperationMethod<
   ListWorkerBlocksRequest,
   ListWorkerBlocksResponse,
   ListWorkerBlocksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkerBlocksRequest,
@@ -2692,7 +2691,7 @@ export const listWorkersWithQualificationType: API.PaginatedOperationMethod<
   ListWorkersWithQualificationTypeRequest,
   ListWorkersWithQualificationTypeResponse,
   ListWorkersWithQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkersWithQualificationTypeRequest,
@@ -2723,7 +2722,7 @@ export const notifyWorkers: API.OperationMethod<
   NotifyWorkersRequest,
   NotifyWorkersResponse,
   NotifyWorkersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyWorkersRequest,
   output: NotifyWorkersResponse,
@@ -2749,7 +2748,7 @@ export const rejectAssignment: API.OperationMethod<
   RejectAssignmentRequest,
   RejectAssignmentResponse,
   RejectAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectAssignmentRequest,
   output: RejectAssignmentResponse,
@@ -2775,7 +2774,7 @@ export const rejectQualificationRequest: API.OperationMethod<
   RejectQualificationRequestRequest,
   RejectQualificationRequestResponse,
   RejectQualificationRequestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectQualificationRequestRequest,
   output: RejectQualificationRequestResponse,
@@ -2804,7 +2803,7 @@ export const sendBonus: API.OperationMethod<
   SendBonusRequest,
   SendBonusResponse,
   SendBonusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendBonusRequest,
   output: SendBonusResponse,
@@ -2829,7 +2828,7 @@ export const sendTestEventNotification: API.OperationMethod<
   SendTestEventNotificationRequest,
   SendTestEventNotificationResponse,
   SendTestEventNotificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTestEventNotificationRequest,
   output: SendTestEventNotificationResponse,
@@ -2851,7 +2850,7 @@ export const updateExpirationForHIT: API.OperationMethod<
   UpdateExpirationForHITRequest,
   UpdateExpirationForHITResponse,
   UpdateExpirationForHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExpirationForHITRequest,
   output: UpdateExpirationForHITResponse,
@@ -2874,7 +2873,7 @@ export const updateHITReviewStatus: API.OperationMethod<
   UpdateHITReviewStatusRequest,
   UpdateHITReviewStatusResponse,
   UpdateHITReviewStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHITReviewStatusRequest,
   output: UpdateHITReviewStatusResponse,
@@ -2900,7 +2899,7 @@ export const updateHITTypeOfHIT: API.OperationMethod<
   UpdateHITTypeOfHITRequest,
   UpdateHITTypeOfHITResponse,
   UpdateHITTypeOfHITError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHITTypeOfHITRequest,
   output: UpdateHITTypeOfHITResponse,
@@ -2930,7 +2929,7 @@ export const updateNotificationSettings: API.OperationMethod<
   UpdateNotificationSettingsRequest,
   UpdateNotificationSettingsResponse,
   UpdateNotificationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationSettingsRequest,
   output: UpdateNotificationSettingsResponse,
@@ -2987,7 +2986,7 @@ export const updateQualificationType: API.OperationMethod<
   UpdateQualificationTypeRequest,
   UpdateQualificationTypeResponse,
   UpdateQualificationTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQualificationTypeRequest,
   output: UpdateQualificationTypeResponse,

--- a/packages/aws/src/services/mwaa-serverless.ts
+++ b/packages/aws/src/services/mwaa-serverless.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "MWAA Serverless",
   serviceShapeName: "AmazonMWAAServerless",
@@ -1087,7 +1086,7 @@ export const createWorkflow: API.OperationMethod<
   CreateWorkflowRequest,
   CreateWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRequest,
   output: CreateWorkflowResponse,
@@ -1120,7 +1119,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -1152,7 +1151,7 @@ export const getTaskInstance: API.OperationMethod<
   GetTaskInstanceRequest,
   GetTaskInstanceResponse,
   GetTaskInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaskInstanceRequest,
   output: GetTaskInstanceResponse,
@@ -1184,7 +1183,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -1216,7 +1215,7 @@ export const getWorkflowRun: API.OperationMethod<
   GetWorkflowRunRequest,
   GetWorkflowRunResponse,
   GetWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRunRequest,
   output: GetWorkflowRunResponse,
@@ -1248,7 +1247,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1279,7 +1278,7 @@ export const listTaskInstances: API.PaginatedOperationMethod<
   ListTaskInstancesRequest,
   ListTaskInstancesResponse,
   ListTaskInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaskInstancesRequest,
@@ -1316,7 +1315,7 @@ export const listWorkflowRuns: API.PaginatedOperationMethod<
   ListWorkflowRunsRequest,
   ListWorkflowRunsResponse,
   ListWorkflowRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowRunsRequest,
@@ -1353,7 +1352,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -1390,7 +1389,7 @@ export const listWorkflowVersions: API.PaginatedOperationMethod<
   ListWorkflowVersionsRequest,
   ListWorkflowVersionsResponse,
   ListWorkflowVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowVersionsRequest,
@@ -1430,7 +1429,7 @@ export const startWorkflowRun: API.OperationMethod<
   StartWorkflowRunRequest,
   StartWorkflowRunResponse,
   StartWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkflowRunRequest,
   output: StartWorkflowRunResponse,
@@ -1464,7 +1463,7 @@ export const stopWorkflowRun: API.OperationMethod<
   StopWorkflowRunRequest,
   StopWorkflowRunResponse,
   StopWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopWorkflowRunRequest,
   output: StopWorkflowRunResponse,
@@ -1496,7 +1495,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1528,7 +1527,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1562,7 +1561,7 @@ export const updateWorkflow: API.OperationMethod<
   UpdateWorkflowRequest,
   UpdateWorkflowResponse,
   UpdateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowRequest,
   output: UpdateWorkflowResponse,

--- a/packages/aws/src/services/mwaa.ts
+++ b/packages/aws/src/services/mwaa.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "MWAA", serviceShapeName: "AmazonMWAA" });
 const auth = T.AwsAuthSigv4({ name: "airflow" });
@@ -870,7 +869,7 @@ export const createCliToken: API.OperationMethod<
   CreateCliTokenRequest,
   CreateCliTokenResponse,
   CreateCliTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCliTokenRequest,
   output: CreateCliTokenResponse,
@@ -893,7 +892,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentInput,
   CreateEnvironmentOutput,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentInput,
   output: CreateEnvironmentOutput,
@@ -921,7 +920,7 @@ export const createWebLoginToken: API.OperationMethod<
   CreateWebLoginTokenRequest,
   CreateWebLoginTokenResponse,
   CreateWebLoginTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebLoginTokenRequest,
   output: CreateWebLoginTokenResponse,
@@ -950,7 +949,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentInput,
   DeleteEnvironmentOutput,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentInput,
   output: DeleteEnvironmentOutput,
@@ -978,7 +977,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentInput,
   GetEnvironmentOutput,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentInput,
   output: GetEnvironmentOutput,
@@ -1008,7 +1007,7 @@ export const invokeRestApi: API.OperationMethod<
   InvokeRestApiRequest,
   InvokeRestApiResponse,
   InvokeRestApiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeRestApiRequest,
   output: InvokeRestApiResponse,
@@ -1037,7 +1036,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsInput,
   ListEnvironmentsOutput,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsInput,
@@ -1067,7 +1066,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1093,7 +1092,7 @@ export const publishMetrics: API.OperationMethod<
   PublishMetricsInput,
   PublishMetricsOutput,
   PublishMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishMetricsInput,
   output: PublishMetricsOutput,
@@ -1116,7 +1115,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1143,7 +1142,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1171,7 +1170,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentInput,
   UpdateEnvironmentOutput,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentInput,
   output: UpdateEnvironmentOutput,

--- a/packages/aws/src/services/neptune-graph.ts
+++ b/packages/aws/src/services/neptune-graph.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Neptune Graph",
   serviceShapeName: "AmazonNeptuneGraph",
@@ -2291,7 +2290,7 @@ export const cancelExportTask: API.OperationMethod<
   CancelExportTaskInput,
   CancelExportTaskOutput,
   CancelExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelExportTaskInput,
   output: CancelExportTaskOutput,
@@ -2321,7 +2320,7 @@ export const cancelImportTask: API.OperationMethod<
   CancelImportTaskInput,
   CancelImportTaskOutput,
   CancelImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelImportTaskInput,
   output: CancelImportTaskOutput,
@@ -2351,7 +2350,7 @@ export const cancelQuery: API.OperationMethod<
   CancelQueryInput,
   CancelQueryResponse,
   CancelQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelQueryInput,
   output: CancelQueryResponse,
@@ -2382,7 +2381,7 @@ export const createGraph: API.OperationMethod<
   CreateGraphInput,
   CreateGraphOutput,
   CreateGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGraphInput,
   output: CreateGraphOutput,
@@ -2413,7 +2412,7 @@ export const createGraphSnapshot: API.OperationMethod<
   CreateGraphSnapshotInput,
   CreateGraphSnapshotOutput,
   CreateGraphSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGraphSnapshotInput,
   output: CreateGraphSnapshotOutput,
@@ -2446,7 +2445,7 @@ export const createGraphUsingImportTask: API.OperationMethod<
   CreateGraphUsingImportTaskInput,
   CreateGraphUsingImportTaskOutput,
   CreateGraphUsingImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGraphUsingImportTaskInput,
   output: CreateGraphUsingImportTaskOutput,
@@ -2479,7 +2478,7 @@ export const createPrivateGraphEndpoint: API.OperationMethod<
   CreatePrivateGraphEndpointInput,
   CreatePrivateGraphEndpointOutput,
   CreatePrivateGraphEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivateGraphEndpointInput,
   output: CreatePrivateGraphEndpointOutput,
@@ -2510,7 +2509,7 @@ export const deleteGraph: API.OperationMethod<
   DeleteGraphInput,
   DeleteGraphOutput,
   DeleteGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGraphInput,
   output: DeleteGraphOutput,
@@ -2540,7 +2539,7 @@ export const deleteGraphSnapshot: API.OperationMethod<
   DeleteGraphSnapshotInput,
   DeleteGraphSnapshotOutput,
   DeleteGraphSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGraphSnapshotInput,
   output: DeleteGraphSnapshotOutput,
@@ -2570,7 +2569,7 @@ export const deletePrivateGraphEndpoint: API.OperationMethod<
   DeletePrivateGraphEndpointInput,
   DeletePrivateGraphEndpointOutput,
   DeletePrivateGraphEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrivateGraphEndpointInput,
   output: DeletePrivateGraphEndpointOutput,
@@ -2609,7 +2608,7 @@ export const executeQuery: API.OperationMethod<
   ExecuteQueryInput,
   ExecuteQueryOutput,
   ExecuteQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteQueryInput,
   output: ExecuteQueryOutput,
@@ -2640,7 +2639,7 @@ export const getExportTask: API.OperationMethod<
   GetExportTaskInput,
   GetExportTaskOutput,
   GetExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportTaskInput,
   output: GetExportTaskOutput,
@@ -2668,7 +2667,7 @@ export const getGraph: API.OperationMethod<
   GetGraphInput,
   GetGraphOutput,
   GetGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGraphInput,
   output: GetGraphOutput,
@@ -2696,7 +2695,7 @@ export const getGraphSnapshot: API.OperationMethod<
   GetGraphSnapshotInput,
   GetGraphSnapshotOutput,
   GetGraphSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGraphSnapshotInput,
   output: GetGraphSnapshotOutput,
@@ -2725,7 +2724,7 @@ export const getGraphSummary: API.OperationMethod<
   GetGraphSummaryInput,
   GetGraphSummaryOutput,
   GetGraphSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGraphSummaryInput,
   output: GetGraphSummaryOutput,
@@ -2755,7 +2754,7 @@ export const getImportTask: API.OperationMethod<
   GetImportTaskInput,
   GetImportTaskOutput,
   GetImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportTaskInput,
   output: GetImportTaskOutput,
@@ -2783,7 +2782,7 @@ export const getPrivateGraphEndpoint: API.OperationMethod<
   GetPrivateGraphEndpointInput,
   GetPrivateGraphEndpointOutput,
   GetPrivateGraphEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPrivateGraphEndpointInput,
   output: GetPrivateGraphEndpointOutput,
@@ -2814,7 +2813,7 @@ export const getQuery: API.OperationMethod<
   GetQueryInput,
   GetQueryOutput,
   GetQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryInput,
   output: GetQueryOutput,
@@ -2844,7 +2843,7 @@ export const listExportTasks: API.PaginatedOperationMethod<
   ListExportTasksInput,
   ListExportTasksOutput,
   ListExportTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportTasksInput,
@@ -2878,7 +2877,7 @@ export const listGraphs: API.PaginatedOperationMethod<
   ListGraphsInput,
   ListGraphsOutput,
   ListGraphsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GraphSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGraphsInput,
@@ -2912,7 +2911,7 @@ export const listGraphSnapshots: API.PaginatedOperationMethod<
   ListGraphSnapshotsInput,
   ListGraphSnapshotsOutput,
   ListGraphSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GraphSnapshotSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGraphSnapshotsInput,
@@ -2947,7 +2946,7 @@ export const listImportTasks: API.PaginatedOperationMethod<
   ListImportTasksInput,
   ListImportTasksOutput,
   ListImportTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportTasksInput,
@@ -2982,7 +2981,7 @@ export const listPrivateGraphEndpoints: API.PaginatedOperationMethod<
   ListPrivateGraphEndpointsInput,
   ListPrivateGraphEndpointsOutput,
   ListPrivateGraphEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrivateGraphEndpointSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrivateGraphEndpointsInput,
@@ -3017,7 +3016,7 @@ export const listQueries: API.OperationMethod<
   ListQueriesInput,
   ListQueriesOutput,
   ListQueriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListQueriesInput,
   output: ListQueriesOutput,
@@ -3046,7 +3045,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -3075,7 +3074,7 @@ export const resetGraph: API.OperationMethod<
   ResetGraphInput,
   ResetGraphOutput,
   ResetGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetGraphInput,
   output: ResetGraphOutput,
@@ -3106,7 +3105,7 @@ export const restoreGraphFromSnapshot: API.OperationMethod<
   RestoreGraphFromSnapshotInput,
   RestoreGraphFromSnapshotOutput,
   RestoreGraphFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreGraphFromSnapshotInput,
   output: RestoreGraphFromSnapshotOutput,
@@ -3137,7 +3136,7 @@ export const startExportTask: API.OperationMethod<
   StartExportTaskInput,
   StartExportTaskOutput,
   StartExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExportTaskInput,
   output: StartExportTaskOutput,
@@ -3167,7 +3166,7 @@ export const startGraph: API.OperationMethod<
   StartGraphInput,
   StartGraphOutput,
   StartGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartGraphInput,
   output: StartGraphOutput,
@@ -3197,7 +3196,7 @@ export const startImportTask: API.OperationMethod<
   StartImportTaskInput,
   StartImportTaskOutput,
   StartImportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportTaskInput,
   output: StartImportTaskOutput,
@@ -3227,7 +3226,7 @@ export const stopGraph: API.OperationMethod<
   StopGraphInput,
   StopGraphOutput,
   StopGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopGraphInput,
   output: StopGraphOutput,
@@ -3256,7 +3255,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -3284,7 +3283,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -3313,7 +3312,7 @@ export const updateGraph: API.OperationMethod<
   UpdateGraphInput,
   UpdateGraphOutput,
   UpdateGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGraphInput,
   output: UpdateGraphOutput,

--- a/packages/aws/src/services/neptune.ts
+++ b/packages/aws/src/services/neptune.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://rds.amazonaws.com/doc/2014-10-31/");
 const svc = T.AwsApiService({
@@ -4889,7 +4888,7 @@ export const addRoleToDBCluster: API.OperationMethod<
   AddRoleToDBClusterMessage,
   AddRoleToDBClusterResponse,
   AddRoleToDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRoleToDBClusterMessage,
   output: AddRoleToDBClusterResponse,
@@ -4915,7 +4914,7 @@ export const addSourceIdentifierToSubscription: API.OperationMethod<
   AddSourceIdentifierToSubscriptionMessage,
   AddSourceIdentifierToSubscriptionResult,
   AddSourceIdentifierToSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddSourceIdentifierToSubscriptionMessage,
   output: AddSourceIdentifierToSubscriptionResult,
@@ -4939,7 +4938,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceMessage,
   AddTagsToResourceResponse,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceMessage,
   output: AddTagsToResourceResponse,
@@ -4963,7 +4962,7 @@ export const applyPendingMaintenanceAction: API.OperationMethod<
   ApplyPendingMaintenanceActionMessage,
   ApplyPendingMaintenanceActionResult,
   ApplyPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyPendingMaintenanceActionMessage,
   output: ApplyPendingMaintenanceActionResult,
@@ -4985,7 +4984,7 @@ export const copyDBClusterParameterGroup: API.OperationMethod<
   CopyDBClusterParameterGroupMessage,
   CopyDBClusterParameterGroupResult,
   CopyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterParameterGroupMessage,
   output: CopyDBClusterParameterGroupResult,
@@ -5018,7 +5017,7 @@ export const copyDBClusterSnapshot: API.OperationMethod<
   CopyDBClusterSnapshotMessage,
   CopyDBClusterSnapshotResult,
   CopyDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterSnapshotMessage,
   output: CopyDBClusterSnapshotResult,
@@ -5047,7 +5046,7 @@ export const copyDBParameterGroup: API.OperationMethod<
   CopyDBParameterGroupMessage,
   CopyDBParameterGroupResult,
   CopyDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBParameterGroupMessage,
   output: CopyDBParameterGroupResult,
@@ -5096,7 +5095,7 @@ export const createDBCluster: API.OperationMethod<
   CreateDBClusterMessage,
   CreateDBClusterResult,
   CreateDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterMessage,
   output: CreateDBClusterResult,
@@ -5140,7 +5139,7 @@ export const createDBClusterEndpoint: API.OperationMethod<
   CreateDBClusterEndpointMessage,
   CreateDBClusterEndpointOutput,
   CreateDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterEndpointMessage,
   output: CreateDBClusterEndpointOutput,
@@ -5193,7 +5192,7 @@ export const createDBClusterParameterGroup: API.OperationMethod<
   CreateDBClusterParameterGroupMessage,
   CreateDBClusterParameterGroupResult,
   CreateDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterParameterGroupMessage,
   output: CreateDBClusterParameterGroupResult,
@@ -5220,7 +5219,7 @@ export const createDBClusterSnapshot: API.OperationMethod<
   CreateDBClusterSnapshotMessage,
   CreateDBClusterSnapshotResult,
   CreateDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterSnapshotMessage,
   output: CreateDBClusterSnapshotResult,
@@ -5263,7 +5262,7 @@ export const createDBInstance: API.OperationMethod<
   CreateDBInstanceMessage,
   CreateDBInstanceResult,
   CreateDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBInstanceMessage,
   output: CreateDBInstanceResult,
@@ -5322,7 +5321,7 @@ export const createDBParameterGroup: API.OperationMethod<
   CreateDBParameterGroupMessage,
   CreateDBParameterGroupResult,
   CreateDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBParameterGroupMessage,
   output: CreateDBParameterGroupResult,
@@ -5350,7 +5349,7 @@ export const createDBSubnetGroup: API.OperationMethod<
   CreateDBSubnetGroupMessage,
   CreateDBSubnetGroupResult,
   CreateDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBSubnetGroupMessage,
   output: CreateDBSubnetGroupResult,
@@ -5398,7 +5397,7 @@ export const createEventSubscription: API.OperationMethod<
   CreateEventSubscriptionMessage,
   CreateEventSubscriptionResult,
   CreateEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSubscriptionMessage,
   output: CreateEventSubscriptionResult,
@@ -5438,7 +5437,7 @@ export const createGlobalCluster: API.OperationMethod<
   CreateGlobalClusterMessage,
   CreateGlobalClusterResult,
   CreateGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalClusterMessage,
   output: CreateGlobalClusterResult,
@@ -5473,7 +5472,7 @@ export const deleteDBCluster: API.OperationMethod<
   DeleteDBClusterMessage,
   DeleteDBClusterResult,
   DeleteDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterMessage,
   output: DeleteDBClusterResult,
@@ -5501,7 +5500,7 @@ export const deleteDBClusterEndpoint: API.OperationMethod<
   DeleteDBClusterEndpointMessage,
   DeleteDBClusterEndpointOutput,
   DeleteDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterEndpointMessage,
   output: DeleteDBClusterEndpointOutput,
@@ -5527,7 +5526,7 @@ export const deleteDBClusterParameterGroup: API.OperationMethod<
   DeleteDBClusterParameterGroupMessage,
   DeleteDBClusterParameterGroupResponse,
   DeleteDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterParameterGroupMessage,
   output: DeleteDBClusterParameterGroupResponse,
@@ -5552,7 +5551,7 @@ export const deleteDBClusterSnapshot: API.OperationMethod<
   DeleteDBClusterSnapshotMessage,
   DeleteDBClusterSnapshotResult,
   DeleteDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterSnapshotMessage,
   output: DeleteDBClusterSnapshotResult,
@@ -5592,7 +5591,7 @@ export const deleteDBInstance: API.OperationMethod<
   DeleteDBInstanceMessage,
   DeleteDBInstanceResult,
   DeleteDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBInstanceMessage,
   output: DeleteDBInstanceResult,
@@ -5620,7 +5619,7 @@ export const deleteDBParameterGroup: API.OperationMethod<
   DeleteDBParameterGroupMessage,
   DeleteDBParameterGroupResponse,
   DeleteDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBParameterGroupMessage,
   output: DeleteDBParameterGroupResponse,
@@ -5644,7 +5643,7 @@ export const deleteDBSubnetGroup: API.OperationMethod<
   DeleteDBSubnetGroupMessage,
   DeleteDBSubnetGroupResponse,
   DeleteDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBSubnetGroupMessage,
   output: DeleteDBSubnetGroupResponse,
@@ -5669,7 +5668,7 @@ export const deleteEventSubscription: API.OperationMethod<
   DeleteEventSubscriptionMessage,
   DeleteEventSubscriptionResult,
   DeleteEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSubscriptionMessage,
   output: DeleteEventSubscriptionResult,
@@ -5691,7 +5690,7 @@ export const deleteGlobalCluster: API.OperationMethod<
   DeleteGlobalClusterMessage,
   DeleteGlobalClusterResult,
   DeleteGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalClusterMessage,
   output: DeleteGlobalClusterResult,
@@ -5714,7 +5713,7 @@ export const describeDBClusterEndpoints: API.PaginatedOperationMethod<
   DescribeDBClusterEndpointsMessage,
   DBClusterEndpointMessage,
   DescribeDBClusterEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterEndpointsMessage,
@@ -5743,7 +5742,7 @@ export const describeDBClusterParameterGroups: API.PaginatedOperationMethod<
   DescribeDBClusterParameterGroupsMessage,
   DBClusterParameterGroupsMessage,
   DescribeDBClusterParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParameterGroupsMessage,
@@ -5770,7 +5769,7 @@ export const describeDBClusterParameters: API.PaginatedOperationMethod<
   DescribeDBClusterParametersMessage,
   DBClusterParameterGroupDetails,
   DescribeDBClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParametersMessage,
@@ -5799,7 +5798,7 @@ export const describeDBClusters: API.PaginatedOperationMethod<
   DescribeDBClustersMessage,
   DBClusterMessage,
   DescribeDBClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClustersMessage,
@@ -5837,7 +5836,7 @@ export const describeDBClusterSnapshotAttributes: API.OperationMethod<
   DescribeDBClusterSnapshotAttributesMessage,
   DescribeDBClusterSnapshotAttributesResult,
   DescribeDBClusterSnapshotAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDBClusterSnapshotAttributesMessage,
   output: DescribeDBClusterSnapshotAttributesResult,
@@ -5858,7 +5857,7 @@ export const describeDBClusterSnapshots: API.PaginatedOperationMethod<
   DescribeDBClusterSnapshotsMessage,
   DBClusterSnapshotMessage,
   DescribeDBClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterSnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterSnapshotsMessage,
@@ -5883,7 +5882,7 @@ export const describeDBEngineVersions: API.PaginatedOperationMethod<
   DescribeDBEngineVersionsMessage,
   DBEngineVersionMessage,
   DescribeDBEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBEngineVersionsMessage,
@@ -5911,7 +5910,7 @@ export const describeDBInstances: API.PaginatedOperationMethod<
   DescribeDBInstancesMessage,
   DBInstanceMessage,
   DescribeDBInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBInstancesMessage,
@@ -5940,7 +5939,7 @@ export const describeDBParameterGroups: API.PaginatedOperationMethod<
   DescribeDBParameterGroupsMessage,
   DBParameterGroupsMessage,
   DescribeDBParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBParameterGroupsMessage,
@@ -5967,7 +5966,7 @@ export const describeDBParameters: API.PaginatedOperationMethod<
   DescribeDBParametersMessage,
   DBParameterGroupDetails,
   DescribeDBParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBParametersMessage,
@@ -5997,7 +5996,7 @@ export const describeDBSubnetGroups: API.PaginatedOperationMethod<
   DescribeDBSubnetGroupsMessage,
   DBSubnetGroupMessage,
   DescribeDBSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSubnetGroupsMessage,
@@ -6023,7 +6022,7 @@ export const describeEngineDefaultClusterParameters: API.OperationMethod<
   DescribeEngineDefaultClusterParametersMessage,
   DescribeEngineDefaultClusterParametersResult,
   DescribeEngineDefaultClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEngineDefaultClusterParametersMessage,
   output: DescribeEngineDefaultClusterParametersResult,
@@ -6042,7 +6041,7 @@ export const describeEngineDefaultParameters: API.PaginatedOperationMethod<
   DescribeEngineDefaultParametersMessage,
   DescribeEngineDefaultParametersResult,
   DescribeEngineDefaultParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineDefaultParametersMessage,
@@ -6068,7 +6067,7 @@ export const describeEventCategories: API.OperationMethod<
   DescribeEventCategoriesMessage,
   EventCategoriesMessage,
   DescribeEventCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventCategoriesMessage,
   output: EventCategoriesMessage,
@@ -6089,7 +6088,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -6120,7 +6119,7 @@ export const describeEventSubscriptions: API.PaginatedOperationMethod<
   DescribeEventSubscriptionsMessage,
   EventSubscriptionsMessage,
   DescribeEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventSubscriptionsMessage,
@@ -6148,7 +6147,7 @@ export const describeGlobalClusters: API.PaginatedOperationMethod<
   DescribeGlobalClustersMessage,
   GlobalClustersMessage,
   DescribeGlobalClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGlobalClustersMessage,
@@ -6173,7 +6172,7 @@ export const describeOrderableDBInstanceOptions: API.PaginatedOperationMethod<
   DescribeOrderableDBInstanceOptionsMessage,
   OrderableDBInstanceOptionsMessage,
   DescribeOrderableDBInstanceOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrderableDBInstanceOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrderableDBInstanceOptionsMessage,
@@ -6201,7 +6200,7 @@ export const describePendingMaintenanceActions: API.PaginatedOperationMethod<
   DescribePendingMaintenanceActionsMessage,
   PendingMaintenanceActionsMessage,
   DescribePendingMaintenanceActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePendingMaintenanceActions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePendingMaintenanceActionsMessage,
@@ -6231,7 +6230,7 @@ export const describeValidDBInstanceModifications: API.OperationMethod<
   DescribeValidDBInstanceModificationsMessage,
   DescribeValidDBInstanceModificationsResult,
   DescribeValidDBInstanceModificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeValidDBInstanceModificationsMessage,
   output: DescribeValidDBInstanceModificationsResult,
@@ -6262,7 +6261,7 @@ export const failoverDBCluster: API.OperationMethod<
   FailoverDBClusterMessage,
   FailoverDBClusterResult,
   FailoverDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverDBClusterMessage,
   output: FailoverDBClusterResult,
@@ -6302,7 +6301,7 @@ export const failoverGlobalCluster: API.OperationMethod<
   FailoverGlobalClusterMessage,
   FailoverGlobalClusterResult,
   FailoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverGlobalClusterMessage,
   output: FailoverGlobalClusterResult,
@@ -6329,7 +6328,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   TagListMessage,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: TagListMessage,
@@ -6366,7 +6365,7 @@ export const modifyDBCluster: API.OperationMethod<
   ModifyDBClusterMessage,
   ModifyDBClusterResult,
   ModifyDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterMessage,
   output: ModifyDBClusterResult,
@@ -6404,7 +6403,7 @@ export const modifyDBClusterEndpoint: API.OperationMethod<
   ModifyDBClusterEndpointMessage,
   ModifyDBClusterEndpointOutput,
   ModifyDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterEndpointMessage,
   output: ModifyDBClusterEndpointOutput,
@@ -6448,7 +6447,7 @@ export const modifyDBClusterParameterGroup: API.OperationMethod<
   ModifyDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ModifyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -6485,7 +6484,7 @@ export const modifyDBClusterSnapshotAttribute: API.OperationMethod<
   ModifyDBClusterSnapshotAttributeMessage,
   ModifyDBClusterSnapshotAttributeResult,
   ModifyDBClusterSnapshotAttributeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterSnapshotAttributeMessage,
   output: ModifyDBClusterSnapshotAttributeResult,
@@ -6526,7 +6525,7 @@ export const modifyDBInstance: API.OperationMethod<
   ModifyDBInstanceMessage,
   ModifyDBInstanceResult,
   ModifyDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBInstanceMessage,
   output: ModifyDBInstanceResult,
@@ -6581,7 +6580,7 @@ export const modifyDBParameterGroup: API.OperationMethod<
   ModifyDBParameterGroupMessage,
   DBParameterGroupNameMessage,
   ModifyDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBParameterGroupMessage,
   output: DBParameterGroupNameMessage,
@@ -6606,7 +6605,7 @@ export const modifyDBSubnetGroup: API.OperationMethod<
   ModifyDBSubnetGroupMessage,
   ModifyDBSubnetGroupResult,
   ModifyDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBSubnetGroupMessage,
   output: ModifyDBSubnetGroupResult,
@@ -6642,7 +6641,7 @@ export const modifyEventSubscription: API.OperationMethod<
   ModifyEventSubscriptionMessage,
   ModifyEventSubscriptionResult,
   ModifyEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEventSubscriptionMessage,
   output: ModifyEventSubscriptionResult,
@@ -6675,7 +6674,7 @@ export const modifyGlobalCluster: API.OperationMethod<
   ModifyGlobalClusterMessage,
   ModifyGlobalClusterResult,
   ModifyGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyGlobalClusterMessage,
   output: ModifyGlobalClusterResult,
@@ -6702,7 +6701,7 @@ export const promoteReadReplicaDBCluster: API.OperationMethod<
   PromoteReadReplicaDBClusterMessage,
   PromoteReadReplicaDBClusterResult,
   PromoteReadReplicaDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromoteReadReplicaDBClusterMessage,
   output: PromoteReadReplicaDBClusterResult,
@@ -6728,7 +6727,7 @@ export const rebootDBInstance: API.OperationMethod<
   RebootDBInstanceMessage,
   RebootDBInstanceResult,
   RebootDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDBInstanceMessage,
   output: RebootDBInstanceResult,
@@ -6753,7 +6752,7 @@ export const removeFromGlobalCluster: API.OperationMethod<
   RemoveFromGlobalClusterMessage,
   RemoveFromGlobalClusterResult,
   RemoveFromGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFromGlobalClusterMessage,
   output: RemoveFromGlobalClusterResult,
@@ -6779,7 +6778,7 @@ export const removeRoleFromDBCluster: API.OperationMethod<
   RemoveRoleFromDBClusterMessage,
   RemoveRoleFromDBClusterResponse,
   RemoveRoleFromDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRoleFromDBClusterMessage,
   output: RemoveRoleFromDBClusterResponse,
@@ -6804,7 +6803,7 @@ export const removeSourceIdentifierFromSubscription: API.OperationMethod<
   RemoveSourceIdentifierFromSubscriptionMessage,
   RemoveSourceIdentifierFromSubscriptionResult,
   RemoveSourceIdentifierFromSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveSourceIdentifierFromSubscriptionMessage,
   output: RemoveSourceIdentifierFromSubscriptionResult,
@@ -6826,7 +6825,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceMessage,
   RemoveTagsFromResourceResponse,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceMessage,
   output: RemoveTagsFromResourceResponse,
@@ -6859,7 +6858,7 @@ export const resetDBClusterParameterGroup: API.OperationMethod<
   ResetDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ResetDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -6886,7 +6885,7 @@ export const resetDBParameterGroup: API.OperationMethod<
   ResetDBParameterGroupMessage,
   DBParameterGroupNameMessage,
   ResetDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDBParameterGroupMessage,
   output: DBParameterGroupNameMessage,
@@ -6929,7 +6928,7 @@ export const restoreDBClusterFromSnapshot: API.OperationMethod<
   RestoreDBClusterFromSnapshotMessage,
   RestoreDBClusterFromSnapshotResult,
   RestoreDBClusterFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterFromSnapshotMessage,
   output: RestoreDBClusterFromSnapshotResult,
@@ -6995,7 +6994,7 @@ export const restoreDBClusterToPointInTime: API.OperationMethod<
   RestoreDBClusterToPointInTimeMessage,
   RestoreDBClusterToPointInTimeResult,
   RestoreDBClusterToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterToPointInTimeMessage,
   output: RestoreDBClusterToPointInTimeResult,
@@ -7037,7 +7036,7 @@ export const startDBCluster: API.OperationMethod<
   StartDBClusterMessage,
   StartDBClusterResult,
   StartDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDBClusterMessage,
   output: StartDBClusterResult,
@@ -7068,7 +7067,7 @@ export const stopDBCluster: API.OperationMethod<
   StopDBClusterMessage,
   StopDBClusterResult,
   StopDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDBClusterMessage,
   output: StopDBClusterResult,
@@ -7105,7 +7104,7 @@ export const switchoverGlobalCluster: API.OperationMethod<
   SwitchoverGlobalClusterMessage,
   SwitchoverGlobalClusterResult,
   SwitchoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverGlobalClusterMessage,
   output: SwitchoverGlobalClusterResult,

--- a/packages/aws/src/services/neptunedata.ts
+++ b/packages/aws/src/services/neptunedata.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "neptunedata",
   serviceShapeName: "AmazonNeptuneDataplane",
@@ -2522,7 +2521,7 @@ export const cancelGremlinQuery: API.OperationMethod<
   CancelGremlinQueryInput,
   CancelGremlinQueryOutput,
   CancelGremlinQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelGremlinQueryInput,
   output: CancelGremlinQueryOutput,
@@ -2571,7 +2570,7 @@ export const cancelLoaderJob: API.OperationMethod<
   CancelLoaderJobInput,
   CancelLoaderJobOutput,
   CancelLoaderJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelLoaderJobInput,
   output: CancelLoaderJobOutput,
@@ -2617,7 +2616,7 @@ export const cancelMLDataProcessingJob: API.OperationMethod<
   CancelMLDataProcessingJobInput,
   CancelMLDataProcessingJobOutput,
   CancelMLDataProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMLDataProcessingJobInput,
   output: CancelMLDataProcessingJobOutput,
@@ -2661,7 +2660,7 @@ export const cancelMLModelTrainingJob: API.OperationMethod<
   CancelMLModelTrainingJobInput,
   CancelMLModelTrainingJobOutput,
   CancelMLModelTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMLModelTrainingJobInput,
   output: CancelMLModelTrainingJobOutput,
@@ -2705,7 +2704,7 @@ export const cancelMLModelTransformJob: API.OperationMethod<
   CancelMLModelTransformJobInput,
   CancelMLModelTransformJobOutput,
   CancelMLModelTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMLModelTransformJobInput,
   output: CancelMLModelTransformJobOutput,
@@ -2753,7 +2752,7 @@ export const cancelOpenCypherQuery: API.OperationMethod<
   CancelOpenCypherQueryInput,
   CancelOpenCypherQueryOutput,
   CancelOpenCypherQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelOpenCypherQueryInput,
   output: CancelOpenCypherQueryOutput,
@@ -2801,7 +2800,7 @@ export const createMLEndpoint: API.OperationMethod<
   CreateMLEndpointInput,
   CreateMLEndpointOutput,
   CreateMLEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMLEndpointInput,
   output: CreateMLEndpointOutput,
@@ -2845,7 +2844,7 @@ export const deleteMLEndpoint: API.OperationMethod<
   DeleteMLEndpointInput,
   DeleteMLEndpointOutput,
   DeleteMLEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMLEndpointInput,
   output: DeleteMLEndpointOutput,
@@ -2891,7 +2890,7 @@ export const deletePropertygraphStatistics: API.OperationMethod<
   DeletePropertygraphStatisticsRequest,
   DeletePropertygraphStatisticsOutput,
   DeletePropertygraphStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePropertygraphStatisticsRequest,
   output: DeletePropertygraphStatisticsOutput,
@@ -2939,7 +2938,7 @@ export const deleteSparqlStatistics: API.OperationMethod<
   DeleteSparqlStatisticsRequest,
   DeleteSparqlStatisticsOutput,
   DeleteSparqlStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSparqlStatisticsRequest,
   output: DeleteSparqlStatisticsOutput,
@@ -2989,7 +2988,7 @@ export const executeFastReset: API.OperationMethod<
   ExecuteFastResetInput,
   ExecuteFastResetOutput,
   ExecuteFastResetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteFastResetInput,
   output: ExecuteFastResetOutput,
@@ -3056,7 +3055,7 @@ export const executeGremlinExplainQuery: API.OperationMethod<
   ExecuteGremlinExplainQueryInput,
   ExecuteGremlinExplainQueryOutput,
   ExecuteGremlinExplainQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteGremlinExplainQueryInput,
   output: ExecuteGremlinExplainQueryOutput,
@@ -3120,7 +3119,7 @@ export const executeGremlinProfileQuery: API.OperationMethod<
   ExecuteGremlinProfileQueryInput,
   ExecuteGremlinProfileQueryOutput,
   ExecuteGremlinProfileQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteGremlinProfileQueryInput,
   output: ExecuteGremlinProfileQueryOutput,
@@ -3190,7 +3189,7 @@ export const executeGremlinQuery: API.OperationMethod<
   ExecuteGremlinQueryInput,
   ExecuteGremlinQueryOutput,
   ExecuteGremlinQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteGremlinQueryInput,
   output: ExecuteGremlinQueryOutput,
@@ -3255,7 +3254,7 @@ export const executeOpenCypherExplainQuery: API.OperationMethod<
   ExecuteOpenCypherExplainQueryInput,
   ExecuteOpenCypherExplainQueryOutput,
   ExecuteOpenCypherExplainQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteOpenCypherExplainQueryInput,
   output: ExecuteOpenCypherExplainQueryOutput,
@@ -3331,7 +3330,7 @@ export const executeOpenCypherQuery: API.OperationMethod<
   ExecuteOpenCypherQueryInput,
   ExecuteOpenCypherQueryOutput,
   ExecuteOpenCypherQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteOpenCypherQueryInput,
   output: ExecuteOpenCypherQueryOutput,
@@ -3382,7 +3381,7 @@ export const getEngineStatus: API.OperationMethod<
   GetEngineStatusRequest,
   GetEngineStatusOutput,
   GetEngineStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEngineStatusRequest,
   output: GetEngineStatusOutput,
@@ -3430,7 +3429,7 @@ export const getGremlinQueryStatus: API.OperationMethod<
   GetGremlinQueryStatusInput,
   GetGremlinQueryStatusOutput,
   GetGremlinQueryStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGremlinQueryStatusInput,
   output: GetGremlinQueryStatusOutput,
@@ -3483,7 +3482,7 @@ export const getLoaderJobStatus: API.OperationMethod<
   GetLoaderJobStatusInput,
   GetLoaderJobStatusOutput,
   GetLoaderJobStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoaderJobStatusInput,
   output: GetLoaderJobStatusOutput,
@@ -3529,7 +3528,7 @@ export const getMLDataProcessingJob: API.OperationMethod<
   GetMLDataProcessingJobInput,
   GetMLDataProcessingJobOutput,
   GetMLDataProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLDataProcessingJobInput,
   output: GetMLDataProcessingJobOutput,
@@ -3573,7 +3572,7 @@ export const getMLEndpoint: API.OperationMethod<
   GetMLEndpointInput,
   GetMLEndpointOutput,
   GetMLEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLEndpointInput,
   output: GetMLEndpointOutput,
@@ -3617,7 +3616,7 @@ export const getMLModelTrainingJob: API.OperationMethod<
   GetMLModelTrainingJobInput,
   GetMLModelTrainingJobOutput,
   GetMLModelTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLModelTrainingJobInput,
   output: GetMLModelTrainingJobOutput,
@@ -3661,7 +3660,7 @@ export const getMLModelTransformJob: API.OperationMethod<
   GetMLModelTransformJobInput,
   GetMLModelTransformJobOutput,
   GetMLModelTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMLModelTransformJobInput,
   output: GetMLModelTransformJobOutput,
@@ -3713,7 +3712,7 @@ export const getOpenCypherQueryStatus: API.OperationMethod<
   GetOpenCypherQueryStatusInput,
   GetOpenCypherQueryStatusOutput,
   GetOpenCypherQueryStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpenCypherQueryStatusInput,
   output: GetOpenCypherQueryStatusOutput,
@@ -3765,7 +3764,7 @@ export const getPropertygraphStatistics: API.OperationMethod<
   GetPropertygraphStatisticsRequest,
   GetPropertygraphStatisticsOutput,
   GetPropertygraphStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPropertygraphStatisticsRequest,
   output: GetPropertygraphStatisticsOutput,
@@ -3828,7 +3827,7 @@ export const getPropertygraphStream: API.OperationMethod<
   GetPropertygraphStreamInput,
   GetPropertygraphStreamOutput,
   GetPropertygraphStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPropertygraphStreamInput,
   output: GetPropertygraphStreamOutput,
@@ -3875,7 +3874,7 @@ export const getPropertygraphSummary: API.OperationMethod<
   GetPropertygraphSummaryInput,
   GetPropertygraphSummaryOutput,
   GetPropertygraphSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPropertygraphSummaryInput,
   output: GetPropertygraphSummaryOutput,
@@ -3923,7 +3922,7 @@ export const getRDFGraphSummary: API.OperationMethod<
   GetRDFGraphSummaryInput,
   GetRDFGraphSummaryOutput,
   GetRDFGraphSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRDFGraphSummaryInput,
   output: GetRDFGraphSummaryOutput,
@@ -3969,7 +3968,7 @@ export const getSparqlStatistics: API.OperationMethod<
   GetSparqlStatisticsRequest,
   GetSparqlStatisticsOutput,
   GetSparqlStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSparqlStatisticsRequest,
   output: GetSparqlStatisticsOutput,
@@ -4024,7 +4023,7 @@ export const getSparqlStream: API.OperationMethod<
   GetSparqlStreamInput,
   GetSparqlStreamOutput,
   GetSparqlStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSparqlStreamInput,
   output: GetSparqlStreamOutput,
@@ -4076,7 +4075,7 @@ export const listGremlinQueries: API.OperationMethod<
   ListGremlinQueriesInput,
   ListGremlinQueriesOutput,
   ListGremlinQueriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGremlinQueriesInput,
   output: ListGremlinQueriesOutput,
@@ -4126,7 +4125,7 @@ export const listLoaderJobs: API.OperationMethod<
   ListLoaderJobsInput,
   ListLoaderJobsOutput,
   ListLoaderJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoaderJobsInput,
   output: ListLoaderJobsOutput,
@@ -4171,7 +4170,7 @@ export const listMLDataProcessingJobs: API.OperationMethod<
   ListMLDataProcessingJobsInput,
   ListMLDataProcessingJobsOutput,
   ListMLDataProcessingJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMLDataProcessingJobsInput,
   output: ListMLDataProcessingJobsOutput,
@@ -4215,7 +4214,7 @@ export const listMLEndpoints: API.OperationMethod<
   ListMLEndpointsInput,
   ListMLEndpointsOutput,
   ListMLEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMLEndpointsInput,
   output: ListMLEndpointsOutput,
@@ -4259,7 +4258,7 @@ export const listMLModelTrainingJobs: API.OperationMethod<
   ListMLModelTrainingJobsInput,
   ListMLModelTrainingJobsOutput,
   ListMLModelTrainingJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMLModelTrainingJobsInput,
   output: ListMLModelTrainingJobsOutput,
@@ -4303,7 +4302,7 @@ export const listMLModelTransformJobs: API.OperationMethod<
   ListMLModelTransformJobsInput,
   ListMLModelTransformJobsOutput,
   ListMLModelTransformJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMLModelTransformJobsInput,
   output: ListMLModelTransformJobsOutput,
@@ -4355,7 +4354,7 @@ export const listOpenCypherQueries: API.OperationMethod<
   ListOpenCypherQueriesInput,
   ListOpenCypherQueriesOutput,
   ListOpenCypherQueriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOpenCypherQueriesInput,
   output: ListOpenCypherQueriesOutput,
@@ -4407,7 +4406,7 @@ export const managePropertygraphStatistics: API.OperationMethod<
   ManagePropertygraphStatisticsInput,
   ManagePropertygraphStatisticsOutput,
   ManagePropertygraphStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ManagePropertygraphStatisticsInput,
   output: ManagePropertygraphStatisticsOutput,
@@ -4455,7 +4454,7 @@ export const manageSparqlStatistics: API.OperationMethod<
   ManageSparqlStatisticsInput,
   ManageSparqlStatisticsOutput,
   ManageSparqlStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ManageSparqlStatisticsInput,
   output: ManageSparqlStatisticsOutput,
@@ -4504,7 +4503,7 @@ export const startLoaderJob: API.OperationMethod<
   StartLoaderJobInput,
   StartLoaderJobOutput,
   StartLoaderJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLoaderJobInput,
   output: StartLoaderJobOutput,
@@ -4551,7 +4550,7 @@ export const startMLDataProcessingJob: API.OperationMethod<
   StartMLDataProcessingJobInput,
   StartMLDataProcessingJobOutput,
   StartMLDataProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMLDataProcessingJobInput,
   output: StartMLDataProcessingJobOutput,
@@ -4595,7 +4594,7 @@ export const startMLModelTrainingJob: API.OperationMethod<
   StartMLModelTrainingJobInput,
   StartMLModelTrainingJobOutput,
   StartMLModelTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMLModelTrainingJobInput,
   output: StartMLModelTrainingJobOutput,
@@ -4639,7 +4638,7 @@ export const startMLModelTransformJob: API.OperationMethod<
   StartMLModelTransformJobInput,
   StartMLModelTransformJobOutput,
   StartMLModelTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMLModelTransformJobInput,
   output: StartMLModelTransformJobOutput,

--- a/packages/aws/src/services/network-firewall.ts
+++ b/packages/aws/src/services/network-firewall.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Network Firewall",
   serviceShapeName: "NetworkFirewall_20201112",
@@ -4407,7 +4406,7 @@ export const acceptNetworkFirewallTransitGatewayAttachment: API.OperationMethod<
   AcceptNetworkFirewallTransitGatewayAttachmentRequest,
   AcceptNetworkFirewallTransitGatewayAttachmentResponse,
   AcceptNetworkFirewallTransitGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptNetworkFirewallTransitGatewayAttachmentRequest,
   output: AcceptNetworkFirewallTransitGatewayAttachmentResponse,
@@ -4440,7 +4439,7 @@ export const associateAvailabilityZones: API.OperationMethod<
   AssociateAvailabilityZonesRequest,
   AssociateAvailabilityZonesResponse,
   AssociateAvailabilityZonesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAvailabilityZonesRequest,
   output: AssociateAvailabilityZonesResponse,
@@ -4478,7 +4477,7 @@ export const associateFirewallPolicy: API.OperationMethod<
   AssociateFirewallPolicyRequest,
   AssociateFirewallPolicyResponse,
   AssociateFirewallPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFirewallPolicyRequest,
   output: AssociateFirewallPolicyResponse,
@@ -4517,7 +4516,7 @@ export const associateSubnets: API.OperationMethod<
   AssociateSubnetsRequest,
   AssociateSubnetsResponse,
   AssociateSubnetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSubnetsRequest,
   output: AssociateSubnetsResponse,
@@ -4550,7 +4549,7 @@ export const attachRuleGroupsToProxyConfiguration: API.OperationMethod<
   AttachRuleGroupsToProxyConfigurationRequest,
   AttachRuleGroupsToProxyConfigurationResponse,
   AttachRuleGroupsToProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachRuleGroupsToProxyConfigurationRequest,
   output: AttachRuleGroupsToProxyConfigurationResponse,
@@ -4593,7 +4592,7 @@ export const createFirewall: API.OperationMethod<
   CreateFirewallRequest,
   CreateFirewallResponse,
   CreateFirewallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallRequest,
   output: CreateFirewallResponse,
@@ -4628,7 +4627,7 @@ export const createFirewallPolicy: API.OperationMethod<
   CreateFirewallPolicyRequest,
   CreateFirewallPolicyResponse,
   CreateFirewallPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallPolicyRequest,
   output: CreateFirewallPolicyResponse,
@@ -4665,7 +4664,7 @@ export const createProxy: API.OperationMethod<
   CreateProxyRequest,
   CreateProxyResponse,
   CreateProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProxyRequest,
   output: CreateProxyResponse,
@@ -4702,7 +4701,7 @@ export const createProxyConfiguration: API.OperationMethod<
   CreateProxyConfigurationRequest,
   CreateProxyConfigurationResponse,
   CreateProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProxyConfigurationRequest,
   output: CreateProxyConfigurationResponse,
@@ -4739,7 +4738,7 @@ export const createProxyRuleGroup: API.OperationMethod<
   CreateProxyRuleGroupRequest,
   CreateProxyRuleGroupResponse,
   CreateProxyRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProxyRuleGroupRequest,
   output: CreateProxyRuleGroupResponse,
@@ -4770,7 +4769,7 @@ export const createProxyRules: API.OperationMethod<
   CreateProxyRulesRequest,
   CreateProxyRulesResponse,
   CreateProxyRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProxyRulesRequest,
   output: CreateProxyRulesResponse,
@@ -4798,7 +4797,7 @@ export const createRuleGroup: API.OperationMethod<
   CreateRuleGroupRequest,
   CreateRuleGroupResponse,
   CreateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleGroupRequest,
   output: CreateRuleGroupResponse,
@@ -4837,7 +4836,7 @@ export const createTLSInspectionConfiguration: API.OperationMethod<
   CreateTLSInspectionConfigurationRequest,
   CreateTLSInspectionConfigurationResponse,
   CreateTLSInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTLSInspectionConfigurationRequest,
   output: CreateTLSInspectionConfigurationResponse,
@@ -4869,7 +4868,7 @@ export const createVpcEndpointAssociation: API.OperationMethod<
   CreateVpcEndpointAssociationRequest,
   CreateVpcEndpointAssociationResponse,
   CreateVpcEndpointAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointAssociationRequest,
   output: CreateVpcEndpointAssociationResponse,
@@ -4914,7 +4913,7 @@ export const deleteFirewall: API.OperationMethod<
   DeleteFirewallRequest,
   DeleteFirewallResponse,
   DeleteFirewallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallRequest,
   output: DeleteFirewallResponse,
@@ -4946,7 +4945,7 @@ export const deleteFirewallPolicy: API.OperationMethod<
   DeleteFirewallPolicyRequest,
   DeleteFirewallPolicyResponse,
   DeleteFirewallPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallPolicyRequest,
   output: DeleteFirewallPolicyResponse,
@@ -4980,7 +4979,7 @@ export const deleteNetworkFirewallTransitGatewayAttachment: API.OperationMethod<
   DeleteNetworkFirewallTransitGatewayAttachmentRequest,
   DeleteNetworkFirewallTransitGatewayAttachmentResponse,
   DeleteNetworkFirewallTransitGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkFirewallTransitGatewayAttachmentRequest,
   output: DeleteNetworkFirewallTransitGatewayAttachmentResponse,
@@ -5011,7 +5010,7 @@ export const deleteProxy: API.OperationMethod<
   DeleteProxyRequest,
   DeleteProxyResponse,
   DeleteProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProxyRequest,
   output: DeleteProxyResponse,
@@ -5040,7 +5039,7 @@ export const deleteProxyConfiguration: API.OperationMethod<
   DeleteProxyConfigurationRequest,
   DeleteProxyConfigurationResponse,
   DeleteProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProxyConfigurationRequest,
   output: DeleteProxyConfigurationResponse,
@@ -5068,7 +5067,7 @@ export const deleteProxyRuleGroup: API.OperationMethod<
   DeleteProxyRuleGroupRequest,
   DeleteProxyRuleGroupResponse,
   DeleteProxyRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProxyRuleGroupRequest,
   output: DeleteProxyRuleGroupResponse,
@@ -5096,7 +5095,7 @@ export const deleteProxyRules: API.OperationMethod<
   DeleteProxyRulesRequest,
   DeleteProxyRulesResponse,
   DeleteProxyRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProxyRulesRequest,
   output: DeleteProxyRulesResponse,
@@ -5125,7 +5124,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -5156,7 +5155,7 @@ export const deleteRuleGroup: API.OperationMethod<
   DeleteRuleGroupRequest,
   DeleteRuleGroupResponse,
   DeleteRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleGroupRequest,
   output: DeleteRuleGroupResponse,
@@ -5187,7 +5186,7 @@ export const deleteTLSInspectionConfiguration: API.OperationMethod<
   DeleteTLSInspectionConfigurationRequest,
   DeleteTLSInspectionConfigurationResponse,
   DeleteTLSInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTLSInspectionConfigurationRequest,
   output: DeleteTLSInspectionConfigurationResponse,
@@ -5224,7 +5223,7 @@ export const deleteVpcEndpointAssociation: API.OperationMethod<
   DeleteVpcEndpointAssociationRequest,
   DeleteVpcEndpointAssociationResponse,
   DeleteVpcEndpointAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointAssociationRequest,
   output: DeleteVpcEndpointAssociationResponse,
@@ -5253,7 +5252,7 @@ export const describeFirewall: API.OperationMethod<
   DescribeFirewallRequest,
   DescribeFirewallResponse,
   DescribeFirewallError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFirewallRequest,
   output: DescribeFirewallResponse,
@@ -5282,7 +5281,7 @@ export const describeFirewallMetadata: API.OperationMethod<
   DescribeFirewallMetadataRequest,
   DescribeFirewallMetadataResponse,
   DescribeFirewallMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFirewallMetadataRequest,
   output: DescribeFirewallMetadataResponse,
@@ -5310,7 +5309,7 @@ export const describeFirewallPolicy: API.OperationMethod<
   DescribeFirewallPolicyRequest,
   DescribeFirewallPolicyResponse,
   DescribeFirewallPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFirewallPolicyRequest,
   output: DescribeFirewallPolicyResponse,
@@ -5338,7 +5337,7 @@ export const describeFlowOperation: API.OperationMethod<
   DescribeFlowOperationRequest,
   DescribeFlowOperationResponse,
   DescribeFlowOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowOperationRequest,
   output: DescribeFlowOperationResponse,
@@ -5366,7 +5365,7 @@ export const describeLoggingConfiguration: API.OperationMethod<
   DescribeLoggingConfigurationRequest,
   DescribeLoggingConfigurationResponse,
   DescribeLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoggingConfigurationRequest,
   output: DescribeLoggingConfigurationResponse,
@@ -5394,7 +5393,7 @@ export const describeProxy: API.OperationMethod<
   DescribeProxyRequest,
   DescribeProxyResponse,
   DescribeProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProxyRequest,
   output: DescribeProxyResponse,
@@ -5422,7 +5421,7 @@ export const describeProxyConfiguration: API.OperationMethod<
   DescribeProxyConfigurationRequest,
   DescribeProxyConfigurationResponse,
   DescribeProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProxyConfigurationRequest,
   output: DescribeProxyConfigurationResponse,
@@ -5450,7 +5449,7 @@ export const describeProxyRule: API.OperationMethod<
   DescribeProxyRuleRequest,
   DescribeProxyRuleResponse,
   DescribeProxyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProxyRuleRequest,
   output: DescribeProxyRuleResponse,
@@ -5478,7 +5477,7 @@ export const describeProxyRuleGroup: API.OperationMethod<
   DescribeProxyRuleGroupRequest,
   DescribeProxyRuleGroupResponse,
   DescribeProxyRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProxyRuleGroupRequest,
   output: DescribeProxyRuleGroupResponse,
@@ -5506,7 +5505,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -5534,7 +5533,7 @@ export const describeRuleGroup: API.OperationMethod<
   DescribeRuleGroupRequest,
   DescribeRuleGroupResponse,
   DescribeRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleGroupRequest,
   output: DescribeRuleGroupResponse,
@@ -5564,7 +5563,7 @@ export const describeRuleGroupMetadata: API.OperationMethod<
   DescribeRuleGroupMetadataRequest,
   DescribeRuleGroupMetadataResponse,
   DescribeRuleGroupMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleGroupMetadataRequest,
   output: DescribeRuleGroupMetadataResponse,
@@ -5596,7 +5595,7 @@ export const describeRuleGroupSummary: API.OperationMethod<
   DescribeRuleGroupSummaryRequest,
   DescribeRuleGroupSummaryResponse,
   DescribeRuleGroupSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRuleGroupSummaryRequest,
   output: DescribeRuleGroupSummaryResponse,
@@ -5624,7 +5623,7 @@ export const describeTLSInspectionConfiguration: API.OperationMethod<
   DescribeTLSInspectionConfigurationRequest,
   DescribeTLSInspectionConfigurationResponse,
   DescribeTLSInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTLSInspectionConfigurationRequest,
   output: DescribeTLSInspectionConfigurationResponse,
@@ -5652,7 +5651,7 @@ export const describeVpcEndpointAssociation: API.OperationMethod<
   DescribeVpcEndpointAssociationRequest,
   DescribeVpcEndpointAssociationResponse,
   DescribeVpcEndpointAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEndpointAssociationRequest,
   output: DescribeVpcEndpointAssociationResponse,
@@ -5682,7 +5681,7 @@ export const detachRuleGroupsFromProxyConfiguration: API.OperationMethod<
   DetachRuleGroupsFromProxyConfigurationRequest,
   DetachRuleGroupsFromProxyConfigurationResponse,
   DetachRuleGroupsFromProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachRuleGroupsFromProxyConfigurationRequest,
   output: DetachRuleGroupsFromProxyConfigurationResponse,
@@ -5716,7 +5715,7 @@ export const disassociateAvailabilityZones: API.OperationMethod<
   DisassociateAvailabilityZonesRequest,
   DisassociateAvailabilityZonesResponse,
   DisassociateAvailabilityZonesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAvailabilityZonesRequest,
   output: DisassociateAvailabilityZonesResponse,
@@ -5750,7 +5749,7 @@ export const disassociateSubnets: API.OperationMethod<
   DisassociateSubnetsRequest,
   DisassociateSubnetsResponse,
   DisassociateSubnetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSubnetsRequest,
   output: DisassociateSubnetsResponse,
@@ -5782,7 +5781,7 @@ export const getAnalysisReportResults: API.PaginatedOperationMethod<
   GetAnalysisReportResultsRequest,
   GetAnalysisReportResultsResponse,
   GetAnalysisReportResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisTypeReportResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAnalysisReportResultsRequest,
@@ -5817,7 +5816,7 @@ export const listAnalysisReports: API.PaginatedOperationMethod<
   ListAnalysisReportsRequest,
   ListAnalysisReportsResponse,
   ListAnalysisReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisReport
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalysisReportsRequest,
@@ -5853,7 +5852,7 @@ export const listFirewallPolicies: API.PaginatedOperationMethod<
   ListFirewallPoliciesRequest,
   ListFirewallPoliciesResponse,
   ListFirewallPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallPolicyMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallPoliciesRequest,
@@ -5886,7 +5885,7 @@ export const listFirewalls: API.PaginatedOperationMethod<
   ListFirewallsRequest,
   ListFirewallsResponse,
   ListFirewallsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallsRequest,
@@ -5921,7 +5920,7 @@ export const listFlowOperationResults: API.PaginatedOperationMethod<
   ListFlowOperationResultsRequest,
   ListFlowOperationResultsResponse,
   ListFlowOperationResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Flow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowOperationResultsRequest,
@@ -5962,7 +5961,7 @@ export const listFlowOperations: API.PaginatedOperationMethod<
   ListFlowOperationsRequest,
   ListFlowOperationsResponse,
   ListFlowOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowOperationMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowOperationsRequest,
@@ -5998,7 +5997,7 @@ export const listProxies: API.PaginatedOperationMethod<
   ListProxiesRequest,
   ListProxiesResponse,
   ListProxiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProxyMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProxiesRequest,
@@ -6030,7 +6029,7 @@ export const listProxyConfigurations: API.PaginatedOperationMethod<
   ListProxyConfigurationsRequest,
   ListProxyConfigurationsResponse,
   ListProxyConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProxyConfigurationMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProxyConfigurationsRequest,
@@ -6067,7 +6066,7 @@ export const listProxyRuleGroups: API.PaginatedOperationMethod<
   ListProxyRuleGroupsRequest,
   ListProxyRuleGroupsResponse,
   ListProxyRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProxyRuleGroupMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProxyRuleGroupsRequest,
@@ -6103,7 +6102,7 @@ export const listRuleGroups: API.PaginatedOperationMethod<
   ListRuleGroupsRequest,
   ListRuleGroupsResponse,
   ListRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleGroupMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRuleGroupsRequest,
@@ -6140,7 +6139,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -6174,7 +6173,7 @@ export const listTLSInspectionConfigurations: API.PaginatedOperationMethod<
   ListTLSInspectionConfigurationsRequest,
   ListTLSInspectionConfigurationsResponse,
   ListTLSInspectionConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TLSInspectionConfigurationMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTLSInspectionConfigurationsRequest,
@@ -6207,7 +6206,7 @@ export const listVpcEndpointAssociations: API.PaginatedOperationMethod<
   ListVpcEndpointAssociationsRequest,
   ListVpcEndpointAssociationsResponse,
   ListVpcEndpointAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VpcEndpointAssociationMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVpcEndpointAssociationsRequest,
@@ -6251,7 +6250,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -6286,7 +6285,7 @@ export const rejectNetworkFirewallTransitGatewayAttachment: API.OperationMethod<
   RejectNetworkFirewallTransitGatewayAttachmentRequest,
   RejectNetworkFirewallTransitGatewayAttachmentResponse,
   RejectNetworkFirewallTransitGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectNetworkFirewallTransitGatewayAttachmentRequest,
   output: RejectNetworkFirewallTransitGatewayAttachmentResponse,
@@ -6316,7 +6315,7 @@ export const startAnalysisReport: API.OperationMethod<
   StartAnalysisReportRequest,
   StartAnalysisReportResponse,
   StartAnalysisReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAnalysisReportRequest,
   output: StartAnalysisReportResponse,
@@ -6352,7 +6351,7 @@ export const startFlowCapture: API.OperationMethod<
   StartFlowCaptureRequest,
   StartFlowCaptureResponse,
   StartFlowCaptureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlowCaptureRequest,
   output: StartFlowCaptureResponse,
@@ -6386,7 +6385,7 @@ export const startFlowFlush: API.OperationMethod<
   StartFlowFlushRequest,
   StartFlowFlushResponse,
   StartFlowFlushError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFlowFlushRequest,
   output: StartFlowFlushResponse,
@@ -6420,7 +6419,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6455,7 +6454,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6487,7 +6486,7 @@ export const updateAvailabilityZoneChangeProtection: API.OperationMethod<
   UpdateAvailabilityZoneChangeProtectionRequest,
   UpdateAvailabilityZoneChangeProtectionResponse,
   UpdateAvailabilityZoneChangeProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAvailabilityZoneChangeProtectionRequest,
   output: UpdateAvailabilityZoneChangeProtectionResponse,
@@ -6518,7 +6517,7 @@ export const updateFirewallAnalysisSettings: API.OperationMethod<
   UpdateFirewallAnalysisSettingsRequest,
   UpdateFirewallAnalysisSettingsResponse,
   UpdateFirewallAnalysisSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallAnalysisSettingsRequest,
   output: UpdateFirewallAnalysisSettingsResponse,
@@ -6552,7 +6551,7 @@ export const updateFirewallDeleteProtection: API.OperationMethod<
   UpdateFirewallDeleteProtectionRequest,
   UpdateFirewallDeleteProtectionResponse,
   UpdateFirewallDeleteProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallDeleteProtectionRequest,
   output: UpdateFirewallDeleteProtectionResponse,
@@ -6584,7 +6583,7 @@ export const updateFirewallDescription: API.OperationMethod<
   UpdateFirewallDescriptionRequest,
   UpdateFirewallDescriptionResponse,
   UpdateFirewallDescriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallDescriptionRequest,
   output: UpdateFirewallDescriptionResponse,
@@ -6615,7 +6614,7 @@ export const updateFirewallEncryptionConfiguration: API.OperationMethod<
   UpdateFirewallEncryptionConfigurationRequest,
   UpdateFirewallEncryptionConfigurationResponse,
   UpdateFirewallEncryptionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallEncryptionConfigurationRequest,
   output: UpdateFirewallEncryptionConfigurationResponse,
@@ -6646,7 +6645,7 @@ export const updateFirewallPolicy: API.OperationMethod<
   UpdateFirewallPolicyRequest,
   UpdateFirewallPolicyResponse,
   UpdateFirewallPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallPolicyRequest,
   output: UpdateFirewallPolicyResponse,
@@ -6679,7 +6678,7 @@ export const updateFirewallPolicyChangeProtection: API.OperationMethod<
   UpdateFirewallPolicyChangeProtectionRequest,
   UpdateFirewallPolicyChangeProtectionResponse,
   UpdateFirewallPolicyChangeProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallPolicyChangeProtectionRequest,
   output: UpdateFirewallPolicyChangeProtectionResponse,
@@ -6734,7 +6733,7 @@ export const updateLoggingConfiguration: API.OperationMethod<
   UpdateLoggingConfigurationRequest,
   UpdateLoggingConfigurationResponse,
   UpdateLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLoggingConfigurationRequest,
   output: UpdateLoggingConfigurationResponse,
@@ -6765,7 +6764,7 @@ export const updateProxy: API.OperationMethod<
   UpdateProxyRequest,
   UpdateProxyResponse,
   UpdateProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxyRequest,
   output: UpdateProxyResponse,
@@ -6794,7 +6793,7 @@ export const updateProxyConfiguration: API.OperationMethod<
   UpdateProxyConfigurationRequest,
   UpdateProxyConfigurationResponse,
   UpdateProxyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxyConfigurationRequest,
   output: UpdateProxyConfigurationResponse,
@@ -6822,7 +6821,7 @@ export const updateProxyRule: API.OperationMethod<
   UpdateProxyRuleRequest,
   UpdateProxyRuleResponse,
   UpdateProxyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxyRuleRequest,
   output: UpdateProxyRuleResponse,
@@ -6850,7 +6849,7 @@ export const updateProxyRuleGroupPriorities: API.OperationMethod<
   UpdateProxyRuleGroupPrioritiesRequest,
   UpdateProxyRuleGroupPrioritiesResponse,
   UpdateProxyRuleGroupPrioritiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxyRuleGroupPrioritiesRequest,
   output: UpdateProxyRuleGroupPrioritiesResponse,
@@ -6878,7 +6877,7 @@ export const updateProxyRulePriorities: API.OperationMethod<
   UpdateProxyRulePrioritiesRequest,
   UpdateProxyRulePrioritiesResponse,
   UpdateProxyRulePrioritiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProxyRulePrioritiesRequest,
   output: UpdateProxyRulePrioritiesResponse,
@@ -6913,7 +6912,7 @@ export const updateRuleGroup: API.OperationMethod<
   UpdateRuleGroupRequest,
   UpdateRuleGroupResponse,
   UpdateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleGroupRequest,
   output: UpdateRuleGroupResponse,
@@ -6944,7 +6943,7 @@ export const updateSubnetChangeProtection: API.OperationMethod<
   UpdateSubnetChangeProtectionRequest,
   UpdateSubnetChangeProtectionResponse,
   UpdateSubnetChangeProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubnetChangeProtectionRequest,
   output: UpdateSubnetChangeProtectionResponse,
@@ -6981,7 +6980,7 @@ export const updateTLSInspectionConfiguration: API.OperationMethod<
   UpdateTLSInspectionConfigurationRequest,
   UpdateTLSInspectionConfigurationResponse,
   UpdateTLSInspectionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTLSInspectionConfigurationRequest,
   output: UpdateTLSInspectionConfigurationResponse,

--- a/packages/aws/src/services/networkflowmonitor.ts
+++ b/packages/aws/src/services/networkflowmonitor.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "NetworkFlowMonitor",
   serviceShapeName: "NetworkFlowMonitor",
@@ -1350,7 +1349,7 @@ export const createMonitor: API.OperationMethod<
   CreateMonitorInput,
   CreateMonitorOutput,
   CreateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitorInput,
   output: CreateMonitorOutput,
@@ -1392,7 +1391,7 @@ export const createScope: API.OperationMethod<
   CreateScopeInput,
   CreateScopeOutput,
   CreateScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScopeInput,
   output: CreateScopeOutput,
@@ -1424,7 +1423,7 @@ export const deleteMonitor: API.OperationMethod<
   DeleteMonitorInput,
   DeleteMonitorOutput,
   DeleteMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitorInput,
   output: DeleteMonitorOutput,
@@ -1457,7 +1456,7 @@ export const deleteScope: API.OperationMethod<
   DeleteScopeInput,
   DeleteScopeOutput,
   DeleteScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScopeInput,
   output: DeleteScopeOutput,
@@ -1489,7 +1488,7 @@ export const getMonitor: API.OperationMethod<
   GetMonitorInput,
   GetMonitorOutput,
   GetMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitorInput,
   output: GetMonitorOutput,
@@ -1524,7 +1523,7 @@ export const getQueryResultsMonitorTopContributors: API.PaginatedOperationMethod
   GetQueryResultsMonitorTopContributorsInput,
   GetQueryResultsMonitorTopContributorsOutput,
   GetQueryResultsMonitorTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitorTopContributorsRow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsMonitorTopContributorsInput,
@@ -1569,7 +1568,7 @@ export const getQueryResultsWorkloadInsightsTopContributors: API.PaginatedOperat
   GetQueryResultsWorkloadInsightsTopContributorsInput,
   GetQueryResultsWorkloadInsightsTopContributorsOutput,
   GetQueryResultsWorkloadInsightsTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadInsightsTopContributorsRow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsWorkloadInsightsTopContributorsInput,
@@ -1616,7 +1615,7 @@ export const getQueryResultsWorkloadInsightsTopContributorsData: API.PaginatedOp
   GetQueryResultsWorkloadInsightsTopContributorsDataInput,
   GetQueryResultsWorkloadInsightsTopContributorsDataOutput,
   GetQueryResultsWorkloadInsightsTopContributorsDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkloadInsightsTopContributorsDataPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetQueryResultsWorkloadInsightsTopContributorsDataInput,
@@ -1658,7 +1657,7 @@ export const getQueryStatusMonitorTopContributors: API.OperationMethod<
   GetQueryStatusMonitorTopContributorsInput,
   GetQueryStatusMonitorTopContributorsOutput,
   GetQueryStatusMonitorTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStatusMonitorTopContributorsInput,
   output: GetQueryStatusMonitorTopContributorsOutput,
@@ -1692,7 +1691,7 @@ export const getQueryStatusWorkloadInsightsTopContributors: API.OperationMethod<
   GetQueryStatusWorkloadInsightsTopContributorsInput,
   GetQueryStatusWorkloadInsightsTopContributorsOutput,
   GetQueryStatusWorkloadInsightsTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStatusWorkloadInsightsTopContributorsInput,
   output: GetQueryStatusWorkloadInsightsTopContributorsOutput,
@@ -1728,7 +1727,7 @@ export const getQueryStatusWorkloadInsightsTopContributorsData: API.OperationMet
   GetQueryStatusWorkloadInsightsTopContributorsDataInput,
   GetQueryStatusWorkloadInsightsTopContributorsDataOutput,
   GetQueryStatusWorkloadInsightsTopContributorsDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryStatusWorkloadInsightsTopContributorsDataInput,
   output: GetQueryStatusWorkloadInsightsTopContributorsDataOutput,
@@ -1759,7 +1758,7 @@ export const getScope: API.OperationMethod<
   GetScopeInput,
   GetScopeOutput,
   GetScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScopeInput,
   output: GetScopeOutput,
@@ -1789,7 +1788,7 @@ export const listMonitors: API.PaginatedOperationMethod<
   ListMonitorsInput,
   ListMonitorsOutput,
   ListMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorsInput,
@@ -1825,7 +1824,7 @@ export const listScopes: API.PaginatedOperationMethod<
   ListScopesInput,
   ListScopesOutput,
   ListScopesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScopeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScopesInput,
@@ -1863,7 +1862,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1898,7 +1897,7 @@ export const startQueryMonitorTopContributors: API.OperationMethod<
   StartQueryMonitorTopContributorsInput,
   StartQueryMonitorTopContributorsOutput,
   StartQueryMonitorTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryMonitorTopContributorsInput,
   output: StartQueryMonitorTopContributorsOutput,
@@ -1932,7 +1931,7 @@ export const startQueryWorkloadInsightsTopContributors: API.OperationMethod<
   StartQueryWorkloadInsightsTopContributorsInput,
   StartQueryWorkloadInsightsTopContributorsOutput,
   StartQueryWorkloadInsightsTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryWorkloadInsightsTopContributorsInput,
   output: StartQueryWorkloadInsightsTopContributorsOutput,
@@ -1966,7 +1965,7 @@ export const startQueryWorkloadInsightsTopContributorsData: API.OperationMethod<
   StartQueryWorkloadInsightsTopContributorsDataInput,
   StartQueryWorkloadInsightsTopContributorsDataOutput,
   StartQueryWorkloadInsightsTopContributorsDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQueryWorkloadInsightsTopContributorsDataInput,
   output: StartQueryWorkloadInsightsTopContributorsDataOutput,
@@ -1998,7 +1997,7 @@ export const stopQueryMonitorTopContributors: API.OperationMethod<
   StopQueryMonitorTopContributorsInput,
   StopQueryMonitorTopContributorsOutput,
   StopQueryMonitorTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryMonitorTopContributorsInput,
   output: StopQueryMonitorTopContributorsOutput,
@@ -2030,7 +2029,7 @@ export const stopQueryWorkloadInsightsTopContributors: API.OperationMethod<
   StopQueryWorkloadInsightsTopContributorsInput,
   StopQueryWorkloadInsightsTopContributorsOutput,
   StopQueryWorkloadInsightsTopContributorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryWorkloadInsightsTopContributorsInput,
   output: StopQueryWorkloadInsightsTopContributorsOutput,
@@ -2062,7 +2061,7 @@ export const stopQueryWorkloadInsightsTopContributorsData: API.OperationMethod<
   StopQueryWorkloadInsightsTopContributorsDataInput,
   StopQueryWorkloadInsightsTopContributorsDataOutput,
   StopQueryWorkloadInsightsTopContributorsDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQueryWorkloadInsightsTopContributorsDataInput,
   output: StopQueryWorkloadInsightsTopContributorsDataOutput,
@@ -2093,7 +2092,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2125,7 +2124,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2156,7 +2155,7 @@ export const updateMonitor: API.OperationMethod<
   UpdateMonitorInput,
   UpdateMonitorOutput,
   UpdateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitorInput,
   output: UpdateMonitorOutput,
@@ -2188,7 +2187,7 @@ export const updateScope: API.OperationMethod<
   UpdateScopeInput,
   UpdateScopeOutput,
   UpdateScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScopeInput,
   output: UpdateScopeOutput,

--- a/packages/aws/src/services/networkmanager.ts
+++ b/packages/aws/src/services/networkmanager.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "NetworkManager",
   serviceShapeName: "NetworkManager",
@@ -5547,7 +5546,7 @@ export const acceptAttachment: API.OperationMethod<
   AcceptAttachmentRequest,
   AcceptAttachmentResponse,
   AcceptAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAttachmentRequest,
   output: AcceptAttachmentResponse,
@@ -5584,7 +5583,7 @@ export const associateConnectPeer: API.OperationMethod<
   AssociateConnectPeerRequest,
   AssociateConnectPeerResponse,
   AssociateConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateConnectPeerRequest,
   output: AssociateConnectPeerResponse,
@@ -5628,7 +5627,7 @@ export const associateCustomerGateway: API.OperationMethod<
   AssociateCustomerGatewayRequest,
   AssociateCustomerGatewayResponse,
   AssociateCustomerGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCustomerGatewayRequest,
   output: AssociateCustomerGatewayResponse,
@@ -5662,7 +5661,7 @@ export const associateLink: API.OperationMethod<
   AssociateLinkRequest,
   AssociateLinkResponse,
   AssociateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLinkRequest,
   output: AssociateLinkResponse,
@@ -5702,7 +5701,7 @@ export const associateTransitGatewayConnectPeer: API.OperationMethod<
   AssociateTransitGatewayConnectPeerRequest,
   AssociateTransitGatewayConnectPeerResponse,
   AssociateTransitGatewayConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTransitGatewayConnectPeerRequest,
   output: AssociateTransitGatewayConnectPeerResponse,
@@ -5739,7 +5738,7 @@ export const createConnectAttachment: API.OperationMethod<
   CreateConnectAttachmentRequest,
   CreateConnectAttachmentResponse,
   CreateConnectAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectAttachmentRequest,
   output: CreateConnectAttachmentResponse,
@@ -5771,7 +5770,7 @@ export const createConnection: API.OperationMethod<
   CreateConnectionRequest,
   CreateConnectionResponse,
   CreateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionRequest,
   output: CreateConnectionResponse,
@@ -5804,7 +5803,7 @@ export const createConnectPeer: API.OperationMethod<
   CreateConnectPeerRequest,
   CreateConnectPeerResponse,
   CreateConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectPeerRequest,
   output: CreateConnectPeerResponse,
@@ -5837,7 +5836,7 @@ export const createCoreNetwork: API.OperationMethod<
   CreateCoreNetworkRequest,
   CreateCoreNetworkResponse,
   CreateCoreNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoreNetworkRequest,
   output: CreateCoreNetworkResponse,
@@ -5871,7 +5870,7 @@ export const createCoreNetworkPrefixListAssociation: API.OperationMethod<
   CreateCoreNetworkPrefixListAssociationRequest,
   CreateCoreNetworkPrefixListAssociationResponse,
   CreateCoreNetworkPrefixListAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCoreNetworkPrefixListAssociationRequest,
   output: CreateCoreNetworkPrefixListAssociationResponse,
@@ -5906,7 +5905,7 @@ export const createDevice: API.OperationMethod<
   CreateDeviceRequest,
   CreateDeviceResponse,
   CreateDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeviceRequest,
   output: CreateDeviceResponse,
@@ -5939,7 +5938,7 @@ export const createDirectConnectGatewayAttachment: API.OperationMethod<
   CreateDirectConnectGatewayAttachmentRequest,
   CreateDirectConnectGatewayAttachmentResponse,
   CreateDirectConnectGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectConnectGatewayAttachmentRequest,
   output: CreateDirectConnectGatewayAttachmentResponse,
@@ -5971,7 +5970,7 @@ export const createGlobalNetwork: API.OperationMethod<
   CreateGlobalNetworkRequest,
   CreateGlobalNetworkResponse,
   CreateGlobalNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalNetworkRequest,
   output: CreateGlobalNetworkResponse,
@@ -6004,7 +6003,7 @@ export const createLink: API.OperationMethod<
   CreateLinkRequest,
   CreateLinkResponse,
   CreateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLinkRequest,
   output: CreateLinkResponse,
@@ -6038,7 +6037,7 @@ export const createSite: API.OperationMethod<
   CreateSiteRequest,
   CreateSiteResponse,
   CreateSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSiteRequest,
   output: CreateSiteResponse,
@@ -6071,7 +6070,7 @@ export const createSiteToSiteVpnAttachment: API.OperationMethod<
   CreateSiteToSiteVpnAttachmentRequest,
   CreateSiteToSiteVpnAttachmentResponse,
   CreateSiteToSiteVpnAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSiteToSiteVpnAttachmentRequest,
   output: CreateSiteToSiteVpnAttachmentResponse,
@@ -6103,7 +6102,7 @@ export const createTransitGatewayPeering: API.OperationMethod<
   CreateTransitGatewayPeeringRequest,
   CreateTransitGatewayPeeringResponse,
   CreateTransitGatewayPeeringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayPeeringRequest,
   output: CreateTransitGatewayPeeringResponse,
@@ -6135,7 +6134,7 @@ export const createTransitGatewayRouteTableAttachment: API.OperationMethod<
   CreateTransitGatewayRouteTableAttachmentRequest,
   CreateTransitGatewayRouteTableAttachmentResponse,
   CreateTransitGatewayRouteTableAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransitGatewayRouteTableAttachmentRequest,
   output: CreateTransitGatewayRouteTableAttachmentResponse,
@@ -6167,7 +6166,7 @@ export const createVpcAttachment: API.OperationMethod<
   CreateVpcAttachmentRequest,
   CreateVpcAttachmentResponse,
   CreateVpcAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcAttachmentRequest,
   output: CreateVpcAttachmentResponse,
@@ -6199,7 +6198,7 @@ export const deleteAttachment: API.OperationMethod<
   DeleteAttachmentRequest,
   DeleteAttachmentResponse,
   DeleteAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttachmentRequest,
   output: DeleteAttachmentResponse,
@@ -6231,7 +6230,7 @@ export const deleteConnection: API.OperationMethod<
   DeleteConnectionRequest,
   DeleteConnectionResponse,
   DeleteConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRequest,
   output: DeleteConnectionResponse,
@@ -6263,7 +6262,7 @@ export const deleteConnectPeer: API.OperationMethod<
   DeleteConnectPeerRequest,
   DeleteConnectPeerResponse,
   DeleteConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectPeerRequest,
   output: DeleteConnectPeerResponse,
@@ -6295,7 +6294,7 @@ export const deleteCoreNetwork: API.OperationMethod<
   DeleteCoreNetworkRequest,
   DeleteCoreNetworkResponse,
   DeleteCoreNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoreNetworkRequest,
   output: DeleteCoreNetworkResponse,
@@ -6327,7 +6326,7 @@ export const deleteCoreNetworkPolicyVersion: API.OperationMethod<
   DeleteCoreNetworkPolicyVersionRequest,
   DeleteCoreNetworkPolicyVersionResponse,
   DeleteCoreNetworkPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoreNetworkPolicyVersionRequest,
   output: DeleteCoreNetworkPolicyVersionResponse,
@@ -6360,7 +6359,7 @@ export const deleteCoreNetworkPrefixListAssociation: API.OperationMethod<
   DeleteCoreNetworkPrefixListAssociationRequest,
   DeleteCoreNetworkPrefixListAssociationResponse,
   DeleteCoreNetworkPrefixListAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCoreNetworkPrefixListAssociationRequest,
   output: DeleteCoreNetworkPrefixListAssociationResponse,
@@ -6394,7 +6393,7 @@ export const deleteDevice: API.OperationMethod<
   DeleteDeviceRequest,
   DeleteDeviceResponse,
   DeleteDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceRequest,
   output: DeleteDeviceResponse,
@@ -6427,7 +6426,7 @@ export const deleteGlobalNetwork: API.OperationMethod<
   DeleteGlobalNetworkRequest,
   DeleteGlobalNetworkResponse,
   DeleteGlobalNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalNetworkRequest,
   output: DeleteGlobalNetworkResponse,
@@ -6460,7 +6459,7 @@ export const deleteLink: API.OperationMethod<
   DeleteLinkRequest,
   DeleteLinkResponse,
   DeleteLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLinkRequest,
   output: DeleteLinkResponse,
@@ -6492,7 +6491,7 @@ export const deletePeering: API.OperationMethod<
   DeletePeeringRequest,
   DeletePeeringResponse,
   DeletePeeringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePeeringRequest,
   output: DeletePeeringResponse,
@@ -6523,7 +6522,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -6554,7 +6553,7 @@ export const deleteSite: API.OperationMethod<
   DeleteSiteRequest,
   DeleteSiteResponse,
   DeleteSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSiteRequest,
   output: DeleteSiteResponse,
@@ -6587,7 +6586,7 @@ export const deregisterTransitGateway: API.OperationMethod<
   DeregisterTransitGatewayRequest,
   DeregisterTransitGatewayResponse,
   DeregisterTransitGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTransitGatewayRequest,
   output: DeregisterTransitGatewayResponse,
@@ -6621,7 +6620,7 @@ export const describeGlobalNetworks: API.PaginatedOperationMethod<
   DescribeGlobalNetworksRequest,
   DescribeGlobalNetworksResponse,
   DescribeGlobalNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalNetwork
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGlobalNetworksRequest,
@@ -6659,7 +6658,7 @@ export const disassociateConnectPeer: API.OperationMethod<
   DisassociateConnectPeerRequest,
   DisassociateConnectPeerResponse,
   DisassociateConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateConnectPeerRequest,
   output: DisassociateConnectPeerResponse,
@@ -6691,7 +6690,7 @@ export const disassociateCustomerGateway: API.OperationMethod<
   DisassociateCustomerGatewayRequest,
   DisassociateCustomerGatewayResponse,
   DisassociateCustomerGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCustomerGatewayRequest,
   output: DisassociateCustomerGatewayResponse,
@@ -6724,7 +6723,7 @@ export const disassociateLink: API.OperationMethod<
   DisassociateLinkRequest,
   DisassociateLinkResponse,
   DisassociateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLinkRequest,
   output: DisassociateLinkResponse,
@@ -6756,7 +6755,7 @@ export const disassociateTransitGatewayConnectPeer: API.OperationMethod<
   DisassociateTransitGatewayConnectPeerRequest,
   DisassociateTransitGatewayConnectPeerResponse,
   DisassociateTransitGatewayConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTransitGatewayConnectPeerRequest,
   output: DisassociateTransitGatewayConnectPeerResponse,
@@ -6788,7 +6787,7 @@ export const executeCoreNetworkChangeSet: API.OperationMethod<
   ExecuteCoreNetworkChangeSetRequest,
   ExecuteCoreNetworkChangeSetResponse,
   ExecuteCoreNetworkChangeSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteCoreNetworkChangeSetRequest,
   output: ExecuteCoreNetworkChangeSetResponse,
@@ -6819,7 +6818,7 @@ export const getConnectAttachment: API.OperationMethod<
   GetConnectAttachmentRequest,
   GetConnectAttachmentResponse,
   GetConnectAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectAttachmentRequest,
   output: GetConnectAttachmentResponse,
@@ -6849,7 +6848,7 @@ export const getConnections: API.PaginatedOperationMethod<
   GetConnectionsRequest,
   GetConnectionsResponse,
   GetConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Connection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConnectionsRequest,
@@ -6886,7 +6885,7 @@ export const getConnectPeer: API.OperationMethod<
   GetConnectPeerRequest,
   GetConnectPeerResponse,
   GetConnectPeerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectPeerRequest,
   output: GetConnectPeerResponse,
@@ -6917,7 +6916,7 @@ export const getConnectPeerAssociations: API.PaginatedOperationMethod<
   GetConnectPeerAssociationsRequest,
   GetConnectPeerAssociationsResponse,
   GetConnectPeerAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectPeerAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConnectPeerAssociationsRequest,
@@ -6955,7 +6954,7 @@ export const getCoreNetwork: API.OperationMethod<
   GetCoreNetworkRequest,
   GetCoreNetworkResponse,
   GetCoreNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoreNetworkRequest,
   output: GetCoreNetworkResponse,
@@ -6985,7 +6984,7 @@ export const getCoreNetworkChangeEvents: API.PaginatedOperationMethod<
   GetCoreNetworkChangeEventsRequest,
   GetCoreNetworkChangeEventsResponse,
   GetCoreNetworkChangeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreNetworkChangeEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCoreNetworkChangeEventsRequest,
@@ -7022,7 +7021,7 @@ export const getCoreNetworkChangeSet: API.PaginatedOperationMethod<
   GetCoreNetworkChangeSetRequest,
   GetCoreNetworkChangeSetResponse,
   GetCoreNetworkChangeSetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreNetworkChange
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCoreNetworkChangeSetRequest,
@@ -7059,7 +7058,7 @@ export const getCoreNetworkPolicy: API.OperationMethod<
   GetCoreNetworkPolicyRequest,
   GetCoreNetworkPolicyResponse,
   GetCoreNetworkPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCoreNetworkPolicyRequest,
   output: GetCoreNetworkPolicyResponse,
@@ -7091,7 +7090,7 @@ export const getCustomerGatewayAssociations: API.PaginatedOperationMethod<
   GetCustomerGatewayAssociationsRequest,
   GetCustomerGatewayAssociationsResponse,
   GetCustomerGatewayAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomerGatewayAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCustomerGatewayAssociationsRequest,
@@ -7129,7 +7128,7 @@ export const getDevices: API.PaginatedOperationMethod<
   GetDevicesRequest,
   GetDevicesResponse,
   GetDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Device
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDevicesRequest,
@@ -7166,7 +7165,7 @@ export const getDirectConnectGatewayAttachment: API.OperationMethod<
   GetDirectConnectGatewayAttachmentRequest,
   GetDirectConnectGatewayAttachmentResponse,
   GetDirectConnectGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDirectConnectGatewayAttachmentRequest,
   output: GetDirectConnectGatewayAttachmentResponse,
@@ -7197,7 +7196,7 @@ export const getLinkAssociations: API.PaginatedOperationMethod<
   GetLinkAssociationsRequest,
   GetLinkAssociationsResponse,
   GetLinkAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LinkAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLinkAssociationsRequest,
@@ -7236,7 +7235,7 @@ export const getLinks: API.PaginatedOperationMethod<
   GetLinksRequest,
   GetLinksResponse,
   GetLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Link
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLinksRequest,
@@ -7272,7 +7271,7 @@ export const getNetworkResourceCounts: API.PaginatedOperationMethod<
   GetNetworkResourceCountsRequest,
   GetNetworkResourceCountsResponse,
   GetNetworkResourceCountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkResourceCount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetNetworkResourceCountsRequest,
@@ -7308,7 +7307,7 @@ export const getNetworkResourceRelationships: API.PaginatedOperationMethod<
   GetNetworkResourceRelationshipsRequest,
   GetNetworkResourceRelationshipsResponse,
   GetNetworkResourceRelationshipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Relationship
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetNetworkResourceRelationshipsRequest,
@@ -7347,7 +7346,7 @@ export const getNetworkResources: API.PaginatedOperationMethod<
   GetNetworkResourcesRequest,
   GetNetworkResourcesResponse,
   GetNetworkResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetNetworkResourcesRequest,
@@ -7384,7 +7383,7 @@ export const getNetworkRoutes: API.OperationMethod<
   GetNetworkRoutesRequest,
   GetNetworkRoutesResponse,
   GetNetworkRoutesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkRoutesRequest,
   output: GetNetworkRoutesResponse,
@@ -7414,7 +7413,7 @@ export const getNetworkTelemetry: API.PaginatedOperationMethod<
   GetNetworkTelemetryRequest,
   GetNetworkTelemetryResponse,
   GetNetworkTelemetryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NetworkTelemetry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetNetworkTelemetryRequest,
@@ -7450,7 +7449,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -7479,7 +7478,7 @@ export const getRouteAnalysis: API.OperationMethod<
   GetRouteAnalysisRequest,
   GetRouteAnalysisResponse,
   GetRouteAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRouteAnalysisRequest,
   output: GetRouteAnalysisResponse,
@@ -7509,7 +7508,7 @@ export const getSites: API.PaginatedOperationMethod<
   GetSitesRequest,
   GetSitesResponse,
   GetSitesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Site
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSitesRequest,
@@ -7546,7 +7545,7 @@ export const getSiteToSiteVpnAttachment: API.OperationMethod<
   GetSiteToSiteVpnAttachmentRequest,
   GetSiteToSiteVpnAttachmentResponse,
   GetSiteToSiteVpnAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSiteToSiteVpnAttachmentRequest,
   output: GetSiteToSiteVpnAttachmentResponse,
@@ -7577,7 +7576,7 @@ export const getTransitGatewayConnectPeerAssociations: API.PaginatedOperationMet
   GetTransitGatewayConnectPeerAssociationsRequest,
   GetTransitGatewayConnectPeerAssociationsResponse,
   GetTransitGatewayConnectPeerAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayConnectPeerAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayConnectPeerAssociationsRequest,
@@ -7615,7 +7614,7 @@ export const getTransitGatewayPeering: API.OperationMethod<
   GetTransitGatewayPeeringRequest,
   GetTransitGatewayPeeringResponse,
   GetTransitGatewayPeeringError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransitGatewayPeeringRequest,
   output: GetTransitGatewayPeeringResponse,
@@ -7646,7 +7645,7 @@ export const getTransitGatewayRegistrations: API.PaginatedOperationMethod<
   GetTransitGatewayRegistrationsRequest,
   GetTransitGatewayRegistrationsResponse,
   GetTransitGatewayRegistrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransitGatewayRegistration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTransitGatewayRegistrationsRequest,
@@ -7683,7 +7682,7 @@ export const getTransitGatewayRouteTableAttachment: API.OperationMethod<
   GetTransitGatewayRouteTableAttachmentRequest,
   GetTransitGatewayRouteTableAttachmentResponse,
   GetTransitGatewayRouteTableAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTransitGatewayRouteTableAttachmentRequest,
   output: GetTransitGatewayRouteTableAttachmentResponse,
@@ -7713,7 +7712,7 @@ export const getVpcAttachment: API.OperationMethod<
   GetVpcAttachmentRequest,
   GetVpcAttachmentResponse,
   GetVpcAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVpcAttachmentRequest,
   output: GetVpcAttachmentResponse,
@@ -7743,7 +7742,7 @@ export const listAttachmentRoutingPolicyAssociations: API.PaginatedOperationMeth
   ListAttachmentRoutingPolicyAssociationsRequest,
   ListAttachmentRoutingPolicyAssociationsResponse,
   ListAttachmentRoutingPolicyAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachmentRoutingPolicyAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachmentRoutingPolicyAssociationsRequest,
@@ -7779,7 +7778,7 @@ export const listAttachments: API.PaginatedOperationMethod<
   ListAttachmentsRequest,
   ListAttachmentsResponse,
   ListAttachmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Attachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachmentsRequest,
@@ -7814,7 +7813,7 @@ export const listConnectPeers: API.PaginatedOperationMethod<
   ListConnectPeersRequest,
   ListConnectPeersResponse,
   ListConnectPeersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectPeerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectPeersRequest,
@@ -7850,7 +7849,7 @@ export const listCoreNetworkPolicyVersions: API.PaginatedOperationMethod<
   ListCoreNetworkPolicyVersionsRequest,
   ListCoreNetworkPolicyVersionsResponse,
   ListCoreNetworkPolicyVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreNetworkPolicyVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoreNetworkPolicyVersionsRequest,
@@ -7887,7 +7886,7 @@ export const listCoreNetworkPrefixListAssociations: API.PaginatedOperationMethod
   ListCoreNetworkPrefixListAssociationsRequest,
   ListCoreNetworkPrefixListAssociationsResponse,
   ListCoreNetworkPrefixListAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrefixListAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoreNetworkPrefixListAssociationsRequest,
@@ -7924,7 +7923,7 @@ export const listCoreNetworkRoutingInformation: API.PaginatedOperationMethod<
   ListCoreNetworkRoutingInformationRequest,
   ListCoreNetworkRoutingInformationResponse,
   ListCoreNetworkRoutingInformationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreNetworkRoutingInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoreNetworkRoutingInformationRequest,
@@ -7960,7 +7959,7 @@ export const listCoreNetworks: API.PaginatedOperationMethod<
   ListCoreNetworksRequest,
   ListCoreNetworksResponse,
   ListCoreNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CoreNetworkSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCoreNetworksRequest,
@@ -7990,7 +7989,7 @@ export const listOrganizationServiceAccessStatus: API.OperationMethod<
   ListOrganizationServiceAccessStatusRequest,
   ListOrganizationServiceAccessStatusResponse,
   ListOrganizationServiceAccessStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOrganizationServiceAccessStatusRequest,
   output: ListOrganizationServiceAccessStatusResponse,
@@ -8013,7 +8012,7 @@ export const listPeerings: API.PaginatedOperationMethod<
   ListPeeringsRequest,
   ListPeeringsResponse,
   ListPeeringsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Peering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPeeringsRequest,
@@ -8049,7 +8048,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8081,7 +8080,7 @@ export const putAttachmentRoutingPolicyLabel: API.OperationMethod<
   PutAttachmentRoutingPolicyLabelRequest,
   PutAttachmentRoutingPolicyLabelResponse,
   PutAttachmentRoutingPolicyLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAttachmentRoutingPolicyLabelRequest,
   output: PutAttachmentRoutingPolicyLabelResponse,
@@ -8115,7 +8114,7 @@ export const putCoreNetworkPolicy: API.OperationMethod<
   PutCoreNetworkPolicyRequest,
   PutCoreNetworkPolicyResponse,
   PutCoreNetworkPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCoreNetworkPolicyRequest,
   output: PutCoreNetworkPolicyResponse,
@@ -8148,7 +8147,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -8184,7 +8183,7 @@ export const registerTransitGateway: API.OperationMethod<
   RegisterTransitGatewayRequest,
   RegisterTransitGatewayResponse,
   RegisterTransitGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTransitGatewayRequest,
   output: RegisterTransitGatewayResponse,
@@ -8216,7 +8215,7 @@ export const rejectAttachment: API.OperationMethod<
   RejectAttachmentRequest,
   RejectAttachmentResponse,
   RejectAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectAttachmentRequest,
   output: RejectAttachmentResponse,
@@ -8249,7 +8248,7 @@ export const removeAttachmentRoutingPolicyLabel: API.OperationMethod<
   RemoveAttachmentRoutingPolicyLabelRequest,
   RemoveAttachmentRoutingPolicyLabelResponse,
   RemoveAttachmentRoutingPolicyLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAttachmentRoutingPolicyLabelRequest,
   output: RemoveAttachmentRoutingPolicyLabelResponse,
@@ -8282,7 +8281,7 @@ export const restoreCoreNetworkPolicyVersion: API.OperationMethod<
   RestoreCoreNetworkPolicyVersionRequest,
   RestoreCoreNetworkPolicyVersionResponse,
   RestoreCoreNetworkPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreCoreNetworkPolicyVersionRequest,
   output: RestoreCoreNetworkPolicyVersionResponse,
@@ -8314,7 +8313,7 @@ export const startOrganizationServiceAccessUpdate: API.OperationMethod<
   StartOrganizationServiceAccessUpdateRequest,
   StartOrganizationServiceAccessUpdateResponse,
   StartOrganizationServiceAccessUpdateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOrganizationServiceAccessUpdateRequest,
   output: StartOrganizationServiceAccessUpdateResponse,
@@ -8347,7 +8346,7 @@ export const startRouteAnalysis: API.OperationMethod<
   StartRouteAnalysisRequest,
   StartRouteAnalysisResponse,
   StartRouteAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRouteAnalysisRequest,
   output: StartRouteAnalysisResponse,
@@ -8380,7 +8379,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8413,7 +8412,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8446,7 +8445,7 @@ export const updateConnection: API.OperationMethod<
   UpdateConnectionRequest,
   UpdateConnectionResponse,
   UpdateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRequest,
   output: UpdateConnectionResponse,
@@ -8478,7 +8477,7 @@ export const updateCoreNetwork: API.OperationMethod<
   UpdateCoreNetworkRequest,
   UpdateCoreNetworkResponse,
   UpdateCoreNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCoreNetworkRequest,
   output: UpdateCoreNetworkResponse,
@@ -8511,7 +8510,7 @@ export const updateDevice: API.OperationMethod<
   UpdateDeviceRequest,
   UpdateDeviceResponse,
   UpdateDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceRequest,
   output: UpdateDeviceResponse,
@@ -8543,7 +8542,7 @@ export const updateDirectConnectGatewayAttachment: API.OperationMethod<
   UpdateDirectConnectGatewayAttachmentRequest,
   UpdateDirectConnectGatewayAttachmentResponse,
   UpdateDirectConnectGatewayAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectConnectGatewayAttachmentRequest,
   output: UpdateDirectConnectGatewayAttachmentResponse,
@@ -8576,7 +8575,7 @@ export const updateGlobalNetwork: API.OperationMethod<
   UpdateGlobalNetworkRequest,
   UpdateGlobalNetworkResponse,
   UpdateGlobalNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalNetworkRequest,
   output: UpdateGlobalNetworkResponse,
@@ -8610,7 +8609,7 @@ export const updateLink: API.OperationMethod<
   UpdateLinkRequest,
   UpdateLinkResponse,
   UpdateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkRequest,
   output: UpdateLinkResponse,
@@ -8643,7 +8642,7 @@ export const updateNetworkResourceMetadata: API.OperationMethod<
   UpdateNetworkResourceMetadataRequest,
   UpdateNetworkResourceMetadataResponse,
   UpdateNetworkResourceMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkResourceMetadataRequest,
   output: UpdateNetworkResourceMetadataResponse,
@@ -8676,7 +8675,7 @@ export const updateSite: API.OperationMethod<
   UpdateSiteRequest,
   UpdateSiteResponse,
   UpdateSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSiteRequest,
   output: UpdateSiteResponse,
@@ -8708,7 +8707,7 @@ export const updateVpcAttachment: API.OperationMethod<
   UpdateVpcAttachmentRequest,
   UpdateVpcAttachmentResponse,
   UpdateVpcAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcAttachmentRequest,
   output: UpdateVpcAttachmentResponse,

--- a/packages/aws/src/services/networkmonitor.ts
+++ b/packages/aws/src/services/networkmonitor.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "NetworkMonitor",
   serviceShapeName: "NetworkMonitor",
@@ -771,7 +770,7 @@ export const createMonitor: API.OperationMethod<
   CreateMonitorInput,
   CreateMonitorOutput,
   CreateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitorInput,
   output: CreateMonitorOutput,
@@ -807,7 +806,7 @@ export const createProbe: API.OperationMethod<
   CreateProbeInput,
   CreateProbeOutput,
   CreateProbeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProbeInput,
   output: CreateProbeOutput,
@@ -841,7 +840,7 @@ export const deleteMonitor: API.OperationMethod<
   DeleteMonitorInput,
   DeleteMonitorOutput,
   DeleteMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitorInput,
   output: DeleteMonitorOutput,
@@ -878,7 +877,7 @@ export const deleteProbe: API.OperationMethod<
   DeleteProbeInput,
   DeleteProbeOutput,
   DeleteProbeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProbeInput,
   output: DeleteProbeOutput,
@@ -912,7 +911,7 @@ export const getMonitor: API.OperationMethod<
   GetMonitorInput,
   GetMonitorOutput,
   GetMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMonitorInput,
   output: GetMonitorOutput,
@@ -945,7 +944,7 @@ export const getProbe: API.OperationMethod<
   GetProbeInput,
   GetProbeOutput,
   GetProbeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProbeInput,
   output: GetProbeOutput,
@@ -974,7 +973,7 @@ export const listMonitors: API.PaginatedOperationMethod<
   ListMonitorsInput,
   ListMonitorsOutput,
   ListMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitorsInput,
@@ -1011,7 +1010,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1043,7 +1042,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1075,7 +1074,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1110,7 +1109,7 @@ export const updateMonitor: API.OperationMethod<
   UpdateMonitorInput,
   UpdateMonitorOutput,
   UpdateMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitorInput,
   output: UpdateMonitorOutput,
@@ -1162,7 +1161,7 @@ export const updateProbe: API.OperationMethod<
   UpdateProbeInput,
   UpdateProbeOutput,
   UpdateProbeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProbeInput,
   output: UpdateProbeOutput,

--- a/packages/aws/src/services/notifications.ts
+++ b/packages/aws/src/services/notifications.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Notifications",
   serviceShapeName: "Notifications",
@@ -2213,7 +2212,7 @@ export const associateChannel: API.OperationMethod<
   AssociateChannelRequest,
   AssociateChannelResponse,
   AssociateChannelError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateChannelRequest,
   output: AssociateChannelResponse,
@@ -2247,7 +2246,7 @@ export const associateManagedNotificationAccountContact: API.OperationMethod<
   AssociateManagedNotificationAccountContactRequest,
   AssociateManagedNotificationAccountContactResponse,
   AssociateManagedNotificationAccountContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateManagedNotificationAccountContactRequest,
   output: AssociateManagedNotificationAccountContactResponse,
@@ -2283,7 +2282,7 @@ export const associateManagedNotificationAdditionalChannel: API.OperationMethod<
   AssociateManagedNotificationAdditionalChannelRequest,
   AssociateManagedNotificationAdditionalChannelResponse,
   AssociateManagedNotificationAdditionalChannelError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateManagedNotificationAdditionalChannelRequest,
   output: AssociateManagedNotificationAdditionalChannelResponse,
@@ -2317,7 +2316,7 @@ export const associateOrganizationalUnit: API.OperationMethod<
   AssociateOrganizationalUnitRequest,
   AssociateOrganizationalUnitResponse,
   AssociateOrganizationalUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateOrganizationalUnitRequest,
   output: AssociateOrganizationalUnitResponse,
@@ -2351,7 +2350,7 @@ export const createEventRule: API.OperationMethod<
   CreateEventRuleRequest,
   CreateEventRuleResponse,
   CreateEventRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventRuleRequest,
   output: CreateEventRuleResponse,
@@ -2384,7 +2383,7 @@ export const createNotificationConfiguration: API.OperationMethod<
   CreateNotificationConfigurationRequest,
   CreateNotificationConfigurationResponse,
   CreateNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationConfigurationRequest,
   output: CreateNotificationConfigurationResponse,
@@ -2416,7 +2415,7 @@ export const deleteEventRule: API.OperationMethod<
   DeleteEventRuleRequest,
   DeleteEventRuleResponse,
   DeleteEventRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventRuleRequest,
   output: DeleteEventRuleResponse,
@@ -2448,7 +2447,7 @@ export const deleteNotificationConfiguration: API.OperationMethod<
   DeleteNotificationConfigurationRequest,
   DeleteNotificationConfigurationResponse,
   DeleteNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationConfigurationRequest,
   output: DeleteNotificationConfigurationResponse,
@@ -2482,7 +2481,7 @@ export const deregisterNotificationHub: API.OperationMethod<
   DeregisterNotificationHubRequest,
   DeregisterNotificationHubResponse,
   DeregisterNotificationHubError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterNotificationHubRequest,
   output: DeregisterNotificationHubResponse,
@@ -2515,7 +2514,7 @@ export const disableNotificationsAccessForOrganization: API.OperationMethod<
   DisableNotificationsAccessForOrganizationRequest,
   DisableNotificationsAccessForOrganizationResponse,
   DisableNotificationsAccessForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableNotificationsAccessForOrganizationRequest,
   output: DisableNotificationsAccessForOrganizationResponse,
@@ -2547,7 +2546,7 @@ export const disassociateChannel: API.OperationMethod<
   DisassociateChannelRequest,
   DisassociateChannelResponse,
   DisassociateChannelError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateChannelRequest,
   output: DisassociateChannelResponse,
@@ -2578,7 +2577,7 @@ export const disassociateManagedNotificationAccountContact: API.OperationMethod<
   DisassociateManagedNotificationAccountContactRequest,
   DisassociateManagedNotificationAccountContactResponse,
   DisassociateManagedNotificationAccountContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateManagedNotificationAccountContactRequest,
   output: DisassociateManagedNotificationAccountContactResponse,
@@ -2611,7 +2610,7 @@ export const disassociateManagedNotificationAdditionalChannel: API.OperationMeth
   DisassociateManagedNotificationAdditionalChannelRequest,
   DisassociateManagedNotificationAdditionalChannelResponse,
   DisassociateManagedNotificationAdditionalChannelError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateManagedNotificationAdditionalChannelRequest,
   output: DisassociateManagedNotificationAdditionalChannelResponse,
@@ -2641,7 +2640,7 @@ export const disassociateOrganizationalUnit: API.OperationMethod<
   DisassociateOrganizationalUnitRequest,
   DisassociateOrganizationalUnitResponse,
   DisassociateOrganizationalUnitError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateOrganizationalUnitRequest,
   output: DisassociateOrganizationalUnitResponse,
@@ -2673,7 +2672,7 @@ export const enableNotificationsAccessForOrganization: API.OperationMethod<
   EnableNotificationsAccessForOrganizationRequest,
   EnableNotificationsAccessForOrganizationResponse,
   EnableNotificationsAccessForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableNotificationsAccessForOrganizationRequest,
   output: EnableNotificationsAccessForOrganizationResponse,
@@ -2705,7 +2704,7 @@ export const getEventRule: API.OperationMethod<
   GetEventRuleRequest,
   GetEventRuleResponse,
   GetEventRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventRuleRequest,
   output: GetEventRuleResponse,
@@ -2735,7 +2734,7 @@ export const getManagedNotificationChildEvent: API.OperationMethod<
   GetManagedNotificationChildEventRequest,
   GetManagedNotificationChildEventResponse,
   GetManagedNotificationChildEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedNotificationChildEventRequest,
   output: GetManagedNotificationChildEventResponse,
@@ -2765,7 +2764,7 @@ export const getManagedNotificationConfiguration: API.OperationMethod<
   GetManagedNotificationConfigurationRequest,
   GetManagedNotificationConfigurationResponse,
   GetManagedNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedNotificationConfigurationRequest,
   output: GetManagedNotificationConfigurationResponse,
@@ -2795,7 +2794,7 @@ export const getManagedNotificationEvent: API.OperationMethod<
   GetManagedNotificationEventRequest,
   GetManagedNotificationEventResponse,
   GetManagedNotificationEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedNotificationEventRequest,
   output: GetManagedNotificationEventResponse,
@@ -2825,7 +2824,7 @@ export const getNotificationConfiguration: API.OperationMethod<
   GetNotificationConfigurationRequest,
   GetNotificationConfigurationResponse,
   GetNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationConfigurationRequest,
   output: GetNotificationConfigurationResponse,
@@ -2857,7 +2856,7 @@ export const getNotificationEvent: API.OperationMethod<
   GetNotificationEventRequest,
   GetNotificationEventResponse,
   GetNotificationEventError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationEventRequest,
   output: GetNotificationEventResponse,
@@ -2886,7 +2885,7 @@ export const getNotificationsAccessForOrganization: API.OperationMethod<
   GetNotificationsAccessForOrganizationRequest,
   GetNotificationsAccessForOrganizationResponse,
   GetNotificationsAccessForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNotificationsAccessForOrganizationRequest,
   output: GetNotificationsAccessForOrganizationResponse,
@@ -2915,7 +2914,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsRequest,
   ListChannelsResponse,
   ListChannelsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsRequest,
@@ -2952,7 +2951,7 @@ export const listEventRules: API.PaginatedOperationMethod<
   ListEventRulesRequest,
   ListEventRulesResponse,
   ListEventRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventRuleStructure
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventRulesRequest,
@@ -2989,7 +2988,7 @@ export const listManagedNotificationChannelAssociations: API.PaginatedOperationM
   ListManagedNotificationChannelAssociationsRequest,
   ListManagedNotificationChannelAssociationsResponse,
   ListManagedNotificationChannelAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedNotificationChannelAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedNotificationChannelAssociationsRequest,
@@ -3026,7 +3025,7 @@ export const listManagedNotificationChildEvents: API.PaginatedOperationMethod<
   ListManagedNotificationChildEventsRequest,
   ListManagedNotificationChildEventsResponse,
   ListManagedNotificationChildEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedNotificationChildEventOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedNotificationChildEventsRequest,
@@ -3062,7 +3061,7 @@ export const listManagedNotificationConfigurations: API.PaginatedOperationMethod
   ListManagedNotificationConfigurationsRequest,
   ListManagedNotificationConfigurationsResponse,
   ListManagedNotificationConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedNotificationConfigurationStructure
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedNotificationConfigurationsRequest,
@@ -3097,7 +3096,7 @@ export const listManagedNotificationEvents: API.PaginatedOperationMethod<
   ListManagedNotificationEventsRequest,
   ListManagedNotificationEventsResponse,
   ListManagedNotificationEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedNotificationEventOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedNotificationEventsRequest,
@@ -3133,7 +3132,7 @@ export const listMemberAccounts: API.PaginatedOperationMethod<
   ListMemberAccountsRequest,
   ListMemberAccountsResponse,
   ListMemberAccountsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemberAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMemberAccountsRequest,
@@ -3169,7 +3168,7 @@ export const listNotificationConfigurations: API.PaginatedOperationMethod<
   ListNotificationConfigurationsRequest,
   ListNotificationConfigurationsResponse,
   ListNotificationConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationConfigurationStructure
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationConfigurationsRequest,
@@ -3206,7 +3205,7 @@ export const listNotificationEvents: API.PaginatedOperationMethod<
   ListNotificationEventsRequest,
   ListNotificationEventsResponse,
   ListNotificationEventsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationEventOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationEventsRequest,
@@ -3241,7 +3240,7 @@ export const listNotificationHubs: API.PaginatedOperationMethod<
   ListNotificationHubsRequest,
   ListNotificationHubsResponse,
   ListNotificationHubsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotificationHubOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationHubsRequest,
@@ -3277,7 +3276,7 @@ export const listOrganizationalUnits: API.PaginatedOperationMethod<
   ListOrganizationalUnitsRequest,
   ListOrganizationalUnitsResponse,
   ListOrganizationalUnitsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationalUnitId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationalUnitsRequest,
@@ -3318,7 +3317,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3351,7 +3350,7 @@ export const registerNotificationHub: API.OperationMethod<
   RegisterNotificationHubRequest,
   RegisterNotificationHubResponse,
   RegisterNotificationHubError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterNotificationHubRequest,
   output: RegisterNotificationHubResponse,
@@ -3386,7 +3385,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3418,7 +3417,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3449,7 +3448,7 @@ export const updateEventRule: API.OperationMethod<
   UpdateEventRuleRequest,
   UpdateEventRuleResponse,
   UpdateEventRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventRuleRequest,
   output: UpdateEventRuleResponse,
@@ -3481,7 +3480,7 @@ export const updateNotificationConfiguration: API.OperationMethod<
   UpdateNotificationConfigurationRequest,
   UpdateNotificationConfigurationResponse,
   UpdateNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotificationConfigurationRequest,
   output: UpdateNotificationConfigurationResponse,

--- a/packages/aws/src/services/notificationscontacts.ts
+++ b/packages/aws/src/services/notificationscontacts.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "NotificationsContacts",
@@ -450,7 +449,7 @@ export const activateEmailContact: API.OperationMethod<
   ActivateEmailContactRequest,
   ActivateEmailContactResponse,
   ActivateEmailContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateEmailContactRequest,
   output: ActivateEmailContactResponse,
@@ -482,7 +481,7 @@ export const createEmailContact: API.OperationMethod<
   CreateEmailContactRequest,
   CreateEmailContactResponse,
   CreateEmailContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailContactRequest,
   output: CreateEmailContactResponse,
@@ -516,7 +515,7 @@ export const deleteEmailContact: API.OperationMethod<
   DeleteEmailContactRequest,
   DeleteEmailContactResponse,
   DeleteEmailContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailContactRequest,
   output: DeleteEmailContactResponse,
@@ -547,7 +546,7 @@ export const getEmailContact: API.OperationMethod<
   GetEmailContactRequest,
   GetEmailContactResponse,
   GetEmailContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailContactRequest,
   output: GetEmailContactResponse,
@@ -576,7 +575,7 @@ export const listEmailContacts: API.PaginatedOperationMethod<
   ListEmailContactsRequest,
   ListEmailContactsResponse,
   ListEmailContactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EmailContact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEmailContactsRequest,
@@ -612,7 +611,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -645,7 +644,7 @@ export const sendActivationCode: API.OperationMethod<
   SendActivationCodeRequest,
   SendActivationCodeResponse,
   SendActivationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendActivationCodeRequest,
   output: SendActivationCodeResponse,
@@ -676,7 +675,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -706,7 +705,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/nova-act.ts
+++ b/packages/aws/src/services/nova-act.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Nova Act",
@@ -1088,7 +1087,7 @@ export const createAct: API.OperationMethod<
   CreateActRequest,
   CreateActResponse,
   CreateActError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActRequest,
   output: CreateActResponse,
@@ -1122,7 +1121,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionResponse,
   CreateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionResponse,
@@ -1155,7 +1154,7 @@ export const createWorkflowDefinition: API.OperationMethod<
   CreateWorkflowDefinitionRequest,
   CreateWorkflowDefinitionResponse,
   CreateWorkflowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowDefinitionRequest,
   output: CreateWorkflowDefinitionResponse,
@@ -1187,7 +1186,7 @@ export const createWorkflowRun: API.OperationMethod<
   CreateWorkflowRunRequest,
   CreateWorkflowRunResponse,
   CreateWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRunRequest,
   output: CreateWorkflowRunResponse,
@@ -1219,7 +1218,7 @@ export const deleteWorkflowDefinition: API.OperationMethod<
   DeleteWorkflowDefinitionRequest,
   DeleteWorkflowDefinitionResponse,
   DeleteWorkflowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowDefinitionRequest,
   output: DeleteWorkflowDefinitionResponse,
@@ -1251,7 +1250,7 @@ export const deleteWorkflowRun: API.OperationMethod<
   DeleteWorkflowRunRequest,
   DeleteWorkflowRunResponse,
   DeleteWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRunRequest,
   output: DeleteWorkflowRunResponse,
@@ -1282,7 +1281,7 @@ export const getWorkflowDefinition: API.OperationMethod<
   GetWorkflowDefinitionRequest,
   GetWorkflowDefinitionResponse,
   GetWorkflowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowDefinitionRequest,
   output: GetWorkflowDefinitionResponse,
@@ -1313,7 +1312,7 @@ export const getWorkflowRun: API.OperationMethod<
   GetWorkflowRunRequest,
   GetWorkflowRunResponse,
   GetWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRunRequest,
   output: GetWorkflowRunResponse,
@@ -1346,7 +1345,7 @@ export const invokeActStep: API.OperationMethod<
   InvokeActStepRequest,
   InvokeActStepResponse,
   InvokeActStepError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeActStepRequest,
   output: InvokeActStepResponse,
@@ -1379,7 +1378,7 @@ export const listActs: API.PaginatedOperationMethod<
   ListActsRequest,
   ListActsResponse,
   ListActsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActsRequest,
@@ -1415,7 +1414,7 @@ export const listModels: API.OperationMethod<
   ListModelsRequest,
   ListModelsResponse,
   ListModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListModelsRequest,
   output: ListModelsResponse,
@@ -1440,7 +1439,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -1477,7 +1476,7 @@ export const listWorkflowDefinitions: API.PaginatedOperationMethod<
   ListWorkflowDefinitionsRequest,
   ListWorkflowDefinitionsResponse,
   ListWorkflowDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowDefinitionsRequest,
@@ -1514,7 +1513,7 @@ export const listWorkflowRuns: API.PaginatedOperationMethod<
   ListWorkflowRunsRequest,
   ListWorkflowRunsResponse,
   ListWorkflowRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowRunSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowRunsRequest,
@@ -1553,7 +1552,7 @@ export const updateAct: API.OperationMethod<
   UpdateActRequest,
   UpdateActResponse,
   UpdateActError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActRequest,
   output: UpdateActResponse,
@@ -1585,7 +1584,7 @@ export const updateWorkflowRun: API.OperationMethod<
   UpdateWorkflowRunRequest,
   UpdateWorkflowRunResponse,
   UpdateWorkflowRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowRunRequest,
   output: UpdateWorkflowRunResponse,

--- a/packages/aws/src/services/oam.ts
+++ b/packages/aws/src/services/oam.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "OAM", serviceShapeName: "oamservice" });
 const auth = T.AwsAuthSigv4({ name: "oam" });
 const ver = T.ServiceVersion("2022-06-10");
@@ -784,7 +783,7 @@ export const createLink: API.OperationMethod<
   CreateLinkInput,
   CreateLinkOutput,
   CreateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLinkInput,
   output: CreateLinkOutput,
@@ -820,7 +819,7 @@ export const createSink: API.OperationMethod<
   CreateSinkInput,
   CreateSinkOutput,
   CreateSinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSinkInput,
   output: CreateSinkOutput,
@@ -851,7 +850,7 @@ export const deleteLink: API.OperationMethod<
   DeleteLinkInput,
   DeleteLinkOutput,
   DeleteLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLinkInput,
   output: DeleteLinkOutput,
@@ -882,7 +881,7 @@ export const deleteSink: API.OperationMethod<
   DeleteSinkInput,
   DeleteSinkOutput,
   DeleteSinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSinkInput,
   output: DeleteSinkOutput,
@@ -915,7 +914,7 @@ export const getLink: API.OperationMethod<
   GetLinkInput,
   GetLinkOutput,
   GetLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkInput,
   output: GetLinkOutput,
@@ -947,7 +946,7 @@ export const getSink: API.OperationMethod<
   GetSinkInput,
   GetSinkOutput,
   GetSinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSinkInput,
   output: GetSinkOutput,
@@ -977,7 +976,7 @@ export const getSinkPolicy: API.OperationMethod<
   GetSinkPolicyInput,
   GetSinkPolicyOutput,
   GetSinkPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSinkPolicyInput,
   output: GetSinkPolicyOutput,
@@ -1011,7 +1010,7 @@ export const listAttachedLinks: API.PaginatedOperationMethod<
   ListAttachedLinksInput,
   ListAttachedLinksOutput,
   ListAttachedLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListAttachedLinksItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachedLinksInput,
@@ -1049,7 +1048,7 @@ export const listLinks: API.PaginatedOperationMethod<
   ListLinksInput,
   ListLinksOutput,
   ListLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListLinksItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinksInput,
@@ -1084,7 +1083,7 @@ export const listSinks: API.PaginatedOperationMethod<
   ListSinksInput,
   ListSinksOutput,
   ListSinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSinksItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSinksInput,
@@ -1118,7 +1117,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1162,7 +1161,7 @@ export const putSinkPolicy: API.OperationMethod<
   PutSinkPolicyInput,
   PutSinkPolicyOutput,
   PutSinkPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSinkPolicyInput,
   output: PutSinkPolicyOutput,
@@ -1201,7 +1200,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1230,7 +1229,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1262,7 +1261,7 @@ export const updateLink: API.OperationMethod<
   UpdateLinkInput,
   UpdateLinkOutput,
   UpdateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkInput,
   output: UpdateLinkOutput,

--- a/packages/aws/src/services/observabilityadmin.ts
+++ b/packages/aws/src/services/observabilityadmin.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ObservabilityAdmin",
   serviceShapeName: "ObservabilityAdmin",
@@ -2266,7 +2265,7 @@ export const createCentralizationRuleForOrganization: API.OperationMethod<
   CreateCentralizationRuleForOrganizationInput,
   CreateCentralizationRuleForOrganizationOutput,
   CreateCentralizationRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCentralizationRuleForOrganizationInput,
   output: CreateCentralizationRuleForOrganizationOutput,
@@ -2298,7 +2297,7 @@ export const createS3TableIntegration: API.OperationMethod<
   CreateS3TableIntegrationInput,
   CreateS3TableIntegrationOutput,
   CreateS3TableIntegrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateS3TableIntegrationInput,
   output: CreateS3TableIntegrationOutput,
@@ -2330,7 +2329,7 @@ export const createTelemetryPipeline: API.OperationMethod<
   CreateTelemetryPipelineInput,
   CreateTelemetryPipelineOutput,
   CreateTelemetryPipelineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTelemetryPipelineInput,
   output: CreateTelemetryPipelineOutput,
@@ -2362,7 +2361,7 @@ export const createTelemetryRule: API.OperationMethod<
   CreateTelemetryRuleInput,
   CreateTelemetryRuleOutput,
   CreateTelemetryRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTelemetryRuleInput,
   output: CreateTelemetryRuleOutput,
@@ -2394,7 +2393,7 @@ export const createTelemetryRuleForOrganization: API.OperationMethod<
   CreateTelemetryRuleForOrganizationInput,
   CreateTelemetryRuleForOrganizationOutput,
   CreateTelemetryRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTelemetryRuleForOrganizationInput,
   output: CreateTelemetryRuleForOrganizationOutput,
@@ -2425,7 +2424,7 @@ export const deleteCentralizationRuleForOrganization: API.OperationMethod<
   DeleteCentralizationRuleForOrganizationInput,
   DeleteCentralizationRuleForOrganizationResponse,
   DeleteCentralizationRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCentralizationRuleForOrganizationInput,
   output: DeleteCentralizationRuleForOrganizationResponse,
@@ -2456,7 +2455,7 @@ export const deleteS3TableIntegration: API.OperationMethod<
   DeleteS3TableIntegrationInput,
   DeleteS3TableIntegrationResponse,
   DeleteS3TableIntegrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteS3TableIntegrationInput,
   output: DeleteS3TableIntegrationResponse,
@@ -2488,7 +2487,7 @@ export const deleteTelemetryPipeline: API.OperationMethod<
   DeleteTelemetryPipelineInput,
   DeleteTelemetryPipelineOutput,
   DeleteTelemetryPipelineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTelemetryPipelineInput,
   output: DeleteTelemetryPipelineOutput,
@@ -2519,7 +2518,7 @@ export const deleteTelemetryRule: API.OperationMethod<
   DeleteTelemetryRuleInput,
   DeleteTelemetryRuleResponse,
   DeleteTelemetryRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTelemetryRuleInput,
   output: DeleteTelemetryRuleResponse,
@@ -2549,7 +2548,7 @@ export const deleteTelemetryRuleForOrganization: API.OperationMethod<
   DeleteTelemetryRuleForOrganizationInput,
   DeleteTelemetryRuleForOrganizationResponse,
   DeleteTelemetryRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTelemetryRuleForOrganizationInput,
   output: DeleteTelemetryRuleForOrganizationResponse,
@@ -2579,7 +2578,7 @@ export const getCentralizationRuleForOrganization: API.OperationMethod<
   GetCentralizationRuleForOrganizationInput,
   GetCentralizationRuleForOrganizationOutput,
   GetCentralizationRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCentralizationRuleForOrganizationInput,
   output: GetCentralizationRuleForOrganizationOutput,
@@ -2609,7 +2608,7 @@ export const getS3TableIntegration: API.OperationMethod<
   GetS3TableIntegrationInput,
   GetS3TableIntegrationOutput,
   GetS3TableIntegrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetS3TableIntegrationInput,
   output: GetS3TableIntegrationOutput,
@@ -2638,7 +2637,7 @@ export const getTelemetryEnrichmentStatus: API.OperationMethod<
   GetTelemetryEnrichmentStatusRequest,
   GetTelemetryEnrichmentStatusOutput,
   GetTelemetryEnrichmentStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryEnrichmentStatusRequest,
   output: GetTelemetryEnrichmentStatusOutput,
@@ -2665,7 +2664,7 @@ export const getTelemetryEvaluationStatus: API.OperationMethod<
   GetTelemetryEvaluationStatusRequest,
   GetTelemetryEvaluationStatusOutput,
   GetTelemetryEvaluationStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryEvaluationStatusRequest,
   output: GetTelemetryEvaluationStatusOutput,
@@ -2692,7 +2691,7 @@ export const getTelemetryEvaluationStatusForOrganization: API.OperationMethod<
   GetTelemetryEvaluationStatusForOrganizationRequest,
   GetTelemetryEvaluationStatusForOrganizationOutput,
   GetTelemetryEvaluationStatusForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryEvaluationStatusForOrganizationRequest,
   output: GetTelemetryEvaluationStatusForOrganizationOutput,
@@ -2721,7 +2720,7 @@ export const getTelemetryPipeline: API.OperationMethod<
   GetTelemetryPipelineInput,
   GetTelemetryPipelineOutput,
   GetTelemetryPipelineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryPipelineInput,
   output: GetTelemetryPipelineOutput,
@@ -2751,7 +2750,7 @@ export const getTelemetryRule: API.OperationMethod<
   GetTelemetryRuleInput,
   GetTelemetryRuleOutput,
   GetTelemetryRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryRuleInput,
   output: GetTelemetryRuleOutput,
@@ -2781,7 +2780,7 @@ export const getTelemetryRuleForOrganization: API.OperationMethod<
   GetTelemetryRuleForOrganizationInput,
   GetTelemetryRuleForOrganizationOutput,
   GetTelemetryRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTelemetryRuleForOrganizationInput,
   output: GetTelemetryRuleForOrganizationOutput,
@@ -2810,7 +2809,7 @@ export const listCentralizationRulesForOrganization: API.PaginatedOperationMetho
   ListCentralizationRulesForOrganizationInput,
   ListCentralizationRulesForOrganizationOutput,
   ListCentralizationRulesForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CentralizationRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCentralizationRulesForOrganizationInput,
@@ -2845,7 +2844,7 @@ export const listResourceTelemetry: API.PaginatedOperationMethod<
   ListResourceTelemetryInput,
   ListResourceTelemetryOutput,
   ListResourceTelemetryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TelemetryConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceTelemetryInput,
@@ -2880,7 +2879,7 @@ export const listResourceTelemetryForOrganization: API.PaginatedOperationMethod<
   ListResourceTelemetryForOrganizationInput,
   ListResourceTelemetryForOrganizationOutput,
   ListResourceTelemetryForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TelemetryConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceTelemetryForOrganizationInput,
@@ -2915,7 +2914,7 @@ export const listS3TableIntegrations: API.PaginatedOperationMethod<
   ListS3TableIntegrationsInput,
   ListS3TableIntegrationsOutput,
   ListS3TableIntegrationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IntegrationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListS3TableIntegrationsInput,
@@ -2951,7 +2950,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2980,7 +2979,7 @@ export const listTelemetryPipelines: API.PaginatedOperationMethod<
   ListTelemetryPipelinesInput,
   ListTelemetryPipelinesOutput,
   ListTelemetryPipelinesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TelemetryPipelineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTelemetryPipelinesInput,
@@ -3015,7 +3014,7 @@ export const listTelemetryRules: API.PaginatedOperationMethod<
   ListTelemetryRulesInput,
   ListTelemetryRulesOutput,
   ListTelemetryRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TelemetryRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTelemetryRulesInput,
@@ -3050,7 +3049,7 @@ export const listTelemetryRulesForOrganization: API.PaginatedOperationMethod<
   ListTelemetryRulesForOrganizationInput,
   ListTelemetryRulesForOrganizationOutput,
   ListTelemetryRulesForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TelemetryRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTelemetryRulesForOrganizationInput,
@@ -3085,7 +3084,7 @@ export const startTelemetryEnrichment: API.OperationMethod<
   StartTelemetryEnrichmentRequest,
   StartTelemetryEnrichmentOutput,
   StartTelemetryEnrichmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTelemetryEnrichmentRequest,
   output: StartTelemetryEnrichmentOutput,
@@ -3113,7 +3112,7 @@ export const startTelemetryEvaluation: API.OperationMethod<
   StartTelemetryEvaluationInput,
   StartTelemetryEvaluationResponse,
   StartTelemetryEvaluationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTelemetryEvaluationInput,
   output: StartTelemetryEvaluationResponse,
@@ -3141,7 +3140,7 @@ export const startTelemetryEvaluationForOrganization: API.OperationMethod<
   StartTelemetryEvaluationForOrganizationInput,
   StartTelemetryEvaluationForOrganizationResponse,
   StartTelemetryEvaluationForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTelemetryEvaluationForOrganizationInput,
   output: StartTelemetryEvaluationForOrganizationResponse,
@@ -3169,7 +3168,7 @@ export const stopTelemetryEnrichment: API.OperationMethod<
   StopTelemetryEnrichmentRequest,
   StopTelemetryEnrichmentOutput,
   StopTelemetryEnrichmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTelemetryEnrichmentRequest,
   output: StopTelemetryEnrichmentOutput,
@@ -3197,7 +3196,7 @@ export const stopTelemetryEvaluation: API.OperationMethod<
   StopTelemetryEvaluationRequest,
   StopTelemetryEvaluationResponse,
   StopTelemetryEvaluationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTelemetryEvaluationRequest,
   output: StopTelemetryEvaluationResponse,
@@ -3225,7 +3224,7 @@ export const stopTelemetryEvaluationForOrganization: API.OperationMethod<
   StopTelemetryEvaluationForOrganizationRequest,
   StopTelemetryEvaluationForOrganizationResponse,
   StopTelemetryEvaluationForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTelemetryEvaluationForOrganizationRequest,
   output: StopTelemetryEvaluationForOrganizationResponse,
@@ -3255,7 +3254,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -3285,7 +3284,7 @@ export const testTelemetryPipeline: API.OperationMethod<
   TestTelemetryPipelineInput,
   TestTelemetryPipelineOutput,
   TestTelemetryPipelineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestTelemetryPipelineInput,
   output: TestTelemetryPipelineOutput,
@@ -3314,7 +3313,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -3345,7 +3344,7 @@ export const updateCentralizationRuleForOrganization: API.OperationMethod<
   UpdateCentralizationRuleForOrganizationInput,
   UpdateCentralizationRuleForOrganizationOutput,
   UpdateCentralizationRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCentralizationRuleForOrganizationInput,
   output: UpdateCentralizationRuleForOrganizationOutput,
@@ -3424,7 +3423,7 @@ export const updateTelemetryPipeline: API.OperationMethod<
   UpdateTelemetryPipelineInput,
   UpdateTelemetryPipelineOutput,
   UpdateTelemetryPipelineError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTelemetryPipelineInput,
   output: UpdateTelemetryPipelineOutput,
@@ -3456,7 +3455,7 @@ export const updateTelemetryRule: API.OperationMethod<
   UpdateTelemetryRuleInput,
   UpdateTelemetryRuleOutput,
   UpdateTelemetryRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTelemetryRuleInput,
   output: UpdateTelemetryRuleOutput,
@@ -3489,7 +3488,7 @@ export const updateTelemetryRuleForOrganization: API.OperationMethod<
   UpdateTelemetryRuleForOrganizationInput,
   UpdateTelemetryRuleForOrganizationOutput,
   UpdateTelemetryRuleForOrganizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTelemetryRuleForOrganizationInput,
   output: UpdateTelemetryRuleForOrganizationOutput,
@@ -3519,7 +3518,7 @@ export const validateTelemetryPipelineConfiguration: API.OperationMethod<
   ValidateTelemetryPipelineConfigurationInput,
   ValidateTelemetryPipelineConfigurationOutput,
   ValidateTelemetryPipelineConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateTelemetryPipelineConfigurationInput,
   output: ValidateTelemetryPipelineConfigurationOutput,

--- a/packages/aws/src/services/odb.ts
+++ b/packages/aws/src/services/odb.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "odb", serviceShapeName: "Odb" });
 const auth = T.AwsAuthSigv4({ name: "odb" });
@@ -5222,7 +5221,7 @@ export const acceptMarketplaceRegistration: API.OperationMethod<
   AcceptMarketplaceRegistrationInput,
   AcceptMarketplaceRegistrationOutput,
   AcceptMarketplaceRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptMarketplaceRegistrationInput,
   output: AcceptMarketplaceRegistrationOutput,
@@ -5253,7 +5252,7 @@ export const associateIamRoleToResource: API.OperationMethod<
   AssociateIamRoleToResourceInput,
   AssociateIamRoleToResourceOutput,
   AssociateIamRoleToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIamRoleToResourceInput,
   output: AssociateIamRoleToResourceOutput,
@@ -5286,7 +5285,7 @@ export const createAutonomousDatabase: API.OperationMethod<
   CreateAutonomousDatabaseInput,
   CreateAutonomousDatabaseOutput,
   CreateAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutonomousDatabaseInput,
   output: CreateAutonomousDatabaseOutput,
@@ -5320,7 +5319,7 @@ export const createAutonomousDatabaseBackup: API.OperationMethod<
   CreateAutonomousDatabaseBackupInput,
   CreateAutonomousDatabaseBackupOutput,
   CreateAutonomousDatabaseBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutonomousDatabaseBackupInput,
   output: CreateAutonomousDatabaseBackupOutput,
@@ -5352,7 +5351,7 @@ export const createAutonomousDatabaseWallet: API.OperationMethod<
   CreateAutonomousDatabaseWalletInput,
   CreateAutonomousDatabaseWalletOutput,
   CreateAutonomousDatabaseWalletError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutonomousDatabaseWalletInput,
   output: CreateAutonomousDatabaseWalletOutput,
@@ -5384,7 +5383,7 @@ export const createCloudAutonomousVmCluster: API.OperationMethod<
   CreateCloudAutonomousVmClusterInput,
   CreateCloudAutonomousVmClusterOutput,
   CreateCloudAutonomousVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudAutonomousVmClusterInput,
   output: CreateCloudAutonomousVmClusterOutput,
@@ -5417,7 +5416,7 @@ export const createCloudExadataInfrastructure: API.OperationMethod<
   CreateCloudExadataInfrastructureInput,
   CreateCloudExadataInfrastructureOutput,
   CreateCloudExadataInfrastructureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudExadataInfrastructureInput,
   output: CreateCloudExadataInfrastructureOutput,
@@ -5450,7 +5449,7 @@ export const createCloudVmCluster: API.OperationMethod<
   CreateCloudVmClusterInput,
   CreateCloudVmClusterOutput,
   CreateCloudVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudVmClusterInput,
   output: CreateCloudVmClusterOutput,
@@ -5483,7 +5482,7 @@ export const createOdbNetwork: API.OperationMethod<
   CreateOdbNetworkInput,
   CreateOdbNetworkOutput,
   CreateOdbNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOdbNetworkInput,
   output: CreateOdbNetworkOutput,
@@ -5517,7 +5516,7 @@ export const createOdbPeeringConnection: API.OperationMethod<
   CreateOdbPeeringConnectionInput,
   CreateOdbPeeringConnectionOutput,
   CreateOdbPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOdbPeeringConnectionInput,
   output: CreateOdbPeeringConnectionOutput,
@@ -5549,7 +5548,7 @@ export const deleteAutonomousDatabase: API.OperationMethod<
   DeleteAutonomousDatabaseInput,
   DeleteAutonomousDatabaseOutput,
   DeleteAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutonomousDatabaseInput,
   output: DeleteAutonomousDatabaseOutput,
@@ -5581,7 +5580,7 @@ export const deleteAutonomousDatabaseBackup: API.OperationMethod<
   DeleteAutonomousDatabaseBackupInput,
   DeleteAutonomousDatabaseBackupOutput,
   DeleteAutonomousDatabaseBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutonomousDatabaseBackupInput,
   output: DeleteAutonomousDatabaseBackupOutput,
@@ -5612,7 +5611,7 @@ export const deleteCloudAutonomousVmCluster: API.OperationMethod<
   DeleteCloudAutonomousVmClusterInput,
   DeleteCloudAutonomousVmClusterOutput,
   DeleteCloudAutonomousVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudAutonomousVmClusterInput,
   output: DeleteCloudAutonomousVmClusterOutput,
@@ -5643,7 +5642,7 @@ export const deleteCloudExadataInfrastructure: API.OperationMethod<
   DeleteCloudExadataInfrastructureInput,
   DeleteCloudExadataInfrastructureOutput,
   DeleteCloudExadataInfrastructureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudExadataInfrastructureInput,
   output: DeleteCloudExadataInfrastructureOutput,
@@ -5674,7 +5673,7 @@ export const deleteCloudVmCluster: API.OperationMethod<
   DeleteCloudVmClusterInput,
   DeleteCloudVmClusterOutput,
   DeleteCloudVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCloudVmClusterInput,
   output: DeleteCloudVmClusterOutput,
@@ -5704,7 +5703,7 @@ export const deleteOdbNetwork: API.OperationMethod<
   DeleteOdbNetworkInput,
   DeleteOdbNetworkOutput,
   DeleteOdbNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOdbNetworkInput,
   output: DeleteOdbNetworkOutput,
@@ -5736,7 +5735,7 @@ export const deleteOdbPeeringConnection: API.OperationMethod<
   DeleteOdbPeeringConnectionInput,
   DeleteOdbPeeringConnectionOutput,
   DeleteOdbPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOdbPeeringConnectionInput,
   output: DeleteOdbPeeringConnectionOutput,
@@ -5767,7 +5766,7 @@ export const disassociateIamRoleFromResource: API.OperationMethod<
   DisassociateIamRoleFromResourceInput,
   DisassociateIamRoleFromResourceOutput,
   DisassociateIamRoleFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIamRoleFromResourceInput,
   output: DisassociateIamRoleFromResourceOutput,
@@ -5799,7 +5798,7 @@ export const failoverAutonomousDatabase: API.OperationMethod<
   FailoverAutonomousDatabaseInput,
   FailoverAutonomousDatabaseOutput,
   FailoverAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverAutonomousDatabaseInput,
   output: FailoverAutonomousDatabaseOutput,
@@ -5830,7 +5829,7 @@ export const getAutonomousDatabase: API.OperationMethod<
   GetAutonomousDatabaseInput,
   GetAutonomousDatabaseOutput,
   GetAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutonomousDatabaseInput,
   output: GetAutonomousDatabaseOutput,
@@ -5860,7 +5859,7 @@ export const getAutonomousDatabaseBackup: API.OperationMethod<
   GetAutonomousDatabaseBackupInput,
   GetAutonomousDatabaseBackupOutput,
   GetAutonomousDatabaseBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutonomousDatabaseBackupInput,
   output: GetAutonomousDatabaseBackupOutput,
@@ -5890,7 +5889,7 @@ export const getAutonomousDatabaseWalletDetails: API.OperationMethod<
   GetAutonomousDatabaseWalletDetailsInput,
   GetAutonomousDatabaseWalletDetailsOutput,
   GetAutonomousDatabaseWalletDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutonomousDatabaseWalletDetailsInput,
   output: GetAutonomousDatabaseWalletDetailsOutput,
@@ -5920,7 +5919,7 @@ export const getCloudAutonomousVmCluster: API.OperationMethod<
   GetCloudAutonomousVmClusterInput,
   GetCloudAutonomousVmClusterOutput,
   GetCloudAutonomousVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudAutonomousVmClusterInput,
   output: GetCloudAutonomousVmClusterOutput,
@@ -5950,7 +5949,7 @@ export const getCloudExadataInfrastructure: API.OperationMethod<
   GetCloudExadataInfrastructureInput,
   GetCloudExadataInfrastructureOutput,
   GetCloudExadataInfrastructureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudExadataInfrastructureInput,
   output: GetCloudExadataInfrastructureOutput,
@@ -5980,7 +5979,7 @@ export const getCloudExadataInfrastructureUnallocatedResources: API.OperationMet
   GetCloudExadataInfrastructureUnallocatedResourcesInput,
   GetCloudExadataInfrastructureUnallocatedResourcesOutput,
   GetCloudExadataInfrastructureUnallocatedResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudExadataInfrastructureUnallocatedResourcesInput,
   output: GetCloudExadataInfrastructureUnallocatedResourcesOutput,
@@ -6010,7 +6009,7 @@ export const getCloudVmCluster: API.OperationMethod<
   GetCloudVmClusterInput,
   GetCloudVmClusterOutput,
   GetCloudVmClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudVmClusterInput,
   output: GetCloudVmClusterOutput,
@@ -6040,7 +6039,7 @@ export const getDbNode: API.OperationMethod<
   GetDbNodeInput,
   GetDbNodeOutput,
   GetDbNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDbNodeInput,
   output: GetDbNodeOutput,
@@ -6070,7 +6069,7 @@ export const getDbServer: API.OperationMethod<
   GetDbServerInput,
   GetDbServerOutput,
   GetDbServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDbServerInput,
   output: GetDbServerOutput,
@@ -6099,7 +6098,7 @@ export const getOciOnboardingStatus: API.OperationMethod<
   GetOciOnboardingStatusInput,
   GetOciOnboardingStatusOutput,
   GetOciOnboardingStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOciOnboardingStatusInput,
   output: GetOciOnboardingStatusOutput,
@@ -6128,7 +6127,7 @@ export const getOdbNetwork: API.OperationMethod<
   GetOdbNetworkInput,
   GetOdbNetworkOutput,
   GetOdbNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOdbNetworkInput,
   output: GetOdbNetworkOutput,
@@ -6158,7 +6157,7 @@ export const getOdbPeeringConnection: API.OperationMethod<
   GetOdbPeeringConnectionInput,
   GetOdbPeeringConnectionOutput,
   GetOdbPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOdbPeeringConnectionInput,
   output: GetOdbPeeringConnectionOutput,
@@ -6187,7 +6186,7 @@ export const initializeService: API.OperationMethod<
   InitializeServiceInput,
   InitializeServiceOutput,
   InitializeServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitializeServiceInput,
   output: InitializeServiceOutput,
@@ -6216,7 +6215,7 @@ export const listAutonomousDatabaseBackups: API.PaginatedOperationMethod<
   ListAutonomousDatabaseBackupsInput,
   ListAutonomousDatabaseBackupsOutput,
   ListAutonomousDatabaseBackupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabaseBackupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabaseBackupsInput,
@@ -6252,7 +6251,7 @@ export const listAutonomousDatabaseCharacterSets: API.PaginatedOperationMethod<
   ListAutonomousDatabaseCharacterSetsInput,
   ListAutonomousDatabaseCharacterSetsOutput,
   ListAutonomousDatabaseCharacterSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabaseCharacterSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabaseCharacterSetsInput,
@@ -6288,7 +6287,7 @@ export const listAutonomousDatabaseClones: API.PaginatedOperationMethod<
   ListAutonomousDatabaseClonesInput,
   ListAutonomousDatabaseClonesOutput,
   ListAutonomousDatabaseClonesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabaseClonesInput,
@@ -6325,7 +6324,7 @@ export const listAutonomousDatabasePeers: API.PaginatedOperationMethod<
   ListAutonomousDatabasePeersInput,
   ListAutonomousDatabasePeersOutput,
   ListAutonomousDatabasePeersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabasePeerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabasePeersInput,
@@ -6361,7 +6360,7 @@ export const listAutonomousDatabases: API.PaginatedOperationMethod<
   ListAutonomousDatabasesInput,
   ListAutonomousDatabasesOutput,
   ListAutonomousDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabasesInput,
@@ -6396,7 +6395,7 @@ export const listAutonomousDatabaseVersions: API.PaginatedOperationMethod<
   ListAutonomousDatabaseVersionsInput,
   ListAutonomousDatabaseVersionsOutput,
   ListAutonomousDatabaseVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousDatabaseVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousDatabaseVersionsInput,
@@ -6432,7 +6431,7 @@ export const listAutonomousVirtualMachines: API.PaginatedOperationMethod<
   ListAutonomousVirtualMachinesInput,
   ListAutonomousVirtualMachinesOutput,
   ListAutonomousVirtualMachinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutonomousVirtualMachineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutonomousVirtualMachinesInput,
@@ -6469,7 +6468,7 @@ export const listCloudAutonomousVmClusters: API.PaginatedOperationMethod<
   ListCloudAutonomousVmClustersInput,
   ListCloudAutonomousVmClustersOutput,
   ListCloudAutonomousVmClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CloudAutonomousVmClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudAutonomousVmClustersInput,
@@ -6505,7 +6504,7 @@ export const listCloudExadataInfrastructures: API.PaginatedOperationMethod<
   ListCloudExadataInfrastructuresInput,
   ListCloudExadataInfrastructuresOutput,
   ListCloudExadataInfrastructuresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CloudExadataInfrastructureSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudExadataInfrastructuresInput,
@@ -6541,7 +6540,7 @@ export const listCloudVmClusters: API.PaginatedOperationMethod<
   ListCloudVmClustersInput,
   ListCloudVmClustersOutput,
   ListCloudVmClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CloudVmClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCloudVmClustersInput,
@@ -6578,7 +6577,7 @@ export const listDbNodes: API.PaginatedOperationMethod<
   ListDbNodesInput,
   ListDbNodesOutput,
   ListDbNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbNodeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbNodesInput,
@@ -6615,7 +6614,7 @@ export const listDbServers: API.PaginatedOperationMethod<
   ListDbServersInput,
   ListDbServersOutput,
   ListDbServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbServerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbServersInput,
@@ -6651,7 +6650,7 @@ export const listDbSystemShapes: API.PaginatedOperationMethod<
   ListDbSystemShapesInput,
   ListDbSystemShapesOutput,
   ListDbSystemShapesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbSystemShapeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbSystemShapesInput,
@@ -6686,7 +6685,7 @@ export const listGiVersions: API.PaginatedOperationMethod<
   ListGiVersionsInput,
   ListGiVersionsOutput,
   ListGiVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GiVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGiVersionsInput,
@@ -6721,7 +6720,7 @@ export const listOdbNetworks: API.PaginatedOperationMethod<
   ListOdbNetworksInput,
   ListOdbNetworksOutput,
   ListOdbNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OdbNetworkSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOdbNetworksInput,
@@ -6757,7 +6756,7 @@ export const listOdbPeeringConnections: API.PaginatedOperationMethod<
   ListOdbPeeringConnectionsInput,
   ListOdbPeeringConnectionsOutput,
   ListOdbPeeringConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OdbPeeringConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOdbPeeringConnectionsInput,
@@ -6794,7 +6793,7 @@ export const listSystemVersions: API.PaginatedOperationMethod<
   ListSystemVersionsInput,
   ListSystemVersionsOutput,
   ListSystemVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSystemVersionsInput,
@@ -6825,7 +6824,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6850,7 +6849,7 @@ export const rebootAutonomousDatabase: API.OperationMethod<
   RebootAutonomousDatabaseInput,
   RebootAutonomousDatabaseOutput,
   RebootAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootAutonomousDatabaseInput,
   output: RebootAutonomousDatabaseOutput,
@@ -6881,7 +6880,7 @@ export const rebootDbNode: API.OperationMethod<
   RebootDbNodeInput,
   RebootDbNodeOutput,
   RebootDbNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDbNodeInput,
   output: RebootDbNodeOutput,
@@ -6912,7 +6911,7 @@ export const restoreAutonomousDatabase: API.OperationMethod<
   RestoreAutonomousDatabaseInput,
   RestoreAutonomousDatabaseOutput,
   RestoreAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreAutonomousDatabaseInput,
   output: RestoreAutonomousDatabaseOutput,
@@ -6944,7 +6943,7 @@ export const shrinkAutonomousDatabase: API.OperationMethod<
   ShrinkAutonomousDatabaseInput,
   ShrinkAutonomousDatabaseOutput,
   ShrinkAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ShrinkAutonomousDatabaseInput,
   output: ShrinkAutonomousDatabaseOutput,
@@ -6976,7 +6975,7 @@ export const startAutonomousDatabase: API.OperationMethod<
   StartAutonomousDatabaseInput,
   StartAutonomousDatabaseOutput,
   StartAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutonomousDatabaseInput,
   output: StartAutonomousDatabaseOutput,
@@ -7007,7 +7006,7 @@ export const startDbNode: API.OperationMethod<
   StartDbNodeInput,
   StartDbNodeOutput,
   StartDbNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDbNodeInput,
   output: StartDbNodeOutput,
@@ -7038,7 +7037,7 @@ export const stopAutonomousDatabase: API.OperationMethod<
   StopAutonomousDatabaseInput,
   StopAutonomousDatabaseOutput,
   StopAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAutonomousDatabaseInput,
   output: StopAutonomousDatabaseOutput,
@@ -7069,7 +7068,7 @@ export const stopDbNode: API.OperationMethod<
   StopDbNodeInput,
   StopDbNodeOutput,
   StopDbNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDbNodeInput,
   output: StopDbNodeOutput,
@@ -7100,7 +7099,7 @@ export const switchoverAutonomousDatabase: API.OperationMethod<
   SwitchoverAutonomousDatabaseInput,
   SwitchoverAutonomousDatabaseOutput,
   SwitchoverAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverAutonomousDatabaseInput,
   output: SwitchoverAutonomousDatabaseOutput,
@@ -7128,7 +7127,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -7146,7 +7145,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7171,7 +7170,7 @@ export const updateAutonomousDatabase: API.OperationMethod<
   UpdateAutonomousDatabaseInput,
   UpdateAutonomousDatabaseOutput,
   UpdateAutonomousDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutonomousDatabaseInput,
   output: UpdateAutonomousDatabaseOutput,
@@ -7203,7 +7202,7 @@ export const updateAutonomousDatabaseBackup: API.OperationMethod<
   UpdateAutonomousDatabaseBackupInput,
   UpdateAutonomousDatabaseBackupOutput,
   UpdateAutonomousDatabaseBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutonomousDatabaseBackupInput,
   output: UpdateAutonomousDatabaseBackupOutput,
@@ -7235,7 +7234,7 @@ export const updateCloudExadataInfrastructure: API.OperationMethod<
   UpdateCloudExadataInfrastructureInput,
   UpdateCloudExadataInfrastructureOutput,
   UpdateCloudExadataInfrastructureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCloudExadataInfrastructureInput,
   output: UpdateCloudExadataInfrastructureOutput,
@@ -7267,7 +7266,7 @@ export const updateOdbNetwork: API.OperationMethod<
   UpdateOdbNetworkInput,
   UpdateOdbNetworkOutput,
   UpdateOdbNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOdbNetworkInput,
   output: UpdateOdbNetworkOutput,
@@ -7299,7 +7298,7 @@ export const updateOdbPeeringConnection: API.OperationMethod<
   UpdateOdbPeeringConnectionInput,
   UpdateOdbPeeringConnectionOutput,
   UpdateOdbPeeringConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOdbPeeringConnectionInput,
   output: UpdateOdbPeeringConnectionOutput,

--- a/packages/aws/src/services/omics.ts
+++ b/packages/aws/src/services/omics.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "Omics", serviceShapeName: "Omics" });
 const auth = T.AwsAuthSigv4({ name: "omics" });
 const ver = T.ServiceVersion("2022-11-28");
@@ -6661,7 +6660,7 @@ export const abortMultipartReadSetUpload: API.OperationMethod<
   AbortMultipartReadSetUploadRequest,
   AbortMultipartReadSetUploadResponse,
   AbortMultipartReadSetUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortMultipartReadSetUploadRequest,
   output: AbortMultipartReadSetUploadResponse,
@@ -6697,7 +6696,7 @@ export const acceptShare: API.OperationMethod<
   AcceptShareRequest,
   AcceptShareResponse,
   AcceptShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptShareRequest,
   output: AcceptShareResponse,
@@ -6731,7 +6730,7 @@ export const batchDeleteReadSet: API.OperationMethod<
   BatchDeleteReadSetRequest,
   BatchDeleteReadSetResponse,
   BatchDeleteReadSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteReadSetRequest,
   output: BatchDeleteReadSetResponse,
@@ -6765,7 +6764,7 @@ export const cancelAnnotationImportJob: API.OperationMethod<
   CancelAnnotationImportRequest,
   CancelAnnotationImportResponse,
   CancelAnnotationImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelAnnotationImportRequest,
   output: CancelAnnotationImportResponse,
@@ -6799,7 +6798,7 @@ export const cancelRun: API.OperationMethod<
   CancelRunRequest,
   CancelRunResponse,
   CancelRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelRunRequest,
   output: CancelRunResponse,
@@ -6838,7 +6837,7 @@ export const cancelRunBatch: API.OperationMethod<
   CancelRunBatchRequest,
   CancelRunBatchResponse,
   CancelRunBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelRunBatchRequest,
   output: CancelRunBatchResponse,
@@ -6874,7 +6873,7 @@ export const cancelVariantImportJob: API.OperationMethod<
   CancelVariantImportRequest,
   CancelVariantImportResponse,
   CancelVariantImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelVariantImportRequest,
   output: CancelVariantImportResponse,
@@ -6910,7 +6909,7 @@ export const completeMultipartReadSetUpload: API.OperationMethod<
   CompleteMultipartReadSetUploadRequest,
   CompleteMultipartReadSetUploadResponse,
   CompleteMultipartReadSetUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteMultipartReadSetUploadRequest,
   output: CompleteMultipartReadSetUploadResponse,
@@ -6948,7 +6947,7 @@ export const createAnnotationStore: API.OperationMethod<
   CreateAnnotationStoreRequest,
   CreateAnnotationStoreResponse,
   CreateAnnotationStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnnotationStoreRequest,
   output: CreateAnnotationStoreResponse,
@@ -6983,7 +6982,7 @@ export const createAnnotationStoreVersion: API.OperationMethod<
   CreateAnnotationStoreVersionRequest,
   CreateAnnotationStoreVersionResponse,
   CreateAnnotationStoreVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnnotationStoreVersionRequest,
   output: CreateAnnotationStoreVersionResponse,
@@ -7019,7 +7018,7 @@ export const createConfiguration: API.OperationMethod<
   CreateConfigurationRequest,
   CreateConfigurationResponse,
   CreateConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationRequest,
   output: CreateConfigurationResponse,
@@ -7066,7 +7065,7 @@ export const createMultipartReadSetUpload: API.OperationMethod<
   CreateMultipartReadSetUploadRequest,
   CreateMultipartReadSetUploadResponse,
   CreateMultipartReadSetUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultipartReadSetUploadRequest,
   output: CreateMultipartReadSetUploadResponse,
@@ -7103,7 +7102,7 @@ export const createReferenceStore: API.OperationMethod<
   CreateReferenceStoreRequest,
   CreateReferenceStoreResponse,
   CreateReferenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReferenceStoreRequest,
   output: CreateReferenceStoreResponse,
@@ -7140,7 +7139,7 @@ export const createRunCache: API.OperationMethod<
   CreateRunCacheRequest,
   CreateRunCacheResponse,
   CreateRunCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRunCacheRequest,
   output: CreateRunCacheResponse,
@@ -7177,7 +7176,7 @@ export const createRunGroup: API.OperationMethod<
   CreateRunGroupRequest,
   CreateRunGroupResponse,
   CreateRunGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRunGroupRequest,
   output: CreateRunGroupResponse,
@@ -7226,7 +7225,7 @@ export const createSequenceStore: API.OperationMethod<
   CreateSequenceStoreRequest,
   CreateSequenceStoreResponse,
   CreateSequenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSequenceStoreRequest,
   output: CreateSequenceStoreResponse,
@@ -7268,7 +7267,7 @@ export const createShare: API.OperationMethod<
   CreateShareRequest,
   CreateShareResponse,
   CreateShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateShareRequest,
   output: CreateShareResponse,
@@ -7305,7 +7304,7 @@ export const createVariantStore: API.OperationMethod<
   CreateVariantStoreRequest,
   CreateVariantStoreResponse,
   CreateVariantStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVariantStoreRequest,
   output: CreateVariantStoreResponse,
@@ -7353,7 +7352,7 @@ export const createWorkflow: API.OperationMethod<
   CreateWorkflowRequest,
   CreateWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRequest,
   output: CreateWorkflowResponse,
@@ -7398,7 +7397,7 @@ export const createWorkflowVersion: API.OperationMethod<
   CreateWorkflowVersionRequest,
   CreateWorkflowVersionResponse,
   CreateWorkflowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowVersionRequest,
   output: CreateWorkflowVersionResponse,
@@ -7435,7 +7434,7 @@ export const deleteAnnotationStore: API.OperationMethod<
   DeleteAnnotationStoreRequest,
   DeleteAnnotationStoreResponse,
   DeleteAnnotationStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnnotationStoreRequest,
   output: DeleteAnnotationStoreResponse,
@@ -7468,7 +7467,7 @@ export const deleteAnnotationStoreVersions: API.OperationMethod<
   DeleteAnnotationStoreVersionsRequest,
   DeleteAnnotationStoreVersionsResponse,
   DeleteAnnotationStoreVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnnotationStoreVersionsRequest,
   output: DeleteAnnotationStoreVersionsResponse,
@@ -7505,7 +7504,7 @@ export const deleteBatch: API.OperationMethod<
   DeleteBatchRequest,
   DeleteBatchResponse,
   DeleteBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBatchRequest,
   output: DeleteBatchResponse,
@@ -7542,7 +7541,7 @@ export const deleteConfiguration: API.OperationMethod<
   DeleteConfigurationRequest,
   DeleteConfigurationResponse,
   DeleteConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationRequest,
   output: DeleteConfigurationResponse,
@@ -7580,7 +7579,7 @@ export const deleteReference: API.OperationMethod<
   DeleteReferenceRequest,
   DeleteReferenceResponse,
   DeleteReferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReferenceRequest,
   output: DeleteReferenceResponse,
@@ -7617,7 +7616,7 @@ export const deleteReferenceStore: API.OperationMethod<
   DeleteReferenceStoreRequest,
   DeleteReferenceStoreResponse,
   DeleteReferenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReferenceStoreRequest,
   output: DeleteReferenceStoreResponse,
@@ -7659,7 +7658,7 @@ export const deleteRun: API.OperationMethod<
   DeleteRunRequest,
   DeleteRunResponse,
   DeleteRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRunRequest,
   output: DeleteRunResponse,
@@ -7698,7 +7697,7 @@ export const deleteRunBatch: API.OperationMethod<
   DeleteRunBatchRequest,
   DeleteRunBatchResponse,
   DeleteRunBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRunBatchRequest,
   output: DeleteRunBatchResponse,
@@ -7737,7 +7736,7 @@ export const deleteRunCache: API.OperationMethod<
   DeleteRunCacheRequest,
   DeleteRunCacheResponse,
   DeleteRunCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRunCacheRequest,
   output: DeleteRunCacheResponse,
@@ -7780,7 +7779,7 @@ export const deleteRunGroup: API.OperationMethod<
   DeleteRunGroupRequest,
   DeleteRunGroupResponse,
   DeleteRunGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRunGroupRequest,
   output: DeleteRunGroupResponse,
@@ -7816,7 +7815,7 @@ export const deleteS3AccessPolicy: API.OperationMethod<
   DeleteS3AccessPolicyRequest,
   DeleteS3AccessPolicyResponse,
   DeleteS3AccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteS3AccessPolicyRequest,
   output: DeleteS3AccessPolicyResponse,
@@ -7855,7 +7854,7 @@ export const deleteSequenceStore: API.OperationMethod<
   DeleteSequenceStoreRequest,
   DeleteSequenceStoreResponse,
   DeleteSequenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSequenceStoreRequest,
   output: DeleteSequenceStoreResponse,
@@ -7890,7 +7889,7 @@ export const deleteShare: API.OperationMethod<
   DeleteShareRequest,
   DeleteShareResponse,
   DeleteShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteShareRequest,
   output: DeleteShareResponse,
@@ -7926,7 +7925,7 @@ export const deleteVariantStore: API.OperationMethod<
   DeleteVariantStoreRequest,
   DeleteVariantStoreResponse,
   DeleteVariantStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVariantStoreRequest,
   output: DeleteVariantStoreResponse,
@@ -7967,7 +7966,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -8006,7 +8005,7 @@ export const deleteWorkflowVersion: API.OperationMethod<
   DeleteWorkflowVersionRequest,
   DeleteWorkflowVersionResponse,
   DeleteWorkflowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowVersionRequest,
   output: DeleteWorkflowVersionResponse,
@@ -8042,7 +8041,7 @@ export const getAnnotationImportJob: API.OperationMethod<
   GetAnnotationImportRequest,
   GetAnnotationImportResponse,
   GetAnnotationImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnnotationImportRequest,
   output: GetAnnotationImportResponse,
@@ -8075,7 +8074,7 @@ export const getAnnotationStore: API.OperationMethod<
   GetAnnotationStoreRequest,
   GetAnnotationStoreResponse,
   GetAnnotationStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnnotationStoreRequest,
   output: GetAnnotationStoreResponse,
@@ -8106,7 +8105,7 @@ export const getAnnotationStoreVersion: API.OperationMethod<
   GetAnnotationStoreVersionRequest,
   GetAnnotationStoreVersionResponse,
   GetAnnotationStoreVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnnotationStoreVersionRequest,
   output: GetAnnotationStoreVersionResponse,
@@ -8138,7 +8137,7 @@ export const getBatch: API.OperationMethod<
   GetBatchRequest,
   GetBatchResponse,
   GetBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBatchRequest,
   output: GetBatchResponse,
@@ -8173,7 +8172,7 @@ export const getConfiguration: API.OperationMethod<
   GetConfigurationRequest,
   GetConfigurationResponse,
   GetConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationRequest,
   output: GetConfigurationResponse,
@@ -8210,7 +8209,7 @@ export const getReadSet: API.OperationMethod<
   GetReadSetRequest,
   GetReadSetResponse,
   GetReadSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadSetRequest,
   output: GetReadSetResponse,
@@ -8245,7 +8244,7 @@ export const getReadSetActivationJob: API.OperationMethod<
   GetReadSetActivationJobRequest,
   GetReadSetActivationJobResponse,
   GetReadSetActivationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadSetActivationJobRequest,
   output: GetReadSetActivationJobResponse,
@@ -8278,7 +8277,7 @@ export const getReadSetExportJob: API.OperationMethod<
   GetReadSetExportJobRequest,
   GetReadSetExportJobResponse,
   GetReadSetExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadSetExportJobRequest,
   output: GetReadSetExportJobResponse,
@@ -8311,7 +8310,7 @@ export const getReadSetImportJob: API.OperationMethod<
   GetReadSetImportJobRequest,
   GetReadSetImportJobResponse,
   GetReadSetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadSetImportJobRequest,
   output: GetReadSetImportJobResponse,
@@ -8344,7 +8343,7 @@ export const getReadSetMetadata: API.OperationMethod<
   GetReadSetMetadataRequest,
   GetReadSetMetadataResponse,
   GetReadSetMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadSetMetadataRequest,
   output: GetReadSetMetadataResponse,
@@ -8380,7 +8379,7 @@ export const getReference: API.OperationMethod<
   GetReferenceRequest,
   GetReferenceResponse,
   GetReferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReferenceRequest,
   output: GetReferenceResponse,
@@ -8414,7 +8413,7 @@ export const getReferenceImportJob: API.OperationMethod<
   GetReferenceImportJobRequest,
   GetReferenceImportJobResponse,
   GetReferenceImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReferenceImportJobRequest,
   output: GetReferenceImportJobResponse,
@@ -8447,7 +8446,7 @@ export const getReferenceMetadata: API.OperationMethod<
   GetReferenceMetadataRequest,
   GetReferenceMetadataResponse,
   GetReferenceMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReferenceMetadataRequest,
   output: GetReferenceMetadataResponse,
@@ -8480,7 +8479,7 @@ export const getReferenceStore: API.OperationMethod<
   GetReferenceStoreRequest,
   GetReferenceStoreResponse,
   GetReferenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReferenceStoreRequest,
   output: GetReferenceStoreResponse,
@@ -8517,7 +8516,7 @@ export const getRun: API.OperationMethod<
   GetRunRequest,
   GetRunResponse,
   GetRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRunRequest,
   output: GetRunResponse,
@@ -8556,7 +8555,7 @@ export const getRunCache: API.OperationMethod<
   GetRunCacheRequest,
   GetRunCacheResponse,
   GetRunCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRunCacheRequest,
   output: GetRunCacheResponse,
@@ -8593,7 +8592,7 @@ export const getRunGroup: API.OperationMethod<
   GetRunGroupRequest,
   GetRunGroupResponse,
   GetRunGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRunGroupRequest,
   output: GetRunGroupResponse,
@@ -8630,7 +8629,7 @@ export const getRunTask: API.OperationMethod<
   GetRunTaskRequest,
   GetRunTaskResponse,
   GetRunTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRunTaskRequest,
   output: GetRunTaskResponse,
@@ -8667,7 +8666,7 @@ export const getS3AccessPolicy: API.OperationMethod<
   GetS3AccessPolicyRequest,
   GetS3AccessPolicyResponse,
   GetS3AccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetS3AccessPolicyRequest,
   output: GetS3AccessPolicyResponse,
@@ -8702,7 +8701,7 @@ export const getSequenceStore: API.OperationMethod<
   GetSequenceStoreRequest,
   GetSequenceStoreResponse,
   GetSequenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSequenceStoreRequest,
   output: GetSequenceStoreResponse,
@@ -8736,7 +8735,7 @@ export const getShare: API.OperationMethod<
   GetShareRequest,
   GetShareResponse,
   GetShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetShareRequest,
   output: GetShareResponse,
@@ -8771,7 +8770,7 @@ export const getVariantImportJob: API.OperationMethod<
   GetVariantImportRequest,
   GetVariantImportResponse,
   GetVariantImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVariantImportRequest,
   output: GetVariantImportResponse,
@@ -8805,7 +8804,7 @@ export const getVariantStore: API.OperationMethod<
   GetVariantStoreRequest,
   GetVariantStoreResponse,
   GetVariantStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVariantStoreRequest,
   output: GetVariantStoreResponse,
@@ -8844,7 +8843,7 @@ export const getWorkflow: API.OperationMethod<
   GetWorkflowRequest,
   GetWorkflowResponse,
   GetWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowRequest,
   output: GetWorkflowResponse,
@@ -8881,7 +8880,7 @@ export const getWorkflowVersion: API.OperationMethod<
   GetWorkflowVersionRequest,
   GetWorkflowVersionResponse,
   GetWorkflowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkflowVersionRequest,
   output: GetWorkflowVersionResponse,
@@ -8917,7 +8916,7 @@ export const listAnnotationImportJobs: API.PaginatedOperationMethod<
   ListAnnotationImportJobsRequest,
   ListAnnotationImportJobsResponse,
   ListAnnotationImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnnotationImportJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnnotationImportJobsRequest,
@@ -8957,7 +8956,7 @@ export const listAnnotationStores: API.PaginatedOperationMethod<
   ListAnnotationStoresRequest,
   ListAnnotationStoresResponse,
   ListAnnotationStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnnotationStoreItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnnotationStoresRequest,
@@ -8995,7 +8994,7 @@ export const listAnnotationStoreVersions: API.PaginatedOperationMethod<
   ListAnnotationStoreVersionsRequest,
   ListAnnotationStoreVersionsResponse,
   ListAnnotationStoreVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnnotationStoreVersionItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnnotationStoreVersionsRequest,
@@ -9033,7 +9032,7 @@ export const listBatch: API.PaginatedOperationMethod<
   ListBatchRequest,
   ListBatchResponse,
   ListBatchError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchRequest,
@@ -9074,7 +9073,7 @@ export const listConfigurations: API.PaginatedOperationMethod<
   ListConfigurationsRequest,
   ListConfigurationsResponse,
   ListConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationsRequest,
@@ -9118,7 +9117,7 @@ export const listMultipartReadSetUploads: API.PaginatedOperationMethod<
   ListMultipartReadSetUploadsRequest,
   ListMultipartReadSetUploadsResponse,
   ListMultipartReadSetUploadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultipartReadSetUploadListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultipartReadSetUploadsRequest,
@@ -9160,7 +9159,7 @@ export const listReadSetActivationJobs: API.PaginatedOperationMethod<
   ListReadSetActivationJobsRequest,
   ListReadSetActivationJobsResponse,
   ListReadSetActivationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActivateReadSetJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadSetActivationJobsRequest,
@@ -9200,7 +9199,7 @@ export const listReadSetExportJobs: API.PaginatedOperationMethod<
   ListReadSetExportJobsRequest,
   ListReadSetExportJobsResponse,
   ListReadSetExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportReadSetJobDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadSetExportJobsRequest,
@@ -9240,7 +9239,7 @@ export const listReadSetImportJobs: API.PaginatedOperationMethod<
   ListReadSetImportJobsRequest,
   ListReadSetImportJobsResponse,
   ListReadSetImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportReadSetJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadSetImportJobsRequest,
@@ -9280,7 +9279,7 @@ export const listReadSets: API.PaginatedOperationMethod<
   ListReadSetsRequest,
   ListReadSetsResponse,
   ListReadSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReadSetListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadSetsRequest,
@@ -9322,7 +9321,7 @@ export const listReadSetUploadParts: API.PaginatedOperationMethod<
   ListReadSetUploadPartsRequest,
   ListReadSetUploadPartsResponse,
   ListReadSetUploadPartsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReadSetUploadPartListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadSetUploadPartsRequest,
@@ -9364,7 +9363,7 @@ export const listReferenceImportJobs: API.PaginatedOperationMethod<
   ListReferenceImportJobsRequest,
   ListReferenceImportJobsResponse,
   ListReferenceImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportReferenceJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReferenceImportJobsRequest,
@@ -9406,7 +9405,7 @@ export const listReferences: API.PaginatedOperationMethod<
   ListReferencesRequest,
   ListReferencesResponse,
   ListReferencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReferenceListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReferencesRequest,
@@ -9447,7 +9446,7 @@ export const listReferenceStores: API.PaginatedOperationMethod<
   ListReferenceStoresRequest,
   ListReferenceStoresResponse,
   ListReferenceStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReferenceStoreDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReferenceStoresRequest,
@@ -9488,7 +9487,7 @@ export const listRunCaches: API.PaginatedOperationMethod<
   ListRunCachesRequest,
   ListRunCachesResponse,
   ListRunCachesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RunCacheListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunCachesRequest,
@@ -9532,7 +9531,7 @@ export const listRunGroups: API.PaginatedOperationMethod<
   ListRunGroupsRequest,
   ListRunGroupsResponse,
   ListRunGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RunGroupListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunGroupsRequest,
@@ -9578,7 +9577,7 @@ export const listRuns: API.PaginatedOperationMethod<
   ListRunsRequest,
   ListRunsResponse,
   ListRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RunListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunsRequest,
@@ -9622,7 +9621,7 @@ export const listRunsInBatch: API.PaginatedOperationMethod<
   ListRunsInBatchRequest,
   ListRunsInBatchResponse,
   ListRunsInBatchError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RunBatchListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunsInBatchRequest,
@@ -9666,7 +9665,7 @@ export const listRunTasks: API.PaginatedOperationMethod<
   ListRunTasksRequest,
   ListRunTasksResponse,
   ListRunTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRunTasksRequest,
@@ -9709,7 +9708,7 @@ export const listSequenceStores: API.PaginatedOperationMethod<
   ListSequenceStoresRequest,
   ListSequenceStoresResponse,
   ListSequenceStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SequenceStoreDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSequenceStoresRequest,
@@ -9749,7 +9748,7 @@ export const listShares: API.PaginatedOperationMethod<
   ListSharesRequest,
   ListSharesResponse,
   ListSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ShareDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSharesRequest,
@@ -9792,7 +9791,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -9828,7 +9827,7 @@ export const listVariantImportJobs: API.PaginatedOperationMethod<
   ListVariantImportJobsRequest,
   ListVariantImportJobsResponse,
   ListVariantImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VariantImportJobItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVariantImportJobsRequest,
@@ -9868,7 +9867,7 @@ export const listVariantStores: API.PaginatedOperationMethod<
   ListVariantStoresRequest,
   ListVariantStoresResponse,
   ListVariantStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VariantStoreItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVariantStoresRequest,
@@ -9909,7 +9908,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -9953,7 +9952,7 @@ export const listWorkflowVersions: API.PaginatedOperationMethod<
   ListWorkflowVersionsRequest,
   ListWorkflowVersionsResponse,
   ListWorkflowVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowVersionListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowVersionsRequest,
@@ -9996,7 +9995,7 @@ export const putS3AccessPolicy: API.OperationMethod<
   PutS3AccessPolicyRequest,
   PutS3AccessPolicyResponse,
   PutS3AccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutS3AccessPolicyRequest,
   output: PutS3AccessPolicyResponse,
@@ -10032,7 +10031,7 @@ export const startAnnotationImportJob: API.OperationMethod<
   StartAnnotationImportRequest,
   StartAnnotationImportResponse,
   StartAnnotationImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAnnotationImportRequest,
   output: StartAnnotationImportResponse,
@@ -10068,7 +10067,7 @@ export const startReadSetActivationJob: API.OperationMethod<
   StartReadSetActivationJobRequest,
   StartReadSetActivationJobResponse,
   StartReadSetActivationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReadSetActivationJobRequest,
   output: StartReadSetActivationJobResponse,
@@ -10105,7 +10104,7 @@ export const startReadSetExportJob: API.OperationMethod<
   StartReadSetExportJobRequest,
   StartReadSetExportJobResponse,
   StartReadSetExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReadSetExportJobRequest,
   output: StartReadSetExportJobResponse,
@@ -10140,7 +10139,7 @@ export const startReadSetImportJob: API.OperationMethod<
   StartReadSetImportJobRequest,
   StartReadSetImportJobResponse,
   StartReadSetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReadSetImportJobRequest,
   output: StartReadSetImportJobResponse,
@@ -10175,7 +10174,7 @@ export const startReferenceImportJob: API.OperationMethod<
   StartReferenceImportJobRequest,
   StartReferenceImportJobResponse,
   StartReferenceImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReferenceImportJobRequest,
   output: StartReferenceImportJobResponse,
@@ -10243,7 +10242,7 @@ export const startRun: API.OperationMethod<
   StartRunRequest,
   StartRunResponse,
   StartRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRunRequest,
   output: StartRunResponse,
@@ -10282,7 +10281,7 @@ export const startRunBatch: API.OperationMethod<
   StartRunBatchRequest,
   StartRunBatchResponse,
   StartRunBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRunBatchRequest,
   output: StartRunBatchResponse,
@@ -10319,7 +10318,7 @@ export const startVariantImportJob: API.OperationMethod<
   StartVariantImportRequest,
   StartVariantImportResponse,
   StartVariantImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVariantImportRequest,
   output: StartVariantImportResponse,
@@ -10354,7 +10353,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10391,7 +10390,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10427,7 +10426,7 @@ export const updateAnnotationStore: API.OperationMethod<
   UpdateAnnotationStoreRequest,
   UpdateAnnotationStoreResponse,
   UpdateAnnotationStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnnotationStoreRequest,
   output: UpdateAnnotationStoreResponse,
@@ -10458,7 +10457,7 @@ export const updateAnnotationStoreVersion: API.OperationMethod<
   UpdateAnnotationStoreVersionRequest,
   UpdateAnnotationStoreVersionResponse,
   UpdateAnnotationStoreVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnnotationStoreVersionRequest,
   output: UpdateAnnotationStoreVersionResponse,
@@ -10494,7 +10493,7 @@ export const updateRunCache: API.OperationMethod<
   UpdateRunCacheRequest,
   UpdateRunCacheResponse,
   UpdateRunCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRunCacheRequest,
   output: UpdateRunCacheResponse,
@@ -10545,7 +10544,7 @@ export const updateRunGroup: API.OperationMethod<
   UpdateRunGroupRequest,
   UpdateRunGroupResponse,
   UpdateRunGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRunGroupRequest,
   output: UpdateRunGroupResponse,
@@ -10581,7 +10580,7 @@ export const updateSequenceStore: API.OperationMethod<
   UpdateSequenceStoreRequest,
   UpdateSequenceStoreResponse,
   UpdateSequenceStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSequenceStoreRequest,
   output: UpdateSequenceStoreResponse,
@@ -10616,7 +10615,7 @@ export const updateVariantStore: API.OperationMethod<
   UpdateVariantStoreRequest,
   UpdateVariantStoreResponse,
   UpdateVariantStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVariantStoreRequest,
   output: UpdateVariantStoreResponse,
@@ -10664,7 +10663,7 @@ export const updateWorkflow: API.OperationMethod<
   UpdateWorkflowRequest,
   UpdateWorkflowResponse,
   UpdateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowRequest,
   output: UpdateWorkflowResponse,
@@ -10701,7 +10700,7 @@ export const updateWorkflowVersion: API.OperationMethod<
   UpdateWorkflowVersionRequest,
   UpdateWorkflowVersionResponse,
   UpdateWorkflowVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkflowVersionRequest,
   output: UpdateWorkflowVersionResponse,
@@ -10740,7 +10739,7 @@ export const uploadReadSetPart: API.OperationMethod<
   UploadReadSetPartRequest,
   UploadReadSetPartResponse,
   UploadReadSetPartError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadReadSetPartRequest,
   output: UploadReadSetPartResponse,

--- a/packages/aws/src/services/opensearch.ts
+++ b/packages/aws/src/services/opensearch.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://es.amazonaws.com/doc/2021-01-01/");
 const svc = T.AwsApiService({
@@ -6646,7 +6645,7 @@ export const acceptInboundConnection: API.OperationMethod<
   AcceptInboundConnectionRequest,
   AcceptInboundConnectionResponse,
   AcceptInboundConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInboundConnectionRequest,
   output: AcceptInboundConnectionResponse,
@@ -6678,7 +6677,7 @@ export const addDataSource: API.OperationMethod<
   AddDataSourceRequest,
   AddDataSourceResponse,
   AddDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddDataSourceRequest,
   output: AddDataSourceResponse,
@@ -6712,7 +6711,7 @@ export const addDirectQueryDataSource: API.OperationMethod<
   AddDirectQueryDataSourceRequest,
   AddDirectQueryDataSourceResponse,
   AddDirectQueryDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddDirectQueryDataSourceRequest,
   output: AddDirectQueryDataSourceResponse,
@@ -6746,7 +6745,7 @@ export const addTags: API.OperationMethod<
   AddTagsRequest,
   AddTagsResponse,
   AddTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsRequest,
   output: AddTagsResponse,
@@ -6778,7 +6777,7 @@ export const associatePackage: API.OperationMethod<
   AssociatePackageRequest,
   AssociatePackageResponse,
   AssociatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePackageRequest,
   output: AssociatePackageResponse,
@@ -6811,7 +6810,7 @@ export const associatePackages: API.OperationMethod<
   AssociatePackagesRequest,
   AssociatePackagesResponse,
   AssociatePackagesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePackagesRequest,
   output: AssociatePackagesResponse,
@@ -6843,7 +6842,7 @@ export const attachDataSource: API.OperationMethod<
   AttachDataSourceRequest,
   AttachDataSourceResponse,
   AttachDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachDataSourceRequest,
   output: AttachDataSourceResponse,
@@ -6876,7 +6875,7 @@ export const authorizeVpcEndpointAccess: API.OperationMethod<
   AuthorizeVpcEndpointAccessRequest,
   AuthorizeVpcEndpointAccessResponse,
   AuthorizeVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeVpcEndpointAccessRequest,
   output: AuthorizeVpcEndpointAccessResponse,
@@ -6907,7 +6906,7 @@ export const cancelDomainConfigChange: API.OperationMethod<
   CancelDomainConfigChangeRequest,
   CancelDomainConfigChangeResponse,
   CancelDomainConfigChangeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDomainConfigChangeRequest,
   output: CancelDomainConfigChangeResponse,
@@ -6940,7 +6939,7 @@ export const cancelServiceSoftwareUpdate: API.OperationMethod<
   CancelServiceSoftwareUpdateRequest,
   CancelServiceSoftwareUpdateResponse,
   CancelServiceSoftwareUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelServiceSoftwareUpdateRequest,
   output: CancelServiceSoftwareUpdateResponse,
@@ -6970,7 +6969,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -7004,7 +7003,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -7039,7 +7038,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexRequest,
   CreateIndexResponse,
   CreateIndexError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
@@ -7073,7 +7072,7 @@ export const createOutboundConnection: API.OperationMethod<
   CreateOutboundConnectionRequest,
   CreateOutboundConnectionResponse,
   CreateOutboundConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOutboundConnectionRequest,
   output: CreateOutboundConnectionResponse,
@@ -7106,7 +7105,7 @@ export const createPackage: API.OperationMethod<
   CreatePackageRequest,
   CreatePackageResponse,
   CreatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageRequest,
   output: CreatePackageResponse,
@@ -7139,7 +7138,7 @@ export const createVpcEndpoint: API.OperationMethod<
   CreateVpcEndpointRequest,
   CreateVpcEndpointResponse,
   CreateVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointRequest,
   output: CreateVpcEndpointResponse,
@@ -7172,7 +7171,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -7206,7 +7205,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -7238,7 +7237,7 @@ export const deleteDirectQueryDataSource: API.OperationMethod<
   DeleteDirectQueryDataSourceRequest,
   DeleteDirectQueryDataSourceResponse,
   DeleteDirectQueryDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectQueryDataSourceRequest,
   output: DeleteDirectQueryDataSourceResponse,
@@ -7268,7 +7267,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -7295,7 +7294,7 @@ export const deleteInboundConnection: API.OperationMethod<
   DeleteInboundConnectionRequest,
   DeleteInboundConnectionResponse,
   DeleteInboundConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInboundConnectionRequest,
   output: DeleteInboundConnectionResponse,
@@ -7321,7 +7320,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexRequest,
   DeleteIndexResponse,
   DeleteIndexError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexRequest,
   output: DeleteIndexResponse,
@@ -7351,7 +7350,7 @@ export const deleteOutboundConnection: API.OperationMethod<
   DeleteOutboundConnectionRequest,
   DeleteOutboundConnectionResponse,
   DeleteOutboundConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutboundConnectionRequest,
   output: DeleteOutboundConnectionResponse,
@@ -7377,7 +7376,7 @@ export const deletePackage: API.OperationMethod<
   DeletePackageRequest,
   DeletePackageResponse,
   DeletePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageRequest,
   output: DeletePackageResponse,
@@ -7407,7 +7406,7 @@ export const deleteVpcEndpoint: API.OperationMethod<
   DeleteVpcEndpointRequest,
   DeleteVpcEndpointResponse,
   DeleteVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointRequest,
   output: DeleteVpcEndpointResponse,
@@ -7437,7 +7436,7 @@ export const deregisterCapability: API.OperationMethod<
   DeregisterCapabilityRequest,
   DeregisterCapabilityResponse,
   DeregisterCapabilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterCapabilityRequest,
   output: DeregisterCapabilityResponse,
@@ -7468,7 +7467,7 @@ export const describeDataSourceAttachment: API.OperationMethod<
   DescribeDataSourceAttachmentRequest,
   DescribeDataSourceAttachmentResponse,
   DescribeDataSourceAttachmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSourceAttachmentRequest,
   output: DescribeDataSourceAttachmentResponse,
@@ -7498,7 +7497,7 @@ export const describeDomain: API.OperationMethod<
   DescribeDomainRequest,
   DescribeDomainResponse,
   DescribeDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainRequest,
   output: DescribeDomainResponse,
@@ -7528,7 +7527,7 @@ export const describeDomainAutoTunes: API.PaginatedOperationMethod<
   DescribeDomainAutoTunesRequest,
   DescribeDomainAutoTunesResponse,
   DescribeDomainAutoTunesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDomainAutoTunesRequest,
@@ -7563,7 +7562,7 @@ export const describeDomainChangeProgress: API.OperationMethod<
   DescribeDomainChangeProgressRequest,
   DescribeDomainChangeProgressResponse,
   DescribeDomainChangeProgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainChangeProgressRequest,
   output: DescribeDomainChangeProgressResponse,
@@ -7591,7 +7590,7 @@ export const describeDomainConfig: API.OperationMethod<
   DescribeDomainConfigRequest,
   DescribeDomainConfigResponse,
   DescribeDomainConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainConfigRequest,
   output: DescribeDomainConfigResponse,
@@ -7621,7 +7620,7 @@ export const describeDomainHealth: API.OperationMethod<
   DescribeDomainHealthRequest,
   DescribeDomainHealthResponse,
   DescribeDomainHealthError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainHealthRequest,
   output: DescribeDomainHealthResponse,
@@ -7654,7 +7653,7 @@ export const describeDomainNodes: API.OperationMethod<
   DescribeDomainNodesRequest,
   DescribeDomainNodesResponse,
   DescribeDomainNodesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainNodesRequest,
   output: DescribeDomainNodesResponse,
@@ -7684,7 +7683,7 @@ export const describeDomains: API.OperationMethod<
   DescribeDomainsRequest,
   DescribeDomainsResponse,
   DescribeDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainsRequest,
   output: DescribeDomainsResponse,
@@ -7709,7 +7708,7 @@ export const describeDryRunProgress: API.OperationMethod<
   DescribeDryRunProgressRequest,
   DescribeDryRunProgressResponse,
   DescribeDryRunProgressError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDryRunProgressRequest,
   output: DescribeDryRunProgressResponse,
@@ -7737,7 +7736,7 @@ export const describeInboundConnections: API.PaginatedOperationMethod<
   DescribeInboundConnectionsRequest,
   DescribeInboundConnectionsResponse,
   DescribeInboundConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInboundConnectionsRequest,
@@ -7770,7 +7769,7 @@ export const describeInsightDetails: API.OperationMethod<
   DescribeInsightDetailsRequest,
   DescribeInsightDetailsResponse,
   DescribeInsightDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInsightDetailsRequest,
   output: DescribeInsightDetailsResponse,
@@ -7803,7 +7802,7 @@ export const describeInstanceTypeLimits: API.OperationMethod<
   DescribeInstanceTypeLimitsRequest,
   DescribeInstanceTypeLimitsResponse,
   DescribeInstanceTypeLimitsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceTypeLimitsRequest,
   output: DescribeInstanceTypeLimitsResponse,
@@ -7832,7 +7831,7 @@ export const describeOutboundConnections: API.PaginatedOperationMethod<
   DescribeOutboundConnectionsRequest,
   DescribeOutboundConnectionsResponse,
   DescribeOutboundConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOutboundConnectionsRequest,
@@ -7864,7 +7863,7 @@ export const describePackages: API.PaginatedOperationMethod<
   DescribePackagesRequest,
   DescribePackagesResponse,
   DescribePackagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePackagesRequest,
@@ -7901,7 +7900,7 @@ export const describeReservedInstanceOfferings: API.PaginatedOperationMethod<
   DescribeReservedInstanceOfferingsRequest,
   DescribeReservedInstanceOfferingsResponse,
   DescribeReservedInstanceOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedInstanceOfferingsRequest,
@@ -7937,7 +7936,7 @@ export const describeReservedInstances: API.PaginatedOperationMethod<
   DescribeReservedInstancesRequest,
   DescribeReservedInstancesResponse,
   DescribeReservedInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedInstancesRequest,
@@ -7971,7 +7970,7 @@ export const describeVpcEndpoints: API.OperationMethod<
   DescribeVpcEndpointsRequest,
   DescribeVpcEndpointsResponse,
   DescribeVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVpcEndpointsRequest,
   output: DescribeVpcEndpointsResponse,
@@ -8001,7 +8000,7 @@ export const detachDataSource: API.OperationMethod<
   DetachDataSourceRequest,
   DetachDataSourceResponse,
   DetachDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachDataSourceRequest,
   output: DetachDataSourceResponse,
@@ -8037,7 +8036,7 @@ export const dissociatePackage: API.OperationMethod<
   DissociatePackageRequest,
   DissociatePackageResponse,
   DissociatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DissociatePackageRequest,
   output: DissociatePackageResponse,
@@ -8069,7 +8068,7 @@ export const dissociatePackages: API.OperationMethod<
   DissociatePackagesRequest,
   DissociatePackagesResponse,
   DissociatePackagesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DissociatePackagesRequest,
   output: DissociatePackagesResponse,
@@ -8101,7 +8100,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -8132,7 +8131,7 @@ export const getCapability: API.OperationMethod<
   GetCapabilityRequest,
   GetCapabilityResponse,
   GetCapabilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapabilityRequest,
   output: GetCapabilityResponse,
@@ -8163,7 +8162,7 @@ export const getCompatibleVersions: API.OperationMethod<
   GetCompatibleVersionsRequest,
   GetCompatibleVersionsResponse,
   GetCompatibleVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCompatibleVersionsRequest,
   output: GetCompatibleVersionsResponse,
@@ -8194,7 +8193,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceRequest,
   GetDataSourceResponse,
   GetDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceRequest,
   output: GetDataSourceResponse,
@@ -8227,7 +8226,7 @@ export const getDefaultApplicationSetting: API.OperationMethod<
   GetDefaultApplicationSettingRequest,
   GetDefaultApplicationSettingResponse,
   GetDefaultApplicationSettingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultApplicationSettingRequest,
   output: GetDefaultApplicationSettingResponse,
@@ -8257,7 +8256,7 @@ export const getDirectQueryDataSource: API.OperationMethod<
   GetDirectQueryDataSourceRequest,
   GetDirectQueryDataSourceResponse,
   GetDirectQueryDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDirectQueryDataSourceRequest,
   output: GetDirectQueryDataSourceResponse,
@@ -8287,7 +8286,7 @@ export const getDomainMaintenanceStatus: API.OperationMethod<
   GetDomainMaintenanceStatusRequest,
   GetDomainMaintenanceStatusResponse,
   GetDomainMaintenanceStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainMaintenanceStatusRequest,
   output: GetDomainMaintenanceStatusResponse,
@@ -8319,7 +8318,7 @@ export const getIndex: API.OperationMethod<
   GetIndexRequest,
   GetIndexResponse,
   GetIndexError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexRequest,
   output: GetIndexResponse,
@@ -8354,7 +8353,7 @@ export const getPackageVersionHistory: API.PaginatedOperationMethod<
   GetPackageVersionHistoryRequest,
   GetPackageVersionHistoryResponse,
   GetPackageVersionHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPackageVersionHistoryRequest,
@@ -8391,7 +8390,7 @@ export const getUpgradeHistory: API.PaginatedOperationMethod<
   GetUpgradeHistoryRequest,
   GetUpgradeHistoryResponse,
   GetUpgradeHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetUpgradeHistoryRequest,
@@ -8428,7 +8427,7 @@ export const getUpgradeStatus: API.OperationMethod<
   GetUpgradeStatusRequest,
   GetUpgradeStatusResponse,
   GetUpgradeStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUpgradeStatusRequest,
   output: GetUpgradeStatusResponse,
@@ -8459,7 +8458,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -8497,7 +8496,7 @@ export const listDataSourceAttachments: API.OperationMethod<
   ListDataSourceAttachmentsRequest,
   ListDataSourceAttachmentsResponse,
   ListDataSourceAttachmentsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataSourceAttachmentsRequest,
   output: ListDataSourceAttachmentsResponse,
@@ -8530,7 +8529,7 @@ export const listDataSources: API.OperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataSourcesRequest,
   output: ListDataSourcesResponse,
@@ -8562,7 +8561,7 @@ export const listDirectQueryDataSources: API.OperationMethod<
   ListDirectQueryDataSourcesRequest,
   ListDirectQueryDataSourcesResponse,
   ListDirectQueryDataSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDirectQueryDataSourcesRequest,
   output: ListDirectQueryDataSourcesResponse,
@@ -8592,7 +8591,7 @@ export const listDomainMaintenances: API.PaginatedOperationMethod<
   ListDomainMaintenancesRequest,
   ListDomainMaintenancesResponse,
   ListDomainMaintenancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainMaintenancesRequest,
@@ -8626,7 +8625,7 @@ export const listDomainNames: API.OperationMethod<
   ListDomainNamesRequest,
   ListDomainNamesResponse,
   ListDomainNamesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDomainNamesRequest,
   output: ListDomainNamesResponse,
@@ -8652,7 +8651,7 @@ export const listDomainsForPackage: API.PaginatedOperationMethod<
   ListDomainsForPackageRequest,
   ListDomainsForPackageResponse,
   ListDomainsForPackageError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsForPackageRequest,
@@ -8691,7 +8690,7 @@ export const listInsights: API.OperationMethod<
   ListInsightsRequest,
   ListInsightsResponse,
   ListInsightsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInsightsRequest,
   output: ListInsightsResponse,
@@ -8722,7 +8721,7 @@ export const listInstanceTypeDetails: API.PaginatedOperationMethod<
   ListInstanceTypeDetailsRequest,
   ListInstanceTypeDetailsResponse,
   ListInstanceTypeDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceTypeDetailsRequest,
@@ -8759,7 +8758,7 @@ export const listPackagesForDomain: API.PaginatedOperationMethod<
   ListPackagesForDomainRequest,
   ListPackagesForDomainResponse,
   ListPackagesForDomainError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagesForDomainRequest,
@@ -8797,7 +8796,7 @@ export const listScheduledActions: API.PaginatedOperationMethod<
   ListScheduledActionsRequest,
   ListScheduledActionsResponse,
   ListScheduledActionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledActionsRequest,
@@ -8833,7 +8832,7 @@ export const listTags: API.OperationMethod<
   ListTagsRequest,
   ListTagsResponse,
   ListTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsRequest,
   output: ListTagsResponse,
@@ -8862,7 +8861,7 @@ export const listVersions: API.PaginatedOperationMethod<
   ListVersionsRequest,
   ListVersionsResponse,
   ListVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVersionsRequest,
@@ -8898,7 +8897,7 @@ export const listVpcEndpointAccess: API.OperationMethod<
   ListVpcEndpointAccessRequest,
   ListVpcEndpointAccessResponse,
   ListVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointAccessRequest,
   output: ListVpcEndpointAccessResponse,
@@ -8925,7 +8924,7 @@ export const listVpcEndpoints: API.OperationMethod<
   ListVpcEndpointsRequest,
   ListVpcEndpointsResponse,
   ListVpcEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointsRequest,
   output: ListVpcEndpointsResponse,
@@ -8949,7 +8948,7 @@ export const listVpcEndpointsForDomain: API.OperationMethod<
   ListVpcEndpointsForDomainRequest,
   ListVpcEndpointsForDomainResponse,
   ListVpcEndpointsForDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVpcEndpointsForDomainRequest,
   output: ListVpcEndpointsForDomainResponse,
@@ -8979,7 +8978,7 @@ export const purchaseReservedInstanceOffering: API.OperationMethod<
   PurchaseReservedInstanceOfferingRequest,
   PurchaseReservedInstanceOfferingResponse,
   PurchaseReservedInstanceOfferingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedInstanceOfferingRequest,
   output: PurchaseReservedInstanceOfferingResponse,
@@ -9014,7 +9013,7 @@ export const putDefaultApplicationSetting: API.OperationMethod<
   PutDefaultApplicationSettingRequest,
   PutDefaultApplicationSettingResponse,
   PutDefaultApplicationSettingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDefaultApplicationSettingRequest,
   output: PutDefaultApplicationSettingResponse,
@@ -9045,7 +9044,7 @@ export const registerCapability: API.OperationMethod<
   RegisterCapabilityRequest,
   RegisterCapabilityResponse,
   RegisterCapabilityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterCapabilityRequest,
   output: RegisterCapabilityResponse,
@@ -9075,7 +9074,7 @@ export const rejectInboundConnection: API.OperationMethod<
   RejectInboundConnectionRequest,
   RejectInboundConnectionResponse,
   RejectInboundConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectInboundConnectionRequest,
   output: RejectInboundConnectionResponse,
@@ -9098,7 +9097,7 @@ export const removeTags: API.OperationMethod<
   RemoveTagsRequest,
   RemoveTagsResponse,
   RemoveTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsRequest,
   output: RemoveTagsResponse,
@@ -9123,7 +9122,7 @@ export const revokeVpcEndpointAccess: API.OperationMethod<
   RevokeVpcEndpointAccessRequest,
   RevokeVpcEndpointAccessResponse,
   RevokeVpcEndpointAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeVpcEndpointAccessRequest,
   output: RevokeVpcEndpointAccessResponse,
@@ -9155,7 +9154,7 @@ export const rollbackServiceSoftwareUpdate: API.OperationMethod<
   RollbackServiceSoftwareUpdateRequest,
   RollbackServiceSoftwareUpdateResponse,
   RollbackServiceSoftwareUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackServiceSoftwareUpdateRequest,
   output: RollbackServiceSoftwareUpdateResponse,
@@ -9187,7 +9186,7 @@ export const startDomainMaintenance: API.OperationMethod<
   StartDomainMaintenanceRequest,
   StartDomainMaintenanceResponse,
   StartDomainMaintenanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDomainMaintenanceRequest,
   output: StartDomainMaintenanceResponse,
@@ -9218,7 +9217,7 @@ export const startServiceSoftwareUpdate: API.OperationMethod<
   StartServiceSoftwareUpdateRequest,
   StartServiceSoftwareUpdateResponse,
   StartServiceSoftwareUpdateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartServiceSoftwareUpdateRequest,
   output: StartServiceSoftwareUpdateResponse,
@@ -9249,7 +9248,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -9284,7 +9283,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -9317,7 +9316,7 @@ export const updateDirectQueryDataSource: API.OperationMethod<
   UpdateDirectQueryDataSourceRequest,
   UpdateDirectQueryDataSourceResponse,
   UpdateDirectQueryDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDirectQueryDataSourceRequest,
   output: UpdateDirectQueryDataSourceResponse,
@@ -9350,7 +9349,7 @@ export const updateDomainConfig: API.OperationMethod<
   UpdateDomainConfigRequest,
   UpdateDomainConfigResponse,
   UpdateDomainConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainConfigRequest,
   output: UpdateDomainConfigResponse,
@@ -9383,7 +9382,7 @@ export const updateIndex: API.OperationMethod<
   UpdateIndexRequest,
   UpdateIndexResponse,
   UpdateIndexError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexRequest,
   output: UpdateIndexResponse,
@@ -9418,7 +9417,7 @@ export const updatePackage: API.OperationMethod<
   UpdatePackageRequest,
   UpdatePackageResponse,
   UpdatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageRequest,
   output: UpdatePackageResponse,
@@ -9450,7 +9449,7 @@ export const updatePackageScope: API.OperationMethod<
   UpdatePackageScopeRequest,
   UpdatePackageScopeResponse,
   UpdatePackageScopeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePackageScopeRequest,
   output: UpdatePackageScopeResponse,
@@ -9484,7 +9483,7 @@ export const updateScheduledAction: API.OperationMethod<
   UpdateScheduledActionRequest,
   UpdateScheduledActionResponse,
   UpdateScheduledActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledActionRequest,
   output: UpdateScheduledActionResponse,
@@ -9517,7 +9516,7 @@ export const updateVpcEndpoint: API.OperationMethod<
   UpdateVpcEndpointRequest,
   UpdateVpcEndpointResponse,
   UpdateVpcEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcEndpointRequest,
   output: UpdateVpcEndpointResponse,
@@ -9550,7 +9549,7 @@ export const upgradeDomain: API.OperationMethod<
   UpgradeDomainRequest,
   UpgradeDomainResponse,
   UpgradeDomainError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeDomainRequest,
   output: UpgradeDomainResponse,

--- a/packages/aws/src/services/opensearchserverless.ts
+++ b/packages/aws/src/services/opensearchserverless.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "OpenSearchServerless",
   serviceShapeName: "OpenSearchServerless",
@@ -2278,7 +2277,7 @@ export const batchGetCollection: API.OperationMethod<
   BatchGetCollectionRequest,
   BatchGetCollectionResponse,
   BatchGetCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCollectionRequest,
   output: BatchGetCollectionResponse,
@@ -2299,7 +2298,7 @@ export const batchGetCollectionGroup: API.OperationMethod<
   BatchGetCollectionGroupRequest,
   BatchGetCollectionGroupResponse,
   BatchGetCollectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCollectionGroupRequest,
   output: BatchGetCollectionGroupResponse,
@@ -2320,7 +2319,7 @@ export const batchGetEffectiveLifecyclePolicy: API.OperationMethod<
   BatchGetEffectiveLifecyclePolicyRequest,
   BatchGetEffectiveLifecyclePolicyResponse,
   BatchGetEffectiveLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetEffectiveLifecyclePolicyRequest,
   output: BatchGetEffectiveLifecyclePolicyResponse,
@@ -2341,7 +2340,7 @@ export const batchGetLifecyclePolicy: API.OperationMethod<
   BatchGetLifecyclePolicyRequest,
   BatchGetLifecyclePolicyResponse,
   BatchGetLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetLifecyclePolicyRequest,
   output: BatchGetLifecyclePolicyResponse,
@@ -2362,7 +2361,7 @@ export const batchGetVpcEndpoint: API.OperationMethod<
   BatchGetVpcEndpointRequest,
   BatchGetVpcEndpointResponse,
   BatchGetVpcEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetVpcEndpointRequest,
   output: BatchGetVpcEndpointResponse,
@@ -2385,7 +2384,7 @@ export const createAccessPolicy: API.OperationMethod<
   CreateAccessPolicyRequest,
   CreateAccessPolicyResponse,
   CreateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPolicyRequest,
   output: CreateAccessPolicyResponse,
@@ -2414,7 +2413,7 @@ export const createCollection: API.OperationMethod<
   CreateCollectionRequest,
   CreateCollectionResponse,
   CreateCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCollectionRequest,
   output: CreateCollectionResponse,
@@ -2445,7 +2444,7 @@ export const createCollectionGroup: API.OperationMethod<
   CreateCollectionGroupRequest,
   CreateCollectionGroupResponse,
   CreateCollectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCollectionGroupRequest,
   output: CreateCollectionGroupResponse,
@@ -2473,7 +2472,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexRequest,
   CreateIndexResponse,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
@@ -2501,7 +2500,7 @@ export const createLifecyclePolicy: API.OperationMethod<
   CreateLifecyclePolicyRequest,
   CreateLifecyclePolicyResponse,
   CreateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLifecyclePolicyRequest,
   output: CreateLifecyclePolicyResponse,
@@ -2529,7 +2528,7 @@ export const createSecurityConfig: API.OperationMethod<
   CreateSecurityConfigRequest,
   CreateSecurityConfigResponse,
   CreateSecurityConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityConfigRequest,
   output: CreateSecurityConfigResponse,
@@ -2557,7 +2556,7 @@ export const createSecurityPolicy: API.OperationMethod<
   CreateSecurityPolicyRequest,
   CreateSecurityPolicyResponse,
   CreateSecurityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityPolicyRequest,
   output: CreateSecurityPolicyResponse,
@@ -2585,7 +2584,7 @@ export const createVpcEndpoint: API.OperationMethod<
   CreateVpcEndpointRequest,
   CreateVpcEndpointResponse,
   CreateVpcEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVpcEndpointRequest,
   output: CreateVpcEndpointResponse,
@@ -2613,7 +2612,7 @@ export const deleteAccessPolicy: API.OperationMethod<
   DeleteAccessPolicyRequest,
   DeleteAccessPolicyResponse,
   DeleteAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPolicyRequest,
   output: DeleteAccessPolicyResponse,
@@ -2641,7 +2640,7 @@ export const deleteCollection: API.OperationMethod<
   DeleteCollectionRequest,
   DeleteCollectionResponse,
   DeleteCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCollectionRequest,
   output: DeleteCollectionResponse,
@@ -2669,7 +2668,7 @@ export const deleteCollectionGroup: API.OperationMethod<
   DeleteCollectionGroupRequest,
   DeleteCollectionGroupResponse,
   DeleteCollectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCollectionGroupRequest,
   output: DeleteCollectionGroupResponse,
@@ -2696,7 +2695,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexRequest,
   DeleteIndexResponse,
   DeleteIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexRequest,
   output: DeleteIndexResponse,
@@ -2723,7 +2722,7 @@ export const deleteLifecyclePolicy: API.OperationMethod<
   DeleteLifecyclePolicyRequest,
   DeleteLifecyclePolicyResponse,
   DeleteLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLifecyclePolicyRequest,
   output: DeleteLifecyclePolicyResponse,
@@ -2751,7 +2750,7 @@ export const deleteSecurityConfig: API.OperationMethod<
   DeleteSecurityConfigRequest,
   DeleteSecurityConfigResponse,
   DeleteSecurityConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityConfigRequest,
   output: DeleteSecurityConfigResponse,
@@ -2779,7 +2778,7 @@ export const deleteSecurityPolicy: API.OperationMethod<
   DeleteSecurityPolicyRequest,
   DeleteSecurityPolicyResponse,
   DeleteSecurityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityPolicyRequest,
   output: DeleteSecurityPolicyResponse,
@@ -2807,7 +2806,7 @@ export const deleteVpcEndpoint: API.OperationMethod<
   DeleteVpcEndpointRequest,
   DeleteVpcEndpointResponse,
   DeleteVpcEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVpcEndpointRequest,
   output: DeleteVpcEndpointResponse,
@@ -2834,7 +2833,7 @@ export const getAccessPolicy: API.OperationMethod<
   GetAccessPolicyRequest,
   GetAccessPolicyResponse,
   GetAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPolicyRequest,
   output: GetAccessPolicyResponse,
@@ -2859,7 +2858,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsResponse,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsResponse,
@@ -2881,7 +2880,7 @@ export const getIndex: API.OperationMethod<
   GetIndexRequest,
   GetIndexResponse,
   GetIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexRequest,
   output: GetIndexResponse,
@@ -2903,7 +2902,7 @@ export const getPoliciesStats: API.OperationMethod<
   GetPoliciesStatsRequest,
   GetPoliciesStatsResponse,
   GetPoliciesStatsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPoliciesStatsRequest,
   output: GetPoliciesStatsResponse,
@@ -2925,7 +2924,7 @@ export const getSecurityConfig: API.OperationMethod<
   GetSecurityConfigRequest,
   GetSecurityConfigResponse,
   GetSecurityConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityConfigRequest,
   output: GetSecurityConfigResponse,
@@ -2951,7 +2950,7 @@ export const getSecurityPolicy: API.OperationMethod<
   GetSecurityPolicyRequest,
   GetSecurityPolicyResponse,
   GetSecurityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityPolicyRequest,
   output: GetSecurityPolicyResponse,
@@ -2976,7 +2975,7 @@ export const listAccessPolicies: API.PaginatedOperationMethod<
   ListAccessPoliciesRequest,
   ListAccessPoliciesResponse,
   ListAccessPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPoliciesRequest,
@@ -2999,7 +2998,7 @@ export const listCollectionGroups: API.PaginatedOperationMethod<
   ListCollectionGroupsRequest,
   ListCollectionGroupsResponse,
   ListCollectionGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollectionGroupsRequest,
@@ -3024,7 +3023,7 @@ export const listCollections: API.PaginatedOperationMethod<
   ListCollectionsRequest,
   ListCollectionsResponse,
   ListCollectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollectionsRequest,
@@ -3047,7 +3046,7 @@ export const listLifecyclePolicies: API.PaginatedOperationMethod<
   ListLifecyclePoliciesRequest,
   ListLifecyclePoliciesResponse,
   ListLifecyclePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLifecyclePoliciesRequest,
@@ -3070,7 +3069,7 @@ export const listSecurityConfigs: API.PaginatedOperationMethod<
   ListSecurityConfigsRequest,
   ListSecurityConfigsResponse,
   ListSecurityConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityConfigsRequest,
@@ -3093,7 +3092,7 @@ export const listSecurityPolicies: API.PaginatedOperationMethod<
   ListSecurityPoliciesRequest,
   ListSecurityPoliciesResponse,
   ListSecurityPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityPoliciesRequest,
@@ -3117,7 +3116,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3142,7 +3141,7 @@ export const listVpcEndpoints: API.PaginatedOperationMethod<
   ListVpcEndpointsRequest,
   ListVpcEndpointsResponse,
   ListVpcEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVpcEndpointsRequest,
@@ -3168,7 +3167,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3197,7 +3196,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3225,7 +3224,7 @@ export const updateAccessPolicy: API.OperationMethod<
   UpdateAccessPolicyRequest,
   UpdateAccessPolicyResponse,
   UpdateAccessPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessPolicyRequest,
   output: UpdateAccessPolicyResponse,
@@ -3252,7 +3251,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsRequest,
   UpdateAccountSettingsResponse,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsRequest,
   output: UpdateAccountSettingsResponse,
@@ -3278,7 +3277,7 @@ export const updateCollection: API.OperationMethod<
   UpdateCollectionRequest,
   UpdateCollectionResponse,
   UpdateCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCollectionRequest,
   output: UpdateCollectionResponse,
@@ -3301,7 +3300,7 @@ export const updateCollectionGroup: API.OperationMethod<
   UpdateCollectionGroupRequest,
   UpdateCollectionGroupResponse,
   UpdateCollectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCollectionGroupRequest,
   output: UpdateCollectionGroupResponse,
@@ -3328,7 +3327,7 @@ export const updateIndex: API.OperationMethod<
   UpdateIndexRequest,
   UpdateIndexResponse,
   UpdateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexRequest,
   output: UpdateIndexResponse,
@@ -3356,7 +3355,7 @@ export const updateLifecyclePolicy: API.OperationMethod<
   UpdateLifecyclePolicyRequest,
   UpdateLifecyclePolicyResponse,
   UpdateLifecyclePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLifecyclePolicyRequest,
   output: UpdateLifecyclePolicyResponse,
@@ -3385,7 +3384,7 @@ export const updateSecurityConfig: API.OperationMethod<
   UpdateSecurityConfigRequest,
   UpdateSecurityConfigResponse,
   UpdateSecurityConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityConfigRequest,
   output: UpdateSecurityConfigResponse,
@@ -3414,7 +3413,7 @@ export const updateSecurityPolicy: API.OperationMethod<
   UpdateSecurityPolicyRequest,
   UpdateSecurityPolicyResponse,
   UpdateSecurityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityPolicyRequest,
   output: UpdateSecurityPolicyResponse,
@@ -3442,7 +3441,7 @@ export const updateVpcEndpoint: API.OperationMethod<
   UpdateVpcEndpointRequest,
   UpdateVpcEndpointResponse,
   UpdateVpcEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVpcEndpointRequest,
   output: UpdateVpcEndpointResponse,

--- a/packages/aws/src/services/organizations.ts
+++ b/packages/aws/src/services/organizations.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://organizations.amazonaws.com/doc/2016-11-28/");
 const svc = T.AwsApiService({
@@ -3300,7 +3299,7 @@ export const acceptHandshake: API.OperationMethod<
   AcceptHandshakeRequest,
   AcceptHandshakeResponse,
   AcceptHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptHandshakeRequest,
   output: AcceptHandshakeResponse,
@@ -3376,7 +3375,7 @@ export const attachPolicy: API.OperationMethod<
   AttachPolicyRequest,
   AttachPolicyResponse,
   AttachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachPolicyRequest,
   output: AttachPolicyResponse,
@@ -3423,7 +3422,7 @@ export const cancelHandshake: API.OperationMethod<
   CancelHandshakeRequest,
   CancelHandshakeResponse,
   CancelHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelHandshakeRequest,
   output: CancelHandshakeResponse,
@@ -3508,7 +3507,7 @@ export const closeAccount: API.OperationMethod<
   CloseAccountRequest,
   CloseAccountResponse,
   CloseAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloseAccountRequest,
   output: CloseAccountResponse,
@@ -3617,7 +3616,7 @@ export const createAccount: API.OperationMethod<
   CreateAccountRequest,
   CreateAccountResponse,
   CreateAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountRequest,
   output: CreateAccountResponse,
@@ -3768,7 +3767,7 @@ export const createGovCloudAccount: API.OperationMethod<
   CreateGovCloudAccountRequest,
   CreateGovCloudAccountResponse,
   CreateGovCloudAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGovCloudAccountRequest,
   output: CreateGovCloudAccountResponse,
@@ -3822,7 +3821,7 @@ export const createOrganization: API.OperationMethod<
   CreateOrganizationRequest,
   CreateOrganizationResponse,
   CreateOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOrganizationRequest,
   output: CreateOrganizationResponse,
@@ -3871,7 +3870,7 @@ export const createOrganizationalUnit: API.OperationMethod<
   CreateOrganizationalUnitRequest,
   CreateOrganizationalUnitResponse,
   CreateOrganizationalUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOrganizationalUnitRequest,
   output: CreateOrganizationalUnitResponse,
@@ -3920,7 +3919,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyRequest,
   CreatePolicyResponse,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyRequest,
   output: CreatePolicyResponse,
@@ -3965,7 +3964,7 @@ export const declineHandshake: API.OperationMethod<
   DeclineHandshakeRequest,
   DeclineHandshakeResponse,
   DeclineHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeclineHandshakeRequest,
   output: DeclineHandshakeResponse,
@@ -4007,7 +4006,7 @@ export const deleteOrganization: API.OperationMethod<
   DeleteOrganizationRequest,
   DeleteOrganizationResponse,
   DeleteOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOrganizationRequest,
   output: DeleteOrganizationResponse,
@@ -4046,7 +4045,7 @@ export const deleteOrganizationalUnit: API.OperationMethod<
   DeleteOrganizationalUnitRequest,
   DeleteOrganizationalUnitResponse,
   DeleteOrganizationalUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOrganizationalUnitRequest,
   output: DeleteOrganizationalUnitResponse,
@@ -4087,7 +4086,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -4126,7 +4125,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -4177,7 +4176,7 @@ export const deregisterDelegatedAdministrator: API.OperationMethod<
   DeregisterDelegatedAdministratorRequest,
   DeregisterDelegatedAdministratorResponse,
   DeregisterDelegatedAdministratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterDelegatedAdministratorRequest,
   output: DeregisterDelegatedAdministratorResponse,
@@ -4215,7 +4214,7 @@ export const describeAccount: API.OperationMethod<
   DescribeAccountRequest,
   DescribeAccountResponse,
   DescribeAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountRequest,
   output: DescribeAccountResponse,
@@ -4250,7 +4249,7 @@ export const describeCreateAccountStatus: API.OperationMethod<
   DescribeCreateAccountStatusRequest,
   DescribeCreateAccountStatusResponse,
   DescribeCreateAccountStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCreateAccountStatusRequest,
   output: DescribeCreateAccountStatusResponse,
@@ -4298,7 +4297,7 @@ export const describeEffectivePolicy: API.OperationMethod<
   DescribeEffectivePolicyRequest,
   DescribeEffectivePolicyResponse,
   DescribeEffectivePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEffectivePolicyRequest,
   output: DescribeEffectivePolicyResponse,
@@ -4339,7 +4338,7 @@ export const describeHandshake: API.OperationMethod<
   DescribeHandshakeRequest,
   DescribeHandshakeResponse,
   DescribeHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHandshakeRequest,
   output: DescribeHandshakeResponse,
@@ -4377,7 +4376,7 @@ export const describeOrganization: API.OperationMethod<
   DescribeOrganizationRequest,
   DescribeOrganizationResponse,
   DescribeOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationRequest,
   output: DescribeOrganizationResponse,
@@ -4410,7 +4409,7 @@ export const describeOrganizationalUnit: API.OperationMethod<
   DescribeOrganizationalUnitRequest,
   DescribeOrganizationalUnitResponse,
   DescribeOrganizationalUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationalUnitRequest,
   output: DescribeOrganizationalUnitResponse,
@@ -4445,7 +4444,7 @@ export const describePolicy: API.OperationMethod<
   DescribePolicyRequest,
   DescribePolicyResponse,
   DescribePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePolicyRequest,
   output: DescribePolicyResponse,
@@ -4481,7 +4480,7 @@ export const describeResourcePolicy: API.OperationMethod<
   DescribeResourcePolicyRequest,
   DescribeResourcePolicyResponse,
   DescribeResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourcePolicyRequest,
   output: DescribeResourcePolicyResponse,
@@ -4517,7 +4516,7 @@ export const describeResponsibilityTransfer: API.OperationMethod<
   DescribeResponsibilityTransferRequest,
   DescribeResponsibilityTransferResponse,
   DescribeResponsibilityTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResponsibilityTransferRequest,
   output: DescribeResponsibilityTransferResponse,
@@ -4571,7 +4570,7 @@ export const detachPolicy: API.OperationMethod<
   DetachPolicyRequest,
   DetachPolicyResponse,
   DetachPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachPolicyRequest,
   output: DetachPolicyResponse,
@@ -4665,7 +4664,7 @@ export const disableAWSServiceAccess: API.OperationMethod<
   DisableAWSServiceAccessRequest,
   DisableAWSServiceAccessResponse,
   DisableAWSServiceAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAWSServiceAccessRequest,
   output: DisableAWSServiceAccessResponse,
@@ -4717,7 +4716,7 @@ export const disablePolicyType: API.OperationMethod<
   DisablePolicyTypeRequest,
   DisablePolicyTypeResponse,
   DisablePolicyTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisablePolicyTypeRequest,
   output: DisablePolicyTypeResponse,
@@ -4783,7 +4782,7 @@ export const enableAllFeatures: API.OperationMethod<
   EnableAllFeaturesRequest,
   EnableAllFeaturesResponse,
   EnableAllFeaturesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAllFeaturesRequest,
   output: EnableAllFeaturesResponse,
@@ -4837,7 +4836,7 @@ export const enableAWSServiceAccess: API.OperationMethod<
   EnableAWSServiceAccessRequest,
   EnableAWSServiceAccessResponse,
   EnableAWSServiceAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAWSServiceAccessRequest,
   output: EnableAWSServiceAccessResponse,
@@ -4890,7 +4889,7 @@ export const enablePolicyType: API.OperationMethod<
   EnablePolicyTypeRequest,
   EnablePolicyTypeResponse,
   EnablePolicyTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnablePolicyTypeRequest,
   output: EnablePolicyTypeResponse,
@@ -4947,7 +4946,7 @@ export const inviteAccountToOrganization: API.OperationMethod<
   InviteAccountToOrganizationRequest,
   InviteAccountToOrganizationResponse,
   InviteAccountToOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InviteAccountToOrganizationRequest,
   output: InviteAccountToOrganizationResponse,
@@ -4992,7 +4991,7 @@ export const inviteOrganizationToTransferResponsibility: API.OperationMethod<
   InviteOrganizationToTransferResponsibilityRequest,
   InviteOrganizationToTransferResponsibilityResponse,
   InviteOrganizationToTransferResponsibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InviteOrganizationToTransferResponsibilityRequest,
   output: InviteOrganizationToTransferResponsibilityResponse,
@@ -5084,7 +5083,7 @@ export const leaveOrganization: API.OperationMethod<
   LeaveOrganizationRequest,
   LeaveOrganizationResponse,
   LeaveOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LeaveOrganizationRequest,
   output: LeaveOrganizationResponse,
@@ -5125,7 +5124,7 @@ export const listAccounts: API.PaginatedOperationMethod<
   ListAccountsRequest,
   ListAccountsResponse,
   ListAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsRequest,
@@ -5172,7 +5171,7 @@ export const listAccountsForParent: API.PaginatedOperationMethod<
   ListAccountsForParentRequest,
   ListAccountsForParentResponse,
   ListAccountsForParentError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsForParentRequest,
@@ -5217,7 +5216,7 @@ export const listAccountsWithInvalidEffectivePolicy: API.PaginatedOperationMetho
   ListAccountsWithInvalidEffectivePolicyRequest,
   ListAccountsWithInvalidEffectivePolicyResponse,
   ListAccountsWithInvalidEffectivePolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Account
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsWithInvalidEffectivePolicyRequest,
@@ -5267,7 +5266,7 @@ export const listAWSServiceAccessForOrganization: API.PaginatedOperationMethod<
   ListAWSServiceAccessForOrganizationRequest,
   ListAWSServiceAccessForOrganizationResponse,
   ListAWSServiceAccessForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAWSServiceAccessForOrganizationRequest,
@@ -5314,7 +5313,7 @@ export const listChildren: API.PaginatedOperationMethod<
   ListChildrenRequest,
   ListChildrenResponse,
   ListChildrenError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChildrenRequest,
@@ -5359,7 +5358,7 @@ export const listCreateAccountStatus: API.PaginatedOperationMethod<
   ListCreateAccountStatusRequest,
   ListCreateAccountStatusResponse,
   ListCreateAccountStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCreateAccountStatusRequest,
@@ -5401,7 +5400,7 @@ export const listDelegatedAdministrators: API.PaginatedOperationMethod<
   ListDelegatedAdministratorsRequest,
   ListDelegatedAdministratorsResponse,
   ListDelegatedAdministratorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DelegatedAdministrator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDelegatedAdministratorsRequest,
@@ -5447,7 +5446,7 @@ export const listDelegatedServicesForAccount: API.PaginatedOperationMethod<
   ListDelegatedServicesForAccountRequest,
   ListDelegatedServicesForAccountResponse,
   ListDelegatedServicesForAccountError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DelegatedService
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDelegatedServicesForAccountRequest,
@@ -5495,7 +5494,7 @@ export const listEffectivePolicyValidationErrors: API.PaginatedOperationMethod<
   ListEffectivePolicyValidationErrorsRequest,
   ListEffectivePolicyValidationErrorsResponse,
   ListEffectivePolicyValidationErrorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EffectivePolicyValidationError
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEffectivePolicyValidationErrorsRequest,
@@ -5546,7 +5545,7 @@ export const listHandshakesForAccount: API.PaginatedOperationMethod<
   ListHandshakesForAccountRequest,
   ListHandshakesForAccountResponse,
   ListHandshakesForAccountError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHandshakesForAccountRequest,
@@ -5593,7 +5592,7 @@ export const listHandshakesForOrganization: API.PaginatedOperationMethod<
   ListHandshakesForOrganizationRequest,
   ListHandshakesForOrganizationResponse,
   ListHandshakesForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHandshakesForOrganizationRequest,
@@ -5638,7 +5637,7 @@ export const listInboundResponsibilityTransfers: API.OperationMethod<
   ListInboundResponsibilityTransfersRequest,
   ListInboundResponsibilityTransfersResponse,
   ListInboundResponsibilityTransfersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInboundResponsibilityTransfersRequest,
   output: ListInboundResponsibilityTransfersResponse,
@@ -5678,7 +5677,7 @@ export const listOrganizationalUnitsForParent: API.PaginatedOperationMethod<
   ListOrganizationalUnitsForParentRequest,
   ListOrganizationalUnitsForParentResponse,
   ListOrganizationalUnitsForParentError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationalUnitsForParentRequest,
@@ -5723,7 +5722,7 @@ export const listOutboundResponsibilityTransfers: API.OperationMethod<
   ListOutboundResponsibilityTransfersRequest,
   ListOutboundResponsibilityTransfersResponse,
   ListOutboundResponsibilityTransfersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListOutboundResponsibilityTransfersRequest,
   output: ListOutboundResponsibilityTransfersResponse,
@@ -5766,7 +5765,7 @@ export const listParents: API.PaginatedOperationMethod<
   ListParentsRequest,
   ListParentsResponse,
   ListParentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListParentsRequest,
@@ -5810,7 +5809,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -5857,7 +5856,7 @@ export const listPoliciesForTarget: API.PaginatedOperationMethod<
   ListPoliciesForTargetRequest,
   ListPoliciesForTargetResponse,
   ListPoliciesForTargetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesForTargetRequest,
@@ -5907,7 +5906,7 @@ export const listRoots: API.PaginatedOperationMethod<
   ListRootsRequest,
   ListRootsResponse,
   ListRootsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRootsRequest,
@@ -5956,7 +5955,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -6002,7 +6001,7 @@ export const listTargetsForPolicy: API.PaginatedOperationMethod<
   ListTargetsForPolicyRequest,
   ListTargetsForPolicyResponse,
   ListTargetsForPolicyError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetsForPolicyRequest,
@@ -6048,7 +6047,7 @@ export const moveAccount: API.OperationMethod<
   MoveAccountRequest,
   MoveAccountResponse,
   MoveAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MoveAccountRequest,
   output: MoveAccountResponse,
@@ -6088,7 +6087,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -6135,7 +6134,7 @@ export const registerDelegatedAdministrator: API.OperationMethod<
   RegisterDelegatedAdministratorRequest,
   RegisterDelegatedAdministratorResponse,
   RegisterDelegatedAdministratorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDelegatedAdministratorRequest,
   output: RegisterDelegatedAdministratorResponse,
@@ -6205,7 +6204,7 @@ export const removeAccountFromOrganization: API.OperationMethod<
   RemoveAccountFromOrganizationRequest,
   RemoveAccountFromOrganizationResponse,
   RemoveAccountFromOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAccountFromOrganizationRequest,
   output: RemoveAccountFromOrganizationResponse,
@@ -6254,7 +6253,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6295,7 +6294,7 @@ export const terminateResponsibilityTransfer: API.OperationMethod<
   TerminateResponsibilityTransferRequest,
   TerminateResponsibilityTransferResponse,
   TerminateResponsibilityTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateResponsibilityTransferRequest,
   output: TerminateResponsibilityTransferResponse,
@@ -6346,7 +6345,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6386,7 +6385,7 @@ export const updateOrganizationalUnit: API.OperationMethod<
   UpdateOrganizationalUnitRequest,
   UpdateOrganizationalUnitResponse,
   UpdateOrganizationalUnitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationalUnitRequest,
   output: UpdateOrganizationalUnitResponse,
@@ -6430,7 +6429,7 @@ export const updatePolicy: API.OperationMethod<
   UpdatePolicyRequest,
   UpdatePolicyResponse,
   UpdatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyRequest,
   output: UpdatePolicyResponse,
@@ -6474,7 +6473,7 @@ export const updateResponsibilityTransfer: API.OperationMethod<
   UpdateResponsibilityTransferRequest,
   UpdateResponsibilityTransferResponse,
   UpdateResponsibilityTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResponsibilityTransferRequest,
   output: UpdateResponsibilityTransferResponse,

--- a/packages/aws/src/services/osis.ts
+++ b/packages/aws/src/services/osis.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://osis.amazonaws.com/doc/2022-01-01");
 const svc = T.AwsApiService({
   sdkId: "OSIS",
@@ -1287,7 +1286,7 @@ export const createPipeline: API.OperationMethod<
   CreatePipelineRequest,
   CreatePipelineResponse,
   CreatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipelineRequest,
   output: CreatePipelineResponse,
@@ -1321,7 +1320,7 @@ export const createPipelineEndpoint: API.OperationMethod<
   CreatePipelineEndpointRequest,
   CreatePipelineEndpointResponse,
   CreatePipelineEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipelineEndpointRequest,
   output: CreatePipelineEndpointResponse,
@@ -1354,7 +1353,7 @@ export const deletePipeline: API.OperationMethod<
   DeletePipelineRequest,
   DeletePipelineResponse,
   DeletePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipelineRequest,
   output: DeletePipelineResponse,
@@ -1384,7 +1383,7 @@ export const deletePipelineEndpoint: API.OperationMethod<
   DeletePipelineEndpointRequest,
   DeletePipelineEndpointResponse,
   DeletePipelineEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipelineEndpointRequest,
   output: DeletePipelineEndpointResponse,
@@ -1414,7 +1413,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -1445,7 +1444,7 @@ export const getPipeline: API.OperationMethod<
   GetPipelineRequest,
   GetPipelineResponse,
   GetPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineRequest,
   output: GetPipelineResponse,
@@ -1478,7 +1477,7 @@ export const getPipelineBlueprint: API.OperationMethod<
   GetPipelineBlueprintRequest,
   GetPipelineBlueprintResponse,
   GetPipelineBlueprintError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineBlueprintRequest,
   output: GetPipelineBlueprintResponse,
@@ -1512,7 +1511,7 @@ export const getPipelineChangeProgress: API.OperationMethod<
   GetPipelineChangeProgressRequest,
   GetPipelineChangeProgressResponse,
   GetPipelineChangeProgressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPipelineChangeProgressRequest,
   output: GetPipelineChangeProgressResponse,
@@ -1543,7 +1542,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1576,7 +1575,7 @@ export const listPipelineBlueprints: API.OperationMethod<
   ListPipelineBlueprintsRequest,
   ListPipelineBlueprintsResponse,
   ListPipelineBlueprintsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListPipelineBlueprintsRequest,
   output: ListPipelineBlueprintsResponse,
@@ -1606,7 +1605,7 @@ export const listPipelineEndpointConnections: API.PaginatedOperationMethod<
   ListPipelineEndpointConnectionsRequest,
   ListPipelineEndpointConnectionsResponse,
   ListPipelineEndpointConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineEndpointConnection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineEndpointConnectionsRequest,
@@ -1643,7 +1642,7 @@ export const listPipelineEndpoints: API.PaginatedOperationMethod<
   ListPipelineEndpointsRequest,
   ListPipelineEndpointsResponse,
   ListPipelineEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineEndpointsRequest,
@@ -1682,7 +1681,7 @@ export const listPipelines: API.PaginatedOperationMethod<
   ListPipelinesRequest,
   ListPipelinesResponse,
   ListPipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelinesRequest,
@@ -1719,7 +1718,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1751,7 +1750,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -1782,7 +1781,7 @@ export const revokePipelineEndpointConnections: API.OperationMethod<
   RevokePipelineEndpointConnectionsRequest,
   RevokePipelineEndpointConnectionsResponse,
   RevokePipelineEndpointConnectionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokePipelineEndpointConnectionsRequest,
   output: RevokePipelineEndpointConnectionsResponse,
@@ -1813,7 +1812,7 @@ export const startPipeline: API.OperationMethod<
   StartPipelineRequest,
   StartPipelineResponse,
   StartPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPipelineRequest,
   output: StartPipelineResponse,
@@ -1846,7 +1845,7 @@ export const stopPipeline: API.OperationMethod<
   StopPipelineRequest,
   StopPipelineResponse,
   StopPipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPipelineRequest,
   output: StopPipelineResponse,
@@ -1879,7 +1878,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1911,7 +1910,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1943,7 +1942,7 @@ export const updatePipeline: API.OperationMethod<
   UpdatePipelineRequest,
   UpdatePipelineResponse,
   UpdatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipelineRequest,
   output: UpdatePipelineResponse,
@@ -1975,7 +1974,7 @@ export const validatePipeline: API.OperationMethod<
   ValidatePipelineRequest,
   ValidatePipelineResponse,
   ValidatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidatePipelineRequest,
   output: ValidatePipelineResponse,

--- a/packages/aws/src/services/outposts.ts
+++ b/packages/aws/src/services/outposts.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Outposts",
@@ -2936,7 +2935,7 @@ export const cancelCapacityTask: API.OperationMethod<
   CancelCapacityTaskInput,
   CancelCapacityTaskOutput,
   CancelCapacityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCapacityTaskInput,
   output: CancelCapacityTaskOutput,
@@ -2966,7 +2965,7 @@ export const cancelOrder: API.OperationMethod<
   CancelOrderInput,
   CancelOrderOutput,
   CancelOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelOrderInput,
   output: CancelOrderOutput,
@@ -2997,7 +2996,7 @@ export const createOrder: API.OperationMethod<
   CreateOrderInput,
   CreateOrderOutput,
   CreateOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOrderInput,
   output: CreateOrderOutput,
@@ -3031,7 +3030,7 @@ export const createOutpost: API.OperationMethod<
   CreateOutpostInput,
   CreateOutpostOutput,
   CreateOutpostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOutpostInput,
   output: CreateOutpostOutput,
@@ -3063,7 +3062,7 @@ export const createQuote: API.OperationMethod<
   CreateQuoteInput,
   CreateQuoteOutput,
   CreateQuoteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuoteInput,
   output: CreateQuoteOutput,
@@ -3091,7 +3090,7 @@ export const createRenewal: API.OperationMethod<
   CreateRenewalInput,
   CreateRenewalOutput,
   CreateRenewalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRenewalInput,
   output: CreateRenewalOutput,
@@ -3120,7 +3119,7 @@ export const createSite: API.OperationMethod<
   CreateSiteInput,
   CreateSiteOutput,
   CreateSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSiteInput,
   output: CreateSiteOutput,
@@ -3150,7 +3149,7 @@ export const deleteOutpost: API.OperationMethod<
   DeleteOutpostInput,
   DeleteOutpostOutput,
   DeleteOutpostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutpostInput,
   output: DeleteOutpostOutput,
@@ -3179,7 +3178,7 @@ export const deleteQuote: API.OperationMethod<
   DeleteQuoteInput,
   DeleteQuoteOutput,
   DeleteQuoteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuoteInput,
   output: DeleteQuoteOutput,
@@ -3208,7 +3207,7 @@ export const deleteSite: API.OperationMethod<
   DeleteSiteInput,
   DeleteSiteOutput,
   DeleteSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSiteInput,
   output: DeleteSiteOutput,
@@ -3237,7 +3236,7 @@ export const getCapacityTask: API.OperationMethod<
   GetCapacityTaskInput,
   GetCapacityTaskOutput,
   GetCapacityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCapacityTaskInput,
   output: GetCapacityTaskOutput,
@@ -3265,7 +3264,7 @@ export const getCatalogItem: API.OperationMethod<
   GetCatalogItemInput,
   GetCatalogItemOutput,
   GetCatalogItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCatalogItemInput,
   output: GetCatalogItemOutput,
@@ -3300,7 +3299,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -3327,7 +3326,7 @@ export const getOrder: API.OperationMethod<
   GetOrderInput,
   GetOrderOutput,
   GetOrderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrderInput,
   output: GetOrderOutput,
@@ -3350,7 +3349,7 @@ export const getOutpost: API.OperationMethod<
   GetOutpostInput,
   GetOutpostOutput,
   GetOutpostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOutpostInput,
   output: GetOutpostOutput,
@@ -3377,7 +3376,7 @@ export const getOutpostBillingInformation: API.PaginatedOperationMethod<
   GetOutpostBillingInformationInput,
   GetOutpostBillingInformationOutput,
   GetOutpostBillingInformationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOutpostBillingInformationInput,
@@ -3407,7 +3406,7 @@ export const getOutpostInstanceTypes: API.PaginatedOperationMethod<
   GetOutpostInstanceTypesInput,
   GetOutpostInstanceTypesOutput,
   GetOutpostInstanceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOutpostInstanceTypesInput,
@@ -3444,7 +3443,7 @@ export const getOutpostSupportedInstanceTypes: API.PaginatedOperationMethod<
   GetOutpostSupportedInstanceTypesInput,
   GetOutpostSupportedInstanceTypesOutput,
   GetOutpostSupportedInstanceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOutpostSupportedInstanceTypesInput,
@@ -3479,7 +3478,7 @@ export const getQuote: API.OperationMethod<
   GetQuoteInput,
   GetQuoteOutput,
   GetQuoteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuoteInput,
   output: GetQuoteOutput,
@@ -3507,7 +3506,7 @@ export const getRenewalPricing: API.OperationMethod<
   GetRenewalPricingInput,
   GetRenewalPricingOutput,
   GetRenewalPricingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRenewalPricingInput,
   output: GetRenewalPricingOutput,
@@ -3535,7 +3534,7 @@ export const getSite: API.OperationMethod<
   GetSiteInput,
   GetSiteOutput,
   GetSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSiteInput,
   output: GetSiteOutput,
@@ -3563,7 +3562,7 @@ export const getSiteAddress: API.OperationMethod<
   GetSiteAddressInput,
   GetSiteAddressOutput,
   GetSiteAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSiteAddressInput,
   output: GetSiteAddressOutput,
@@ -3592,7 +3591,7 @@ export const listAssetInstances: API.PaginatedOperationMethod<
   ListAssetInstancesInput,
   ListAssetInstancesOutput,
   ListAssetInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetInstancesInput,
@@ -3631,7 +3630,7 @@ export const listAssets: API.PaginatedOperationMethod<
   ListAssetsInput,
   ListAssetsOutput,
   ListAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetsInput,
@@ -3668,7 +3667,7 @@ export const listBlockingInstancesForCapacityTask: API.PaginatedOperationMethod<
   ListBlockingInstancesForCapacityTaskInput,
   ListBlockingInstancesForCapacityTaskOutput,
   ListBlockingInstancesForCapacityTaskError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BlockingInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBlockingInstancesForCapacityTaskInput,
@@ -3707,7 +3706,7 @@ export const listCapacityTasks: API.PaginatedOperationMethod<
   ListCapacityTasksInput,
   ListCapacityTasksOutput,
   ListCapacityTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CapacityTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCapacityTasksInput,
@@ -3746,7 +3745,7 @@ export const listCatalogItems: API.PaginatedOperationMethod<
   ListCatalogItemsInput,
   ListCatalogItemsOutput,
   ListCatalogItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CatalogItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCatalogItemsInput,
@@ -3782,7 +3781,7 @@ export const listOrderableInstanceTypes: API.PaginatedOperationMethod<
   ListOrderableInstanceTypesInput,
   ListOrderableInstanceTypesOutput,
   ListOrderableInstanceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DetailedInstanceTypeItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrderableInstanceTypesInput,
@@ -3817,7 +3816,7 @@ export const listOrders: API.PaginatedOperationMethod<
   ListOrdersInput,
   ListOrdersOutput,
   ListOrdersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrdersInput,
@@ -3855,7 +3854,7 @@ export const listOutposts: API.PaginatedOperationMethod<
   ListOutpostsInput,
   ListOutpostsOutput,
   ListOutpostsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Outpost
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOutpostsInput,
@@ -3883,7 +3882,7 @@ export const listQuotes: API.PaginatedOperationMethod<
   ListQuotesInput,
   ListQuotesOutput,
   ListQuotesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuoteSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuotesInput,
@@ -3917,7 +3916,7 @@ export const listSites: API.PaginatedOperationMethod<
   ListSitesInput,
   ListSitesOutput,
   ListSitesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Site
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSitesInput,
@@ -3946,7 +3945,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3971,7 +3970,7 @@ export const startCapacityTask: API.OperationMethod<
   StartCapacityTaskInput,
   StartCapacityTaskOutput,
   StartCapacityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCapacityTaskInput,
   output: StartCapacityTaskOutput,
@@ -4007,7 +4006,7 @@ export const startConnection: API.OperationMethod<
   StartConnectionRequest,
   StartConnectionResponse,
   StartConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConnectionRequest,
   output: StartConnectionResponse,
@@ -4036,7 +4035,7 @@ export const startOutpostDecommission: API.OperationMethod<
   StartOutpostDecommissionInput,
   StartOutpostDecommissionOutput,
   StartOutpostDecommissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOutpostDecommissionInput,
   output: StartOutpostDecommissionOutput,
@@ -4064,7 +4063,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4086,7 +4085,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4110,7 +4109,7 @@ export const updateOutpost: API.OperationMethod<
   UpdateOutpostInput,
   UpdateOutpostOutput,
   UpdateOutpostError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOutpostInput,
   output: UpdateOutpostOutput,
@@ -4140,7 +4139,7 @@ export const updateQuote: API.OperationMethod<
   UpdateQuoteInput,
   UpdateQuoteOutput,
   UpdateQuoteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuoteInput,
   output: UpdateQuoteOutput,
@@ -4169,7 +4168,7 @@ export const updateSite: API.OperationMethod<
   UpdateSiteInput,
   UpdateSiteOutput,
   UpdateSiteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSiteInput,
   output: UpdateSiteOutput,
@@ -4205,7 +4204,7 @@ export const updateSiteAddress: API.OperationMethod<
   UpdateSiteAddressInput,
   UpdateSiteAddressOutput,
   UpdateSiteAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSiteAddressInput,
   output: UpdateSiteAddressOutput,
@@ -4240,7 +4239,7 @@ export const updateSiteRackPhysicalProperties: API.OperationMethod<
   UpdateSiteRackPhysicalPropertiesInput,
   UpdateSiteRackPhysicalPropertiesOutput,
   UpdateSiteRackPhysicalPropertiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSiteRackPhysicalPropertiesInput,
   output: UpdateSiteRackPhysicalPropertiesOutput,

--- a/packages/aws/src/services/panorama.ts
+++ b/packages/aws/src/services/panorama.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Panorama",
@@ -2204,7 +2203,7 @@ export const createApplicationInstance: API.OperationMethod<
   CreateApplicationInstanceRequest,
   CreateApplicationInstanceResponse,
   CreateApplicationInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationInstanceRequest,
   output: CreateApplicationInstanceResponse,
@@ -2233,7 +2232,7 @@ export const createJobForDevices: API.OperationMethod<
   CreateJobForDevicesRequest,
   CreateJobForDevicesResponse,
   CreateJobForDevicesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobForDevicesRequest,
   output: CreateJobForDevicesResponse,
@@ -2262,7 +2261,7 @@ export const createNodeFromTemplateJob: API.OperationMethod<
   CreateNodeFromTemplateJobRequest,
   CreateNodeFromTemplateJobResponse,
   CreateNodeFromTemplateJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNodeFromTemplateJobRequest,
   output: CreateNodeFromTemplateJobResponse,
@@ -2290,7 +2289,7 @@ export const createPackage: API.OperationMethod<
   CreatePackageRequest,
   CreatePackageResponse,
   CreatePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageRequest,
   output: CreatePackageResponse,
@@ -2318,7 +2317,7 @@ export const createPackageImportJob: API.OperationMethod<
   CreatePackageImportJobRequest,
   CreatePackageImportJobResponse,
   CreatePackageImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePackageImportJobRequest,
   output: CreatePackageImportJobResponse,
@@ -2347,7 +2346,7 @@ export const deleteDevice: API.OperationMethod<
   DeleteDeviceRequest,
   DeleteDeviceResponse,
   DeleteDeviceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceRequest,
   output: DeleteDeviceResponse,
@@ -2380,7 +2379,7 @@ export const deletePackage: API.OperationMethod<
   DeletePackageRequest,
   DeletePackageResponse,
   DeletePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePackageRequest,
   output: DeletePackageResponse,
@@ -2410,7 +2409,7 @@ export const deregisterPackageVersion: API.OperationMethod<
   DeregisterPackageVersionRequest,
   DeregisterPackageVersionResponse,
   DeregisterPackageVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterPackageVersionRequest,
   output: DeregisterPackageVersionResponse,
@@ -2440,7 +2439,7 @@ export const describeApplicationInstance: API.OperationMethod<
   DescribeApplicationInstanceRequest,
   DescribeApplicationInstanceResponse,
   DescribeApplicationInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationInstanceRequest,
   output: DescribeApplicationInstanceResponse,
@@ -2470,7 +2469,7 @@ export const describeApplicationInstanceDetails: API.OperationMethod<
   DescribeApplicationInstanceDetailsRequest,
   DescribeApplicationInstanceDetailsResponse,
   DescribeApplicationInstanceDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationInstanceDetailsRequest,
   output: DescribeApplicationInstanceDetailsResponse,
@@ -2499,7 +2498,7 @@ export const describeDevice: API.OperationMethod<
   DescribeDeviceRequest,
   DescribeDeviceResponse,
   DescribeDeviceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceRequest,
   output: DescribeDeviceResponse,
@@ -2528,7 +2527,7 @@ export const describeDeviceJob: API.OperationMethod<
   DescribeDeviceJobRequest,
   DescribeDeviceJobResponse,
   DescribeDeviceJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceJobRequest,
   output: DescribeDeviceJobResponse,
@@ -2558,7 +2557,7 @@ export const describeNode: API.OperationMethod<
   DescribeNodeRequest,
   DescribeNodeResponse,
   DescribeNodeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNodeRequest,
   output: DescribeNodeResponse,
@@ -2587,7 +2586,7 @@ export const describeNodeFromTemplateJob: API.OperationMethod<
   DescribeNodeFromTemplateJobRequest,
   DescribeNodeFromTemplateJobResponse,
   DescribeNodeFromTemplateJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNodeFromTemplateJobRequest,
   output: DescribeNodeFromTemplateJobResponse,
@@ -2616,7 +2615,7 @@ export const describePackage: API.OperationMethod<
   DescribePackageRequest,
   DescribePackageResponse,
   DescribePackageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageRequest,
   output: DescribePackageResponse,
@@ -2645,7 +2644,7 @@ export const describePackageImportJob: API.OperationMethod<
   DescribePackageImportJobRequest,
   DescribePackageImportJobResponse,
   DescribePackageImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageImportJobRequest,
   output: DescribePackageImportJobResponse,
@@ -2674,7 +2673,7 @@ export const describePackageVersion: API.OperationMethod<
   DescribePackageVersionRequest,
   DescribePackageVersionResponse,
   DescribePackageVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePackageVersionRequest,
   output: DescribePackageVersionResponse,
@@ -2701,7 +2700,7 @@ export const listApplicationInstanceDependencies: API.PaginatedOperationMethod<
   ListApplicationInstanceDependenciesRequest,
   ListApplicationInstanceDependenciesResponse,
   ListApplicationInstanceDependenciesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationInstanceDependenciesRequest,
@@ -2728,7 +2727,7 @@ export const listApplicationInstanceNodeInstances: API.PaginatedOperationMethod<
   ListApplicationInstanceNodeInstancesRequest,
   ListApplicationInstanceNodeInstancesResponse,
   ListApplicationInstanceNodeInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationInstanceNodeInstancesRequest,
@@ -2755,7 +2754,7 @@ export const listApplicationInstances: API.PaginatedOperationMethod<
   ListApplicationInstancesRequest,
   ListApplicationInstancesResponse,
   ListApplicationInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationInstancesRequest,
@@ -2784,7 +2783,7 @@ export const listDevices: API.PaginatedOperationMethod<
   ListDevicesRequest,
   ListDevicesResponse,
   ListDevicesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesRequest,
@@ -2819,7 +2818,7 @@ export const listDevicesJobs: API.PaginatedOperationMethod<
   ListDevicesJobsRequest,
   ListDevicesJobsResponse,
   ListDevicesJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesJobsRequest,
@@ -2854,7 +2853,7 @@ export const listNodeFromTemplateJobs: API.PaginatedOperationMethod<
   ListNodeFromTemplateJobsRequest,
   ListNodeFromTemplateJobsResponse,
   ListNodeFromTemplateJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodeFromTemplateJobsRequest,
@@ -2887,7 +2886,7 @@ export const listNodes: API.PaginatedOperationMethod<
   ListNodesRequest,
   ListNodesResponse,
   ListNodesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesRequest,
@@ -2916,7 +2915,7 @@ export const listPackageImportJobs: API.PaginatedOperationMethod<
   ListPackageImportJobsRequest,
   ListPackageImportJobsResponse,
   ListPackageImportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackageImportJobsRequest,
@@ -2951,7 +2950,7 @@ export const listPackages: API.PaginatedOperationMethod<
   ListPackagesRequest,
   ListPackagesResponse,
   ListPackagesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPackagesRequest,
@@ -2985,7 +2984,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3016,7 +3015,7 @@ export const provisionDevice: API.OperationMethod<
   ProvisionDeviceRequest,
   ProvisionDeviceResponse,
   ProvisionDeviceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionDeviceRequest,
   output: ProvisionDeviceResponse,
@@ -3045,7 +3044,7 @@ export const registerPackageVersion: API.OperationMethod<
   RegisterPackageVersionRequest,
   RegisterPackageVersionResponse,
   RegisterPackageVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterPackageVersionRequest,
   output: RegisterPackageVersionResponse,
@@ -3074,7 +3073,7 @@ export const removeApplicationInstance: API.OperationMethod<
   RemoveApplicationInstanceRequest,
   RemoveApplicationInstanceResponse,
   RemoveApplicationInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveApplicationInstanceRequest,
   output: RemoveApplicationInstanceResponse,
@@ -3103,7 +3102,7 @@ export const signalApplicationInstanceNodeInstances: API.OperationMethod<
   SignalApplicationInstanceNodeInstancesRequest,
   SignalApplicationInstanceNodeInstancesResponse,
   SignalApplicationInstanceNodeInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignalApplicationInstanceNodeInstancesRequest,
   output: SignalApplicationInstanceNodeInstancesResponse,
@@ -3130,7 +3129,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3156,7 +3155,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3184,7 +3183,7 @@ export const updateDeviceMetadata: API.OperationMethod<
   UpdateDeviceMetadataRequest,
   UpdateDeviceMetadataResponse,
   UpdateDeviceMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceMetadataRequest,
   output: UpdateDeviceMetadataResponse,

--- a/packages/aws/src/services/partnercentral-account.ts
+++ b/packages/aws/src/services/partnercentral-account.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "PartnerCentral Account",
@@ -1784,7 +1783,7 @@ export const acceptConnectionInvitation: API.OperationMethod<
   AcceptConnectionInvitationRequest,
   AcceptConnectionInvitationResponse,
   AcceptConnectionInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptConnectionInvitationRequest,
   output: AcceptConnectionInvitationResponse,
@@ -1817,7 +1816,7 @@ export const associateAwsTrainingCertificationEmailDomain: API.OperationMethod<
   AssociateAwsTrainingCertificationEmailDomainRequest,
   AssociateAwsTrainingCertificationEmailDomainResponse,
   AssociateAwsTrainingCertificationEmailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAwsTrainingCertificationEmailDomainRequest,
   output: AssociateAwsTrainingCertificationEmailDomainResponse,
@@ -1849,7 +1848,7 @@ export const cancelConnection: API.OperationMethod<
   CancelConnectionRequest,
   CancelConnectionResponse,
   CancelConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelConnectionRequest,
   output: CancelConnectionResponse,
@@ -1881,7 +1880,7 @@ export const cancelConnectionInvitation: API.OperationMethod<
   CancelConnectionInvitationRequest,
   CancelConnectionInvitationResponse,
   CancelConnectionInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelConnectionInvitationRequest,
   output: CancelConnectionInvitationResponse,
@@ -1913,7 +1912,7 @@ export const cancelProfileUpdateTask: API.OperationMethod<
   CancelProfileUpdateTaskRequest,
   CancelProfileUpdateTaskResponse,
   CancelProfileUpdateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelProfileUpdateTaskRequest,
   output: CancelProfileUpdateTaskResponse,
@@ -1946,7 +1945,7 @@ export const createConnectionInvitation: API.OperationMethod<
   CreateConnectionInvitationRequest,
   CreateConnectionInvitationResponse,
   CreateConnectionInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionInvitationRequest,
   output: CreateConnectionInvitationResponse,
@@ -1978,7 +1977,7 @@ export const createPartner: API.OperationMethod<
   CreatePartnerRequest,
   CreatePartnerResponse,
   CreatePartnerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerRequest,
   output: CreatePartnerResponse,
@@ -2008,7 +2007,7 @@ export const disassociateAwsTrainingCertificationEmailDomain: API.OperationMetho
   DisassociateAwsTrainingCertificationEmailDomainRequest,
   DisassociateAwsTrainingCertificationEmailDomainResponse,
   DisassociateAwsTrainingCertificationEmailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAwsTrainingCertificationEmailDomainRequest,
   output: DisassociateAwsTrainingCertificationEmailDomainResponse,
@@ -2038,7 +2037,7 @@ export const getAllianceLeadContact: API.OperationMethod<
   GetAllianceLeadContactRequest,
   GetAllianceLeadContactResponse,
   GetAllianceLeadContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAllianceLeadContactRequest,
   output: GetAllianceLeadContactResponse,
@@ -2068,7 +2067,7 @@ export const getConnection: API.OperationMethod<
   GetConnectionRequest,
   GetConnectionResponse,
   GetConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRequest,
   output: GetConnectionResponse,
@@ -2098,7 +2097,7 @@ export const getConnectionInvitation: API.OperationMethod<
   GetConnectionInvitationRequest,
   GetConnectionInvitationResponse,
   GetConnectionInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionInvitationRequest,
   output: GetConnectionInvitationResponse,
@@ -2127,7 +2126,7 @@ export const getConnectionPreferences: API.OperationMethod<
   GetConnectionPreferencesRequest,
   GetConnectionPreferencesResponse,
   GetConnectionPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionPreferencesRequest,
   output: GetConnectionPreferencesResponse,
@@ -2156,7 +2155,7 @@ export const getPartner: API.OperationMethod<
   GetPartnerRequest,
   GetPartnerResponse,
   GetPartnerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPartnerRequest,
   output: GetPartnerResponse,
@@ -2186,7 +2185,7 @@ export const getProfileUpdateTask: API.OperationMethod<
   GetProfileUpdateTaskRequest,
   GetProfileUpdateTaskResponse,
   GetProfileUpdateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileUpdateTaskRequest,
   output: GetProfileUpdateTaskResponse,
@@ -2216,7 +2215,7 @@ export const getProfileVisibility: API.OperationMethod<
   GetProfileVisibilityRequest,
   GetProfileVisibilityResponse,
   GetProfileVisibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileVisibilityRequest,
   output: GetProfileVisibilityResponse,
@@ -2246,7 +2245,7 @@ export const getVerification: API.OperationMethod<
   GetVerificationRequest,
   GetVerificationResponse,
   GetVerificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVerificationRequest,
   output: GetVerificationResponse,
@@ -2275,7 +2274,7 @@ export const listConnectionInvitations: API.PaginatedOperationMethod<
   ListConnectionInvitationsRequest,
   ListConnectionInvitationsResponse,
   ListConnectionInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionInvitationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionInvitationsRequest,
@@ -2310,7 +2309,7 @@ export const listConnections: API.PaginatedOperationMethod<
   ListConnectionsRequest,
   ListConnectionsResponse,
   ListConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectionsRequest,
@@ -2345,7 +2344,7 @@ export const listPartners: API.PaginatedOperationMethod<
   ListPartnersRequest,
   ListPartnersResponse,
   ListPartnersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PartnerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPartnersRequest,
@@ -2380,7 +2379,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2410,7 +2409,7 @@ export const putAllianceLeadContact: API.OperationMethod<
   PutAllianceLeadContactRequest,
   PutAllianceLeadContactResponse,
   PutAllianceLeadContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAllianceLeadContactRequest,
   output: PutAllianceLeadContactResponse,
@@ -2441,7 +2440,7 @@ export const putProfileVisibility: API.OperationMethod<
   PutProfileVisibilityRequest,
   PutProfileVisibilityResponse,
   PutProfileVisibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProfileVisibilityRequest,
   output: PutProfileVisibilityResponse,
@@ -2473,7 +2472,7 @@ export const rejectConnectionInvitation: API.OperationMethod<
   RejectConnectionInvitationRequest,
   RejectConnectionInvitationResponse,
   RejectConnectionInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectConnectionInvitationRequest,
   output: RejectConnectionInvitationResponse,
@@ -2504,7 +2503,7 @@ export const sendEmailVerificationCode: API.OperationMethod<
   SendEmailVerificationCodeRequest,
   SendEmailVerificationCodeResponse,
   SendEmailVerificationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEmailVerificationCodeRequest,
   output: SendEmailVerificationCodeResponse,
@@ -2536,7 +2535,7 @@ export const startProfileUpdateTask: API.OperationMethod<
   StartProfileUpdateTaskRequest,
   StartProfileUpdateTaskResponse,
   StartProfileUpdateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProfileUpdateTaskRequest,
   output: StartProfileUpdateTaskResponse,
@@ -2569,7 +2568,7 @@ export const startVerification: API.OperationMethod<
   StartVerificationRequest,
   StartVerificationResponse,
   StartVerificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVerificationRequest,
   output: StartVerificationResponse,
@@ -2601,7 +2600,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2633,7 +2632,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2664,7 +2663,7 @@ export const updateConnectionPreferences: API.OperationMethod<
   UpdateConnectionPreferencesRequest,
   UpdateConnectionPreferencesResponse,
   UpdateConnectionPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionPreferencesRequest,
   output: UpdateConnectionPreferencesResponse,

--- a/packages/aws/src/services/partnercentral-benefits.ts
+++ b/packages/aws/src/services/partnercentral-benefits.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "PartnerCentral Benefits",
@@ -1354,7 +1353,7 @@ export const amendBenefitApplication: API.OperationMethod<
   AmendBenefitApplicationInput,
   AmendBenefitApplicationOutput,
   AmendBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AmendBenefitApplicationInput,
   output: AmendBenefitApplicationOutput,
@@ -1386,7 +1385,7 @@ export const associateBenefitApplicationResource: API.OperationMethod<
   AssociateBenefitApplicationResourceInput,
   AssociateBenefitApplicationResourceOutput,
   AssociateBenefitApplicationResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateBenefitApplicationResourceInput,
   output: AssociateBenefitApplicationResourceOutput,
@@ -1418,7 +1417,7 @@ export const cancelBenefitApplication: API.OperationMethod<
   CancelBenefitApplicationInput,
   CancelBenefitApplicationOutput,
   CancelBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelBenefitApplicationInput,
   output: CancelBenefitApplicationOutput,
@@ -1450,7 +1449,7 @@ export const createBenefitApplication: API.OperationMethod<
   CreateBenefitApplicationInput,
   CreateBenefitApplicationOutput,
   CreateBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBenefitApplicationInput,
   output: CreateBenefitApplicationOutput,
@@ -1482,7 +1481,7 @@ export const disassociateBenefitApplicationResource: API.OperationMethod<
   DisassociateBenefitApplicationResourceInput,
   DisassociateBenefitApplicationResourceOutput,
   DisassociateBenefitApplicationResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateBenefitApplicationResourceInput,
   output: DisassociateBenefitApplicationResourceOutput,
@@ -1513,7 +1512,7 @@ export const getBenefit: API.OperationMethod<
   GetBenefitInput,
   GetBenefitOutput,
   GetBenefitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBenefitInput,
   output: GetBenefitOutput,
@@ -1543,7 +1542,7 @@ export const getBenefitAllocation: API.OperationMethod<
   GetBenefitAllocationInput,
   GetBenefitAllocationOutput,
   GetBenefitAllocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBenefitAllocationInput,
   output: GetBenefitAllocationOutput,
@@ -1574,7 +1573,7 @@ export const getBenefitApplication: API.OperationMethod<
   GetBenefitApplicationInput,
   GetBenefitApplicationOutput,
   GetBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBenefitApplicationInput,
   output: GetBenefitApplicationOutput,
@@ -1605,7 +1604,7 @@ export const listBenefitAllocations: API.PaginatedOperationMethod<
   ListBenefitAllocationsInput,
   ListBenefitAllocationsOutput,
   ListBenefitAllocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BenefitAllocationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBenefitAllocationsInput,
@@ -1642,7 +1641,7 @@ export const listBenefitApplications: API.PaginatedOperationMethod<
   ListBenefitApplicationsInput,
   ListBenefitApplicationsOutput,
   ListBenefitApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BenefitApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBenefitApplicationsInput,
@@ -1679,7 +1678,7 @@ export const listBenefits: API.PaginatedOperationMethod<
   ListBenefitsInput,
   ListBenefitsOutput,
   ListBenefitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BenefitSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBenefitsInput,
@@ -1716,7 +1715,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1747,7 +1746,7 @@ export const recallBenefitApplication: API.OperationMethod<
   RecallBenefitApplicationInput,
   RecallBenefitApplicationOutput,
   RecallBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecallBenefitApplicationInput,
   output: RecallBenefitApplicationOutput,
@@ -1779,7 +1778,7 @@ export const submitBenefitApplication: API.OperationMethod<
   SubmitBenefitApplicationInput,
   SubmitBenefitApplicationOutput,
   SubmitBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitBenefitApplicationInput,
   output: SubmitBenefitApplicationOutput,
@@ -1812,7 +1811,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1846,7 +1845,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1879,7 +1878,7 @@ export const updateBenefitApplication: API.OperationMethod<
   UpdateBenefitApplicationInput,
   UpdateBenefitApplicationOutput,
   UpdateBenefitApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBenefitApplicationInput,
   output: UpdateBenefitApplicationOutput,

--- a/packages/aws/src/services/partnercentral-channel.ts
+++ b/packages/aws/src/services/partnercentral-channel.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "PartnerCentral Channel",
   serviceShapeName: "PartnerCentralChannel",
@@ -1511,7 +1510,7 @@ export const acceptChannelHandshake: API.OperationMethod<
   AcceptChannelHandshakeRequest,
   AcceptChannelHandshakeResponse,
   AcceptChannelHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptChannelHandshakeRequest,
   output: AcceptChannelHandshakeResponse,
@@ -1541,7 +1540,7 @@ export const cancelChannelHandshake: API.OperationMethod<
   CancelChannelHandshakeRequest,
   CancelChannelHandshakeResponse,
   CancelChannelHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelChannelHandshakeRequest,
   output: CancelChannelHandshakeResponse,
@@ -1573,7 +1572,7 @@ export const createChannelHandshake: API.OperationMethod<
   CreateChannelHandshakeRequest,
   CreateChannelHandshakeResponse,
   CreateChannelHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelHandshakeRequest,
   output: CreateChannelHandshakeResponse,
@@ -1607,7 +1606,7 @@ export const createProgramManagementAccount: API.OperationMethod<
   CreateProgramManagementAccountRequest,
   CreateProgramManagementAccountResponse,
   CreateProgramManagementAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProgramManagementAccountRequest,
   output: CreateProgramManagementAccountResponse,
@@ -1641,7 +1640,7 @@ export const createRelationship: API.OperationMethod<
   CreateRelationshipRequest,
   CreateRelationshipResponse,
   CreateRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRelationshipRequest,
   output: CreateRelationshipResponse,
@@ -1674,7 +1673,7 @@ export const deleteProgramManagementAccount: API.OperationMethod<
   DeleteProgramManagementAccountRequest,
   DeleteProgramManagementAccountResponse,
   DeleteProgramManagementAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProgramManagementAccountRequest,
   output: DeleteProgramManagementAccountResponse,
@@ -1706,7 +1705,7 @@ export const deleteRelationship: API.OperationMethod<
   DeleteRelationshipRequest,
   DeleteRelationshipResponse,
   DeleteRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRelationshipRequest,
   output: DeleteRelationshipResponse,
@@ -1737,7 +1736,7 @@ export const getRelationship: API.OperationMethod<
   GetRelationshipRequest,
   GetRelationshipResponse,
   GetRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRelationshipRequest,
   output: GetRelationshipResponse,
@@ -1767,7 +1766,7 @@ export const listChannelHandshakes: API.PaginatedOperationMethod<
   ListChannelHandshakesRequest,
   ListChannelHandshakesResponse,
   ListChannelHandshakesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelHandshakeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelHandshakesRequest,
@@ -1804,7 +1803,7 @@ export const listProgramManagementAccounts: API.PaginatedOperationMethod<
   ListProgramManagementAccountsRequest,
   ListProgramManagementAccountsResponse,
   ListProgramManagementAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProgramManagementAccountSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProgramManagementAccountsRequest,
@@ -1841,7 +1840,7 @@ export const listRelationships: API.PaginatedOperationMethod<
   ListRelationshipsRequest,
   ListRelationshipsResponse,
   ListRelationshipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RelationshipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRelationshipsRequest,
@@ -1878,7 +1877,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1908,7 +1907,7 @@ export const rejectChannelHandshake: API.OperationMethod<
   RejectChannelHandshakeRequest,
   RejectChannelHandshakeResponse,
   RejectChannelHandshakeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectChannelHandshakeRequest,
   output: RejectChannelHandshakeResponse,
@@ -1939,7 +1938,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1971,7 +1970,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2003,7 +2002,7 @@ export const updateProgramManagementAccount: API.OperationMethod<
   UpdateProgramManagementAccountRequest,
   UpdateProgramManagementAccountResponse,
   UpdateProgramManagementAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProgramManagementAccountRequest,
   output: UpdateProgramManagementAccountResponse,
@@ -2035,7 +2034,7 @@ export const updateRelationship: API.OperationMethod<
   UpdateRelationshipRequest,
   UpdateRelationshipResponse,
   UpdateRelationshipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelationshipRequest,
   output: UpdateRelationshipResponse,

--- a/packages/aws/src/services/partnercentral-selling.ts
+++ b/packages/aws/src/services/partnercentral-selling.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "PartnerCentral Selling",
@@ -4632,7 +4631,7 @@ export const acceptEngagementInvitation: API.OperationMethod<
   AcceptEngagementInvitationRequest,
   AcceptEngagementInvitationResponse,
   AcceptEngagementInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptEngagementInvitationRequest,
   output: AcceptEngagementInvitationResponse,
@@ -4665,7 +4664,7 @@ export const assignOpportunity: API.OperationMethod<
   AssignOpportunityRequest,
   AssignOpportunityResponse,
   AssignOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssignOpportunityRequest,
   output: AssignOpportunityResponse,
@@ -4709,7 +4708,7 @@ export const associateOpportunity: API.OperationMethod<
   AssociateOpportunityRequest,
   AssociateOpportunityResponse,
   AssociateOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateOpportunityRequest,
   output: AssociateOpportunityResponse,
@@ -4741,7 +4740,7 @@ export const createEngagement: API.OperationMethod<
   CreateEngagementRequest,
   CreateEngagementResponse,
   CreateEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEngagementRequest,
   output: CreateEngagementResponse,
@@ -4775,7 +4774,7 @@ export const createEngagementContext: API.OperationMethod<
   CreateEngagementContextRequest,
   CreateEngagementContextResponse,
   CreateEngagementContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEngagementContextRequest,
   output: CreateEngagementContextResponse,
@@ -4809,7 +4808,7 @@ export const createEngagementInvitation: API.OperationMethod<
   CreateEngagementInvitationRequest,
   CreateEngagementInvitationResponse,
   CreateEngagementInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEngagementInvitationRequest,
   output: CreateEngagementInvitationResponse,
@@ -4854,7 +4853,7 @@ export const createOpportunity: API.OperationMethod<
   CreateOpportunityRequest,
   CreateOpportunityResponse,
   CreateOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOpportunityRequest,
   output: CreateOpportunityResponse,
@@ -4887,7 +4886,7 @@ export const createResourceSnapshot: API.OperationMethod<
   CreateResourceSnapshotRequest,
   CreateResourceSnapshotResponse,
   CreateResourceSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceSnapshotRequest,
   output: CreateResourceSnapshotResponse,
@@ -4921,7 +4920,7 @@ export const createResourceSnapshotJob: API.OperationMethod<
   CreateResourceSnapshotJobRequest,
   CreateResourceSnapshotJobResponse,
   CreateResourceSnapshotJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceSnapshotJobRequest,
   output: CreateResourceSnapshotJobResponse,
@@ -4954,7 +4953,7 @@ export const deleteResourceSnapshotJob: API.OperationMethod<
   DeleteResourceSnapshotJobRequest,
   DeleteResourceSnapshotJobResponse,
   DeleteResourceSnapshotJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceSnapshotJobRequest,
   output: DeleteResourceSnapshotJobResponse,
@@ -4987,7 +4986,7 @@ export const disassociateOpportunity: API.OperationMethod<
   DisassociateOpportunityRequest,
   DisassociateOpportunityResponse,
   DisassociateOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateOpportunityRequest,
   output: DisassociateOpportunityResponse,
@@ -5017,7 +5016,7 @@ export const getAwsOpportunitySummary: API.OperationMethod<
   GetAwsOpportunitySummaryRequest,
   GetAwsOpportunitySummaryResponse,
   GetAwsOpportunitySummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAwsOpportunitySummaryRequest,
   output: GetAwsOpportunitySummaryResponse,
@@ -5047,7 +5046,7 @@ export const getEngagement: API.OperationMethod<
   GetEngagementRequest,
   GetEngagementResponse,
   GetEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEngagementRequest,
   output: GetEngagementResponse,
@@ -5077,7 +5076,7 @@ export const getEngagementInvitation: API.OperationMethod<
   GetEngagementInvitationRequest,
   GetEngagementInvitationResponse,
   GetEngagementInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEngagementInvitationRequest,
   output: GetEngagementInvitationResponse,
@@ -5109,7 +5108,7 @@ export const getOpportunity: API.OperationMethod<
   GetOpportunityRequest,
   GetOpportunityResponse,
   GetOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpportunityRequest,
   output: GetOpportunityResponse,
@@ -5139,7 +5138,7 @@ export const getProspectingFromEngagementTask: API.OperationMethod<
   GetProspectingFromEngagementTaskRequest,
   GetProspectingFromEngagementTaskResponse,
   GetProspectingFromEngagementTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProspectingFromEngagementTaskRequest,
   output: GetProspectingFromEngagementTaskResponse,
@@ -5169,7 +5168,7 @@ export const getResourceSnapshot: API.OperationMethod<
   GetResourceSnapshotRequest,
   GetResourceSnapshotResponse,
   GetResourceSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSnapshotRequest,
   output: GetResourceSnapshotResponse,
@@ -5199,7 +5198,7 @@ export const getResourceSnapshotJob: API.OperationMethod<
   GetResourceSnapshotJobRequest,
   GetResourceSnapshotJobResponse,
   GetResourceSnapshotJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSnapshotJobRequest,
   output: GetResourceSnapshotJobResponse,
@@ -5229,7 +5228,7 @@ export const getSellingSystemSettings: API.OperationMethod<
   GetSellingSystemSettingsRequest,
   GetSellingSystemSettingsResponse,
   GetSellingSystemSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSellingSystemSettingsRequest,
   output: GetSellingSystemSettingsResponse,
@@ -5259,7 +5258,7 @@ export const listEngagementByAcceptingInvitationTasks: API.PaginatedOperationMet
   ListEngagementByAcceptingInvitationTasksRequest,
   ListEngagementByAcceptingInvitationTasksResponse,
   ListEngagementByAcceptingInvitationTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListEngagementByAcceptingInvitationTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementByAcceptingInvitationTasksRequest,
@@ -5296,7 +5295,7 @@ export const listEngagementFromOpportunityTasks: API.PaginatedOperationMethod<
   ListEngagementFromOpportunityTasksRequest,
   ListEngagementFromOpportunityTasksResponse,
   ListEngagementFromOpportunityTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListEngagementFromOpportunityTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementFromOpportunityTasksRequest,
@@ -5333,7 +5332,7 @@ export const listEngagementInvitations: API.PaginatedOperationMethod<
   ListEngagementInvitationsRequest,
   ListEngagementInvitationsResponse,
   ListEngagementInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngagementInvitationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementInvitationsRequest,
@@ -5370,7 +5369,7 @@ export const listEngagementMembers: API.PaginatedOperationMethod<
   ListEngagementMembersRequest,
   ListEngagementMembersResponse,
   ListEngagementMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngagementMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementMembersRequest,
@@ -5407,7 +5406,7 @@ export const listEngagementResourceAssociations: API.PaginatedOperationMethod<
   ListEngagementResourceAssociationsRequest,
   ListEngagementResourceAssociationsResponse,
   ListEngagementResourceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngagementResourceAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementResourceAssociationsRequest,
@@ -5444,7 +5443,7 @@ export const listEngagements: API.PaginatedOperationMethod<
   ListEngagementsRequest,
   ListEngagementsResponse,
   ListEngagementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EngagementSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementsRequest,
@@ -5491,7 +5490,7 @@ export const listOpportunities: API.PaginatedOperationMethod<
   ListOpportunitiesRequest,
   ListOpportunitiesResponse,
   ListOpportunitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OpportunitySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpportunitiesRequest,
@@ -5528,7 +5527,7 @@ export const listOpportunityFromEngagementTasks: API.PaginatedOperationMethod<
   ListOpportunityFromEngagementTasksRequest,
   ListOpportunityFromEngagementTasksResponse,
   ListOpportunityFromEngagementTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListOpportunityFromEngagementTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpportunityFromEngagementTasksRequest,
@@ -5564,7 +5563,7 @@ export const listProspectingFromEngagementTasks: API.PaginatedOperationMethod<
   ListProspectingFromEngagementTasksRequest,
   ListProspectingFromEngagementTasksResponse,
   ListProspectingFromEngagementTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProspectingTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProspectingFromEngagementTasksRequest,
@@ -5600,7 +5599,7 @@ export const listResourceSnapshotJobs: API.PaginatedOperationMethod<
   ListResourceSnapshotJobsRequest,
   ListResourceSnapshotJobsResponse,
   ListResourceSnapshotJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceSnapshotJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceSnapshotJobsRequest,
@@ -5647,7 +5646,7 @@ export const listResourceSnapshots: API.PaginatedOperationMethod<
   ListResourceSnapshotsRequest,
   ListResourceSnapshotsResponse,
   ListResourceSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceSnapshotSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceSnapshotsRequest,
@@ -5684,7 +5683,7 @@ export const listSolutions: API.PaginatedOperationMethod<
   ListSolutionsRequest,
   ListSolutionsResponse,
   ListSolutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SolutionBase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolutionsRequest,
@@ -5721,7 +5720,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5751,7 +5750,7 @@ export const putSellingSystemSettings: API.OperationMethod<
   PutSellingSystemSettingsRequest,
   PutSellingSystemSettingsResponse,
   PutSellingSystemSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSellingSystemSettingsRequest,
   output: PutSellingSystemSettingsResponse,
@@ -5782,7 +5781,7 @@ export const rejectEngagementInvitation: API.OperationMethod<
   RejectEngagementInvitationRequest,
   RejectEngagementInvitationResponse,
   RejectEngagementInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectEngagementInvitationRequest,
   output: RejectEngagementInvitationResponse,
@@ -5815,7 +5814,7 @@ export const startEngagementByAcceptingInvitationTask: API.OperationMethod<
   StartEngagementByAcceptingInvitationTaskRequest,
   StartEngagementByAcceptingInvitationTaskResponse,
   StartEngagementByAcceptingInvitationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEngagementByAcceptingInvitationTaskRequest,
   output: StartEngagementByAcceptingInvitationTaskResponse,
@@ -5849,7 +5848,7 @@ export const startEngagementFromOpportunityTask: API.OperationMethod<
   StartEngagementFromOpportunityTaskRequest,
   StartEngagementFromOpportunityTaskResponse,
   StartEngagementFromOpportunityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEngagementFromOpportunityTaskRequest,
   output: StartEngagementFromOpportunityTaskResponse,
@@ -5883,7 +5882,7 @@ export const startOpportunityFromEngagementTask: API.OperationMethod<
   StartOpportunityFromEngagementTaskRequest,
   StartOpportunityFromEngagementTaskResponse,
   StartOpportunityFromEngagementTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartOpportunityFromEngagementTaskRequest,
   output: StartOpportunityFromEngagementTaskResponse,
@@ -5916,7 +5915,7 @@ export const startProspectingFromEngagementTask: API.OperationMethod<
   StartProspectingFromEngagementTaskRequest,
   StartProspectingFromEngagementTaskResponse,
   StartProspectingFromEngagementTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProspectingFromEngagementTaskRequest,
   output: StartProspectingFromEngagementTaskResponse,
@@ -5947,7 +5946,7 @@ export const startResourceSnapshotJob: API.OperationMethod<
   StartResourceSnapshotJobRequest,
   StartResourceSnapshotJobResponse,
   StartResourceSnapshotJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceSnapshotJobRequest,
   output: StartResourceSnapshotJobResponse,
@@ -5977,7 +5976,7 @@ export const stopResourceSnapshotJob: API.OperationMethod<
   StopResourceSnapshotJobRequest,
   StopResourceSnapshotJobResponse,
   StopResourceSnapshotJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopResourceSnapshotJobRequest,
   output: StopResourceSnapshotJobResponse,
@@ -6007,7 +6006,7 @@ export const submitOpportunity: API.OperationMethod<
   SubmitOpportunityRequest,
   SubmitOpportunityResponse,
   SubmitOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitOpportunityRequest,
   output: SubmitOpportunityResponse,
@@ -6038,7 +6037,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6070,7 +6069,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6103,7 +6102,7 @@ export const updateEngagementContext: API.OperationMethod<
   UpdateEngagementContextRequest,
   UpdateEngagementContextResponse,
   UpdateEngagementContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEngagementContextRequest,
   output: UpdateEngagementContextResponse,
@@ -6138,7 +6137,7 @@ export const updateOpportunity: API.OperationMethod<
   UpdateOpportunityRequest,
   UpdateOpportunityResponse,
   UpdateOpportunityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOpportunityRequest,
   output: UpdateOpportunityResponse,

--- a/packages/aws/src/services/payment-cryptography-data.ts
+++ b/packages/aws/src/services/payment-cryptography-data.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Payment Cryptography Data",
@@ -2154,7 +2153,7 @@ export const decryptData: API.OperationMethod<
   DecryptDataInput,
   DecryptDataOutput,
   DecryptDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecryptDataInput,
   output: DecryptDataOutput,
@@ -2210,7 +2209,7 @@ export const encryptData: API.OperationMethod<
   EncryptDataInput,
   EncryptDataOutput,
   EncryptDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EncryptDataInput,
   output: EncryptDataOutput,
@@ -2250,7 +2249,7 @@ export const generateAs2805KekValidation: API.OperationMethod<
   GenerateAs2805KekValidationInput,
   GenerateAs2805KekValidationOutput,
   GenerateAs2805KekValidationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateAs2805KekValidationInput,
   output: GenerateAs2805KekValidationOutput,
@@ -2292,7 +2291,7 @@ export const generateAuthRequestCryptogram: API.OperationMethod<
   GenerateAuthRequestCryptogramInput,
   GenerateAuthRequestCryptogramOutput,
   GenerateAuthRequestCryptogramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateAuthRequestCryptogramInput,
   output: GenerateAuthRequestCryptogramOutput,
@@ -2334,7 +2333,7 @@ export const generateCardValidationData: API.OperationMethod<
   GenerateCardValidationDataInput,
   GenerateCardValidationDataOutput,
   GenerateCardValidationDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateCardValidationDataInput,
   output: GenerateCardValidationDataOutput,
@@ -2376,7 +2375,7 @@ export const generateMac: API.OperationMethod<
   GenerateMacInput,
   GenerateMacOutput,
   GenerateMacError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMacInput,
   output: GenerateMacOutput,
@@ -2424,7 +2423,7 @@ export const generateMacEmvPinChange: API.OperationMethod<
   GenerateMacEmvPinChangeInput,
   GenerateMacEmvPinChangeOutput,
   GenerateMacEmvPinChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMacEmvPinChangeInput,
   output: GenerateMacEmvPinChangeOutput,
@@ -2470,7 +2469,7 @@ export const generatePinData: API.OperationMethod<
   GeneratePinDataInput,
   GeneratePinDataOutput,
   GeneratePinDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GeneratePinDataInput,
   output: GeneratePinDataOutput,
@@ -2520,7 +2519,7 @@ export const reEncryptData: API.OperationMethod<
   ReEncryptDataInput,
   ReEncryptDataOutput,
   ReEncryptDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReEncryptDataInput,
   output: ReEncryptDataOutput,
@@ -2566,7 +2565,7 @@ export const translateKeyMaterial: API.OperationMethod<
   TranslateKeyMaterialInput,
   TranslateKeyMaterialOutput,
   TranslateKeyMaterialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TranslateKeyMaterialInput,
   output: TranslateKeyMaterialOutput,
@@ -2618,7 +2617,7 @@ export const translatePinData: API.OperationMethod<
   TranslatePinDataInput,
   TranslatePinDataOutput,
   TranslatePinDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TranslatePinDataInput,
   output: TranslatePinDataOutput,
@@ -2661,7 +2660,7 @@ export const verifyAuthRequestCryptogram: API.OperationMethod<
   VerifyAuthRequestCryptogramInput,
   VerifyAuthRequestCryptogramOutput,
   VerifyAuthRequestCryptogramError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyAuthRequestCryptogramInput,
   output: VerifyAuthRequestCryptogramOutput,
@@ -2707,7 +2706,7 @@ export const verifyCardValidationData: API.OperationMethod<
   VerifyCardValidationDataInput,
   VerifyCardValidationDataOutput,
   VerifyCardValidationDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyCardValidationDataInput,
   output: VerifyCardValidationDataOutput,
@@ -2749,7 +2748,7 @@ export const verifyMac: API.OperationMethod<
   VerifyMacInput,
   VerifyMacOutput,
   VerifyMacError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyMacInput,
   output: VerifyMacOutput,
@@ -2793,7 +2792,7 @@ export const verifyPinData: API.OperationMethod<
   VerifyPinDataInput,
   VerifyPinDataOutput,
   VerifyPinDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyPinDataInput,
   output: VerifyPinDataOutput,

--- a/packages/aws/src/services/payment-cryptography.ts
+++ b/packages/aws/src/services/payment-cryptography.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Payment Cryptography",
@@ -1512,7 +1511,7 @@ export const addKeyReplicationRegions: API.OperationMethod<
   AddKeyReplicationRegionsInput,
   AddKeyReplicationRegionsOutput,
   AddKeyReplicationRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddKeyReplicationRegionsInput,
   output: AddKeyReplicationRegionsOutput,
@@ -1555,7 +1554,7 @@ export const associateMpaTeam: API.OperationMethod<
   AssociateMpaTeamInput,
   AssociateMpaTeamOutput,
   AssociateMpaTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMpaTeamInput,
   output: AssociateMpaTeamOutput,
@@ -1607,7 +1606,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasInput,
   CreateAliasOutput,
   CreateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasInput,
   output: CreateAliasOutput,
@@ -1663,7 +1662,7 @@ export const createKey: API.OperationMethod<
   CreateKeyInput,
   CreateKeyOutput,
   CreateKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeyInput,
   output: CreateKeyOutput,
@@ -1712,7 +1711,7 @@ export const deleteAlias: API.OperationMethod<
   DeleteAliasInput,
   DeleteAliasOutput,
   DeleteAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAliasInput,
   output: DeleteAliasOutput,
@@ -1760,7 +1759,7 @@ export const deleteKey: API.OperationMethod<
   DeleteKeyInput,
   DeleteKeyOutput,
   DeleteKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeyInput,
   output: DeleteKeyOutput,
@@ -1802,7 +1801,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyInput,
   DeleteResourcePolicyOutput,
   DeleteResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyInput,
   output: DeleteResourcePolicyOutput,
@@ -1848,7 +1847,7 @@ export const disableDefaultKeyReplicationRegions: API.OperationMethod<
   DisableDefaultKeyReplicationRegionsInput,
   DisableDefaultKeyReplicationRegionsOutput,
   DisableDefaultKeyReplicationRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDefaultKeyReplicationRegionsInput,
   output: DisableDefaultKeyReplicationRegionsOutput,
@@ -1891,7 +1890,7 @@ export const disassociateMpaTeam: API.OperationMethod<
   DisassociateMpaTeamInput,
   DisassociateMpaTeamOutput,
   DisassociateMpaTeamError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMpaTeamInput,
   output: DisassociateMpaTeamOutput,
@@ -1938,7 +1937,7 @@ export const enableDefaultKeyReplicationRegions: API.OperationMethod<
   EnableDefaultKeyReplicationRegionsInput,
   EnableDefaultKeyReplicationRegionsOutput,
   EnableDefaultKeyReplicationRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDefaultKeyReplicationRegionsInput,
   output: EnableDefaultKeyReplicationRegionsOutput,
@@ -2060,7 +2059,7 @@ export const exportKey: API.OperationMethod<
   ExportKeyInput,
   ExportKeyOutput,
   ExportKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportKeyInput,
   output: ExportKeyOutput,
@@ -2105,7 +2104,7 @@ export const getAlias: API.OperationMethod<
   GetAliasInput,
   GetAliasOutput,
   GetAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAliasInput,
   output: GetAliasOutput,
@@ -2137,7 +2136,7 @@ export const getCertificateSigningRequest: API.OperationMethod<
   GetCertificateSigningRequestInput,
   GetCertificateSigningRequestOutput,
   GetCertificateSigningRequestError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateSigningRequestInput,
   output: GetCertificateSigningRequestOutput,
@@ -2180,7 +2179,7 @@ export const getDefaultKeyReplicationRegions: API.OperationMethod<
   GetDefaultKeyReplicationRegionsInput,
   GetDefaultKeyReplicationRegionsOutput,
   GetDefaultKeyReplicationRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultKeyReplicationRegionsInput,
   output: GetDefaultKeyReplicationRegionsOutput,
@@ -2223,7 +2222,7 @@ export const getKey: API.OperationMethod<
   GetKeyInput,
   GetKeyOutput,
   GetKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKeyInput,
   output: GetKeyOutput,
@@ -2265,7 +2264,7 @@ export const getMpaTeamAssociation: API.OperationMethod<
   GetMpaTeamAssociationInput,
   GetMpaTeamAssociationOutput,
   GetMpaTeamAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMpaTeamAssociationInput,
   output: GetMpaTeamAssociationOutput,
@@ -2313,7 +2312,7 @@ export const getParametersForExport: API.OperationMethod<
   GetParametersForExportInput,
   GetParametersForExportOutput,
   GetParametersForExportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParametersForExportInput,
   output: GetParametersForExportOutput,
@@ -2361,7 +2360,7 @@ export const getParametersForImport: API.OperationMethod<
   GetParametersForImportInput,
   GetParametersForImportOutput,
   GetParametersForImportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParametersForImportInput,
   output: GetParametersForImportOutput,
@@ -2399,7 +2398,7 @@ export const getPublicKeyCertificate: API.OperationMethod<
   GetPublicKeyCertificateInput,
   GetPublicKeyCertificateOutput,
   GetPublicKeyCertificateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicKeyCertificateInput,
   output: GetPublicKeyCertificateOutput,
@@ -2439,7 +2438,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -2567,7 +2566,7 @@ export const importKey: API.OperationMethod<
   ImportKeyInput,
   ImportKeyOutput,
   ImportKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportKeyInput,
   output: ImportKeyOutput,
@@ -2615,7 +2614,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesInput,
   ListAliasesOutput,
   ListAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Alias
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesInput,
@@ -2666,7 +2665,7 @@ export const listKeys: API.PaginatedOperationMethod<
   ListKeysInput,
   ListKeysOutput,
   ListKeysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KeySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKeysInput,
@@ -2715,7 +2714,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -2769,7 +2768,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyInput,
   PutResourcePolicyOutput,
   PutResourcePolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyInput,
   output: PutResourcePolicyOutput,
@@ -2817,7 +2816,7 @@ export const removeKeyReplicationRegions: API.OperationMethod<
   RemoveKeyReplicationRegionsInput,
   RemoveKeyReplicationRegionsOutput,
   RemoveKeyReplicationRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveKeyReplicationRegionsInput,
   output: RemoveKeyReplicationRegionsOutput,
@@ -2864,7 +2863,7 @@ export const restoreKey: API.OperationMethod<
   RestoreKeyInput,
   RestoreKeyOutput,
   RestoreKeyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreKeyInput,
   output: RestoreKeyOutput,
@@ -2906,7 +2905,7 @@ export const startKeyUsage: API.OperationMethod<
   StartKeyUsageInput,
   StartKeyUsageOutput,
   StartKeyUsageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartKeyUsageInput,
   output: StartKeyUsageOutput,
@@ -2952,7 +2951,7 @@ export const stopKeyUsage: API.OperationMethod<
   StopKeyUsageInput,
   StopKeyUsageOutput,
   StopKeyUsageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopKeyUsageInput,
   output: StopKeyUsageOutput,
@@ -3000,7 +2999,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -3045,7 +3044,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -3091,7 +3090,7 @@ export const updateAlias: API.OperationMethod<
   UpdateAliasInput,
   UpdateAliasOutput,
   UpdateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAliasInput,
   output: UpdateAliasOutput,

--- a/packages/aws/src/services/pca-connector-ad.ts
+++ b/packages/aws/src/services/pca-connector-ad.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pca Connector Ad",
   serviceShapeName: "PcaConnectorAd",
@@ -1910,7 +1909,7 @@ export const createConnector: API.OperationMethod<
   CreateConnectorRequest,
   CreateConnectorResponse,
   CreateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorRequest,
   output: CreateConnectorResponse,
@@ -1944,7 +1943,7 @@ export const createDirectoryRegistration: API.OperationMethod<
   CreateDirectoryRegistrationRequest,
   CreateDirectoryRegistrationResponse,
   CreateDirectoryRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDirectoryRegistrationRequest,
   output: CreateDirectoryRegistrationResponse,
@@ -1978,7 +1977,7 @@ export const createServicePrincipalName: API.OperationMethod<
   CreateServicePrincipalNameRequest,
   CreateServicePrincipalNameResponse,
   CreateServicePrincipalNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServicePrincipalNameRequest,
   output: CreateServicePrincipalNameResponse,
@@ -2012,7 +2011,7 @@ export const createTemplate: API.OperationMethod<
   CreateTemplateRequest,
   CreateTemplateResponse,
   CreateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateRequest,
   output: CreateTemplateResponse,
@@ -2047,7 +2046,7 @@ export const createTemplateGroupAccessControlEntry: API.OperationMethod<
   CreateTemplateGroupAccessControlEntryRequest,
   CreateTemplateGroupAccessControlEntryResponse,
   CreateTemplateGroupAccessControlEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateGroupAccessControlEntryRequest,
   output: CreateTemplateGroupAccessControlEntryResponse,
@@ -2084,7 +2083,7 @@ export const deleteConnector: API.OperationMethod<
   DeleteConnectorRequest,
   DeleteConnectorResponse,
   DeleteConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorRequest,
   output: DeleteConnectorResponse,
@@ -2116,7 +2115,7 @@ export const deleteDirectoryRegistration: API.OperationMethod<
   DeleteDirectoryRegistrationRequest,
   DeleteDirectoryRegistrationResponse,
   DeleteDirectoryRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDirectoryRegistrationRequest,
   output: DeleteDirectoryRegistrationResponse,
@@ -2147,7 +2146,7 @@ export const deleteServicePrincipalName: API.OperationMethod<
   DeleteServicePrincipalNameRequest,
   DeleteServicePrincipalNameResponse,
   DeleteServicePrincipalNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServicePrincipalNameRequest,
   output: DeleteServicePrincipalNameResponse,
@@ -2179,7 +2178,7 @@ export const deleteTemplate: API.OperationMethod<
   DeleteTemplateRequest,
   DeleteTemplateResponse,
   DeleteTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateRequest,
   output: DeleteTemplateResponse,
@@ -2211,7 +2210,7 @@ export const deleteTemplateGroupAccessControlEntry: API.OperationMethod<
   DeleteTemplateGroupAccessControlEntryRequest,
   DeleteTemplateGroupAccessControlEntryResponse,
   DeleteTemplateGroupAccessControlEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateGroupAccessControlEntryRequest,
   output: DeleteTemplateGroupAccessControlEntryResponse,
@@ -2243,7 +2242,7 @@ export const getConnector: API.OperationMethod<
   GetConnectorRequest,
   GetConnectorResponse,
   GetConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorRequest,
   output: GetConnectorResponse,
@@ -2273,7 +2272,7 @@ export const getDirectoryRegistration: API.OperationMethod<
   GetDirectoryRegistrationRequest,
   GetDirectoryRegistrationResponse,
   GetDirectoryRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDirectoryRegistrationRequest,
   output: GetDirectoryRegistrationResponse,
@@ -2304,7 +2303,7 @@ export const getServicePrincipalName: API.OperationMethod<
   GetServicePrincipalNameRequest,
   GetServicePrincipalNameResponse,
   GetServicePrincipalNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServicePrincipalNameRequest,
   output: GetServicePrincipalNameResponse,
@@ -2335,7 +2334,7 @@ export const getTemplate: API.OperationMethod<
   GetTemplateRequest,
   GetTemplateResponse,
   GetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateRequest,
   output: GetTemplateResponse,
@@ -2365,7 +2364,7 @@ export const getTemplateGroupAccessControlEntry: API.OperationMethod<
   GetTemplateGroupAccessControlEntryRequest,
   GetTemplateGroupAccessControlEntryResponse,
   GetTemplateGroupAccessControlEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateGroupAccessControlEntryRequest,
   output: GetTemplateGroupAccessControlEntryResponse,
@@ -2394,7 +2393,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -2430,7 +2429,7 @@ export const listDirectoryRegistrations: API.PaginatedOperationMethod<
   ListDirectoryRegistrationsRequest,
   ListDirectoryRegistrationsResponse,
   ListDirectoryRegistrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DirectoryRegistrationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDirectoryRegistrationsRequest,
@@ -2467,7 +2466,7 @@ export const listServicePrincipalNames: API.PaginatedOperationMethod<
   ListServicePrincipalNamesRequest,
   ListServicePrincipalNamesResponse,
   ListServicePrincipalNamesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServicePrincipalNameSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicePrincipalNamesRequest,
@@ -2504,7 +2503,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2534,7 +2533,7 @@ export const listTemplateGroupAccessControlEntries: API.PaginatedOperationMethod
   ListTemplateGroupAccessControlEntriesRequest,
   ListTemplateGroupAccessControlEntriesResponse,
   ListTemplateGroupAccessControlEntriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessControlEntrySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateGroupAccessControlEntriesRequest,
@@ -2571,7 +2570,7 @@ export const listTemplates: API.PaginatedOperationMethod<
   ListTemplatesRequest,
   ListTemplatesResponse,
   ListTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplatesRequest,
@@ -2608,7 +2607,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2638,7 +2637,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2669,7 +2668,7 @@ export const updateTemplate: API.OperationMethod<
   UpdateTemplateRequest,
   UpdateTemplateResponse,
   UpdateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateRequest,
   output: UpdateTemplateResponse,
@@ -2701,7 +2700,7 @@ export const updateTemplateGroupAccessControlEntry: API.OperationMethod<
   UpdateTemplateGroupAccessControlEntryRequest,
   UpdateTemplateGroupAccessControlEntryResponse,
   UpdateTemplateGroupAccessControlEntryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateGroupAccessControlEntryRequest,
   output: UpdateTemplateGroupAccessControlEntryResponse,

--- a/packages/aws/src/services/pca-connector-scep.ts
+++ b/packages/aws/src/services/pca-connector-scep.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Pca Connector Scep",
@@ -688,7 +687,7 @@ export const createChallenge: API.OperationMethod<
   CreateChallengeRequest,
   CreateChallengeResponse,
   CreateChallengeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChallengeRequest,
   output: CreateChallengeResponse,
@@ -723,7 +722,7 @@ export const createConnector: API.OperationMethod<
   CreateConnectorRequest,
   CreateConnectorResponse,
   CreateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorRequest,
   output: CreateConnectorResponse,
@@ -756,7 +755,7 @@ export const deleteChallenge: API.OperationMethod<
   DeleteChallengeRequest,
   DeleteChallengeResponse,
   DeleteChallengeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChallengeRequest,
   output: DeleteChallengeResponse,
@@ -788,7 +787,7 @@ export const deleteConnector: API.OperationMethod<
   DeleteConnectorRequest,
   DeleteConnectorResponse,
   DeleteConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorRequest,
   output: DeleteConnectorResponse,
@@ -819,7 +818,7 @@ export const getChallengeMetadata: API.OperationMethod<
   GetChallengeMetadataRequest,
   GetChallengeMetadataResponse,
   GetChallengeMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChallengeMetadataRequest,
   output: GetChallengeMetadataResponse,
@@ -849,7 +848,7 @@ export const getChallengePassword: API.OperationMethod<
   GetChallengePasswordRequest,
   GetChallengePasswordResponse,
   GetChallengePasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChallengePasswordRequest,
   output: GetChallengePasswordResponse,
@@ -879,7 +878,7 @@ export const getConnector: API.OperationMethod<
   GetConnectorRequest,
   GetConnectorResponse,
   GetConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorRequest,
   output: GetConnectorResponse,
@@ -909,7 +908,7 @@ export const listChallengeMetadata: API.PaginatedOperationMethod<
   ListChallengeMetadataRequest,
   ListChallengeMetadataResponse,
   ListChallengeMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChallengeMetadataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChallengeMetadataRequest,
@@ -945,7 +944,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -981,7 +980,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1011,7 +1010,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1041,7 +1040,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/pcs.ts
+++ b/packages/aws/src/services/pcs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "PCS",
@@ -1329,7 +1328,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -1362,7 +1361,7 @@ export const createComputeNodeGroup: API.OperationMethod<
   CreateComputeNodeGroupRequest,
   CreateComputeNodeGroupResponse,
   CreateComputeNodeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComputeNodeGroupRequest,
   output: CreateComputeNodeGroupResponse,
@@ -1396,7 +1395,7 @@ export const createQueue: API.OperationMethod<
   CreateQueueRequest,
   CreateQueueResponse,
   CreateQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueRequest,
   output: CreateQueueResponse,
@@ -1429,7 +1428,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -1461,7 +1460,7 @@ export const deleteComputeNodeGroup: API.OperationMethod<
   DeleteComputeNodeGroupRequest,
   DeleteComputeNodeGroupResponse,
   DeleteComputeNodeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComputeNodeGroupRequest,
   output: DeleteComputeNodeGroupResponse,
@@ -1493,7 +1492,7 @@ export const deleteQueue: API.OperationMethod<
   DeleteQueueRequest,
   DeleteQueueResponse,
   DeleteQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueRequest,
   output: DeleteQueueResponse,
@@ -1525,7 +1524,7 @@ export const getCluster: API.OperationMethod<
   GetClusterRequest,
   GetClusterResponse,
   GetClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterRequest,
   output: GetClusterResponse,
@@ -1557,7 +1556,7 @@ export const getComputeNodeGroup: API.OperationMethod<
   GetComputeNodeGroupRequest,
   GetComputeNodeGroupResponse,
   GetComputeNodeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComputeNodeGroupRequest,
   output: GetComputeNodeGroupResponse,
@@ -1589,7 +1588,7 @@ export const getQueue: API.OperationMethod<
   GetQueueRequest,
   GetQueueResponse,
   GetQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueRequest,
   output: GetQueueResponse,
@@ -1621,7 +1620,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -1660,7 +1659,7 @@ export const listComputeNodeGroups: API.PaginatedOperationMethod<
   ListComputeNodeGroupsRequest,
   ListComputeNodeGroupsResponse,
   ListComputeNodeGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputeNodeGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputeNodeGroupsRequest,
@@ -1699,7 +1698,7 @@ export const listQueues: API.PaginatedOperationMethod<
   ListQueuesRequest,
   ListQueuesResponse,
   ListQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueueSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuesRequest,
@@ -1731,7 +1730,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1754,7 +1753,7 @@ export const registerComputeNodeGroupInstance: API.OperationMethod<
   RegisterComputeNodeGroupInstanceRequest,
   RegisterComputeNodeGroupInstanceResponse,
   RegisterComputeNodeGroupInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterComputeNodeGroupInstanceRequest,
   output: RegisterComputeNodeGroupInstanceResponse,
@@ -1775,7 +1774,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1793,7 +1792,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1820,7 +1819,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -1853,7 +1852,7 @@ export const updateComputeNodeGroup: API.OperationMethod<
   UpdateComputeNodeGroupRequest,
   UpdateComputeNodeGroupResponse,
   UpdateComputeNodeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComputeNodeGroupRequest,
   output: UpdateComputeNodeGroupResponse,
@@ -1887,7 +1886,7 @@ export const updateQueue: API.OperationMethod<
   UpdateQueueRequest,
   UpdateQueueResponse,
   UpdateQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQueueRequest,
   output: UpdateQueueResponse,

--- a/packages/aws/src/services/personalize-events.ts
+++ b/packages/aws/src/services/personalize-events.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Personalize Events",
@@ -363,7 +362,7 @@ export const putActionInteractions: API.OperationMethod<
   PutActionInteractionsRequest,
   PutActionInteractionsResponse,
   PutActionInteractionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutActionInteractionsRequest,
   output: PutActionInteractionsResponse,
@@ -390,7 +389,7 @@ export const putActions: API.OperationMethod<
   PutActionsRequest,
   PutActionsResponse,
   PutActionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutActionsRequest,
   output: PutActionsResponse,
@@ -413,7 +412,7 @@ export const putEvents: API.OperationMethod<
   PutEventsRequest,
   PutEventsResponse,
   PutEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventsRequest,
   output: PutEventsResponse,
@@ -436,7 +435,7 @@ export const putItems: API.OperationMethod<
   PutItemsRequest,
   PutItemsResponse,
   PutItemsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutItemsRequest,
   output: PutItemsResponse,
@@ -463,7 +462,7 @@ export const putUsers: API.OperationMethod<
   PutUsersRequest,
   PutUsersResponse,
   PutUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutUsersRequest,
   output: PutUsersResponse,

--- a/packages/aws/src/services/personalize-runtime.ts
+++ b/packages/aws/src/services/personalize-runtime.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Personalize Runtime",
@@ -346,7 +345,7 @@ export const getActionRecommendations: API.OperationMethod<
   GetActionRecommendationsRequest,
   GetActionRecommendationsResponse,
   GetActionRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActionRecommendationsRequest,
   output: GetActionRecommendationsResponse,
@@ -371,7 +370,7 @@ export const getPersonalizedRanking: API.OperationMethod<
   GetPersonalizedRankingRequest,
   GetPersonalizedRankingResponse,
   GetPersonalizedRankingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPersonalizedRankingRequest,
   output: GetPersonalizedRankingResponse,
@@ -403,7 +402,7 @@ export const getRecommendations: API.OperationMethod<
   GetRecommendationsRequest,
   GetRecommendationsResponse,
   GetRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationsRequest,
   output: GetRecommendationsResponse,

--- a/packages/aws/src/services/personalize.ts
+++ b/packages/aws/src/services/personalize.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Personalize",
@@ -3473,7 +3472,7 @@ export const createBatchInferenceJob: API.OperationMethod<
   CreateBatchInferenceJobRequest,
   CreateBatchInferenceJobResponse,
   CreateBatchInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchInferenceJobRequest,
   output: CreateBatchInferenceJobResponse,
@@ -3507,7 +3506,7 @@ export const createBatchSegmentJob: API.OperationMethod<
   CreateBatchSegmentJobRequest,
   CreateBatchSegmentJobResponse,
   CreateBatchSegmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchSegmentJobRequest,
   output: CreateBatchSegmentJobResponse,
@@ -3593,7 +3592,7 @@ export const createCampaign: API.OperationMethod<
   CreateCampaignRequest,
   CreateCampaignResponse,
   CreateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCampaignRequest,
   output: CreateCampaignResponse,
@@ -3659,7 +3658,7 @@ export const createDataDeletionJob: API.OperationMethod<
   CreateDataDeletionJobRequest,
   CreateDataDeletionJobResponse,
   CreateDataDeletionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataDeletionJobRequest,
   output: CreateDataDeletionJobResponse,
@@ -3728,7 +3727,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -3776,7 +3775,7 @@ export const createDatasetExportJob: API.OperationMethod<
   CreateDatasetExportJobRequest,
   CreateDatasetExportJobResponse,
   CreateDatasetExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetExportJobRequest,
   output: CreateDatasetExportJobResponse,
@@ -3860,7 +3859,7 @@ export const createDatasetGroup: API.OperationMethod<
   CreateDatasetGroupRequest,
   CreateDatasetGroupResponse,
   CreateDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetGroupRequest,
   output: CreateDatasetGroupResponse,
@@ -3927,7 +3926,7 @@ export const createDatasetImportJob: API.OperationMethod<
   CreateDatasetImportJobRequest,
   CreateDatasetImportJobResponse,
   CreateDatasetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetImportJobRequest,
   output: CreateDatasetImportJobResponse,
@@ -3988,7 +3987,7 @@ export const createEventTracker: API.OperationMethod<
   CreateEventTrackerRequest,
   CreateEventTrackerResponse,
   CreateEventTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventTrackerRequest,
   output: CreateEventTrackerResponse,
@@ -4019,7 +4018,7 @@ export const createFilter: API.OperationMethod<
   CreateFilterRequest,
   CreateFilterResponse,
   CreateFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFilterRequest,
   output: CreateFilterResponse,
@@ -4051,7 +4050,7 @@ export const createMetricAttribution: API.OperationMethod<
   CreateMetricAttributionRequest,
   CreateMetricAttributionResponse,
   CreateMetricAttributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMetricAttributionRequest,
   output: CreateMetricAttributionResponse,
@@ -4135,7 +4134,7 @@ export const createRecommender: API.OperationMethod<
   CreateRecommenderRequest,
   CreateRecommenderResponse,
   CreateRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommenderRequest,
   output: CreateRecommenderResponse,
@@ -4178,7 +4177,7 @@ export const createSchema: API.OperationMethod<
   CreateSchemaRequest,
   CreateSchemaResponse,
   CreateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchemaRequest,
   output: CreateSchemaResponse,
@@ -4263,7 +4262,7 @@ export const createSolution: API.OperationMethod<
   CreateSolutionRequest,
   CreateSolutionResponse,
   CreateSolutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSolutionRequest,
   output: CreateSolutionResponse,
@@ -4334,7 +4333,7 @@ export const createSolutionVersion: API.OperationMethod<
   CreateSolutionVersionRequest,
   CreateSolutionVersionResponse,
   CreateSolutionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSolutionVersionRequest,
   output: CreateSolutionVersionResponse,
@@ -4368,7 +4367,7 @@ export const deleteCampaign: API.OperationMethod<
   DeleteCampaignRequest,
   DeleteCampaignResponse,
   DeleteCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignRequest,
   output: DeleteCampaignResponse,
@@ -4397,7 +4396,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -4430,7 +4429,7 @@ export const deleteDatasetGroup: API.OperationMethod<
   DeleteDatasetGroupRequest,
   DeleteDatasetGroupResponse,
   DeleteDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetGroupRequest,
   output: DeleteDatasetGroupResponse,
@@ -4458,7 +4457,7 @@ export const deleteEventTracker: API.OperationMethod<
   DeleteEventTrackerRequest,
   DeleteEventTrackerResponse,
   DeleteEventTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventTrackerRequest,
   output: DeleteEventTrackerResponse,
@@ -4484,7 +4483,7 @@ export const deleteFilter: API.OperationMethod<
   DeleteFilterRequest,
   DeleteFilterResponse,
   DeleteFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFilterRequest,
   output: DeleteFilterResponse,
@@ -4510,7 +4509,7 @@ export const deleteMetricAttribution: API.OperationMethod<
   DeleteMetricAttributionRequest,
   DeleteMetricAttributionResponse,
   DeleteMetricAttributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMetricAttributionRequest,
   output: DeleteMetricAttributionResponse,
@@ -4537,7 +4536,7 @@ export const deleteRecommender: API.OperationMethod<
   DeleteRecommenderRequest,
   DeleteRecommenderResponse,
   DeleteRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommenderRequest,
   output: DeleteRecommenderResponse,
@@ -4565,7 +4564,7 @@ export const deleteSchema: API.OperationMethod<
   DeleteSchemaRequest,
   DeleteSchemaResponse,
   DeleteSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaRequest,
   output: DeleteSchemaResponse,
@@ -4597,7 +4596,7 @@ export const deleteSolution: API.OperationMethod<
   DeleteSolutionRequest,
   DeleteSolutionResponse,
   DeleteSolutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSolutionRequest,
   output: DeleteSolutionResponse,
@@ -4622,7 +4621,7 @@ export const describeAlgorithm: API.OperationMethod<
   DescribeAlgorithmRequest,
   DescribeAlgorithmResponse,
   DescribeAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlgorithmRequest,
   output: DescribeAlgorithmResponse,
@@ -4645,7 +4644,7 @@ export const describeBatchInferenceJob: API.OperationMethod<
   DescribeBatchInferenceJobRequest,
   DescribeBatchInferenceJobResponse,
   DescribeBatchInferenceJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBatchInferenceJobRequest,
   output: DescribeBatchInferenceJobResponse,
@@ -4668,7 +4667,7 @@ export const describeBatchSegmentJob: API.OperationMethod<
   DescribeBatchSegmentJobRequest,
   DescribeBatchSegmentJobResponse,
   DescribeBatchSegmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBatchSegmentJobRequest,
   output: DescribeBatchSegmentJobResponse,
@@ -4700,7 +4699,7 @@ export const describeCampaign: API.OperationMethod<
   DescribeCampaignRequest,
   DescribeCampaignResponse,
   DescribeCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCampaignRequest,
   output: DescribeCampaignResponse,
@@ -4721,7 +4720,7 @@ export const describeDataDeletionJob: API.OperationMethod<
   DescribeDataDeletionJobRequest,
   DescribeDataDeletionJobResponse,
   DescribeDataDeletionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataDeletionJobRequest,
   output: DescribeDataDeletionJobResponse,
@@ -4743,7 +4742,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -4764,7 +4763,7 @@ export const describeDatasetExportJob: API.OperationMethod<
   DescribeDatasetExportJobRequest,
   DescribeDatasetExportJobResponse,
   DescribeDatasetExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetExportJobRequest,
   output: DescribeDatasetExportJobResponse,
@@ -4786,7 +4785,7 @@ export const describeDatasetGroup: API.OperationMethod<
   DescribeDatasetGroupRequest,
   DescribeDatasetGroupResponse,
   DescribeDatasetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetGroupRequest,
   output: DescribeDatasetGroupResponse,
@@ -4807,7 +4806,7 @@ export const describeDatasetImportJob: API.OperationMethod<
   DescribeDatasetImportJobRequest,
   DescribeDatasetImportJobResponse,
   DescribeDatasetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetImportJobRequest,
   output: DescribeDatasetImportJobResponse,
@@ -4830,7 +4829,7 @@ export const describeEventTracker: API.OperationMethod<
   DescribeEventTrackerRequest,
   DescribeEventTrackerResponse,
   DescribeEventTrackerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventTrackerRequest,
   output: DescribeEventTrackerResponse,
@@ -4851,7 +4850,7 @@ export const describeFeatureTransformation: API.OperationMethod<
   DescribeFeatureTransformationRequest,
   DescribeFeatureTransformationResponse,
   DescribeFeatureTransformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFeatureTransformationRequest,
   output: DescribeFeatureTransformationResponse,
@@ -4872,7 +4871,7 @@ export const describeFilter: API.OperationMethod<
   DescribeFilterRequest,
   DescribeFilterResponse,
   DescribeFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFilterRequest,
   output: DescribeFilterResponse,
@@ -4893,7 +4892,7 @@ export const describeMetricAttribution: API.OperationMethod<
   DescribeMetricAttributionRequest,
   DescribeMetricAttributionResponse,
   DescribeMetricAttributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMetricAttributionRequest,
   output: DescribeMetricAttributionResponse,
@@ -4929,7 +4928,7 @@ export const describeRecipe: API.OperationMethod<
   DescribeRecipeRequest,
   DescribeRecipeResponse,
   DescribeRecipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecipeRequest,
   output: DescribeRecipeResponse,
@@ -4966,7 +4965,7 @@ export const describeRecommender: API.OperationMethod<
   DescribeRecommenderRequest,
   DescribeRecommenderResponse,
   DescribeRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecommenderRequest,
   output: DescribeRecommenderResponse,
@@ -4988,7 +4987,7 @@ export const describeSchema: API.OperationMethod<
   DescribeSchemaRequest,
   DescribeSchemaResponse,
   DescribeSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSchemaRequest,
   output: DescribeSchemaResponse,
@@ -5010,7 +5009,7 @@ export const describeSolution: API.OperationMethod<
   DescribeSolutionRequest,
   DescribeSolutionResponse,
   DescribeSolutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSolutionRequest,
   output: DescribeSolutionResponse,
@@ -5031,7 +5030,7 @@ export const describeSolutionVersion: API.OperationMethod<
   DescribeSolutionVersionRequest,
   DescribeSolutionVersionResponse,
   DescribeSolutionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSolutionVersionRequest,
   output: DescribeSolutionVersionResponse,
@@ -5053,7 +5052,7 @@ export const getSolutionMetrics: API.OperationMethod<
   GetSolutionMetricsRequest,
   GetSolutionMetricsResponse,
   GetSolutionMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolutionMetricsRequest,
   output: GetSolutionMetricsResponse,
@@ -5079,7 +5078,7 @@ export const listBatchInferenceJobs: API.PaginatedOperationMethod<
   ListBatchInferenceJobsRequest,
   ListBatchInferenceJobsResponse,
   ListBatchInferenceJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchInferenceJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchInferenceJobsRequest,
@@ -5108,7 +5107,7 @@ export const listBatchSegmentJobs: API.PaginatedOperationMethod<
   ListBatchSegmentJobsRequest,
   ListBatchSegmentJobsResponse,
   ListBatchSegmentJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BatchSegmentJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchSegmentJobsRequest,
@@ -5139,7 +5138,7 @@ export const listCampaigns: API.PaginatedOperationMethod<
   ListCampaignsRequest,
   ListCampaignsResponse,
   ListCampaignsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CampaignSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCampaignsRequest,
@@ -5173,7 +5172,7 @@ export const listDataDeletionJobs: API.OperationMethod<
   ListDataDeletionJobsRequest,
   ListDataDeletionJobsResponse,
   ListDataDeletionJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataDeletionJobsRequest,
   output: ListDataDeletionJobsResponse,
@@ -5199,7 +5198,7 @@ export const listDatasetExportJobs: API.PaginatedOperationMethod<
   ListDatasetExportJobsRequest,
   ListDatasetExportJobsResponse,
   ListDatasetExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetExportJobsRequest,
@@ -5226,7 +5225,7 @@ export const listDatasetGroups: API.PaginatedOperationMethod<
   ListDatasetGroupsRequest,
   ListDatasetGroupsResponse,
   ListDatasetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetGroupsRequest,
@@ -5259,7 +5258,7 @@ export const listDatasetImportJobs: API.PaginatedOperationMethod<
   ListDatasetImportJobsRequest,
   ListDatasetImportJobsResponse,
   ListDatasetImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetImportJobsRequest,
@@ -5289,7 +5288,7 @@ export const listDatasets: API.PaginatedOperationMethod<
   ListDatasetsRequest,
   ListDatasetsResponse,
   ListDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetsRequest,
@@ -5320,7 +5319,7 @@ export const listEventTrackers: API.PaginatedOperationMethod<
   ListEventTrackersRequest,
   ListEventTrackersResponse,
   ListEventTrackersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventTrackerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEventTrackersRequest,
@@ -5348,7 +5347,7 @@ export const listFilters: API.PaginatedOperationMethod<
   ListFiltersRequest,
   ListFiltersResponse,
   ListFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FilterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFiltersRequest,
@@ -5376,7 +5375,7 @@ export const listMetricAttributionMetrics: API.PaginatedOperationMethod<
   ListMetricAttributionMetricsRequest,
   ListMetricAttributionMetricsResponse,
   ListMetricAttributionMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricAttributionMetricsRequest,
@@ -5404,7 +5403,7 @@ export const listMetricAttributions: API.PaginatedOperationMethod<
   ListMetricAttributionsRequest,
   ListMetricAttributionsResponse,
   ListMetricAttributionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricAttributionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricAttributionsRequest,
@@ -5433,7 +5432,7 @@ export const listRecipes: API.PaginatedOperationMethod<
   ListRecipesRequest,
   ListRecipesResponse,
   ListRecipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecipeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecipesRequest,
@@ -5464,7 +5463,7 @@ export const listRecommenders: API.PaginatedOperationMethod<
   ListRecommendersRequest,
   ListRecommendersResponse,
   ListRecommendersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommenderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendersRequest,
@@ -5491,7 +5490,7 @@ export const listSchemas: API.PaginatedOperationMethod<
   ListSchemasRequest,
   ListSchemasResponse,
   ListSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetSchemaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemasRequest,
@@ -5522,7 +5521,7 @@ export const listSolutions: API.PaginatedOperationMethod<
   ListSolutionsRequest,
   ListSolutionsResponse,
   ListSolutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SolutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolutionsRequest,
@@ -5553,7 +5552,7 @@ export const listSolutionVersions: API.PaginatedOperationMethod<
   ListSolutionVersionsRequest,
   ListSolutionVersionsResponse,
   ListSolutionVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SolutionVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolutionVersionsRequest,
@@ -5586,7 +5585,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5613,7 +5612,7 @@ export const startRecommender: API.OperationMethod<
   StartRecommenderRequest,
   StartRecommenderResponse,
   StartRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRecommenderRequest,
   output: StartRecommenderResponse,
@@ -5639,7 +5638,7 @@ export const stopRecommender: API.OperationMethod<
   StopRecommenderRequest,
   StopRecommenderResponse,
   StopRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopRecommenderRequest,
   output: StopRecommenderResponse,
@@ -5676,7 +5675,7 @@ export const stopSolutionVersionCreation: API.OperationMethod<
   StopSolutionVersionCreationRequest,
   StopSolutionVersionCreationResponse,
   StopSolutionVersionCreationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSolutionVersionCreationRequest,
   output: StopSolutionVersionCreationResponse,
@@ -5704,7 +5703,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5733,7 +5732,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5777,7 +5776,7 @@ export const updateCampaign: API.OperationMethod<
   UpdateCampaignRequest,
   UpdateCampaignResponse,
   UpdateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignRequest,
   output: UpdateCampaignResponse,
@@ -5803,7 +5802,7 @@ export const updateDataset: API.OperationMethod<
   UpdateDatasetRequest,
   UpdateDatasetResponse,
   UpdateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetRequest,
   output: UpdateDatasetResponse,
@@ -5830,7 +5829,7 @@ export const updateMetricAttribution: API.OperationMethod<
   UpdateMetricAttributionRequest,
   UpdateMetricAttributionResponse,
   UpdateMetricAttributionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMetricAttributionRequest,
   output: UpdateMetricAttributionResponse,
@@ -5863,7 +5862,7 @@ export const updateRecommender: API.OperationMethod<
   UpdateRecommenderRequest,
   UpdateRecommenderResponse,
   UpdateRecommenderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecommenderRequest,
   output: UpdateRecommenderResponse,
@@ -5902,7 +5901,7 @@ export const updateSolution: API.OperationMethod<
   UpdateSolutionRequest,
   UpdateSolutionResponse,
   UpdateSolutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSolutionRequest,
   output: UpdateSolutionResponse,

--- a/packages/aws/src/services/pi.ts
+++ b/packages/aws/src/services/pi.ts
@@ -7,7 +7,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://pi.amazonaws.com/doc/2018-02-27/");
 const svc = T.AwsApiService({
@@ -1073,7 +1072,7 @@ export const createPerformanceAnalysisReport: API.OperationMethod<
   CreatePerformanceAnalysisReportRequest,
   CreatePerformanceAnalysisReportResponse,
   CreatePerformanceAnalysisReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePerformanceAnalysisReportRequest,
   output: CreatePerformanceAnalysisReportResponse,
@@ -1099,7 +1098,7 @@ export const deletePerformanceAnalysisReport: API.OperationMethod<
   DeletePerformanceAnalysisReportRequest,
   DeletePerformanceAnalysisReportResponse,
   DeletePerformanceAnalysisReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePerformanceAnalysisReportRequest,
   output: DeletePerformanceAnalysisReportResponse,
@@ -1128,7 +1127,7 @@ export const describeDimensionKeys: API.PaginatedOperationMethod<
   DescribeDimensionKeysRequest,
   DescribeDimensionKeysResponse,
   DescribeDimensionKeysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDimensionKeysRequest,
@@ -1163,7 +1162,7 @@ export const getDimensionKeyDetails: API.OperationMethod<
   GetDimensionKeyDetailsRequest,
   GetDimensionKeyDetailsResponse,
   GetDimensionKeyDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDimensionKeyDetailsRequest,
   output: GetDimensionKeyDetailsResponse,
@@ -1192,7 +1191,7 @@ export const getPerformanceAnalysisReport: API.OperationMethod<
   GetPerformanceAnalysisReportRequest,
   GetPerformanceAnalysisReportResponse,
   GetPerformanceAnalysisReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPerformanceAnalysisReportRequest,
   output: GetPerformanceAnalysisReportResponse,
@@ -1219,7 +1218,7 @@ export const getResourceMetadata: API.OperationMethod<
   GetResourceMetadataRequest,
   GetResourceMetadataResponse,
   GetResourceMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceMetadataRequest,
   output: GetResourceMetadataResponse,
@@ -1250,7 +1249,7 @@ export const getResourceMetrics: API.PaginatedOperationMethod<
   GetResourceMetricsRequest,
   GetResourceMetricsResponse,
   GetResourceMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceMetricsRequest,
@@ -1282,7 +1281,7 @@ export const listAvailableResourceDimensions: API.PaginatedOperationMethod<
   ListAvailableResourceDimensionsRequest,
   ListAvailableResourceDimensionsResponse,
   ListAvailableResourceDimensionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAvailableResourceDimensionsRequest,
@@ -1314,7 +1313,7 @@ export const listAvailableResourceMetrics: API.PaginatedOperationMethod<
   ListAvailableResourceMetricsRequest,
   ListAvailableResourceMetricsResponse,
   ListAvailableResourceMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAvailableResourceMetricsRequest,
@@ -1346,7 +1345,7 @@ export const listPerformanceAnalysisReportRecommendations: API.PaginatedOperatio
   ListPerformanceAnalysisReportRecommendationsRequest,
   ListPerformanceAnalysisReportRecommendationsResponse,
   ListPerformanceAnalysisReportRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPerformanceAnalysisReportRecommendationsRequest,
@@ -1379,7 +1378,7 @@ export const listPerformanceAnalysisReports: API.PaginatedOperationMethod<
   ListPerformanceAnalysisReportsRequest,
   ListPerformanceAnalysisReportsResponse,
   ListPerformanceAnalysisReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPerformanceAnalysisReportsRequest,
@@ -1411,7 +1410,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1437,7 +1436,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1463,7 +1462,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/pinpoint-email.ts
+++ b/packages/aws/src/services/pinpoint-email.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pinpoint Email",
   serviceShapeName: "AmazonPinpointEmailService",
@@ -2123,7 +2122,7 @@ export const createConfigurationSet: API.OperationMethod<
   CreateConfigurationSetRequest,
   CreateConfigurationSetResponse,
   CreateConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetRequest,
   output: CreateConfigurationSetResponse,
@@ -2161,7 +2160,7 @@ export const createConfigurationSetEventDestination: API.OperationMethod<
   CreateConfigurationSetEventDestinationRequest,
   CreateConfigurationSetEventDestinationResponse,
   CreateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetEventDestinationRequest,
   output: CreateConfigurationSetEventDestinationResponse,
@@ -2194,7 +2193,7 @@ export const createDedicatedIpPool: API.OperationMethod<
   CreateDedicatedIpPoolRequest,
   CreateDedicatedIpPoolResponse,
   CreateDedicatedIpPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDedicatedIpPoolRequest,
   output: CreateDedicatedIpPoolResponse,
@@ -2234,7 +2233,7 @@ export const createDeliverabilityTestReport: API.OperationMethod<
   CreateDeliverabilityTestReportRequest,
   CreateDeliverabilityTestReportResponse,
   CreateDeliverabilityTestReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeliverabilityTestReportRequest,
   output: CreateDeliverabilityTestReportResponse,
@@ -2280,7 +2279,7 @@ export const createEmailIdentity: API.OperationMethod<
   CreateEmailIdentityRequest,
   CreateEmailIdentityResponse,
   CreateEmailIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailIdentityRequest,
   output: CreateEmailIdentityResponse,
@@ -2314,7 +2313,7 @@ export const deleteConfigurationSet: API.OperationMethod<
   DeleteConfigurationSetRequest,
   DeleteConfigurationSetResponse,
   DeleteConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetRequest,
   output: DeleteConfigurationSetResponse,
@@ -2347,7 +2346,7 @@ export const deleteConfigurationSetEventDestination: API.OperationMethod<
   DeleteConfigurationSetEventDestinationRequest,
   DeleteConfigurationSetEventDestinationResponse,
   DeleteConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetEventDestinationRequest,
   output: DeleteConfigurationSetEventDestinationResponse,
@@ -2370,7 +2369,7 @@ export const deleteDedicatedIpPool: API.OperationMethod<
   DeleteDedicatedIpPoolRequest,
   DeleteDedicatedIpPoolResponse,
   DeleteDedicatedIpPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDedicatedIpPoolRequest,
   output: DeleteDedicatedIpPoolResponse,
@@ -2399,7 +2398,7 @@ export const deleteEmailIdentity: API.OperationMethod<
   DeleteEmailIdentityRequest,
   DeleteEmailIdentityResponse,
   DeleteEmailIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailIdentityRequest,
   output: DeleteEmailIdentityResponse,
@@ -2426,7 +2425,7 @@ export const getAccount: API.OperationMethod<
   GetAccountRequest,
   GetAccountResponse,
   GetAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountRequest,
   output: GetAccountResponse,
@@ -2448,7 +2447,7 @@ export const getBlacklistReports: API.OperationMethod<
   GetBlacklistReportsRequest,
   GetBlacklistReportsResponse,
   GetBlacklistReportsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlacklistReportsRequest,
   output: GetBlacklistReportsResponse,
@@ -2478,7 +2477,7 @@ export const getConfigurationSet: API.OperationMethod<
   GetConfigurationSetRequest,
   GetConfigurationSetResponse,
   GetConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationSetRequest,
   output: GetConfigurationSetResponse,
@@ -2507,7 +2506,7 @@ export const getConfigurationSetEventDestinations: API.OperationMethod<
   GetConfigurationSetEventDestinationsRequest,
   GetConfigurationSetEventDestinationsResponse,
   GetConfigurationSetEventDestinationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationSetEventDestinationsRequest,
   output: GetConfigurationSetEventDestinationsResponse,
@@ -2531,7 +2530,7 @@ export const getDedicatedIp: API.OperationMethod<
   GetDedicatedIpRequest,
   GetDedicatedIpResponse,
   GetDedicatedIpError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDedicatedIpRequest,
   output: GetDedicatedIpResponse,
@@ -2554,7 +2553,7 @@ export const getDedicatedIps: API.PaginatedOperationMethod<
   GetDedicatedIpsRequest,
   GetDedicatedIpsResponse,
   GetDedicatedIpsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDedicatedIpsRequest,
@@ -2589,7 +2588,7 @@ export const getDeliverabilityDashboardOptions: API.OperationMethod<
   GetDeliverabilityDashboardOptionsRequest,
   GetDeliverabilityDashboardOptionsResponse,
   GetDeliverabilityDashboardOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliverabilityDashboardOptionsRequest,
   output: GetDeliverabilityDashboardOptionsResponse,
@@ -2615,7 +2614,7 @@ export const getDeliverabilityTestReport: API.OperationMethod<
   GetDeliverabilityTestReportRequest,
   GetDeliverabilityTestReportResponse,
   GetDeliverabilityTestReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliverabilityTestReportRequest,
   output: GetDeliverabilityTestReportResponse,
@@ -2640,7 +2639,7 @@ export const getDomainDeliverabilityCampaign: API.OperationMethod<
   GetDomainDeliverabilityCampaignRequest,
   GetDomainDeliverabilityCampaignResponse,
   GetDomainDeliverabilityCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainDeliverabilityCampaignRequest,
   output: GetDomainDeliverabilityCampaignResponse,
@@ -2663,7 +2662,7 @@ export const getDomainStatisticsReport: API.OperationMethod<
   GetDomainStatisticsReportRequest,
   GetDomainStatisticsReportResponse,
   GetDomainStatisticsReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainStatisticsReportRequest,
   output: GetDomainStatisticsReportResponse,
@@ -2687,7 +2686,7 @@ export const getEmailIdentity: API.OperationMethod<
   GetEmailIdentityRequest,
   GetEmailIdentityResponse,
   GetEmailIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailIdentityRequest,
   output: GetEmailIdentityResponse,
@@ -2715,7 +2714,7 @@ export const listConfigurationSets: API.PaginatedOperationMethod<
   ListConfigurationSetsRequest,
   ListConfigurationSetsResponse,
   ListConfigurationSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationSetsRequest,
@@ -2743,7 +2742,7 @@ export const listDedicatedIpPools: API.PaginatedOperationMethod<
   ListDedicatedIpPoolsRequest,
   ListDedicatedIpPoolsResponse,
   ListDedicatedIpPoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDedicatedIpPoolsRequest,
@@ -2773,7 +2772,7 @@ export const listDeliverabilityTestReports: API.PaginatedOperationMethod<
   ListDeliverabilityTestReportsRequest,
   ListDeliverabilityTestReportsResponse,
   ListDeliverabilityTestReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeliverabilityTestReportsRequest,
@@ -2804,7 +2803,7 @@ export const listDomainDeliverabilityCampaigns: API.PaginatedOperationMethod<
   ListDomainDeliverabilityCampaignsRequest,
   ListDomainDeliverabilityCampaignsResponse,
   ListDomainDeliverabilityCampaignsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainDeliverabilityCampaignsRequest,
@@ -2833,7 +2832,7 @@ export const listEmailIdentities: API.PaginatedOperationMethod<
   ListEmailIdentitiesRequest,
   ListEmailIdentitiesResponse,
   ListEmailIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEmailIdentitiesRequest,
@@ -2866,7 +2865,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2887,7 +2886,7 @@ export const putAccountDedicatedIpWarmupAttributes: API.OperationMethod<
   PutAccountDedicatedIpWarmupAttributesRequest,
   PutAccountDedicatedIpWarmupAttributesResponse,
   PutAccountDedicatedIpWarmupAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountDedicatedIpWarmupAttributesRequest,
   output: PutAccountDedicatedIpWarmupAttributesResponse,
@@ -2908,7 +2907,7 @@ export const putAccountSendingAttributes: API.OperationMethod<
   PutAccountSendingAttributesRequest,
   PutAccountSendingAttributesResponse,
   PutAccountSendingAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSendingAttributesRequest,
   output: PutAccountSendingAttributesResponse,
@@ -2931,7 +2930,7 @@ export const putConfigurationSetDeliveryOptions: API.OperationMethod<
   PutConfigurationSetDeliveryOptionsRequest,
   PutConfigurationSetDeliveryOptionsResponse,
   PutConfigurationSetDeliveryOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetDeliveryOptionsRequest,
   output: PutConfigurationSetDeliveryOptionsResponse,
@@ -2954,7 +2953,7 @@ export const putConfigurationSetReputationOptions: API.OperationMethod<
   PutConfigurationSetReputationOptionsRequest,
   PutConfigurationSetReputationOptionsResponse,
   PutConfigurationSetReputationOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetReputationOptionsRequest,
   output: PutConfigurationSetReputationOptionsResponse,
@@ -2977,7 +2976,7 @@ export const putConfigurationSetSendingOptions: API.OperationMethod<
   PutConfigurationSetSendingOptionsRequest,
   PutConfigurationSetSendingOptionsResponse,
   PutConfigurationSetSendingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetSendingOptionsRequest,
   output: PutConfigurationSetSendingOptionsResponse,
@@ -3000,7 +2999,7 @@ export const putConfigurationSetTrackingOptions: API.OperationMethod<
   PutConfigurationSetTrackingOptionsRequest,
   PutConfigurationSetTrackingOptionsResponse,
   PutConfigurationSetTrackingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetTrackingOptionsRequest,
   output: PutConfigurationSetTrackingOptionsResponse,
@@ -3028,7 +3027,7 @@ export const putDedicatedIpInPool: API.OperationMethod<
   PutDedicatedIpInPoolRequest,
   PutDedicatedIpInPoolResponse,
   PutDedicatedIpInPoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDedicatedIpInPoolRequest,
   output: PutDedicatedIpInPoolResponse,
@@ -3050,7 +3049,7 @@ export const putDedicatedIpWarmupAttributes: API.OperationMethod<
   PutDedicatedIpWarmupAttributesRequest,
   PutDedicatedIpWarmupAttributesResponse,
   PutDedicatedIpWarmupAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDedicatedIpWarmupAttributesRequest,
   output: PutDedicatedIpWarmupAttributesResponse,
@@ -3081,7 +3080,7 @@ export const putDeliverabilityDashboardOption: API.OperationMethod<
   PutDeliverabilityDashboardOptionRequest,
   PutDeliverabilityDashboardOptionResponse,
   PutDeliverabilityDashboardOptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliverabilityDashboardOptionRequest,
   output: PutDeliverabilityDashboardOptionResponse,
@@ -3109,7 +3108,7 @@ export const putEmailIdentityDkimAttributes: API.OperationMethod<
   PutEmailIdentityDkimAttributesRequest,
   PutEmailIdentityDkimAttributesResponse,
   PutEmailIdentityDkimAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityDkimAttributesRequest,
   output: PutEmailIdentityDkimAttributesResponse,
@@ -3143,7 +3142,7 @@ export const putEmailIdentityFeedbackAttributes: API.OperationMethod<
   PutEmailIdentityFeedbackAttributesRequest,
   PutEmailIdentityFeedbackAttributesResponse,
   PutEmailIdentityFeedbackAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityFeedbackAttributesRequest,
   output: PutEmailIdentityFeedbackAttributesResponse,
@@ -3166,7 +3165,7 @@ export const putEmailIdentityMailFromAttributes: API.OperationMethod<
   PutEmailIdentityMailFromAttributesRequest,
   PutEmailIdentityMailFromAttributesResponse,
   PutEmailIdentityMailFromAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityMailFromAttributesRequest,
   output: PutEmailIdentityMailFromAttributesResponse,
@@ -3204,7 +3203,7 @@ export const sendEmail: API.OperationMethod<
   SendEmailRequest,
   SendEmailResponse,
   SendEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEmailRequest,
   output: SendEmailResponse,
@@ -3245,7 +3244,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3273,7 +3272,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3306,7 +3305,7 @@ export const updateConfigurationSetEventDestination: API.OperationMethod<
   UpdateConfigurationSetEventDestinationRequest,
   UpdateConfigurationSetEventDestinationResponse,
   UpdateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetEventDestinationRequest,
   output: UpdateConfigurationSetEventDestinationResponse,

--- a/packages/aws/src/services/pinpoint-sms-voice-v2.ts
+++ b/packages/aws/src/services/pinpoint-sms-voice-v2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pinpoint SMS Voice V2",
   serviceShapeName: "PinpointSMSVoiceV2",
@@ -5684,7 +5683,7 @@ export const associateOriginationIdentity: API.OperationMethod<
   AssociateOriginationIdentityRequest,
   AssociateOriginationIdentityResult,
   AssociateOriginationIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateOriginationIdentityRequest,
   output: AssociateOriginationIdentityResult,
@@ -5717,7 +5716,7 @@ export const associateProtectConfiguration: API.OperationMethod<
   AssociateProtectConfigurationRequest,
   AssociateProtectConfigurationResult,
   AssociateProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateProtectConfigurationRequest,
   output: AssociateProtectConfigurationResult,
@@ -5748,7 +5747,7 @@ export const carrierLookup: API.OperationMethod<
   CarrierLookupRequest,
   CarrierLookupResult,
   CarrierLookupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CarrierLookupRequest,
   output: CarrierLookupResult,
@@ -5783,7 +5782,7 @@ export const createConfigurationSet: API.OperationMethod<
   CreateConfigurationSetRequest,
   CreateConfigurationSetResult,
   CreateConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetRequest,
   output: CreateConfigurationSetResult,
@@ -5822,7 +5821,7 @@ export const createEventDestination: API.OperationMethod<
   CreateEventDestinationRequest,
   CreateEventDestinationResult,
   CreateEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventDestinationRequest,
   output: CreateEventDestinationResult,
@@ -5856,7 +5855,7 @@ export const createNotifyConfiguration: API.OperationMethod<
   CreateNotifyConfigurationRequest,
   CreateNotifyConfigurationResult,
   CreateNotifyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotifyConfigurationRequest,
   output: CreateNotifyConfigurationResult,
@@ -5893,7 +5892,7 @@ export const createOptOutList: API.OperationMethod<
   CreateOptOutListRequest,
   CreateOptOutListResult,
   CreateOptOutListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOptOutListRequest,
   output: CreateOptOutListResult,
@@ -5930,7 +5929,7 @@ export const createPool: API.OperationMethod<
   CreatePoolRequest,
   CreatePoolResult,
   CreatePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePoolRequest,
   output: CreatePoolResult,
@@ -5963,7 +5962,7 @@ export const createProtectConfiguration: API.OperationMethod<
   CreateProtectConfigurationRequest,
   CreateProtectConfigurationResult,
   CreateProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProtectConfigurationRequest,
   output: CreateProtectConfigurationResult,
@@ -5996,7 +5995,7 @@ export const createRcsAgent: API.OperationMethod<
   CreateRcsAgentRequest,
   CreateRcsAgentResult,
   CreateRcsAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRcsAgentRequest,
   output: CreateRcsAgentResult,
@@ -6029,7 +6028,7 @@ export const createRegistration: API.OperationMethod<
   CreateRegistrationRequest,
   CreateRegistrationResult,
   CreateRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistrationRequest,
   output: CreateRegistrationResult,
@@ -6062,7 +6061,7 @@ export const createRegistrationAssociation: API.OperationMethod<
   CreateRegistrationAssociationRequest,
   CreateRegistrationAssociationResult,
   CreateRegistrationAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistrationAssociationRequest,
   output: CreateRegistrationAssociationResult,
@@ -6097,7 +6096,7 @@ export const createRegistrationAttachment: API.OperationMethod<
   CreateRegistrationAttachmentRequest,
   CreateRegistrationAttachmentResult,
   CreateRegistrationAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistrationAttachmentRequest,
   output: CreateRegistrationAttachmentResult,
@@ -6130,7 +6129,7 @@ export const createRegistrationVersion: API.OperationMethod<
   CreateRegistrationVersionRequest,
   CreateRegistrationVersionResult,
   CreateRegistrationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistrationVersionRequest,
   output: CreateRegistrationVersionResult,
@@ -6164,7 +6163,7 @@ export const createVerifiedDestinationNumber: API.OperationMethod<
   CreateVerifiedDestinationNumberRequest,
   CreateVerifiedDestinationNumberResult,
   CreateVerifiedDestinationNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVerifiedDestinationNumberRequest,
   output: CreateVerifiedDestinationNumberResult,
@@ -6196,7 +6195,7 @@ export const deleteAccountDefaultProtectConfiguration: API.OperationMethod<
   DeleteAccountDefaultProtectConfigurationRequest,
   DeleteAccountDefaultProtectConfigurationResult,
   DeleteAccountDefaultProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountDefaultProtectConfigurationRequest,
   output: DeleteAccountDefaultProtectConfigurationResult,
@@ -6228,7 +6227,7 @@ export const deleteConfigurationSet: API.OperationMethod<
   DeleteConfigurationSetRequest,
   DeleteConfigurationSetResult,
   DeleteConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetRequest,
   output: DeleteConfigurationSetResult,
@@ -6260,7 +6259,7 @@ export const deleteDefaultMessageType: API.OperationMethod<
   DeleteDefaultMessageTypeRequest,
   DeleteDefaultMessageTypeResult,
   DeleteDefaultMessageTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDefaultMessageTypeRequest,
   output: DeleteDefaultMessageTypeResult,
@@ -6292,7 +6291,7 @@ export const deleteDefaultSenderId: API.OperationMethod<
   DeleteDefaultSenderIdRequest,
   DeleteDefaultSenderIdResult,
   DeleteDefaultSenderIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDefaultSenderIdRequest,
   output: DeleteDefaultSenderIdResult,
@@ -6324,7 +6323,7 @@ export const deleteEventDestination: API.OperationMethod<
   DeleteEventDestinationRequest,
   DeleteEventDestinationResult,
   DeleteEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventDestinationRequest,
   output: DeleteEventDestinationResult,
@@ -6359,7 +6358,7 @@ export const deleteKeyword: API.OperationMethod<
   DeleteKeywordRequest,
   DeleteKeywordResult,
   DeleteKeywordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeywordRequest,
   output: DeleteKeywordResult,
@@ -6389,7 +6388,7 @@ export const deleteMediaMessageSpendLimitOverride: API.OperationMethod<
   DeleteMediaMessageSpendLimitOverrideRequest,
   DeleteMediaMessageSpendLimitOverrideResult,
   DeleteMediaMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMediaMessageSpendLimitOverrideRequest,
   output: DeleteMediaMessageSpendLimitOverrideResult,
@@ -6421,7 +6420,7 @@ export const deleteNotifyConfiguration: API.OperationMethod<
   DeleteNotifyConfigurationRequest,
   DeleteNotifyConfigurationResult,
   DeleteNotifyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotifyConfigurationRequest,
   output: DeleteNotifyConfigurationResult,
@@ -6451,7 +6450,7 @@ export const deleteNotifyMessageSpendLimitOverride: API.OperationMethod<
   DeleteNotifyMessageSpendLimitOverrideRequest,
   DeleteNotifyMessageSpendLimitOverrideResult,
   DeleteNotifyMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotifyMessageSpendLimitOverrideRequest,
   output: DeleteNotifyMessageSpendLimitOverrideResult,
@@ -6485,7 +6484,7 @@ export const deleteOptedOutNumber: API.OperationMethod<
   DeleteOptedOutNumberRequest,
   DeleteOptedOutNumberResult,
   DeleteOptedOutNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOptedOutNumberRequest,
   output: DeleteOptedOutNumberResult,
@@ -6519,7 +6518,7 @@ export const deleteOptOutList: API.OperationMethod<
   DeleteOptOutListRequest,
   DeleteOptOutListResult,
   DeleteOptOutListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOptOutListRequest,
   output: DeleteOptOutListResult,
@@ -6555,7 +6554,7 @@ export const deletePool: API.OperationMethod<
   DeletePoolRequest,
   DeletePoolResult,
   DeletePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePoolRequest,
   output: DeletePoolResult,
@@ -6587,7 +6586,7 @@ export const deleteProtectConfiguration: API.OperationMethod<
   DeleteProtectConfigurationRequest,
   DeleteProtectConfigurationResult,
   DeleteProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProtectConfigurationRequest,
   output: DeleteProtectConfigurationResult,
@@ -6618,7 +6617,7 @@ export const deleteProtectConfigurationRuleSetNumberOverride: API.OperationMetho
   DeleteProtectConfigurationRuleSetNumberOverrideRequest,
   DeleteProtectConfigurationRuleSetNumberOverrideResult,
   DeleteProtectConfigurationRuleSetNumberOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProtectConfigurationRuleSetNumberOverrideRequest,
   output: DeleteProtectConfigurationRuleSetNumberOverrideResult,
@@ -6649,7 +6648,7 @@ export const deleteRcsAgent: API.OperationMethod<
   DeleteRcsAgentRequest,
   DeleteRcsAgentResult,
   DeleteRcsAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRcsAgentRequest,
   output: DeleteRcsAgentResult,
@@ -6679,7 +6678,7 @@ export const deleteRcsMessageSpendLimitOverride: API.OperationMethod<
   DeleteRcsMessageSpendLimitOverrideRequest,
   DeleteRcsMessageSpendLimitOverrideResult,
   DeleteRcsMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRcsMessageSpendLimitOverrideRequest,
   output: DeleteRcsMessageSpendLimitOverrideResult,
@@ -6709,7 +6708,7 @@ export const deleteRegistration: API.OperationMethod<
   DeleteRegistrationRequest,
   DeleteRegistrationResult,
   DeleteRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistrationRequest,
   output: DeleteRegistrationResult,
@@ -6741,7 +6740,7 @@ export const deleteRegistrationAttachment: API.OperationMethod<
   DeleteRegistrationAttachmentRequest,
   DeleteRegistrationAttachmentResult,
   DeleteRegistrationAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistrationAttachmentRequest,
   output: DeleteRegistrationAttachmentResult,
@@ -6773,7 +6772,7 @@ export const deleteRegistrationFieldValue: API.OperationMethod<
   DeleteRegistrationFieldValueRequest,
   DeleteRegistrationFieldValueResult,
   DeleteRegistrationFieldValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistrationFieldValueRequest,
   output: DeleteRegistrationFieldValueResult,
@@ -6804,7 +6803,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResult,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResult,
@@ -6833,7 +6832,7 @@ export const deleteTextMessageSpendLimitOverride: API.OperationMethod<
   DeleteTextMessageSpendLimitOverrideRequest,
   DeleteTextMessageSpendLimitOverrideResult,
   DeleteTextMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTextMessageSpendLimitOverrideRequest,
   output: DeleteTextMessageSpendLimitOverrideResult,
@@ -6863,7 +6862,7 @@ export const deleteVerifiedDestinationNumber: API.OperationMethod<
   DeleteVerifiedDestinationNumberRequest,
   DeleteVerifiedDestinationNumberResult,
   DeleteVerifiedDestinationNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedDestinationNumberRequest,
   output: DeleteVerifiedDestinationNumberResult,
@@ -6893,7 +6892,7 @@ export const deleteVoiceMessageSpendLimitOverride: API.OperationMethod<
   DeleteVoiceMessageSpendLimitOverrideRequest,
   DeleteVoiceMessageSpendLimitOverrideResult,
   DeleteVoiceMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceMessageSpendLimitOverrideRequest,
   output: DeleteVoiceMessageSpendLimitOverrideResult,
@@ -6923,7 +6922,7 @@ export const describeAccountAttributes: API.PaginatedOperationMethod<
   DescribeAccountAttributesRequest,
   DescribeAccountAttributesResult,
   DescribeAccountAttributesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAttribute
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccountAttributesRequest,
@@ -6960,7 +6959,7 @@ export const describeAccountLimits: API.PaginatedOperationMethod<
   DescribeAccountLimitsRequest,
   DescribeAccountLimitsResult,
   DescribeAccountLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountLimit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAccountLimitsRequest,
@@ -7000,7 +6999,7 @@ export const describeConfigurationSets: API.PaginatedOperationMethod<
   DescribeConfigurationSetsRequest,
   DescribeConfigurationSetsResult,
   DescribeConfigurationSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationSetInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeConfigurationSetsRequest,
@@ -7041,7 +7040,7 @@ export const describeKeywords: API.PaginatedOperationMethod<
   DescribeKeywordsRequest,
   DescribeKeywordsResult,
   DescribeKeywordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KeywordInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeKeywordsRequest,
@@ -7082,7 +7081,7 @@ export const describeNotifyConfigurations: API.PaginatedOperationMethod<
   DescribeNotifyConfigurationsRequest,
   DescribeNotifyConfigurationsResult,
   DescribeNotifyConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotifyConfigurationInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNotifyConfigurationsRequest,
@@ -7123,7 +7122,7 @@ export const describeNotifyTemplates: API.PaginatedOperationMethod<
   DescribeNotifyTemplatesRequest,
   DescribeNotifyTemplatesResult,
   DescribeNotifyTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotifyTemplateInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNotifyTemplatesRequest,
@@ -7164,7 +7163,7 @@ export const describeOptedOutNumbers: API.PaginatedOperationMethod<
   DescribeOptedOutNumbersRequest,
   DescribeOptedOutNumbersResult,
   DescribeOptedOutNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OptedOutNumberInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOptedOutNumbersRequest,
@@ -7205,7 +7204,7 @@ export const describeOptOutLists: API.PaginatedOperationMethod<
   DescribeOptOutListsRequest,
   DescribeOptOutListsResult,
   DescribeOptOutListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OptOutListInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOptOutListsRequest,
@@ -7246,7 +7245,7 @@ export const describePhoneNumbers: API.PaginatedOperationMethod<
   DescribePhoneNumbersRequest,
   DescribePhoneNumbersResult,
   DescribePhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PhoneNumberInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePhoneNumbersRequest,
@@ -7289,7 +7288,7 @@ export const describePools: API.PaginatedOperationMethod<
   DescribePoolsRequest,
   DescribePoolsResult,
   DescribePoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PoolInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePoolsRequest,
@@ -7326,7 +7325,7 @@ export const describeProtectConfigurations: API.PaginatedOperationMethod<
   DescribeProtectConfigurationsRequest,
   DescribeProtectConfigurationsResult,
   DescribeProtectConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectConfigurationInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeProtectConfigurationsRequest,
@@ -7363,7 +7362,7 @@ export const describeRcsAgentCountryLaunchStatus: API.PaginatedOperationMethod<
   DescribeRcsAgentCountryLaunchStatusRequest,
   DescribeRcsAgentCountryLaunchStatusResult,
   DescribeRcsAgentCountryLaunchStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CountryLaunchStatusInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRcsAgentCountryLaunchStatusRequest,
@@ -7402,7 +7401,7 @@ export const describeRcsAgents: API.PaginatedOperationMethod<
   DescribeRcsAgentsRequest,
   DescribeRcsAgentsResult,
   DescribeRcsAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RcsAgentInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRcsAgentsRequest,
@@ -7439,7 +7438,7 @@ export const describeRegistrationAttachments: API.PaginatedOperationMethod<
   DescribeRegistrationAttachmentsRequest,
   DescribeRegistrationAttachmentsResult,
   DescribeRegistrationAttachmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationAttachmentsInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationAttachmentsRequest,
@@ -7475,7 +7474,7 @@ export const describeRegistrationFieldDefinitions: API.PaginatedOperationMethod<
   DescribeRegistrationFieldDefinitionsRequest,
   DescribeRegistrationFieldDefinitionsResult,
   DescribeRegistrationFieldDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationFieldDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationFieldDefinitionsRequest,
@@ -7511,7 +7510,7 @@ export const describeRegistrationFieldValues: API.PaginatedOperationMethod<
   DescribeRegistrationFieldValuesRequest,
   DescribeRegistrationFieldValuesResult,
   DescribeRegistrationFieldValuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationFieldValueInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationFieldValuesRequest,
@@ -7548,7 +7547,7 @@ export const describeRegistrations: API.PaginatedOperationMethod<
   DescribeRegistrationsRequest,
   DescribeRegistrationsResult,
   DescribeRegistrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationsRequest,
@@ -7584,7 +7583,7 @@ export const describeRegistrationSectionDefinitions: API.PaginatedOperationMetho
   DescribeRegistrationSectionDefinitionsRequest,
   DescribeRegistrationSectionDefinitionsResult,
   DescribeRegistrationSectionDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationSectionDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationSectionDefinitionsRequest,
@@ -7619,7 +7618,7 @@ export const describeRegistrationTypeDefinitions: API.PaginatedOperationMethod<
   DescribeRegistrationTypeDefinitionsRequest,
   DescribeRegistrationTypeDefinitionsResult,
   DescribeRegistrationTypeDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationTypeDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationTypeDefinitionsRequest,
@@ -7655,7 +7654,7 @@ export const describeRegistrationVersions: API.PaginatedOperationMethod<
   DescribeRegistrationVersionsRequest,
   DescribeRegistrationVersionsResult,
   DescribeRegistrationVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationVersionInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRegistrationVersionsRequest,
@@ -7696,7 +7695,7 @@ export const describeSenderIds: API.PaginatedOperationMethod<
   DescribeSenderIdsRequest,
   DescribeSenderIdsResult,
   DescribeSenderIdsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SenderIdInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSenderIdsRequest,
@@ -7734,7 +7733,7 @@ export const describeSpendLimits: API.PaginatedOperationMethod<
   DescribeSpendLimitsRequest,
   DescribeSpendLimitsResult,
   DescribeSpendLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpendLimit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSpendLimitsRequest,
@@ -7770,7 +7769,7 @@ export const describeVerifiedDestinationNumbers: API.PaginatedOperationMethod<
   DescribeVerifiedDestinationNumbersRequest,
   DescribeVerifiedDestinationNumbersResult,
   DescribeVerifiedDestinationNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VerifiedDestinationNumberInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVerifiedDestinationNumbersRequest,
@@ -7810,7 +7809,7 @@ export const disassociateOriginationIdentity: API.OperationMethod<
   DisassociateOriginationIdentityRequest,
   DisassociateOriginationIdentityResult,
   DisassociateOriginationIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateOriginationIdentityRequest,
   output: DisassociateOriginationIdentityResult,
@@ -7842,7 +7841,7 @@ export const disassociateProtectConfiguration: API.OperationMethod<
   DisassociateProtectConfigurationRequest,
   DisassociateProtectConfigurationResult,
   DisassociateProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateProtectConfigurationRequest,
   output: DisassociateProtectConfigurationResult,
@@ -7874,7 +7873,7 @@ export const discardRegistrationVersion: API.OperationMethod<
   DiscardRegistrationVersionRequest,
   DiscardRegistrationVersionResult,
   DiscardRegistrationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscardRegistrationVersionRequest,
   output: DiscardRegistrationVersionResult,
@@ -7905,7 +7904,7 @@ export const getProtectConfigurationCountryRuleSet: API.OperationMethod<
   GetProtectConfigurationCountryRuleSetRequest,
   GetProtectConfigurationCountryRuleSetResult,
   GetProtectConfigurationCountryRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProtectConfigurationCountryRuleSetRequest,
   output: GetProtectConfigurationCountryRuleSetResult,
@@ -7935,7 +7934,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResult,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResult,
@@ -7964,7 +7963,7 @@ export const listNotifyCountries: API.PaginatedOperationMethod<
   ListNotifyCountriesRequest,
   ListNotifyCountriesResult,
   ListNotifyCountriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotifyCountryInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotifyCountriesRequest,
@@ -8002,7 +8001,7 @@ export const listPoolOriginationIdentities: API.PaginatedOperationMethod<
   ListPoolOriginationIdentitiesRequest,
   ListPoolOriginationIdentitiesResult,
   ListPoolOriginationIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OriginationIdentityMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoolOriginationIdentitiesRequest,
@@ -8039,7 +8038,7 @@ export const listProtectConfigurationRuleSetNumberOverrides: API.PaginatedOperat
   ListProtectConfigurationRuleSetNumberOverridesRequest,
   ListProtectConfigurationRuleSetNumberOverridesResult,
   ListProtectConfigurationRuleSetNumberOverridesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProtectConfigurationRuleSetNumberOverride
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectConfigurationRuleSetNumberOverridesRequest,
@@ -8076,7 +8075,7 @@ export const listRegistrationAssociations: API.PaginatedOperationMethod<
   ListRegistrationAssociationsRequest,
   ListRegistrationAssociationsResult,
   ListRegistrationAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrationAssociationMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegistrationAssociationsRequest,
@@ -8113,7 +8112,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -8149,7 +8148,7 @@ export const putKeyword: API.OperationMethod<
   PutKeywordRequest,
   PutKeywordResult,
   PutKeywordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutKeywordRequest,
   output: PutKeywordResult,
@@ -8183,7 +8182,7 @@ export const putMessageFeedback: API.OperationMethod<
   PutMessageFeedbackRequest,
   PutMessageFeedbackResult,
   PutMessageFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMessageFeedbackRequest,
   output: PutMessageFeedbackResult,
@@ -8215,7 +8214,7 @@ export const putOptedOutNumber: API.OperationMethod<
   PutOptedOutNumberRequest,
   PutOptedOutNumberResult,
   PutOptedOutNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutOptedOutNumberRequest,
   output: PutOptedOutNumberResult,
@@ -8247,7 +8246,7 @@ export const putProtectConfigurationRuleSetNumberOverride: API.OperationMethod<
   PutProtectConfigurationRuleSetNumberOverrideRequest,
   PutProtectConfigurationRuleSetNumberOverrideResult,
   PutProtectConfigurationRuleSetNumberOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProtectConfigurationRuleSetNumberOverrideRequest,
   output: PutProtectConfigurationRuleSetNumberOverrideResult,
@@ -8280,7 +8279,7 @@ export const putRegistrationFieldValue: API.OperationMethod<
   PutRegistrationFieldValueRequest,
   PutRegistrationFieldValueResult,
   PutRegistrationFieldValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRegistrationFieldValueRequest,
   output: PutRegistrationFieldValueResult,
@@ -8311,7 +8310,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResult,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResult,
@@ -8344,7 +8343,7 @@ export const releasePhoneNumber: API.OperationMethod<
   ReleasePhoneNumberRequest,
   ReleasePhoneNumberResult,
   ReleasePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleasePhoneNumberRequest,
   output: ReleasePhoneNumberResult,
@@ -8376,7 +8375,7 @@ export const releaseSenderId: API.OperationMethod<
   ReleaseSenderIdRequest,
   ReleaseSenderIdResult,
   ReleaseSenderIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReleaseSenderIdRequest,
   output: ReleaseSenderIdResult,
@@ -8409,7 +8408,7 @@ export const requestPhoneNumber: API.OperationMethod<
   RequestPhoneNumberRequest,
   RequestPhoneNumberResult,
   RequestPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestPhoneNumberRequest,
   output: RequestPhoneNumberResult,
@@ -8442,7 +8441,7 @@ export const requestSenderId: API.OperationMethod<
   RequestSenderIdRequest,
   RequestSenderIdResult,
   RequestSenderIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestSenderIdRequest,
   output: RequestSenderIdResult,
@@ -8475,7 +8474,7 @@ export const sendDestinationNumberVerificationCode: API.OperationMethod<
   SendDestinationNumberVerificationCodeRequest,
   SendDestinationNumberVerificationCodeResult,
   SendDestinationNumberVerificationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDestinationNumberVerificationCodeRequest,
   output: SendDestinationNumberVerificationCodeResult,
@@ -8509,7 +8508,7 @@ export const sendMediaMessage: API.OperationMethod<
   SendMediaMessageRequest,
   SendMediaMessageResult,
   SendMediaMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMediaMessageRequest,
   output: SendMediaMessageResult,
@@ -8543,7 +8542,7 @@ export const sendNotifyTextMessage: API.OperationMethod<
   SendNotifyTextMessageRequest,
   SendNotifyTextMessageResult,
   SendNotifyTextMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendNotifyTextMessageRequest,
   output: SendNotifyTextMessageResult,
@@ -8577,7 +8576,7 @@ export const sendNotifyVoiceMessage: API.OperationMethod<
   SendNotifyVoiceMessageRequest,
   SendNotifyVoiceMessageResult,
   SendNotifyVoiceMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendNotifyVoiceMessageRequest,
   output: SendNotifyVoiceMessageResult,
@@ -8611,7 +8610,7 @@ export const sendRcsMessage: API.OperationMethod<
   SendRcsMessageRequest,
   SendRcsMessageResult,
   SendRcsMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendRcsMessageRequest,
   output: SendRcsMessageResult,
@@ -8647,7 +8646,7 @@ export const sendTextMessage: API.OperationMethod<
   SendTextMessageRequest,
   SendTextMessageResult,
   SendTextMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTextMessageRequest,
   output: SendTextMessageResult,
@@ -8681,7 +8680,7 @@ export const sendVoiceMessage: API.OperationMethod<
   SendVoiceMessageRequest,
   SendVoiceMessageResult,
   SendVoiceMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendVoiceMessageRequest,
   output: SendVoiceMessageResult,
@@ -8713,7 +8712,7 @@ export const setAccountDefaultProtectConfiguration: API.OperationMethod<
   SetAccountDefaultProtectConfigurationRequest,
   SetAccountDefaultProtectConfigurationResult,
   SetAccountDefaultProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetAccountDefaultProtectConfigurationRequest,
   output: SetAccountDefaultProtectConfigurationResult,
@@ -8743,7 +8742,7 @@ export const setDefaultMessageFeedbackEnabled: API.OperationMethod<
   SetDefaultMessageFeedbackEnabledRequest,
   SetDefaultMessageFeedbackEnabledResult,
   SetDefaultMessageFeedbackEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultMessageFeedbackEnabledRequest,
   output: SetDefaultMessageFeedbackEnabledResult,
@@ -8775,7 +8774,7 @@ export const setDefaultMessageType: API.OperationMethod<
   SetDefaultMessageTypeRequest,
   SetDefaultMessageTypeResult,
   SetDefaultMessageTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultMessageTypeRequest,
   output: SetDefaultMessageTypeResult,
@@ -8807,7 +8806,7 @@ export const setDefaultSenderId: API.OperationMethod<
   SetDefaultSenderIdRequest,
   SetDefaultSenderIdResult,
   SetDefaultSenderIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultSenderIdRequest,
   output: SetDefaultSenderIdResult,
@@ -8836,7 +8835,7 @@ export const setMediaMessageSpendLimitOverride: API.OperationMethod<
   SetMediaMessageSpendLimitOverrideRequest,
   SetMediaMessageSpendLimitOverrideResult,
   SetMediaMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetMediaMessageSpendLimitOverrideRequest,
   output: SetMediaMessageSpendLimitOverrideResult,
@@ -8864,7 +8863,7 @@ export const setNotifyMessageSpendLimitOverride: API.OperationMethod<
   SetNotifyMessageSpendLimitOverrideRequest,
   SetNotifyMessageSpendLimitOverrideResult,
   SetNotifyMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetNotifyMessageSpendLimitOverrideRequest,
   output: SetNotifyMessageSpendLimitOverrideResult,
@@ -8892,7 +8891,7 @@ export const setRcsMessageSpendLimitOverride: API.OperationMethod<
   SetRcsMessageSpendLimitOverrideRequest,
   SetRcsMessageSpendLimitOverrideResult,
   SetRcsMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetRcsMessageSpendLimitOverrideRequest,
   output: SetRcsMessageSpendLimitOverrideResult,
@@ -8920,7 +8919,7 @@ export const setTextMessageSpendLimitOverride: API.OperationMethod<
   SetTextMessageSpendLimitOverrideRequest,
   SetTextMessageSpendLimitOverrideResult,
   SetTextMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTextMessageSpendLimitOverrideRequest,
   output: SetTextMessageSpendLimitOverrideResult,
@@ -8948,7 +8947,7 @@ export const setVoiceMessageSpendLimitOverride: API.OperationMethod<
   SetVoiceMessageSpendLimitOverrideRequest,
   SetVoiceMessageSpendLimitOverrideResult,
   SetVoiceMessageSpendLimitOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetVoiceMessageSpendLimitOverrideRequest,
   output: SetVoiceMessageSpendLimitOverrideResult,
@@ -8978,7 +8977,7 @@ export const submitRegistrationVersion: API.OperationMethod<
   SubmitRegistrationVersionRequest,
   SubmitRegistrationVersionResult,
   SubmitRegistrationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitRegistrationVersionRequest,
   output: SubmitRegistrationVersionResult,
@@ -9010,7 +9009,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -9041,7 +9040,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -9074,7 +9073,7 @@ export const updateEventDestination: API.OperationMethod<
   UpdateEventDestinationRequest,
   UpdateEventDestinationResult,
   UpdateEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEventDestinationRequest,
   output: UpdateEventDestinationResult,
@@ -9106,7 +9105,7 @@ export const updateNotifyConfiguration: API.OperationMethod<
   UpdateNotifyConfigurationRequest,
   UpdateNotifyConfigurationResult,
   UpdateNotifyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotifyConfigurationRequest,
   output: UpdateNotifyConfigurationResult,
@@ -9140,7 +9139,7 @@ export const updatePhoneNumber: API.OperationMethod<
   UpdatePhoneNumberRequest,
   UpdatePhoneNumberResult,
   UpdatePhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePhoneNumberRequest,
   output: UpdatePhoneNumberResult,
@@ -9172,7 +9171,7 @@ export const updatePool: API.OperationMethod<
   UpdatePoolRequest,
   UpdatePoolResult,
   UpdatePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePoolRequest,
   output: UpdatePoolResult,
@@ -9203,7 +9202,7 @@ export const updateProtectConfiguration: API.OperationMethod<
   UpdateProtectConfigurationRequest,
   UpdateProtectConfigurationResult,
   UpdateProtectConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProtectConfigurationRequest,
   output: UpdateProtectConfigurationResult,
@@ -9233,7 +9232,7 @@ export const updateProtectConfigurationCountryRuleSet: API.OperationMethod<
   UpdateProtectConfigurationCountryRuleSetRequest,
   UpdateProtectConfigurationCountryRuleSetResult,
   UpdateProtectConfigurationCountryRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProtectConfigurationCountryRuleSetRequest,
   output: UpdateProtectConfigurationCountryRuleSetResult,
@@ -9264,7 +9263,7 @@ export const updateRcsAgent: API.OperationMethod<
   UpdateRcsAgentRequest,
   UpdateRcsAgentResult,
   UpdateRcsAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRcsAgentRequest,
   output: UpdateRcsAgentResult,
@@ -9295,7 +9294,7 @@ export const updateSenderId: API.OperationMethod<
   UpdateSenderIdRequest,
   UpdateSenderIdResult,
   UpdateSenderIdError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSenderIdRequest,
   output: UpdateSenderIdResult,
@@ -9326,7 +9325,7 @@ export const verifyDestinationNumber: API.OperationMethod<
   VerifyDestinationNumberRequest,
   VerifyDestinationNumberResult,
   VerifyDestinationNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyDestinationNumberRequest,
   output: VerifyDestinationNumberResult,

--- a/packages/aws/src/services/pinpoint-sms-voice.ts
+++ b/packages/aws/src/services/pinpoint-sms-voice.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pinpoint SMS Voice",
   serviceShapeName: "PinpointSMSVoice",
@@ -517,7 +516,7 @@ export const createConfigurationSet: API.OperationMethod<
   CreateConfigurationSetRequest,
   CreateConfigurationSetResponse,
   CreateConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetRequest,
   output: CreateConfigurationSetResponse,
@@ -548,7 +547,7 @@ export const createConfigurationSetEventDestination: API.OperationMethod<
   CreateConfigurationSetEventDestinationRequest,
   CreateConfigurationSetEventDestinationResponse,
   CreateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetEventDestinationRequest,
   output: CreateConfigurationSetEventDestinationResponse,
@@ -578,7 +577,7 @@ export const deleteConfigurationSet: API.OperationMethod<
   DeleteConfigurationSetRequest,
   DeleteConfigurationSetResponse,
   DeleteConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetRequest,
   output: DeleteConfigurationSetResponse,
@@ -606,7 +605,7 @@ export const deleteConfigurationSetEventDestination: API.OperationMethod<
   DeleteConfigurationSetEventDestinationRequest,
   DeleteConfigurationSetEventDestinationResponse,
   DeleteConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetEventDestinationRequest,
   output: DeleteConfigurationSetEventDestinationResponse,
@@ -634,7 +633,7 @@ export const getConfigurationSetEventDestinations: API.OperationMethod<
   GetConfigurationSetEventDestinationsRequest,
   GetConfigurationSetEventDestinationsResponse,
   GetConfigurationSetEventDestinationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationSetEventDestinationsRequest,
   output: GetConfigurationSetEventDestinationsResponse,
@@ -661,7 +660,7 @@ export const listConfigurationSets: API.OperationMethod<
   ListConfigurationSetsRequest,
   ListConfigurationSetsResponse,
   ListConfigurationSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConfigurationSetsRequest,
   output: ListConfigurationSetsResponse,
@@ -687,7 +686,7 @@ export const sendVoiceMessage: API.OperationMethod<
   SendVoiceMessageRequest,
   SendVoiceMessageResponse,
   SendVoiceMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendVoiceMessageRequest,
   output: SendVoiceMessageResponse,
@@ -714,7 +713,7 @@ export const updateConfigurationSetEventDestination: API.OperationMethod<
   UpdateConfigurationSetEventDestinationRequest,
   UpdateConfigurationSetEventDestinationResponse,
   UpdateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetEventDestinationRequest,
   output: UpdateConfigurationSetEventDestinationResponse,

--- a/packages/aws/src/services/pinpoint.ts
+++ b/packages/aws/src/services/pinpoint.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pinpoint",
   serviceShapeName: "Pinpoint",
@@ -11891,7 +11890,7 @@ export const createApp: API.OperationMethod<
   CreateAppRequest,
   CreateAppResponse,
   CreateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppRequest,
   output: CreateAppResponse,
@@ -11925,7 +11924,7 @@ export const createCampaign: API.OperationMethod<
   CreateCampaignRequest,
   CreateCampaignResponse,
   CreateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCampaignRequest,
   output: CreateCampaignResponse,
@@ -11957,7 +11956,7 @@ export const createEmailTemplate: API.OperationMethod<
   CreateEmailTemplateRequest,
   CreateEmailTemplateResponse,
   CreateEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailTemplateRequest,
   output: CreateEmailTemplateResponse,
@@ -11989,7 +11988,7 @@ export const createExportJob: API.OperationMethod<
   CreateExportJobRequest,
   CreateExportJobResponse,
   CreateExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportJobRequest,
   output: CreateExportJobResponse,
@@ -12023,7 +12022,7 @@ export const createImportJob: API.OperationMethod<
   CreateImportJobRequest,
   CreateImportJobResponse,
   CreateImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImportJobRequest,
   output: CreateImportJobResponse,
@@ -12055,7 +12054,7 @@ export const createInAppTemplate: API.OperationMethod<
   CreateInAppTemplateRequest,
   CreateInAppTemplateResponse,
   CreateInAppTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInAppTemplateRequest,
   output: CreateInAppTemplateResponse,
@@ -12087,7 +12086,7 @@ export const createJourney: API.OperationMethod<
   CreateJourneyRequest,
   CreateJourneyResponse,
   CreateJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJourneyRequest,
   output: CreateJourneyResponse,
@@ -12119,7 +12118,7 @@ export const createPushTemplate: API.OperationMethod<
   CreatePushTemplateRequest,
   CreatePushTemplateResponse,
   CreatePushTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePushTemplateRequest,
   output: CreatePushTemplateResponse,
@@ -12151,7 +12150,7 @@ export const createRecommenderConfiguration: API.OperationMethod<
   CreateRecommenderConfigurationRequest,
   CreateRecommenderConfigurationResponse,
   CreateRecommenderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommenderConfigurationRequest,
   output: CreateRecommenderConfigurationResponse,
@@ -12185,7 +12184,7 @@ export const createSegment: API.OperationMethod<
   CreateSegmentRequest,
   CreateSegmentResponse,
   CreateSegmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSegmentRequest,
   output: CreateSegmentResponse,
@@ -12217,7 +12216,7 @@ export const createSmsTemplate: API.OperationMethod<
   CreateSmsTemplateRequest,
   CreateSmsTemplateResponse,
   CreateSmsTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSmsTemplateRequest,
   output: CreateSmsTemplateResponse,
@@ -12247,7 +12246,7 @@ export const createVoiceTemplate: API.OperationMethod<
   CreateVoiceTemplateRequest,
   CreateVoiceTemplateResponse,
   CreateVoiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVoiceTemplateRequest,
   output: CreateVoiceTemplateResponse,
@@ -12279,7 +12278,7 @@ export const deleteAdmChannel: API.OperationMethod<
   DeleteAdmChannelRequest,
   DeleteAdmChannelResponse,
   DeleteAdmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAdmChannelRequest,
   output: DeleteAdmChannelResponse,
@@ -12313,7 +12312,7 @@ export const deleteApnsChannel: API.OperationMethod<
   DeleteApnsChannelRequest,
   DeleteApnsChannelResponse,
   DeleteApnsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApnsChannelRequest,
   output: DeleteApnsChannelResponse,
@@ -12347,7 +12346,7 @@ export const deleteApnsSandboxChannel: API.OperationMethod<
   DeleteApnsSandboxChannelRequest,
   DeleteApnsSandboxChannelResponse,
   DeleteApnsSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApnsSandboxChannelRequest,
   output: DeleteApnsSandboxChannelResponse,
@@ -12381,7 +12380,7 @@ export const deleteApnsVoipChannel: API.OperationMethod<
   DeleteApnsVoipChannelRequest,
   DeleteApnsVoipChannelResponse,
   DeleteApnsVoipChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApnsVoipChannelRequest,
   output: DeleteApnsVoipChannelResponse,
@@ -12415,7 +12414,7 @@ export const deleteApnsVoipSandboxChannel: API.OperationMethod<
   DeleteApnsVoipSandboxChannelRequest,
   DeleteApnsVoipSandboxChannelResponse,
   DeleteApnsVoipSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApnsVoipSandboxChannelRequest,
   output: DeleteApnsVoipSandboxChannelResponse,
@@ -12449,7 +12448,7 @@ export const deleteApp: API.OperationMethod<
   DeleteAppRequest,
   DeleteAppResponse,
   DeleteAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppRequest,
   output: DeleteAppResponse,
@@ -12483,7 +12482,7 @@ export const deleteBaiduChannel: API.OperationMethod<
   DeleteBaiduChannelRequest,
   DeleteBaiduChannelResponse,
   DeleteBaiduChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBaiduChannelRequest,
   output: DeleteBaiduChannelResponse,
@@ -12517,7 +12516,7 @@ export const deleteCampaign: API.OperationMethod<
   DeleteCampaignRequest,
   DeleteCampaignResponse,
   DeleteCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCampaignRequest,
   output: DeleteCampaignResponse,
@@ -12551,7 +12550,7 @@ export const deleteEmailChannel: API.OperationMethod<
   DeleteEmailChannelRequest,
   DeleteEmailChannelResponse,
   DeleteEmailChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailChannelRequest,
   output: DeleteEmailChannelResponse,
@@ -12585,7 +12584,7 @@ export const deleteEmailTemplate: API.OperationMethod<
   DeleteEmailTemplateRequest,
   DeleteEmailTemplateResponse,
   DeleteEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailTemplateRequest,
   output: DeleteEmailTemplateResponse,
@@ -12619,7 +12618,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointRequest,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointRequest,
   output: DeleteEndpointResponse,
@@ -12653,7 +12652,7 @@ export const deleteEventStream: API.OperationMethod<
   DeleteEventStreamRequest,
   DeleteEventStreamResponse,
   DeleteEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventStreamRequest,
   output: DeleteEventStreamResponse,
@@ -12687,7 +12686,7 @@ export const deleteGcmChannel: API.OperationMethod<
   DeleteGcmChannelRequest,
   DeleteGcmChannelResponse,
   DeleteGcmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGcmChannelRequest,
   output: DeleteGcmChannelResponse,
@@ -12721,7 +12720,7 @@ export const deleteInAppTemplate: API.OperationMethod<
   DeleteInAppTemplateRequest,
   DeleteInAppTemplateResponse,
   DeleteInAppTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInAppTemplateRequest,
   output: DeleteInAppTemplateResponse,
@@ -12755,7 +12754,7 @@ export const deleteJourney: API.OperationMethod<
   DeleteJourneyRequest,
   DeleteJourneyResponse,
   DeleteJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJourneyRequest,
   output: DeleteJourneyResponse,
@@ -12789,7 +12788,7 @@ export const deletePushTemplate: API.OperationMethod<
   DeletePushTemplateRequest,
   DeletePushTemplateResponse,
   DeletePushTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePushTemplateRequest,
   output: DeletePushTemplateResponse,
@@ -12823,7 +12822,7 @@ export const deleteRecommenderConfiguration: API.OperationMethod<
   DeleteRecommenderConfigurationRequest,
   DeleteRecommenderConfigurationResponse,
   DeleteRecommenderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommenderConfigurationRequest,
   output: DeleteRecommenderConfigurationResponse,
@@ -12857,7 +12856,7 @@ export const deleteSegment: API.OperationMethod<
   DeleteSegmentRequest,
   DeleteSegmentResponse,
   DeleteSegmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSegmentRequest,
   output: DeleteSegmentResponse,
@@ -12891,7 +12890,7 @@ export const deleteSmsChannel: API.OperationMethod<
   DeleteSmsChannelRequest,
   DeleteSmsChannelResponse,
   DeleteSmsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSmsChannelRequest,
   output: DeleteSmsChannelResponse,
@@ -12925,7 +12924,7 @@ export const deleteSmsTemplate: API.OperationMethod<
   DeleteSmsTemplateRequest,
   DeleteSmsTemplateResponse,
   DeleteSmsTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSmsTemplateRequest,
   output: DeleteSmsTemplateResponse,
@@ -12959,7 +12958,7 @@ export const deleteUserEndpoints: API.OperationMethod<
   DeleteUserEndpointsRequest,
   DeleteUserEndpointsResponse,
   DeleteUserEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserEndpointsRequest,
   output: DeleteUserEndpointsResponse,
@@ -12993,7 +12992,7 @@ export const deleteVoiceChannel: API.OperationMethod<
   DeleteVoiceChannelRequest,
   DeleteVoiceChannelResponse,
   DeleteVoiceChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceChannelRequest,
   output: DeleteVoiceChannelResponse,
@@ -13027,7 +13026,7 @@ export const deleteVoiceTemplate: API.OperationMethod<
   DeleteVoiceTemplateRequest,
   DeleteVoiceTemplateResponse,
   DeleteVoiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVoiceTemplateRequest,
   output: DeleteVoiceTemplateResponse,
@@ -13061,7 +13060,7 @@ export const getAdmChannel: API.OperationMethod<
   GetAdmChannelRequest,
   GetAdmChannelResponse,
   GetAdmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdmChannelRequest,
   output: GetAdmChannelResponse,
@@ -13095,7 +13094,7 @@ export const getApnsChannel: API.OperationMethod<
   GetApnsChannelRequest,
   GetApnsChannelResponse,
   GetApnsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApnsChannelRequest,
   output: GetApnsChannelResponse,
@@ -13129,7 +13128,7 @@ export const getApnsSandboxChannel: API.OperationMethod<
   GetApnsSandboxChannelRequest,
   GetApnsSandboxChannelResponse,
   GetApnsSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApnsSandboxChannelRequest,
   output: GetApnsSandboxChannelResponse,
@@ -13163,7 +13162,7 @@ export const getApnsVoipChannel: API.OperationMethod<
   GetApnsVoipChannelRequest,
   GetApnsVoipChannelResponse,
   GetApnsVoipChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApnsVoipChannelRequest,
   output: GetApnsVoipChannelResponse,
@@ -13197,7 +13196,7 @@ export const getApnsVoipSandboxChannel: API.OperationMethod<
   GetApnsVoipSandboxChannelRequest,
   GetApnsVoipSandboxChannelResponse,
   GetApnsVoipSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApnsVoipSandboxChannelRequest,
   output: GetApnsVoipSandboxChannelResponse,
@@ -13231,7 +13230,7 @@ export const getApp: API.OperationMethod<
   GetAppRequest,
   GetAppResponse,
   GetAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppRequest,
   output: GetAppResponse,
@@ -13265,7 +13264,7 @@ export const getApplicationDateRangeKpi: API.OperationMethod<
   GetApplicationDateRangeKpiRequest,
   GetApplicationDateRangeKpiResponse,
   GetApplicationDateRangeKpiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationDateRangeKpiRequest,
   output: GetApplicationDateRangeKpiResponse,
@@ -13299,7 +13298,7 @@ export const getApplicationSettings: API.OperationMethod<
   GetApplicationSettingsRequest,
   GetApplicationSettingsResponse,
   GetApplicationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationSettingsRequest,
   output: GetApplicationSettingsResponse,
@@ -13333,7 +13332,7 @@ export const getApps: API.OperationMethod<
   GetAppsRequest,
   GetAppsResponse,
   GetAppsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppsRequest,
   output: GetAppsResponse,
@@ -13367,7 +13366,7 @@ export const getBaiduChannel: API.OperationMethod<
   GetBaiduChannelRequest,
   GetBaiduChannelResponse,
   GetBaiduChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBaiduChannelRequest,
   output: GetBaiduChannelResponse,
@@ -13401,7 +13400,7 @@ export const getCampaign: API.OperationMethod<
   GetCampaignRequest,
   GetCampaignResponse,
   GetCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignRequest,
   output: GetCampaignResponse,
@@ -13435,7 +13434,7 @@ export const getCampaignActivities: API.OperationMethod<
   GetCampaignActivitiesRequest,
   GetCampaignActivitiesResponse,
   GetCampaignActivitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignActivitiesRequest,
   output: GetCampaignActivitiesResponse,
@@ -13469,7 +13468,7 @@ export const getCampaignDateRangeKpi: API.OperationMethod<
   GetCampaignDateRangeKpiRequest,
   GetCampaignDateRangeKpiResponse,
   GetCampaignDateRangeKpiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignDateRangeKpiRequest,
   output: GetCampaignDateRangeKpiResponse,
@@ -13503,7 +13502,7 @@ export const getCampaigns: API.OperationMethod<
   GetCampaignsRequest,
   GetCampaignsResponse,
   GetCampaignsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignsRequest,
   output: GetCampaignsResponse,
@@ -13537,7 +13536,7 @@ export const getCampaignVersion: API.OperationMethod<
   GetCampaignVersionRequest,
   GetCampaignVersionResponse,
   GetCampaignVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignVersionRequest,
   output: GetCampaignVersionResponse,
@@ -13571,7 +13570,7 @@ export const getCampaignVersions: API.OperationMethod<
   GetCampaignVersionsRequest,
   GetCampaignVersionsResponse,
   GetCampaignVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCampaignVersionsRequest,
   output: GetCampaignVersionsResponse,
@@ -13605,7 +13604,7 @@ export const getChannels: API.OperationMethod<
   GetChannelsRequest,
   GetChannelsResponse,
   GetChannelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelsRequest,
   output: GetChannelsResponse,
@@ -13639,7 +13638,7 @@ export const getEmailChannel: API.OperationMethod<
   GetEmailChannelRequest,
   GetEmailChannelResponse,
   GetEmailChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailChannelRequest,
   output: GetEmailChannelResponse,
@@ -13673,7 +13672,7 @@ export const getEmailTemplate: API.OperationMethod<
   GetEmailTemplateRequest,
   GetEmailTemplateResponse,
   GetEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailTemplateRequest,
   output: GetEmailTemplateResponse,
@@ -13707,7 +13706,7 @@ export const getEndpoint: API.OperationMethod<
   GetEndpointRequest,
   GetEndpointResponse,
   GetEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEndpointRequest,
   output: GetEndpointResponse,
@@ -13741,7 +13740,7 @@ export const getEventStream: API.OperationMethod<
   GetEventStreamRequest,
   GetEventStreamResponse,
   GetEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEventStreamRequest,
   output: GetEventStreamResponse,
@@ -13775,7 +13774,7 @@ export const getExportJob: API.OperationMethod<
   GetExportJobRequest,
   GetExportJobResponse,
   GetExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportJobRequest,
   output: GetExportJobResponse,
@@ -13809,7 +13808,7 @@ export const getExportJobs: API.OperationMethod<
   GetExportJobsRequest,
   GetExportJobsResponse,
   GetExportJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportJobsRequest,
   output: GetExportJobsResponse,
@@ -13843,7 +13842,7 @@ export const getGcmChannel: API.OperationMethod<
   GetGcmChannelRequest,
   GetGcmChannelResponse,
   GetGcmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGcmChannelRequest,
   output: GetGcmChannelResponse,
@@ -13877,7 +13876,7 @@ export const getImportJob: API.OperationMethod<
   GetImportJobRequest,
   GetImportJobResponse,
   GetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportJobRequest,
   output: GetImportJobResponse,
@@ -13911,7 +13910,7 @@ export const getImportJobs: API.OperationMethod<
   GetImportJobsRequest,
   GetImportJobsResponse,
   GetImportJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportJobsRequest,
   output: GetImportJobsResponse,
@@ -13945,7 +13944,7 @@ export const getInAppMessages: API.OperationMethod<
   GetInAppMessagesRequest,
   GetInAppMessagesResponse,
   GetInAppMessagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInAppMessagesRequest,
   output: GetInAppMessagesResponse,
@@ -13979,7 +13978,7 @@ export const getInAppTemplate: API.OperationMethod<
   GetInAppTemplateRequest,
   GetInAppTemplateResponse,
   GetInAppTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInAppTemplateRequest,
   output: GetInAppTemplateResponse,
@@ -14013,7 +14012,7 @@ export const getJourney: API.OperationMethod<
   GetJourneyRequest,
   GetJourneyResponse,
   GetJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyRequest,
   output: GetJourneyResponse,
@@ -14047,7 +14046,7 @@ export const getJourneyDateRangeKpi: API.OperationMethod<
   GetJourneyDateRangeKpiRequest,
   GetJourneyDateRangeKpiResponse,
   GetJourneyDateRangeKpiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyDateRangeKpiRequest,
   output: GetJourneyDateRangeKpiResponse,
@@ -14081,7 +14080,7 @@ export const getJourneyExecutionActivityMetrics: API.OperationMethod<
   GetJourneyExecutionActivityMetricsRequest,
   GetJourneyExecutionActivityMetricsResponse,
   GetJourneyExecutionActivityMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyExecutionActivityMetricsRequest,
   output: GetJourneyExecutionActivityMetricsResponse,
@@ -14115,7 +14114,7 @@ export const getJourneyExecutionMetrics: API.OperationMethod<
   GetJourneyExecutionMetricsRequest,
   GetJourneyExecutionMetricsResponse,
   GetJourneyExecutionMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyExecutionMetricsRequest,
   output: GetJourneyExecutionMetricsResponse,
@@ -14149,7 +14148,7 @@ export const getJourneyRunExecutionActivityMetrics: API.OperationMethod<
   GetJourneyRunExecutionActivityMetricsRequest,
   GetJourneyRunExecutionActivityMetricsResponse,
   GetJourneyRunExecutionActivityMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyRunExecutionActivityMetricsRequest,
   output: GetJourneyRunExecutionActivityMetricsResponse,
@@ -14183,7 +14182,7 @@ export const getJourneyRunExecutionMetrics: API.OperationMethod<
   GetJourneyRunExecutionMetricsRequest,
   GetJourneyRunExecutionMetricsResponse,
   GetJourneyRunExecutionMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyRunExecutionMetricsRequest,
   output: GetJourneyRunExecutionMetricsResponse,
@@ -14217,7 +14216,7 @@ export const getJourneyRuns: API.OperationMethod<
   GetJourneyRunsRequest,
   GetJourneyRunsResponse,
   GetJourneyRunsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJourneyRunsRequest,
   output: GetJourneyRunsResponse,
@@ -14251,7 +14250,7 @@ export const getPushTemplate: API.OperationMethod<
   GetPushTemplateRequest,
   GetPushTemplateResponse,
   GetPushTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPushTemplateRequest,
   output: GetPushTemplateResponse,
@@ -14285,7 +14284,7 @@ export const getRecommenderConfiguration: API.OperationMethod<
   GetRecommenderConfigurationRequest,
   GetRecommenderConfigurationResponse,
   GetRecommenderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommenderConfigurationRequest,
   output: GetRecommenderConfigurationResponse,
@@ -14319,7 +14318,7 @@ export const getRecommenderConfigurations: API.OperationMethod<
   GetRecommenderConfigurationsRequest,
   GetRecommenderConfigurationsResponse,
   GetRecommenderConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommenderConfigurationsRequest,
   output: GetRecommenderConfigurationsResponse,
@@ -14353,7 +14352,7 @@ export const getSegment: API.OperationMethod<
   GetSegmentRequest,
   GetSegmentResponse,
   GetSegmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentRequest,
   output: GetSegmentResponse,
@@ -14387,7 +14386,7 @@ export const getSegmentExportJobs: API.OperationMethod<
   GetSegmentExportJobsRequest,
   GetSegmentExportJobsResponse,
   GetSegmentExportJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentExportJobsRequest,
   output: GetSegmentExportJobsResponse,
@@ -14421,7 +14420,7 @@ export const getSegmentImportJobs: API.OperationMethod<
   GetSegmentImportJobsRequest,
   GetSegmentImportJobsResponse,
   GetSegmentImportJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentImportJobsRequest,
   output: GetSegmentImportJobsResponse,
@@ -14455,7 +14454,7 @@ export const getSegments: API.OperationMethod<
   GetSegmentsRequest,
   GetSegmentsResponse,
   GetSegmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentsRequest,
   output: GetSegmentsResponse,
@@ -14489,7 +14488,7 @@ export const getSegmentVersion: API.OperationMethod<
   GetSegmentVersionRequest,
   GetSegmentVersionResponse,
   GetSegmentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentVersionRequest,
   output: GetSegmentVersionResponse,
@@ -14523,7 +14522,7 @@ export const getSegmentVersions: API.OperationMethod<
   GetSegmentVersionsRequest,
   GetSegmentVersionsResponse,
   GetSegmentVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSegmentVersionsRequest,
   output: GetSegmentVersionsResponse,
@@ -14557,7 +14556,7 @@ export const getSmsChannel: API.OperationMethod<
   GetSmsChannelRequest,
   GetSmsChannelResponse,
   GetSmsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSmsChannelRequest,
   output: GetSmsChannelResponse,
@@ -14591,7 +14590,7 @@ export const getSmsTemplate: API.OperationMethod<
   GetSmsTemplateRequest,
   GetSmsTemplateResponse,
   GetSmsTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSmsTemplateRequest,
   output: GetSmsTemplateResponse,
@@ -14625,7 +14624,7 @@ export const getUserEndpoints: API.OperationMethod<
   GetUserEndpointsRequest,
   GetUserEndpointsResponse,
   GetUserEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserEndpointsRequest,
   output: GetUserEndpointsResponse,
@@ -14659,7 +14658,7 @@ export const getVoiceChannel: API.OperationMethod<
   GetVoiceChannelRequest,
   GetVoiceChannelResponse,
   GetVoiceChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceChannelRequest,
   output: GetVoiceChannelResponse,
@@ -14693,7 +14692,7 @@ export const getVoiceTemplate: API.OperationMethod<
   GetVoiceTemplateRequest,
   GetVoiceTemplateResponse,
   GetVoiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVoiceTemplateRequest,
   output: GetVoiceTemplateResponse,
@@ -14727,7 +14726,7 @@ export const listJourneys: API.OperationMethod<
   ListJourneysRequest,
   ListJourneysResponse,
   ListJourneysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListJourneysRequest,
   output: ListJourneysResponse,
@@ -14753,7 +14752,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -14777,7 +14776,7 @@ export const listTemplates: API.OperationMethod<
   ListTemplatesRequest,
   ListTemplatesResponse,
   ListTemplatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTemplatesRequest,
   output: ListTemplatesResponse,
@@ -14809,7 +14808,7 @@ export const listTemplateVersions: API.OperationMethod<
   ListTemplateVersionsRequest,
   ListTemplateVersionsResponse,
   ListTemplateVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTemplateVersionsRequest,
   output: ListTemplateVersionsResponse,
@@ -14843,7 +14842,7 @@ export const phoneNumberValidate: API.OperationMethod<
   PhoneNumberValidateRequest,
   PhoneNumberValidateResponse,
   PhoneNumberValidateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PhoneNumberValidateRequest,
   output: PhoneNumberValidateResponse,
@@ -14877,7 +14876,7 @@ export const putEvents: API.OperationMethod<
   PutEventsRequest,
   PutEventsResponse,
   PutEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventsRequest,
   output: PutEventsResponse,
@@ -14911,7 +14910,7 @@ export const putEventStream: API.OperationMethod<
   PutEventStreamRequest,
   PutEventStreamResponse,
   PutEventStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEventStreamRequest,
   output: PutEventStreamResponse,
@@ -14945,7 +14944,7 @@ export const removeAttributes: API.OperationMethod<
   RemoveAttributesRequest,
   RemoveAttributesResponse,
   RemoveAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAttributesRequest,
   output: RemoveAttributesResponse,
@@ -14979,7 +14978,7 @@ export const sendMessages: API.OperationMethod<
   SendMessagesRequest,
   SendMessagesResponse,
   SendMessagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessagesRequest,
   output: SendMessagesResponse,
@@ -15013,7 +15012,7 @@ export const sendOTPMessage: API.OperationMethod<
   SendOTPMessageRequest,
   SendOTPMessageResponse,
   SendOTPMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendOTPMessageRequest,
   output: SendOTPMessageResponse,
@@ -15047,7 +15046,7 @@ export const sendUsersMessages: API.OperationMethod<
   SendUsersMessagesRequest,
   SendUsersMessagesResponse,
   SendUsersMessagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendUsersMessagesRequest,
   output: SendUsersMessagesResponse,
@@ -15073,7 +15072,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -15091,7 +15090,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -15117,7 +15116,7 @@ export const updateAdmChannel: API.OperationMethod<
   UpdateAdmChannelRequest,
   UpdateAdmChannelResponse,
   UpdateAdmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAdmChannelRequest,
   output: UpdateAdmChannelResponse,
@@ -15151,7 +15150,7 @@ export const updateApnsChannel: API.OperationMethod<
   UpdateApnsChannelRequest,
   UpdateApnsChannelResponse,
   UpdateApnsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApnsChannelRequest,
   output: UpdateApnsChannelResponse,
@@ -15185,7 +15184,7 @@ export const updateApnsSandboxChannel: API.OperationMethod<
   UpdateApnsSandboxChannelRequest,
   UpdateApnsSandboxChannelResponse,
   UpdateApnsSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApnsSandboxChannelRequest,
   output: UpdateApnsSandboxChannelResponse,
@@ -15219,7 +15218,7 @@ export const updateApnsVoipChannel: API.OperationMethod<
   UpdateApnsVoipChannelRequest,
   UpdateApnsVoipChannelResponse,
   UpdateApnsVoipChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApnsVoipChannelRequest,
   output: UpdateApnsVoipChannelResponse,
@@ -15253,7 +15252,7 @@ export const updateApnsVoipSandboxChannel: API.OperationMethod<
   UpdateApnsVoipSandboxChannelRequest,
   UpdateApnsVoipSandboxChannelResponse,
   UpdateApnsVoipSandboxChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApnsVoipSandboxChannelRequest,
   output: UpdateApnsVoipSandboxChannelResponse,
@@ -15287,7 +15286,7 @@ export const updateApplicationSettings: API.OperationMethod<
   UpdateApplicationSettingsRequest,
   UpdateApplicationSettingsResponse,
   UpdateApplicationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationSettingsRequest,
   output: UpdateApplicationSettingsResponse,
@@ -15321,7 +15320,7 @@ export const updateBaiduChannel: API.OperationMethod<
   UpdateBaiduChannelRequest,
   UpdateBaiduChannelResponse,
   UpdateBaiduChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBaiduChannelRequest,
   output: UpdateBaiduChannelResponse,
@@ -15355,7 +15354,7 @@ export const updateCampaign: API.OperationMethod<
   UpdateCampaignRequest,
   UpdateCampaignResponse,
   UpdateCampaignError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCampaignRequest,
   output: UpdateCampaignResponse,
@@ -15389,7 +15388,7 @@ export const updateEmailChannel: API.OperationMethod<
   UpdateEmailChannelRequest,
   UpdateEmailChannelResponse,
   UpdateEmailChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmailChannelRequest,
   output: UpdateEmailChannelResponse,
@@ -15423,7 +15422,7 @@ export const updateEmailTemplate: API.OperationMethod<
   UpdateEmailTemplateRequest,
   UpdateEmailTemplateResponse,
   UpdateEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmailTemplateRequest,
   output: UpdateEmailTemplateResponse,
@@ -15457,7 +15456,7 @@ export const updateEndpoint: API.OperationMethod<
   UpdateEndpointRequest,
   UpdateEndpointResponse,
   UpdateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointRequest,
   output: UpdateEndpointResponse,
@@ -15491,7 +15490,7 @@ export const updateEndpointsBatch: API.OperationMethod<
   UpdateEndpointsBatchRequest,
   UpdateEndpointsBatchResponse,
   UpdateEndpointsBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointsBatchRequest,
   output: UpdateEndpointsBatchResponse,
@@ -15525,7 +15524,7 @@ export const updateGcmChannel: API.OperationMethod<
   UpdateGcmChannelRequest,
   UpdateGcmChannelResponse,
   UpdateGcmChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGcmChannelRequest,
   output: UpdateGcmChannelResponse,
@@ -15559,7 +15558,7 @@ export const updateInAppTemplate: API.OperationMethod<
   UpdateInAppTemplateRequest,
   UpdateInAppTemplateResponse,
   UpdateInAppTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInAppTemplateRequest,
   output: UpdateInAppTemplateResponse,
@@ -15594,7 +15593,7 @@ export const updateJourney: API.OperationMethod<
   UpdateJourneyRequest,
   UpdateJourneyResponse,
   UpdateJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJourneyRequest,
   output: UpdateJourneyResponse,
@@ -15629,7 +15628,7 @@ export const updateJourneyState: API.OperationMethod<
   UpdateJourneyStateRequest,
   UpdateJourneyStateResponse,
   UpdateJourneyStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJourneyStateRequest,
   output: UpdateJourneyStateResponse,
@@ -15663,7 +15662,7 @@ export const updatePushTemplate: API.OperationMethod<
   UpdatePushTemplateRequest,
   UpdatePushTemplateResponse,
   UpdatePushTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePushTemplateRequest,
   output: UpdatePushTemplateResponse,
@@ -15697,7 +15696,7 @@ export const updateRecommenderConfiguration: API.OperationMethod<
   UpdateRecommenderConfigurationRequest,
   UpdateRecommenderConfigurationResponse,
   UpdateRecommenderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecommenderConfigurationRequest,
   output: UpdateRecommenderConfigurationResponse,
@@ -15731,7 +15730,7 @@ export const updateSegment: API.OperationMethod<
   UpdateSegmentRequest,
   UpdateSegmentResponse,
   UpdateSegmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSegmentRequest,
   output: UpdateSegmentResponse,
@@ -15765,7 +15764,7 @@ export const updateSmsChannel: API.OperationMethod<
   UpdateSmsChannelRequest,
   UpdateSmsChannelResponse,
   UpdateSmsChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSmsChannelRequest,
   output: UpdateSmsChannelResponse,
@@ -15799,7 +15798,7 @@ export const updateSmsTemplate: API.OperationMethod<
   UpdateSmsTemplateRequest,
   UpdateSmsTemplateResponse,
   UpdateSmsTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSmsTemplateRequest,
   output: UpdateSmsTemplateResponse,
@@ -15833,7 +15832,7 @@ export const updateTemplateActiveVersion: API.OperationMethod<
   UpdateTemplateActiveVersionRequest,
   UpdateTemplateActiveVersionResponse,
   UpdateTemplateActiveVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateActiveVersionRequest,
   output: UpdateTemplateActiveVersionResponse,
@@ -15867,7 +15866,7 @@ export const updateVoiceChannel: API.OperationMethod<
   UpdateVoiceChannelRequest,
   UpdateVoiceChannelResponse,
   UpdateVoiceChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceChannelRequest,
   output: UpdateVoiceChannelResponse,
@@ -15901,7 +15900,7 @@ export const updateVoiceTemplate: API.OperationMethod<
   UpdateVoiceTemplateRequest,
   UpdateVoiceTemplateResponse,
   UpdateVoiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVoiceTemplateRequest,
   output: UpdateVoiceTemplateResponse,
@@ -15935,7 +15934,7 @@ export const verifyOTPMessage: API.OperationMethod<
   VerifyOTPMessageRequest,
   VerifyOTPMessageResponse,
   VerifyOTPMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyOTPMessageRequest,
   output: VerifyOTPMessageResponse,

--- a/packages/aws/src/services/pipes.ts
+++ b/packages/aws/src/services/pipes.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://events.amazonaws.com/doc/2015-10-07");
 const svc = T.AwsApiService({ sdkId: "Pipes", serviceShapeName: "Pipes" });
@@ -1906,7 +1905,7 @@ export const createPipe: API.OperationMethod<
   CreatePipeRequest,
   CreatePipeResponse,
   CreatePipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipeRequest,
   output: CreatePipeResponse,
@@ -1937,7 +1936,7 @@ export const deletePipe: API.OperationMethod<
   DeletePipeRequest,
   DeletePipeResponse,
   DeletePipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipeRequest,
   output: DeletePipeResponse,
@@ -1966,7 +1965,7 @@ export const describePipe: API.OperationMethod<
   DescribePipeRequest,
   DescribePipeResponse,
   DescribePipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePipeRequest,
   output: DescribePipeResponse,
@@ -1993,7 +1992,7 @@ export const listPipes: API.PaginatedOperationMethod<
   ListPipesRequest,
   ListPipesResponse,
   ListPipesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Pipe
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipesRequest,
@@ -2022,7 +2021,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2046,7 +2045,7 @@ export const startPipe: API.OperationMethod<
   StartPipeRequest,
   StartPipeResponse,
   StartPipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPipeRequest,
   output: StartPipeResponse,
@@ -2076,7 +2075,7 @@ export const stopPipe: API.OperationMethod<
   StopPipeRequest,
   StopPipeResponse,
   StopPipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPipeRequest,
   output: StopPipeResponse,
@@ -2117,7 +2116,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2139,7 +2138,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2175,7 +2174,7 @@ export const updatePipe: API.OperationMethod<
   UpdatePipeRequest,
   UpdatePipeResponse,
   UpdatePipeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipeRequest,
   output: UpdatePipeResponse,

--- a/packages/aws/src/services/polly.ts
+++ b/packages/aws/src/services/polly.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://polly.amazonaws.com/doc/v1");
 const svc = T.AwsApiService({ sdkId: "Polly", serviceShapeName: "Parrot_v1" });
@@ -1158,7 +1157,7 @@ export const deleteLexicon: API.OperationMethod<
   DeleteLexiconInput,
   DeleteLexiconOutput,
   DeleteLexiconError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLexiconInput,
   output: DeleteLexiconOutput,
@@ -1198,7 +1197,7 @@ export const describeVoices: API.OperationMethod<
   DescribeVoicesInput,
   DescribeVoicesOutput,
   DescribeVoicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVoicesInput,
   output: DescribeVoicesOutput,
@@ -1220,7 +1219,7 @@ export const getLexicon: API.OperationMethod<
   GetLexiconInput,
   GetLexiconOutput,
   GetLexiconError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLexiconInput,
   output: GetLexiconOutput,
@@ -1245,7 +1244,7 @@ export const getSpeechSynthesisTask: API.OperationMethod<
   GetSpeechSynthesisTaskInput,
   GetSpeechSynthesisTaskOutput,
   GetSpeechSynthesisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpeechSynthesisTaskInput,
   output: GetSpeechSynthesisTaskOutput,
@@ -1270,7 +1269,7 @@ export const listLexicons: API.OperationMethod<
   ListLexiconsInput,
   ListLexiconsOutput,
   ListLexiconsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLexiconsInput,
   output: ListLexiconsOutput,
@@ -1293,7 +1292,7 @@ export const listSpeechSynthesisTasks: API.PaginatedOperationMethod<
   ListSpeechSynthesisTasksInput,
   ListSpeechSynthesisTasksOutput,
   ListSpeechSynthesisTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpeechSynthesisTasksInput,
@@ -1331,7 +1330,7 @@ export const putLexicon: API.OperationMethod<
   PutLexiconInput,
   PutLexiconOutput,
   PutLexiconError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLexiconInput,
   output: PutLexiconOutput,
@@ -1368,7 +1367,7 @@ export const startSpeechSynthesisStream: API.OperationMethod<
   StartSpeechSynthesisStreamInput,
   StartSpeechSynthesisStreamOutput,
   StartSpeechSynthesisStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSpeechSynthesisStreamInput,
   output: StartSpeechSynthesisStreamOutput,
@@ -1413,7 +1412,7 @@ export const startSpeechSynthesisTask: API.OperationMethod<
   StartSpeechSynthesisTaskInput,
   StartSpeechSynthesisTaskOutput,
   StartSpeechSynthesisTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSpeechSynthesisTaskInput,
   output: StartSpeechSynthesisTaskOutput,
@@ -1458,7 +1457,7 @@ export const synthesizeSpeech: API.OperationMethod<
   SynthesizeSpeechInput,
   SynthesizeSpeechOutput,
   SynthesizeSpeechError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SynthesizeSpeechInput,
   output: SynthesizeSpeechOutput,

--- a/packages/aws/src/services/pricing.ts
+++ b/packages/aws/src/services/pricing.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Pricing",
   serviceShapeName: "AWSPriceListService",
@@ -376,7 +375,7 @@ export const describeServices: API.PaginatedOperationMethod<
   DescribeServicesRequest,
   DescribeServicesResponse,
   DescribeServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Service
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServicesRequest,
@@ -417,7 +416,7 @@ export const getAttributeValues: API.PaginatedOperationMethod<
   GetAttributeValuesRequest,
   GetAttributeValuesResponse,
   GetAttributeValuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttributeValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAttributeValuesRequest,
@@ -459,7 +458,7 @@ export const getPriceListFileUrl: API.OperationMethod<
   GetPriceListFileUrlRequest,
   GetPriceListFileUrlResponse,
   GetPriceListFileUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPriceListFileUrlRequest,
   output: GetPriceListFileUrlResponse,
@@ -492,7 +491,7 @@ export const getProducts: API.PaginatedOperationMethod<
   GetProductsRequest,
   GetProductsResponse,
   GetProductsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SynthesizedJsonPriceListJsonItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetProductsRequest,
@@ -536,7 +535,7 @@ export const listPriceLists: API.PaginatedOperationMethod<
   ListPriceListsRequest,
   ListPriceListsResponse,
   ListPriceListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PriceList
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPriceListsRequest,

--- a/packages/aws/src/services/proton.ts
+++ b/packages/aws/src/services/proton.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Proton",
@@ -3671,7 +3670,7 @@ export const acceptEnvironmentAccountConnection: API.OperationMethod<
   AcceptEnvironmentAccountConnectionInput,
   AcceptEnvironmentAccountConnectionOutput,
   AcceptEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptEnvironmentAccountConnectionInput,
   output: AcceptEnvironmentAccountConnectionOutput,
@@ -3707,7 +3706,7 @@ export const cancelComponentDeployment: API.OperationMethod<
   CancelComponentDeploymentInput,
   CancelComponentDeploymentOutput,
   CancelComponentDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelComponentDeploymentInput,
   output: CancelComponentDeploymentOutput,
@@ -3750,7 +3749,7 @@ export const cancelEnvironmentDeployment: API.OperationMethod<
   CancelEnvironmentDeploymentInput,
   CancelEnvironmentDeploymentOutput,
   CancelEnvironmentDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelEnvironmentDeploymentInput,
   output: CancelEnvironmentDeploymentOutput,
@@ -3796,7 +3795,7 @@ export const cancelServiceInstanceDeployment: API.OperationMethod<
   CancelServiceInstanceDeploymentInput,
   CancelServiceInstanceDeploymentOutput,
   CancelServiceInstanceDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelServiceInstanceDeploymentInput,
   output: CancelServiceInstanceDeploymentOutput,
@@ -3842,7 +3841,7 @@ export const cancelServicePipelineDeployment: API.OperationMethod<
   CancelServicePipelineDeploymentInput,
   CancelServicePipelineDeploymentOutput,
   CancelServicePipelineDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelServicePipelineDeploymentInput,
   output: CancelServicePipelineDeploymentOutput,
@@ -3879,7 +3878,7 @@ export const createComponent: API.OperationMethod<
   CreateComponentInput,
   CreateComponentOutput,
   CreateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComponentInput,
   output: CreateComponentOutput,
@@ -3924,7 +3923,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentInput,
   CreateEnvironmentOutput,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentInput,
   output: CreateEnvironmentOutput,
@@ -3962,7 +3961,7 @@ export const createEnvironmentAccountConnection: API.OperationMethod<
   CreateEnvironmentAccountConnectionInput,
   CreateEnvironmentAccountConnectionOutput,
   CreateEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentAccountConnectionInput,
   output: CreateEnvironmentAccountConnectionOutput,
@@ -4005,7 +4004,7 @@ export const createEnvironmentTemplate: API.OperationMethod<
   CreateEnvironmentTemplateInput,
   CreateEnvironmentTemplateOutput,
   CreateEnvironmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentTemplateInput,
   output: CreateEnvironmentTemplateOutput,
@@ -4040,7 +4039,7 @@ export const createEnvironmentTemplateVersion: API.OperationMethod<
   CreateEnvironmentTemplateVersionInput,
   CreateEnvironmentTemplateVersionOutput,
   CreateEnvironmentTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentTemplateVersionInput,
   output: CreateEnvironmentTemplateVersionOutput,
@@ -4079,7 +4078,7 @@ export const createRepository: API.OperationMethod<
   CreateRepositoryInput,
   CreateRepositoryOutput,
   CreateRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRepositoryInput,
   output: CreateRepositoryOutput,
@@ -4115,7 +4114,7 @@ export const createService: API.OperationMethod<
   CreateServiceInput,
   CreateServiceOutput,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceInput,
   output: CreateServiceOutput,
@@ -4148,7 +4147,7 @@ export const createServiceInstance: API.OperationMethod<
   CreateServiceInstanceInput,
   CreateServiceInstanceOutput,
   CreateServiceInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceInstanceInput,
   output: CreateServiceInstanceOutput,
@@ -4180,7 +4179,7 @@ export const createServiceSyncConfig: API.OperationMethod<
   CreateServiceSyncConfigInput,
   CreateServiceSyncConfigOutput,
   CreateServiceSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceSyncConfigInput,
   output: CreateServiceSyncConfigOutput,
@@ -4217,7 +4216,7 @@ export const createServiceTemplate: API.OperationMethod<
   CreateServiceTemplateInput,
   CreateServiceTemplateOutput,
   CreateServiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceTemplateInput,
   output: CreateServiceTemplateOutput,
@@ -4252,7 +4251,7 @@ export const createServiceTemplateVersion: API.OperationMethod<
   CreateServiceTemplateVersionInput,
   CreateServiceTemplateVersionOutput,
   CreateServiceTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceTemplateVersionInput,
   output: CreateServiceTemplateVersionOutput,
@@ -4290,7 +4289,7 @@ export const createTemplateSyncConfig: API.OperationMethod<
   CreateTemplateSyncConfigInput,
   CreateTemplateSyncConfigOutput,
   CreateTemplateSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateSyncConfigInput,
   output: CreateTemplateSyncConfigOutput,
@@ -4326,7 +4325,7 @@ export const deleteComponent: API.OperationMethod<
   DeleteComponentInput,
   DeleteComponentOutput,
   DeleteComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComponentInput,
   output: DeleteComponentOutput,
@@ -4357,7 +4356,7 @@ export const deleteDeployment: API.OperationMethod<
   DeleteDeploymentInput,
   DeleteDeploymentOutput,
   DeleteDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeploymentInput,
   output: DeleteDeploymentOutput,
@@ -4388,7 +4387,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentInput,
   DeleteEnvironmentOutput,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentInput,
   output: DeleteEnvironmentOutput,
@@ -4427,7 +4426,7 @@ export const deleteEnvironmentAccountConnection: API.OperationMethod<
   DeleteEnvironmentAccountConnectionInput,
   DeleteEnvironmentAccountConnectionOutput,
   DeleteEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentAccountConnectionInput,
   output: DeleteEnvironmentAccountConnectionOutput,
@@ -4459,7 +4458,7 @@ export const deleteEnvironmentTemplate: API.OperationMethod<
   DeleteEnvironmentTemplateInput,
   DeleteEnvironmentTemplateOutput,
   DeleteEnvironmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentTemplateInput,
   output: DeleteEnvironmentTemplateOutput,
@@ -4497,7 +4496,7 @@ export const deleteEnvironmentTemplateVersion: API.OperationMethod<
   DeleteEnvironmentTemplateVersionInput,
   DeleteEnvironmentTemplateVersionOutput,
   DeleteEnvironmentTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentTemplateVersionInput,
   output: DeleteEnvironmentTemplateVersionOutput,
@@ -4529,7 +4528,7 @@ export const deleteRepository: API.OperationMethod<
   DeleteRepositoryInput,
   DeleteRepositoryOutput,
   DeleteRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRepositoryInput,
   output: DeleteRepositoryOutput,
@@ -4568,7 +4567,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceInput,
   DeleteServiceOutput,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceInput,
   output: DeleteServiceOutput,
@@ -4600,7 +4599,7 @@ export const deleteServiceSyncConfig: API.OperationMethod<
   DeleteServiceSyncConfigInput,
   DeleteServiceSyncConfigOutput,
   DeleteServiceSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceSyncConfigInput,
   output: DeleteServiceSyncConfigOutput,
@@ -4633,7 +4632,7 @@ export const deleteServiceTemplate: API.OperationMethod<
   DeleteServiceTemplateInput,
   DeleteServiceTemplateOutput,
   DeleteServiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceTemplateInput,
   output: DeleteServiceTemplateOutput,
@@ -4674,7 +4673,7 @@ export const deleteServiceTemplateVersion: API.OperationMethod<
   DeleteServiceTemplateVersionInput,
   DeleteServiceTemplateVersionOutput,
   DeleteServiceTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceTemplateVersionInput,
   output: DeleteServiceTemplateVersionOutput,
@@ -4706,7 +4705,7 @@ export const deleteTemplateSyncConfig: API.OperationMethod<
   DeleteTemplateSyncConfigInput,
   DeleteTemplateSyncConfigOutput,
   DeleteTemplateSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateSyncConfigInput,
   output: DeleteTemplateSyncConfigOutput,
@@ -4737,7 +4736,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsInput,
   GetAccountSettingsOutput,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsInput,
   output: GetAccountSettingsOutput,
@@ -4771,7 +4770,7 @@ export const getComponent: API.OperationMethod<
   GetComponentInput,
   GetComponentOutput,
   GetComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentInput,
   output: GetComponentOutput,
@@ -4801,7 +4800,7 @@ export const getDeployment: API.OperationMethod<
   GetDeploymentInput,
   GetDeploymentOutput,
   GetDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentInput,
   output: GetDeploymentOutput,
@@ -4831,7 +4830,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentInput,
   GetEnvironmentOutput,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentInput,
   output: GetEnvironmentOutput,
@@ -4864,7 +4863,7 @@ export const getEnvironmentAccountConnection: API.OperationMethod<
   GetEnvironmentAccountConnectionInput,
   GetEnvironmentAccountConnectionOutput,
   GetEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentAccountConnectionInput,
   output: GetEnvironmentAccountConnectionOutput,
@@ -4894,7 +4893,7 @@ export const getEnvironmentTemplate: API.OperationMethod<
   GetEnvironmentTemplateInput,
   GetEnvironmentTemplateOutput,
   GetEnvironmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentTemplateInput,
   output: GetEnvironmentTemplateOutput,
@@ -4924,7 +4923,7 @@ export const getEnvironmentTemplateVersion: API.OperationMethod<
   GetEnvironmentTemplateVersionInput,
   GetEnvironmentTemplateVersionOutput,
   GetEnvironmentTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentTemplateVersionInput,
   output: GetEnvironmentTemplateVersionOutput,
@@ -4954,7 +4953,7 @@ export const getRepository: API.OperationMethod<
   GetRepositoryInput,
   GetRepositoryOutput,
   GetRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositoryInput,
   output: GetRepositoryOutput,
@@ -4991,7 +4990,7 @@ export const getRepositorySyncStatus: API.OperationMethod<
   GetRepositorySyncStatusInput,
   GetRepositorySyncStatusOutput,
   GetRepositorySyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRepositorySyncStatusInput,
   output: GetRepositorySyncStatusOutput,
@@ -5033,7 +5032,7 @@ export const getResourcesSummary: API.OperationMethod<
   GetResourcesSummaryInput,
   GetResourcesSummaryOutput,
   GetResourcesSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcesSummaryInput,
   output: GetResourcesSummaryOutput,
@@ -5062,7 +5061,7 @@ export const getService: API.OperationMethod<
   GetServiceInput,
   GetServiceOutput,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceInput,
   output: GetServiceOutput,
@@ -5093,7 +5092,7 @@ export const getServiceInstance: API.OperationMethod<
   GetServiceInstanceInput,
   GetServiceInstanceOutput,
   GetServiceInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceInstanceInput,
   output: GetServiceInstanceOutput,
@@ -5123,7 +5122,7 @@ export const getServiceInstanceSyncStatus: API.OperationMethod<
   GetServiceInstanceSyncStatusInput,
   GetServiceInstanceSyncStatusOutput,
   GetServiceInstanceSyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceInstanceSyncStatusInput,
   output: GetServiceInstanceSyncStatusOutput,
@@ -5153,7 +5152,7 @@ export const getServiceSyncBlockerSummary: API.OperationMethod<
   GetServiceSyncBlockerSummaryInput,
   GetServiceSyncBlockerSummaryOutput,
   GetServiceSyncBlockerSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSyncBlockerSummaryInput,
   output: GetServiceSyncBlockerSummaryOutput,
@@ -5183,7 +5182,7 @@ export const getServiceSyncConfig: API.OperationMethod<
   GetServiceSyncConfigInput,
   GetServiceSyncConfigOutput,
   GetServiceSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSyncConfigInput,
   output: GetServiceSyncConfigOutput,
@@ -5213,7 +5212,7 @@ export const getServiceTemplate: API.OperationMethod<
   GetServiceTemplateInput,
   GetServiceTemplateOutput,
   GetServiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceTemplateInput,
   output: GetServiceTemplateOutput,
@@ -5243,7 +5242,7 @@ export const getServiceTemplateVersion: API.OperationMethod<
   GetServiceTemplateVersionInput,
   GetServiceTemplateVersionOutput,
   GetServiceTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceTemplateVersionInput,
   output: GetServiceTemplateVersionOutput,
@@ -5273,7 +5272,7 @@ export const getTemplateSyncConfig: API.OperationMethod<
   GetTemplateSyncConfigInput,
   GetTemplateSyncConfigOutput,
   GetTemplateSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateSyncConfigInput,
   output: GetTemplateSyncConfigOutput,
@@ -5303,7 +5302,7 @@ export const getTemplateSyncStatus: API.OperationMethod<
   GetTemplateSyncStatusInput,
   GetTemplateSyncStatusOutput,
   GetTemplateSyncStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateSyncStatusInput,
   output: GetTemplateSyncStatusOutput,
@@ -5337,7 +5336,7 @@ export const listComponentOutputs: API.PaginatedOperationMethod<
   ListComponentOutputsInput,
   ListComponentOutputsOutput,
   ListComponentOutputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Output
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentOutputsInput,
@@ -5377,7 +5376,7 @@ export const listComponentProvisionedResources: API.PaginatedOperationMethod<
   ListComponentProvisionedResourcesInput,
   ListComponentProvisionedResourcesOutput,
   ListComponentProvisionedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentProvisionedResourcesInput,
@@ -5416,7 +5415,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsInput,
   ListComponentsOutput,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsInput,
@@ -5452,7 +5451,7 @@ export const listDeployments: API.PaginatedOperationMethod<
   ListDeploymentsInput,
   ListDeploymentsOutput,
   ListDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeploymentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeploymentsInput,
@@ -5491,7 +5490,7 @@ export const listEnvironmentAccountConnections: API.PaginatedOperationMethod<
   ListEnvironmentAccountConnectionsInput,
   ListEnvironmentAccountConnectionsOutput,
   ListEnvironmentAccountConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentAccountConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentAccountConnectionsInput,
@@ -5527,7 +5526,7 @@ export const listEnvironmentOutputs: API.PaginatedOperationMethod<
   ListEnvironmentOutputsInput,
   ListEnvironmentOutputsOutput,
   ListEnvironmentOutputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Output
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentOutputsInput,
@@ -5563,7 +5562,7 @@ export const listEnvironmentProvisionedResources: API.PaginatedOperationMethod<
   ListEnvironmentProvisionedResourcesInput,
   ListEnvironmentProvisionedResourcesOutput,
   ListEnvironmentProvisionedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentProvisionedResourcesInput,
@@ -5599,7 +5598,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsInput,
   ListEnvironmentsOutput,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsInput,
@@ -5635,7 +5634,7 @@ export const listEnvironmentTemplates: API.PaginatedOperationMethod<
   ListEnvironmentTemplatesInput,
   ListEnvironmentTemplatesOutput,
   ListEnvironmentTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentTemplatesInput,
@@ -5671,7 +5670,7 @@ export const listEnvironmentTemplateVersions: API.PaginatedOperationMethod<
   ListEnvironmentTemplateVersionsInput,
   ListEnvironmentTemplateVersionsOutput,
   ListEnvironmentTemplateVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentTemplateVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentTemplateVersionsInput,
@@ -5708,7 +5707,7 @@ export const listRepositories: API.PaginatedOperationMethod<
   ListRepositoriesInput,
   ListRepositoriesOutput,
   ListRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositoriesInput,
@@ -5744,7 +5743,7 @@ export const listRepositorySyncDefinitions: API.PaginatedOperationMethod<
   ListRepositorySyncDefinitionsInput,
   ListRepositorySyncDefinitionsOutput,
   ListRepositorySyncDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RepositorySyncDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRepositorySyncDefinitionsInput,
@@ -5779,7 +5778,7 @@ export const listServiceInstanceOutputs: API.PaginatedOperationMethod<
   ListServiceInstanceOutputsInput,
   ListServiceInstanceOutputsOutput,
   ListServiceInstanceOutputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Output
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceInstanceOutputsInput,
@@ -5815,7 +5814,7 @@ export const listServiceInstanceProvisionedResources: API.PaginatedOperationMeth
   ListServiceInstanceProvisionedResourcesInput,
   ListServiceInstanceProvisionedResourcesOutput,
   ListServiceInstanceProvisionedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceInstanceProvisionedResourcesInput,
@@ -5852,7 +5851,7 @@ export const listServiceInstances: API.PaginatedOperationMethod<
   ListServiceInstancesInput,
   ListServiceInstancesOutput,
   ListServiceInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceInstancesInput,
@@ -5889,7 +5888,7 @@ export const listServicePipelineOutputs: API.PaginatedOperationMethod<
   ListServicePipelineOutputsInput,
   ListServicePipelineOutputsOutput,
   ListServicePipelineOutputsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Output
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicePipelineOutputsInput,
@@ -5925,7 +5924,7 @@ export const listServicePipelineProvisionedResources: API.PaginatedOperationMeth
   ListServicePipelineProvisionedResourcesInput,
   ListServicePipelineProvisionedResourcesOutput,
   ListServicePipelineProvisionedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProvisionedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicePipelineProvisionedResourcesInput,
@@ -5960,7 +5959,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesInput,
   ListServicesOutput,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesInput,
@@ -5995,7 +5994,7 @@ export const listServiceTemplates: API.PaginatedOperationMethod<
   ListServiceTemplatesInput,
   ListServiceTemplatesOutput,
   ListServiceTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceTemplatesInput,
@@ -6031,7 +6030,7 @@ export const listServiceTemplateVersions: API.PaginatedOperationMethod<
   ListServiceTemplateVersionsInput,
   ListServiceTemplateVersionsOutput,
   ListServiceTemplateVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceTemplateVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceTemplateVersionsInput,
@@ -6069,7 +6068,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -6110,7 +6109,7 @@ export const notifyResourceDeploymentStatusChange: API.OperationMethod<
   NotifyResourceDeploymentStatusChangeInput,
   NotifyResourceDeploymentStatusChangeOutput,
   NotifyResourceDeploymentStatusChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyResourceDeploymentStatusChangeInput,
   output: NotifyResourceDeploymentStatusChangeOutput,
@@ -6151,7 +6150,7 @@ export const rejectEnvironmentAccountConnection: API.OperationMethod<
   RejectEnvironmentAccountConnectionInput,
   RejectEnvironmentAccountConnectionOutput,
   RejectEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectEnvironmentAccountConnectionInput,
   output: RejectEnvironmentAccountConnectionOutput,
@@ -6186,7 +6185,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -6221,7 +6220,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -6252,7 +6251,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsInput,
   UpdateAccountSettingsOutput,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsInput,
   output: UpdateAccountSettingsOutput,
@@ -6293,7 +6292,7 @@ export const updateComponent: API.OperationMethod<
   UpdateComponentInput,
   UpdateComponentOutput,
   UpdateComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComponentInput,
   output: UpdateComponentOutput,
@@ -6368,7 +6367,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentInput,
   UpdateEnvironmentOutput,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentInput,
   output: UpdateEnvironmentOutput,
@@ -6403,7 +6402,7 @@ export const updateEnvironmentAccountConnection: API.OperationMethod<
   UpdateEnvironmentAccountConnectionInput,
   UpdateEnvironmentAccountConnectionOutput,
   UpdateEnvironmentAccountConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentAccountConnectionInput,
   output: UpdateEnvironmentAccountConnectionOutput,
@@ -6435,7 +6434,7 @@ export const updateEnvironmentTemplate: API.OperationMethod<
   UpdateEnvironmentTemplateInput,
   UpdateEnvironmentTemplateOutput,
   UpdateEnvironmentTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentTemplateInput,
   output: UpdateEnvironmentTemplateOutput,
@@ -6467,7 +6466,7 @@ export const updateEnvironmentTemplateVersion: API.OperationMethod<
   UpdateEnvironmentTemplateVersionInput,
   UpdateEnvironmentTemplateVersionOutput,
   UpdateEnvironmentTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentTemplateVersionInput,
   output: UpdateEnvironmentTemplateVersionOutput,
@@ -6514,7 +6513,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceInput,
   UpdateServiceOutput,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceInput,
   output: UpdateServiceOutput,
@@ -6557,7 +6556,7 @@ export const updateServiceInstance: API.OperationMethod<
   UpdateServiceInstanceInput,
   UpdateServiceInstanceOutput,
   UpdateServiceInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceInstanceInput,
   output: UpdateServiceInstanceOutput,
@@ -6616,7 +6615,7 @@ export const updateServicePipeline: API.OperationMethod<
   UpdateServicePipelineInput,
   UpdateServicePipelineOutput,
   UpdateServicePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServicePipelineInput,
   output: UpdateServicePipelineOutput,
@@ -6648,7 +6647,7 @@ export const updateServiceSyncBlocker: API.OperationMethod<
   UpdateServiceSyncBlockerInput,
   UpdateServiceSyncBlockerOutput,
   UpdateServiceSyncBlockerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSyncBlockerInput,
   output: UpdateServiceSyncBlockerOutput,
@@ -6680,7 +6679,7 @@ export const updateServiceSyncConfig: API.OperationMethod<
   UpdateServiceSyncConfigInput,
   UpdateServiceSyncConfigOutput,
   UpdateServiceSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSyncConfigInput,
   output: UpdateServiceSyncConfigOutput,
@@ -6712,7 +6711,7 @@ export const updateServiceTemplate: API.OperationMethod<
   UpdateServiceTemplateInput,
   UpdateServiceTemplateOutput,
   UpdateServiceTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceTemplateInput,
   output: UpdateServiceTemplateOutput,
@@ -6744,7 +6743,7 @@ export const updateServiceTemplateVersion: API.OperationMethod<
   UpdateServiceTemplateVersionInput,
   UpdateServiceTemplateVersionOutput,
   UpdateServiceTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceTemplateVersionInput,
   output: UpdateServiceTemplateVersionOutput,
@@ -6778,7 +6777,7 @@ export const updateTemplateSyncConfig: API.OperationMethod<
   UpdateTemplateSyncConfigInput,
   UpdateTemplateSyncConfigOutput,
   UpdateTemplateSyncConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateSyncConfigInput,
   output: UpdateTemplateSyncConfigOutput,

--- a/packages/aws/src/services/qapps.ts
+++ b/packages/aws/src/services/qapps.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "QApps",
   serviceShapeName: "QAppsService",
@@ -2256,7 +2255,7 @@ export const associateLibraryItemReview: API.OperationMethod<
   AssociateLibraryItemReviewInput,
   AssociateLibraryItemReviewResponse,
   AssociateLibraryItemReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLibraryItemReviewInput,
   output: AssociateLibraryItemReviewResponse,
@@ -2291,7 +2290,7 @@ export const associateQAppWithUser: API.OperationMethod<
   AssociateQAppWithUserInput,
   AssociateQAppWithUserResponse,
   AssociateQAppWithUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateQAppWithUserInput,
   output: AssociateQAppWithUserResponse,
@@ -2325,7 +2324,7 @@ export const batchCreateCategory: API.OperationMethod<
   BatchCreateCategoryInput,
   BatchCreateCategoryResponse,
   BatchCreateCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateCategoryInput,
   output: BatchCreateCategoryResponse,
@@ -2359,7 +2358,7 @@ export const batchDeleteCategory: API.OperationMethod<
   BatchDeleteCategoryInput,
   BatchDeleteCategoryResponse,
   BatchDeleteCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteCategoryInput,
   output: BatchDeleteCategoryResponse,
@@ -2393,7 +2392,7 @@ export const batchUpdateCategory: API.OperationMethod<
   BatchUpdateCategoryInput,
   BatchUpdateCategoryResponse,
   BatchUpdateCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateCategoryInput,
   output: BatchUpdateCategoryResponse,
@@ -2427,7 +2426,7 @@ export const createLibraryItem: API.OperationMethod<
   CreateLibraryItemInput,
   CreateLibraryItemOutput,
   CreateLibraryItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLibraryItemInput,
   output: CreateLibraryItemOutput,
@@ -2461,7 +2460,7 @@ export const createPresignedUrl: API.OperationMethod<
   CreatePresignedUrlInput,
   CreatePresignedUrlOutput,
   CreatePresignedUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedUrlInput,
   output: CreatePresignedUrlOutput,
@@ -2494,7 +2493,7 @@ export const createQApp: API.OperationMethod<
   CreateQAppInput,
   CreateQAppOutput,
   CreateQAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQAppInput,
   output: CreateQAppOutput,
@@ -2529,7 +2528,7 @@ export const deleteLibraryItem: API.OperationMethod<
   DeleteLibraryItemInput,
   DeleteLibraryItemResponse,
   DeleteLibraryItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLibraryItemInput,
   output: DeleteLibraryItemResponse,
@@ -2562,7 +2561,7 @@ export const deleteQApp: API.OperationMethod<
   DeleteQAppInput,
   DeleteQAppResponse,
   DeleteQAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQAppInput,
   output: DeleteQAppResponse,
@@ -2594,7 +2593,7 @@ export const describeQAppPermissions: API.OperationMethod<
   DescribeQAppPermissionsInput,
   DescribeQAppPermissionsOutput,
   DescribeQAppPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQAppPermissionsInput,
   output: DescribeQAppPermissionsOutput,
@@ -2628,7 +2627,7 @@ export const disassociateLibraryItemReview: API.OperationMethod<
   DisassociateLibraryItemReviewInput,
   DisassociateLibraryItemReviewResponse,
   DisassociateLibraryItemReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLibraryItemReviewInput,
   output: DisassociateLibraryItemReviewResponse,
@@ -2662,7 +2661,7 @@ export const disassociateQAppFromUser: API.OperationMethod<
   DisassociateQAppFromUserInput,
   DisassociateQAppFromUserResponse,
   DisassociateQAppFromUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateQAppFromUserInput,
   output: DisassociateQAppFromUserResponse,
@@ -2696,7 +2695,7 @@ export const exportQAppSessionData: API.OperationMethod<
   ExportQAppSessionDataInput,
   ExportQAppSessionDataOutput,
   ExportQAppSessionDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportQAppSessionDataInput,
   output: ExportQAppSessionDataOutput,
@@ -2730,7 +2729,7 @@ export const getLibraryItem: API.OperationMethod<
   GetLibraryItemInput,
   GetLibraryItemOutput,
   GetLibraryItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLibraryItemInput,
   output: GetLibraryItemOutput,
@@ -2762,7 +2761,7 @@ export const getQApp: API.OperationMethod<
   GetQAppInput,
   GetQAppOutput,
   GetQAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQAppInput,
   output: GetQAppOutput,
@@ -2795,7 +2794,7 @@ export const getQAppSession: API.OperationMethod<
   GetQAppSessionInput,
   GetQAppSessionOutput,
   GetQAppSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQAppSessionInput,
   output: GetQAppSessionOutput,
@@ -2829,7 +2828,7 @@ export const getQAppSessionMetadata: API.OperationMethod<
   GetQAppSessionMetadataInput,
   GetQAppSessionMetadataOutput,
   GetQAppSessionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQAppSessionMetadataInput,
   output: GetQAppSessionMetadataOutput,
@@ -2864,7 +2863,7 @@ export const importDocument: API.OperationMethod<
   ImportDocumentInput,
   ImportDocumentOutput,
   ImportDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportDocumentInput,
   output: ImportDocumentOutput,
@@ -2898,7 +2897,7 @@ export const listCategories: API.OperationMethod<
   ListCategoriesInput,
   ListCategoriesOutput,
   ListCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListCategoriesInput,
   output: ListCategoriesOutput,
@@ -2930,7 +2929,7 @@ export const listLibraryItems: API.PaginatedOperationMethod<
   ListLibraryItemsInput,
   ListLibraryItemsOutput,
   ListLibraryItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LibraryItemMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLibraryItemsInput,
@@ -2968,7 +2967,7 @@ export const listQApps: API.PaginatedOperationMethod<
   ListQAppsInput,
   ListQAppsOutput,
   ListQAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserAppItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQAppsInput,
@@ -3007,7 +3006,7 @@ export const listQAppSessionData: API.OperationMethod<
   ListQAppSessionDataInput,
   ListQAppSessionDataOutput,
   ListQAppSessionDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListQAppSessionDataInput,
   output: ListQAppSessionDataOutput,
@@ -3039,7 +3038,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3069,7 +3068,7 @@ export const predictQApp: API.OperationMethod<
   PredictQAppInput,
   PredictQAppOutput,
   PredictQAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PredictQAppInput,
   output: PredictQAppOutput,
@@ -3103,7 +3102,7 @@ export const startQAppSession: API.OperationMethod<
   StartQAppSessionInput,
   StartQAppSessionOutput,
   StartQAppSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQAppSessionInput,
   output: StartQAppSessionOutput,
@@ -3137,7 +3136,7 @@ export const stopQAppSession: API.OperationMethod<
   StopQAppSessionInput,
   StopQAppSessionResponse,
   StopQAppSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopQAppSessionInput,
   output: StopQAppSessionResponse,
@@ -3170,7 +3169,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3201,7 +3200,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3233,7 +3232,7 @@ export const updateLibraryItem: API.OperationMethod<
   UpdateLibraryItemInput,
   UpdateLibraryItemOutput,
   UpdateLibraryItemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLibraryItemInput,
   output: UpdateLibraryItemOutput,
@@ -3267,7 +3266,7 @@ export const updateLibraryItemMetadata: API.OperationMethod<
   UpdateLibraryItemMetadataInput,
   UpdateLibraryItemMetadataResponse,
   UpdateLibraryItemMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLibraryItemMetadataInput,
   output: UpdateLibraryItemMetadataResponse,
@@ -3301,7 +3300,7 @@ export const updateQApp: API.OperationMethod<
   UpdateQAppInput,
   UpdateQAppOutput,
   UpdateQAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQAppInput,
   output: UpdateQAppOutput,
@@ -3334,7 +3333,7 @@ export const updateQAppPermissions: API.OperationMethod<
   UpdateQAppPermissionsInput,
   UpdateQAppPermissionsOutput,
   UpdateQAppPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQAppPermissionsInput,
   output: UpdateQAppPermissionsOutput,
@@ -3367,7 +3366,7 @@ export const updateQAppSession: API.OperationMethod<
   UpdateQAppSessionInput,
   UpdateQAppSessionOutput,
   UpdateQAppSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQAppSessionInput,
   output: UpdateQAppSessionOutput,
@@ -3401,7 +3400,7 @@ export const updateQAppSessionMetadata: API.OperationMethod<
   UpdateQAppSessionMetadataInput,
   UpdateQAppSessionMetadataOutput,
   UpdateQAppSessionMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQAppSessionMetadataInput,
   output: UpdateQAppSessionMetadataOutput,

--- a/packages/aws/src/services/qbusiness.ts
+++ b/packages/aws/src/services/qbusiness.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "QBusiness",
@@ -6225,7 +6224,7 @@ export const associatePermission: API.OperationMethod<
   AssociatePermissionRequest,
   AssociatePermissionResponse,
   AssociatePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePermissionRequest,
   output: AssociatePermissionResponse,
@@ -6260,7 +6259,7 @@ export const batchDeleteDocument: API.OperationMethod<
   BatchDeleteDocumentRequest,
   BatchDeleteDocumentResponse,
   BatchDeleteDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteDocumentRequest,
   output: BatchDeleteDocumentResponse,
@@ -6303,7 +6302,7 @@ export const batchPutDocument: API.OperationMethod<
   BatchPutDocumentRequest,
   BatchPutDocumentResponse,
   BatchPutDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutDocumentRequest,
   output: BatchPutDocumentResponse,
@@ -6335,7 +6334,7 @@ export const cancelSubscription: API.OperationMethod<
   CancelSubscriptionRequest,
   CancelSubscriptionResponse,
   CancelSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSubscriptionRequest,
   output: CancelSubscriptionResponse,
@@ -6368,7 +6367,7 @@ export const chat: API.OperationMethod<
   ChatInput,
   ChatOutput,
   ChatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChatInput,
   output: ChatOutput,
@@ -6404,7 +6403,7 @@ export const chatSync: API.OperationMethod<
   ChatSyncInput,
   ChatSyncOutput,
   ChatSyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChatSyncInput,
   output: ChatSyncOutput,
@@ -6437,7 +6436,7 @@ export const checkDocumentAccess: API.OperationMethod<
   CheckDocumentAccessRequest,
   CheckDocumentAccessResponse,
   CheckDocumentAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckDocumentAccessRequest,
   output: CheckDocumentAccessResponse,
@@ -6468,7 +6467,7 @@ export const createAnonymousWebExperienceUrl: API.OperationMethod<
   CreateAnonymousWebExperienceUrlRequest,
   CreateAnonymousWebExperienceUrlResponse,
   CreateAnonymousWebExperienceUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnonymousWebExperienceUrlRequest,
   output: CreateAnonymousWebExperienceUrlResponse,
@@ -6507,7 +6506,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -6541,7 +6540,7 @@ export const createChatResponseConfiguration: API.OperationMethod<
   CreateChatResponseConfigurationRequest,
   CreateChatResponseConfigurationResponse,
   CreateChatResponseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChatResponseConfigurationRequest,
   output: CreateChatResponseConfigurationResponse,
@@ -6575,7 +6574,7 @@ export const createDataAccessor: API.OperationMethod<
   CreateDataAccessorRequest,
   CreateDataAccessorResponse,
   CreateDataAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataAccessorRequest,
   output: CreateDataAccessorResponse,
@@ -6611,7 +6610,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceRequest,
   CreateDataSourceResponse,
   CreateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceRequest,
   output: CreateDataSourceResponse,
@@ -6649,7 +6648,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexRequest,
   CreateIndexResponse,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexRequest,
   output: CreateIndexResponse,
@@ -6683,7 +6682,7 @@ export const createPlugin: API.OperationMethod<
   CreatePluginRequest,
   CreatePluginResponse,
   CreatePluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePluginRequest,
   output: CreatePluginResponse,
@@ -6717,7 +6716,7 @@ export const createRetriever: API.OperationMethod<
   CreateRetrieverRequest,
   CreateRetrieverResponse,
   CreateRetrieverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRetrieverRequest,
   output: CreateRetrieverResponse,
@@ -6754,7 +6753,7 @@ export const createSubscription: API.OperationMethod<
   CreateSubscriptionRequest,
   CreateSubscriptionResponse,
   CreateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionRequest,
   output: CreateSubscriptionResponse,
@@ -6787,7 +6786,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -6821,7 +6820,7 @@ export const createWebExperience: API.OperationMethod<
   CreateWebExperienceRequest,
   CreateWebExperienceResponse,
   CreateWebExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebExperienceRequest,
   output: CreateWebExperienceResponse,
@@ -6854,7 +6853,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -6886,7 +6885,7 @@ export const deleteAttachment: API.OperationMethod<
   DeleteAttachmentRequest,
   DeleteAttachmentResponse,
   DeleteAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttachmentRequest,
   output: DeleteAttachmentResponse,
@@ -6917,7 +6916,7 @@ export const deleteChatControlsConfiguration: API.OperationMethod<
   DeleteChatControlsConfigurationRequest,
   DeleteChatControlsConfigurationResponse,
   DeleteChatControlsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChatControlsConfigurationRequest,
   output: DeleteChatControlsConfigurationResponse,
@@ -6948,7 +6947,7 @@ export const deleteChatResponseConfiguration: API.OperationMethod<
   DeleteChatResponseConfigurationRequest,
   DeleteChatResponseConfigurationResponse,
   DeleteChatResponseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChatResponseConfigurationRequest,
   output: DeleteChatResponseConfigurationResponse,
@@ -6981,7 +6980,7 @@ export const deleteConversation: API.OperationMethod<
   DeleteConversationRequest,
   DeleteConversationResponse,
   DeleteConversationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConversationRequest,
   output: DeleteConversationResponse,
@@ -7014,7 +7013,7 @@ export const deleteDataAccessor: API.OperationMethod<
   DeleteDataAccessorRequest,
   DeleteDataAccessorResponse,
   DeleteDataAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataAccessorRequest,
   output: DeleteDataAccessorResponse,
@@ -7046,7 +7045,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -7080,7 +7079,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -7112,7 +7111,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexRequest,
   DeleteIndexResponse,
   DeleteIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexRequest,
   output: DeleteIndexResponse,
@@ -7144,7 +7143,7 @@ export const deletePlugin: API.OperationMethod<
   DeletePluginRequest,
   DeletePluginResponse,
   DeletePluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePluginRequest,
   output: DeletePluginResponse,
@@ -7176,7 +7175,7 @@ export const deleteRetriever: API.OperationMethod<
   DeleteRetrieverRequest,
   DeleteRetrieverResponse,
   DeleteRetrieverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRetrieverRequest,
   output: DeleteRetrieverResponse,
@@ -7208,7 +7207,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -7240,7 +7239,7 @@ export const deleteWebExperience: API.OperationMethod<
   DeleteWebExperienceRequest,
   DeleteWebExperienceResponse,
   DeleteWebExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebExperienceRequest,
   output: DeleteWebExperienceResponse,
@@ -7272,7 +7271,7 @@ export const disassociatePermission: API.OperationMethod<
   DisassociatePermissionRequest,
   DisassociatePermissionResponse,
   DisassociatePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePermissionRequest,
   output: DisassociatePermissionResponse,
@@ -7303,7 +7302,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -7333,7 +7332,7 @@ export const getChatControlsConfiguration: API.PaginatedOperationMethod<
   GetChatControlsConfigurationRequest,
   GetChatControlsConfigurationResponse,
   GetChatControlsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetChatControlsConfigurationRequest,
@@ -7370,7 +7369,7 @@ export const getChatResponseConfiguration: API.OperationMethod<
   GetChatResponseConfigurationRequest,
   GetChatResponseConfigurationResponse,
   GetChatResponseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChatResponseConfigurationRequest,
   output: GetChatResponseConfigurationResponse,
@@ -7400,7 +7399,7 @@ export const getDataAccessor: API.OperationMethod<
   GetDataAccessorRequest,
   GetDataAccessorResponse,
   GetDataAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAccessorRequest,
   output: GetDataAccessorResponse,
@@ -7430,7 +7429,7 @@ export const getDataSource: API.OperationMethod<
   GetDataSourceRequest,
   GetDataSourceResponse,
   GetDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataSourceRequest,
   output: GetDataSourceResponse,
@@ -7460,7 +7459,7 @@ export const getDocumentContent: API.OperationMethod<
   GetDocumentContentRequest,
   GetDocumentContentResponse,
   GetDocumentContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentContentRequest,
   output: GetDocumentContentResponse,
@@ -7491,7 +7490,7 @@ export const getGroup: API.OperationMethod<
   GetGroupRequest,
   GetGroupResponse,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupRequest,
   output: GetGroupResponse,
@@ -7522,7 +7521,7 @@ export const getIndex: API.OperationMethod<
   GetIndexRequest,
   GetIndexResponse,
   GetIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexRequest,
   output: GetIndexResponse,
@@ -7556,7 +7555,7 @@ export const getMedia: API.OperationMethod<
   GetMediaRequest,
   GetMediaResponse,
   GetMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaRequest,
   output: GetMediaResponse,
@@ -7588,7 +7587,7 @@ export const getPlugin: API.OperationMethod<
   GetPluginRequest,
   GetPluginResponse,
   GetPluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPluginRequest,
   output: GetPluginResponse,
@@ -7618,7 +7617,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -7648,7 +7647,7 @@ export const getRetriever: API.OperationMethod<
   GetRetrieverRequest,
   GetRetrieverResponse,
   GetRetrieverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRetrieverRequest,
   output: GetRetrieverResponse,
@@ -7679,7 +7678,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -7710,7 +7709,7 @@ export const getWebExperience: API.OperationMethod<
   GetWebExperienceRequest,
   GetWebExperienceResponse,
   GetWebExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebExperienceRequest,
   output: GetWebExperienceResponse,
@@ -7741,7 +7740,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Application
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -7778,7 +7777,7 @@ export const listAttachments: API.PaginatedOperationMethod<
   ListAttachmentsRequest,
   ListAttachmentsResponse,
   ListAttachmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Attachment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttachmentsRequest,
@@ -7816,7 +7815,7 @@ export const listChatResponseConfigurations: API.PaginatedOperationMethod<
   ListChatResponseConfigurationsRequest,
   ListChatResponseConfigurationsResponse,
   ListChatResponseConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChatResponseConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChatResponseConfigurationsRequest,
@@ -7854,7 +7853,7 @@ export const listConversations: API.PaginatedOperationMethod<
   ListConversationsRequest,
   ListConversationsResponse,
   ListConversationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Conversation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConversationsRequest,
@@ -7892,7 +7891,7 @@ export const listDataAccessors: API.PaginatedOperationMethod<
   ListDataAccessorsRequest,
   ListDataAccessorsResponse,
   ListDataAccessorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataAccessor
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataAccessorsRequest,
@@ -7929,7 +7928,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesRequest,
@@ -7967,7 +7966,7 @@ export const listDataSourceSyncJobs: API.PaginatedOperationMethod<
   ListDataSourceSyncJobsRequest,
   ListDataSourceSyncJobsResponse,
   ListDataSourceSyncJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceSyncJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourceSyncJobsRequest,
@@ -8005,7 +8004,7 @@ export const listDocuments: API.PaginatedOperationMethod<
   ListDocumentsRequest,
   ListDocumentsResponse,
   ListDocumentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DocumentDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentsRequest,
@@ -8043,7 +8042,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -8081,7 +8080,7 @@ export const listIndices: API.PaginatedOperationMethod<
   ListIndicesRequest,
   ListIndicesResponse,
   ListIndicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Index
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndicesRequest,
@@ -8119,7 +8118,7 @@ export const listMessages: API.PaginatedOperationMethod<
   ListMessagesRequest,
   ListMessagesResponse,
   ListMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Message
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMessagesRequest,
@@ -8157,7 +8156,7 @@ export const listPluginActions: API.PaginatedOperationMethod<
   ListPluginActionsRequest,
   ListPluginActionsResponse,
   ListPluginActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPluginActionsRequest,
@@ -8194,7 +8193,7 @@ export const listPlugins: API.PaginatedOperationMethod<
   ListPluginsRequest,
   ListPluginsResponse,
   ListPluginsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Plugin
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPluginsRequest,
@@ -8230,7 +8229,7 @@ export const listPluginTypeActions: API.PaginatedOperationMethod<
   ListPluginTypeActionsRequest,
   ListPluginTypeActionsResponse,
   ListPluginTypeActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPluginTypeActionsRequest,
@@ -8265,7 +8264,7 @@ export const listPluginTypeMetadata: API.PaginatedOperationMethod<
   ListPluginTypeMetadataRequest,
   ListPluginTypeMetadataResponse,
   ListPluginTypeMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PluginTypeMetadataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPluginTypeMetadataRequest,
@@ -8301,7 +8300,7 @@ export const listRetrievers: API.PaginatedOperationMethod<
   ListRetrieversRequest,
   ListRetrieversResponse,
   ListRetrieversError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Retriever
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRetrieversRequest,
@@ -8339,7 +8338,7 @@ export const listSubscriptions: API.PaginatedOperationMethod<
   ListSubscriptionsRequest,
   ListSubscriptionsResponse,
   ListSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsRequest,
@@ -8377,7 +8376,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8407,7 +8406,7 @@ export const listWebExperiences: API.PaginatedOperationMethod<
   ListWebExperiencesRequest,
   ListWebExperiencesResponse,
   ListWebExperiencesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WebExperience
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWebExperiencesRequest,
@@ -8444,7 +8443,7 @@ export const putFeedback: API.OperationMethod<
   PutFeedbackRequest,
   PutFeedbackResponse,
   PutFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFeedbackRequest,
   output: PutFeedbackResponse,
@@ -8480,7 +8479,7 @@ export const putGroup: API.OperationMethod<
   PutGroupRequest,
   PutGroupResponse,
   PutGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGroupRequest,
   output: PutGroupResponse,
@@ -8513,7 +8512,7 @@ export const searchRelevantContent: API.PaginatedOperationMethod<
   SearchRelevantContentRequest,
   SearchRelevantContentResponse,
   SearchRelevantContentError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RelevantContent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchRelevantContentRequest,
@@ -8553,7 +8552,7 @@ export const startDataSourceSyncJob: API.OperationMethod<
   StartDataSourceSyncJobRequest,
   StartDataSourceSyncJobResponse,
   StartDataSourceSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDataSourceSyncJobRequest,
   output: StartDataSourceSyncJobResponse,
@@ -8586,7 +8585,7 @@ export const stopDataSourceSyncJob: API.OperationMethod<
   StopDataSourceSyncJobRequest,
   StopDataSourceSyncJobResponse,
   StopDataSourceSyncJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDataSourceSyncJobRequest,
   output: StopDataSourceSyncJobResponse,
@@ -8618,7 +8617,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8649,7 +8648,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8684,7 +8683,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -8717,7 +8716,7 @@ export const updateChatControlsConfiguration: API.OperationMethod<
   UpdateChatControlsConfigurationRequest,
   UpdateChatControlsConfigurationResponse,
   UpdateChatControlsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChatControlsConfigurationRequest,
   output: UpdateChatControlsConfigurationResponse,
@@ -8750,7 +8749,7 @@ export const updateChatResponseConfiguration: API.OperationMethod<
   UpdateChatResponseConfigurationRequest,
   UpdateChatResponseConfigurationResponse,
   UpdateChatResponseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChatResponseConfigurationRequest,
   output: UpdateChatResponseConfigurationResponse,
@@ -8782,7 +8781,7 @@ export const updateDataAccessor: API.OperationMethod<
   UpdateDataAccessorRequest,
   UpdateDataAccessorResponse,
   UpdateDataAccessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataAccessorRequest,
   output: UpdateDataAccessorResponse,
@@ -8814,7 +8813,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -8847,7 +8846,7 @@ export const updateIndex: API.OperationMethod<
   UpdateIndexRequest,
   UpdateIndexResponse,
   UpdateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexRequest,
   output: UpdateIndexResponse,
@@ -8881,7 +8880,7 @@ export const updatePlugin: API.OperationMethod<
   UpdatePluginRequest,
   UpdatePluginResponse,
   UpdatePluginError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePluginRequest,
   output: UpdatePluginResponse,
@@ -8915,7 +8914,7 @@ export const updateRetriever: API.OperationMethod<
   UpdateRetrieverRequest,
   UpdateRetrieverResponse,
   UpdateRetrieverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRetrieverRequest,
   output: UpdateRetrieverResponse,
@@ -8948,7 +8947,7 @@ export const updateSubscription: API.OperationMethod<
   UpdateSubscriptionRequest,
   UpdateSubscriptionResponse,
   UpdateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionRequest,
   output: UpdateSubscriptionResponse,
@@ -8981,7 +8980,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,
@@ -9014,7 +9013,7 @@ export const updateWebExperience: API.OperationMethod<
   UpdateWebExperienceRequest,
   UpdateWebExperienceResponse,
   UpdateWebExperienceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebExperienceRequest,
   output: UpdateWebExperienceResponse,

--- a/packages/aws/src/services/qconnect.ts
+++ b/packages/aws/src/services/qconnect.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "QConnect",
@@ -8023,7 +8022,7 @@ export const activateMessageTemplate: API.OperationMethod<
   ActivateMessageTemplateRequest,
   ActivateMessageTemplateResponse,
   ActivateMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateMessageTemplateRequest,
   output: ActivateMessageTemplateResponse,
@@ -8055,7 +8054,7 @@ export const createAIAgent: API.OperationMethod<
   CreateAIAgentRequest,
   CreateAIAgentResponse,
   CreateAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIAgentRequest,
   output: CreateAIAgentResponse,
@@ -8089,7 +8088,7 @@ export const createAIAgentVersion: API.OperationMethod<
   CreateAIAgentVersionRequest,
   CreateAIAgentVersionResponse,
   CreateAIAgentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIAgentVersionRequest,
   output: CreateAIAgentVersionResponse,
@@ -8123,7 +8122,7 @@ export const createAIGuardrail: API.OperationMethod<
   CreateAIGuardrailRequest,
   CreateAIGuardrailResponse,
   CreateAIGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIGuardrailRequest,
   output: CreateAIGuardrailResponse,
@@ -8157,7 +8156,7 @@ export const createAIGuardrailVersion: API.OperationMethod<
   CreateAIGuardrailVersionRequest,
   CreateAIGuardrailVersionResponse,
   CreateAIGuardrailVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIGuardrailVersionRequest,
   output: CreateAIGuardrailVersionResponse,
@@ -8191,7 +8190,7 @@ export const createAIPrompt: API.OperationMethod<
   CreateAIPromptRequest,
   CreateAIPromptResponse,
   CreateAIPromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIPromptRequest,
   output: CreateAIPromptResponse,
@@ -8225,7 +8224,7 @@ export const createAIPromptVersion: API.OperationMethod<
   CreateAIPromptVersionRequest,
   CreateAIPromptVersionResponse,
   CreateAIPromptVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIPromptVersionRequest,
   output: CreateAIPromptVersionResponse,
@@ -8257,7 +8256,7 @@ export const createAssistant: API.OperationMethod<
   CreateAssistantRequest,
   CreateAssistantResponse,
   CreateAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssistantRequest,
   output: CreateAssistantResponse,
@@ -8287,7 +8286,7 @@ export const createAssistantAssociation: API.OperationMethod<
   CreateAssistantAssociationRequest,
   CreateAssistantAssociationResponse,
   CreateAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssistantAssociationRequest,
   output: CreateAssistantAssociationResponse,
@@ -8318,7 +8317,7 @@ export const createContent: API.OperationMethod<
   CreateContentRequest,
   CreateContentResponse,
   CreateContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContentRequest,
   output: CreateContentResponse,
@@ -8361,7 +8360,7 @@ export const createContentAssociation: API.OperationMethod<
   CreateContentAssociationRequest,
   CreateContentAssociationResponse,
   CreateContentAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContentAssociationRequest,
   output: CreateContentAssociationResponse,
@@ -8405,7 +8404,7 @@ export const createKnowledgeBase: API.OperationMethod<
   CreateKnowledgeBaseRequest,
   CreateKnowledgeBaseResponse,
   CreateKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKnowledgeBaseRequest,
   output: CreateKnowledgeBaseResponse,
@@ -8436,7 +8435,7 @@ export const createMessageTemplate: API.OperationMethod<
   CreateMessageTemplateRequest,
   CreateMessageTemplateResponse,
   CreateMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMessageTemplateRequest,
   output: CreateMessageTemplateResponse,
@@ -8469,7 +8468,7 @@ export const createMessageTemplateAttachment: API.OperationMethod<
   CreateMessageTemplateAttachmentRequest,
   CreateMessageTemplateAttachmentResponse,
   CreateMessageTemplateAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMessageTemplateAttachmentRequest,
   output: CreateMessageTemplateAttachmentResponse,
@@ -8502,7 +8501,7 @@ export const createMessageTemplateVersion: API.OperationMethod<
   CreateMessageTemplateVersionRequest,
   CreateMessageTemplateVersionResponse,
   CreateMessageTemplateVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMessageTemplateVersionRequest,
   output: CreateMessageTemplateVersionResponse,
@@ -8534,7 +8533,7 @@ export const createQuickResponse: API.OperationMethod<
   CreateQuickResponseRequest,
   CreateQuickResponseResponse,
   CreateQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuickResponseRequest,
   output: CreateQuickResponseResponse,
@@ -8566,7 +8565,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionResponse,
   CreateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionResponse,
@@ -8597,7 +8596,7 @@ export const deactivateMessageTemplate: API.OperationMethod<
   DeactivateMessageTemplateRequest,
   DeactivateMessageTemplateResponse,
   DeactivateMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateMessageTemplateRequest,
   output: DeactivateMessageTemplateResponse,
@@ -8627,7 +8626,7 @@ export const deleteAIAgent: API.OperationMethod<
   DeleteAIAgentRequest,
   DeleteAIAgentResponse,
   DeleteAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIAgentRequest,
   output: DeleteAIAgentResponse,
@@ -8658,7 +8657,7 @@ export const deleteAIAgentVersion: API.OperationMethod<
   DeleteAIAgentVersionRequest,
   DeleteAIAgentVersionResponse,
   DeleteAIAgentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIAgentVersionRequest,
   output: DeleteAIAgentVersionResponse,
@@ -8690,7 +8689,7 @@ export const deleteAIGuardrail: API.OperationMethod<
   DeleteAIGuardrailRequest,
   DeleteAIGuardrailResponse,
   DeleteAIGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIGuardrailRequest,
   output: DeleteAIGuardrailResponse,
@@ -8722,7 +8721,7 @@ export const deleteAIGuardrailVersion: API.OperationMethod<
   DeleteAIGuardrailVersionRequest,
   DeleteAIGuardrailVersionResponse,
   DeleteAIGuardrailVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIGuardrailVersionRequest,
   output: DeleteAIGuardrailVersionResponse,
@@ -8753,7 +8752,7 @@ export const deleteAIPrompt: API.OperationMethod<
   DeleteAIPromptRequest,
   DeleteAIPromptResponse,
   DeleteAIPromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIPromptRequest,
   output: DeleteAIPromptResponse,
@@ -8784,7 +8783,7 @@ export const deleteAIPromptVersion: API.OperationMethod<
   DeleteAIPromptVersionRequest,
   DeleteAIPromptVersionResponse,
   DeleteAIPromptVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIPromptVersionRequest,
   output: DeleteAIPromptVersionResponse,
@@ -8814,7 +8813,7 @@ export const deleteAssistant: API.OperationMethod<
   DeleteAssistantRequest,
   DeleteAssistantResponse,
   DeleteAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssistantRequest,
   output: DeleteAssistantResponse,
@@ -8842,7 +8841,7 @@ export const deleteAssistantAssociation: API.OperationMethod<
   DeleteAssistantAssociationRequest,
   DeleteAssistantAssociationResponse,
   DeleteAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssistantAssociationRequest,
   output: DeleteAssistantAssociationResponse,
@@ -8871,7 +8870,7 @@ export const deleteContent: API.OperationMethod<
   DeleteContentRequest,
   DeleteContentResponse,
   DeleteContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContentRequest,
   output: DeleteContentResponse,
@@ -8902,7 +8901,7 @@ export const deleteContentAssociation: API.OperationMethod<
   DeleteContentAssociationRequest,
   DeleteContentAssociationResponse,
   DeleteContentAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContentAssociationRequest,
   output: DeleteContentAssociationResponse,
@@ -8931,7 +8930,7 @@ export const deleteImportJob: API.OperationMethod<
   DeleteImportJobRequest,
   DeleteImportJobResponse,
   DeleteImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImportJobRequest,
   output: DeleteImportJobResponse,
@@ -8963,7 +8962,7 @@ export const deleteKnowledgeBase: API.OperationMethod<
   DeleteKnowledgeBaseRequest,
   DeleteKnowledgeBaseResponse,
   DeleteKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnowledgeBaseRequest,
   output: DeleteKnowledgeBaseResponse,
@@ -8993,7 +8992,7 @@ export const deleteMessageTemplate: API.OperationMethod<
   DeleteMessageTemplateRequest,
   DeleteMessageTemplateResponse,
   DeleteMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessageTemplateRequest,
   output: DeleteMessageTemplateResponse,
@@ -9023,7 +9022,7 @@ export const deleteMessageTemplateAttachment: API.OperationMethod<
   DeleteMessageTemplateAttachmentRequest,
   DeleteMessageTemplateAttachmentResponse,
   DeleteMessageTemplateAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessageTemplateAttachmentRequest,
   output: DeleteMessageTemplateAttachmentResponse,
@@ -9052,7 +9051,7 @@ export const deleteQuickResponse: API.OperationMethod<
   DeleteQuickResponseRequest,
   DeleteQuickResponseResponse,
   DeleteQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuickResponseRequest,
   output: DeleteQuickResponseResponse,
@@ -9081,7 +9080,7 @@ export const getAIAgent: API.OperationMethod<
   GetAIAgentRequest,
   GetAIAgentResponse,
   GetAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAIAgentRequest,
   output: GetAIAgentResponse,
@@ -9111,7 +9110,7 @@ export const getAIGuardrail: API.OperationMethod<
   GetAIGuardrailRequest,
   GetAIGuardrailResponse,
   GetAIGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAIGuardrailRequest,
   output: GetAIGuardrailResponse,
@@ -9141,7 +9140,7 @@ export const getAIPrompt: API.OperationMethod<
   GetAIPromptRequest,
   GetAIPromptResponse,
   GetAIPromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAIPromptRequest,
   output: GetAIPromptResponse,
@@ -9170,7 +9169,7 @@ export const getAssistant: API.OperationMethod<
   GetAssistantRequest,
   GetAssistantResponse,
   GetAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssistantRequest,
   output: GetAssistantResponse,
@@ -9198,7 +9197,7 @@ export const getAssistantAssociation: API.OperationMethod<
   GetAssistantAssociationRequest,
   GetAssistantAssociationResponse,
   GetAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssistantAssociationRequest,
   output: GetAssistantAssociationResponse,
@@ -9226,7 +9225,7 @@ export const getContent: API.OperationMethod<
   GetContentRequest,
   GetContentResponse,
   GetContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContentRequest,
   output: GetContentResponse,
@@ -9256,7 +9255,7 @@ export const getContentAssociation: API.OperationMethod<
   GetContentAssociationRequest,
   GetContentAssociationResponse,
   GetContentAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContentAssociationRequest,
   output: GetContentAssociationResponse,
@@ -9284,7 +9283,7 @@ export const getContentSummary: API.OperationMethod<
   GetContentSummaryRequest,
   GetContentSummaryResponse,
   GetContentSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContentSummaryRequest,
   output: GetContentSummaryResponse,
@@ -9311,7 +9310,7 @@ export const getImportJob: API.OperationMethod<
   GetImportJobRequest,
   GetImportJobResponse,
   GetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportJobRequest,
   output: GetImportJobResponse,
@@ -9338,7 +9337,7 @@ export const getKnowledgeBase: API.OperationMethod<
   GetKnowledgeBaseRequest,
   GetKnowledgeBaseResponse,
   GetKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKnowledgeBaseRequest,
   output: GetKnowledgeBaseResponse,
@@ -9367,7 +9366,7 @@ export const getMessageTemplate: API.OperationMethod<
   GetMessageTemplateRequest,
   GetMessageTemplateResponse,
   GetMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMessageTemplateRequest,
   output: GetMessageTemplateResponse,
@@ -9396,7 +9395,7 @@ export const getNextMessage: API.OperationMethod<
   GetNextMessageRequest,
   GetNextMessageResponse,
   GetNextMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNextMessageRequest,
   output: GetNextMessageResponse,
@@ -9424,7 +9423,7 @@ export const getQuickResponse: API.OperationMethod<
   GetQuickResponseRequest,
   GetQuickResponseResponse,
   GetQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuickResponseRequest,
   output: GetQuickResponseResponse,
@@ -9453,7 +9452,7 @@ export const getRecommendations: API.OperationMethod<
   GetRecommendationsRequest,
   GetRecommendationsResponse,
   GetRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationsRequest,
   output: GetRecommendationsResponse,
@@ -9480,7 +9479,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -9509,7 +9508,7 @@ export const listAIAgents: API.PaginatedOperationMethod<
   ListAIAgentsRequest,
   ListAIAgentsResponse,
   ListAIAgentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIAgentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIAgentsRequest,
@@ -9546,7 +9545,7 @@ export const listAIAgentVersions: API.PaginatedOperationMethod<
   ListAIAgentVersionsRequest,
   ListAIAgentVersionsResponse,
   ListAIAgentVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIAgentVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIAgentVersionsRequest,
@@ -9583,7 +9582,7 @@ export const listAIGuardrails: API.PaginatedOperationMethod<
   ListAIGuardrailsRequest,
   ListAIGuardrailsResponse,
   ListAIGuardrailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIGuardrailSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIGuardrailsRequest,
@@ -9620,7 +9619,7 @@ export const listAIGuardrailVersions: API.PaginatedOperationMethod<
   ListAIGuardrailVersionsRequest,
   ListAIGuardrailVersionsResponse,
   ListAIGuardrailVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIGuardrailVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIGuardrailVersionsRequest,
@@ -9657,7 +9656,7 @@ export const listAIPrompts: API.PaginatedOperationMethod<
   ListAIPromptsRequest,
   ListAIPromptsResponse,
   ListAIPromptsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIPromptSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIPromptsRequest,
@@ -9694,7 +9693,7 @@ export const listAIPromptVersions: API.PaginatedOperationMethod<
   ListAIPromptVersionsRequest,
   ListAIPromptVersionsResponse,
   ListAIPromptVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIPromptVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIPromptVersionsRequest,
@@ -9729,7 +9728,7 @@ export const listAssistantAssociations: API.PaginatedOperationMethod<
   ListAssistantAssociationsRequest,
   ListAssistantAssociationsResponse,
   ListAssistantAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssistantAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssistantAssociationsRequest,
@@ -9762,7 +9761,7 @@ export const listAssistants: API.PaginatedOperationMethod<
   ListAssistantsRequest,
   ListAssistantsResponse,
   ListAssistantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssistantSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssistantsRequest,
@@ -9794,7 +9793,7 @@ export const listContentAssociations: API.PaginatedOperationMethod<
   ListContentAssociationsRequest,
   ListContentAssociationsResponse,
   ListContentAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContentAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContentAssociationsRequest,
@@ -9828,7 +9827,7 @@ export const listContents: API.PaginatedOperationMethod<
   ListContentsRequest,
   ListContentsResponse,
   ListContentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContentsRequest,
@@ -9860,7 +9859,7 @@ export const listImportJobs: API.PaginatedOperationMethod<
   ListImportJobsRequest,
   ListImportJobsResponse,
   ListImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportJobsRequest,
@@ -9888,7 +9887,7 @@ export const listKnowledgeBases: API.PaginatedOperationMethod<
   ListKnowledgeBasesRequest,
   ListKnowledgeBasesResponse,
   ListKnowledgeBasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKnowledgeBasesRequest,
@@ -9917,7 +9916,7 @@ export const listMessages: API.PaginatedOperationMethod<
   ListMessagesRequest,
   ListMessagesResponse,
   ListMessagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MessageOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMessagesRequest,
@@ -9951,7 +9950,7 @@ export const listMessageTemplates: API.PaginatedOperationMethod<
   ListMessageTemplatesRequest,
   ListMessageTemplatesResponse,
   ListMessageTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MessageTemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMessageTemplatesRequest,
@@ -9986,7 +9985,7 @@ export const listMessageTemplateVersions: API.PaginatedOperationMethod<
   ListMessageTemplateVersionsRequest,
   ListMessageTemplateVersionsResponse,
   ListMessageTemplateVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MessageTemplateVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMessageTemplateVersionsRequest,
@@ -10023,7 +10022,7 @@ export const listModels: API.PaginatedOperationMethod<
   ListModelsRequest,
   ListModelsResponse,
   ListModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelsRequest,
@@ -10059,7 +10058,7 @@ export const listQuickResponses: API.PaginatedOperationMethod<
   ListQuickResponsesRequest,
   ListQuickResponsesResponse,
   ListQuickResponsesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuickResponseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuickResponsesRequest,
@@ -10092,7 +10091,7 @@ export const listSpans: API.PaginatedOperationMethod<
   ListSpansRequest,
   ListSpansResponse,
   ListSpansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Span
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpansRequest,
@@ -10121,7 +10120,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -10143,7 +10142,7 @@ export const notifyRecommendationsReceived: API.OperationMethod<
   NotifyRecommendationsReceivedRequest,
   NotifyRecommendationsReceivedResponse,
   NotifyRecommendationsReceivedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyRecommendationsReceivedRequest,
   output: NotifyRecommendationsReceivedResponse,
@@ -10169,7 +10168,7 @@ export const putFeedback: API.OperationMethod<
   PutFeedbackRequest,
   PutFeedbackResponse,
   PutFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFeedbackRequest,
   output: PutFeedbackResponse,
@@ -10198,7 +10197,7 @@ export const queryAssistant: API.PaginatedOperationMethod<
   QueryAssistantRequest,
   QueryAssistantResponse,
   QueryAssistantError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResultData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryAssistantRequest,
@@ -10233,7 +10232,7 @@ export const removeAssistantAIAgent: API.OperationMethod<
   RemoveAssistantAIAgentRequest,
   RemoveAssistantAIAgentResponse,
   RemoveAssistantAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAssistantAIAgentRequest,
   output: RemoveAssistantAIAgentResponse,
@@ -10260,7 +10259,7 @@ export const removeKnowledgeBaseTemplateUri: API.OperationMethod<
   RemoveKnowledgeBaseTemplateUriRequest,
   RemoveKnowledgeBaseTemplateUriResponse,
   RemoveKnowledgeBaseTemplateUriError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveKnowledgeBaseTemplateUriRequest,
   output: RemoveKnowledgeBaseTemplateUriResponse,
@@ -10287,7 +10286,7 @@ export const renderMessageTemplate: API.OperationMethod<
   RenderMessageTemplateRequest,
   RenderMessageTemplateResponse,
   RenderMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenderMessageTemplateRequest,
   output: RenderMessageTemplateResponse,
@@ -10319,7 +10318,7 @@ export const retrieve: API.OperationMethod<
   RetrieveRequest,
   RetrieveResponse,
   RetrieveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveRequest,
   output: RetrieveResponse,
@@ -10351,7 +10350,7 @@ export const searchContent: API.PaginatedOperationMethod<
   SearchContentRequest,
   SearchContentResponse,
   SearchContentError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchContentRequest,
@@ -10387,7 +10386,7 @@ export const searchMessageTemplates: API.PaginatedOperationMethod<
   SearchMessageTemplatesRequest,
   SearchMessageTemplatesResponse,
   SearchMessageTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MessageTemplateSearchResultData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchMessageTemplatesRequest,
@@ -10424,7 +10423,7 @@ export const searchQuickResponses: API.PaginatedOperationMethod<
   SearchQuickResponsesRequest,
   SearchQuickResponsesResponse,
   SearchQuickResponsesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuickResponseSearchResultData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchQuickResponsesRequest,
@@ -10460,7 +10459,7 @@ export const searchSessions: API.PaginatedOperationMethod<
   SearchSessionsRequest,
   SearchSessionsResponse,
   SearchSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSessionsRequest,
@@ -10499,7 +10498,7 @@ export const sendMessage: API.OperationMethod<
   SendMessageRequest,
   SendMessageResponse,
   SendMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessageRequest,
   output: SendMessageResponse,
@@ -10531,7 +10530,7 @@ export const startContentUpload: API.OperationMethod<
   StartContentUploadRequest,
   StartContentUploadResponse,
   StartContentUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContentUploadRequest,
   output: StartContentUploadResponse,
@@ -10563,7 +10562,7 @@ export const startImportJob: API.OperationMethod<
   StartImportJobRequest,
   StartImportJobResponse,
   StartImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportJobRequest,
   output: StartImportJobResponse,
@@ -10591,7 +10590,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -10609,7 +10608,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -10634,7 +10633,7 @@ export const updateAIAgent: API.OperationMethod<
   UpdateAIAgentRequest,
   UpdateAIAgentResponse,
   UpdateAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAIAgentRequest,
   output: UpdateAIAgentResponse,
@@ -10666,7 +10665,7 @@ export const updateAIGuardrail: API.OperationMethod<
   UpdateAIGuardrailRequest,
   UpdateAIGuardrailResponse,
   UpdateAIGuardrailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAIGuardrailRequest,
   output: UpdateAIGuardrailResponse,
@@ -10698,7 +10697,7 @@ export const updateAIPrompt: API.OperationMethod<
   UpdateAIPromptRequest,
   UpdateAIPromptResponse,
   UpdateAIPromptError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAIPromptRequest,
   output: UpdateAIPromptResponse,
@@ -10728,7 +10727,7 @@ export const updateAssistantAIAgent: API.OperationMethod<
   UpdateAssistantAIAgentRequest,
   UpdateAssistantAIAgentResponse,
   UpdateAssistantAIAgentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssistantAIAgentRequest,
   output: UpdateAssistantAIAgentResponse,
@@ -10757,7 +10756,7 @@ export const updateContent: API.OperationMethod<
   UpdateContentRequest,
   UpdateContentResponse,
   UpdateContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContentRequest,
   output: UpdateContentResponse,
@@ -10785,7 +10784,7 @@ export const updateKnowledgeBaseTemplateUri: API.OperationMethod<
   UpdateKnowledgeBaseTemplateUriRequest,
   UpdateKnowledgeBaseTemplateUriResponse,
   UpdateKnowledgeBaseTemplateUriError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKnowledgeBaseTemplateUriRequest,
   output: UpdateKnowledgeBaseTemplateUriResponse,
@@ -10813,7 +10812,7 @@ export const updateMessageTemplate: API.OperationMethod<
   UpdateMessageTemplateRequest,
   UpdateMessageTemplateResponse,
   UpdateMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMessageTemplateRequest,
   output: UpdateMessageTemplateResponse,
@@ -10843,7 +10842,7 @@ export const updateMessageTemplateMetadata: API.OperationMethod<
   UpdateMessageTemplateMetadataRequest,
   UpdateMessageTemplateMetadataResponse,
   UpdateMessageTemplateMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMessageTemplateMetadataRequest,
   output: UpdateMessageTemplateMetadataResponse,
@@ -10874,7 +10873,7 @@ export const updateQuickResponse: API.OperationMethod<
   UpdateQuickResponseRequest,
   UpdateQuickResponseResponse,
   UpdateQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuickResponseRequest,
   output: UpdateQuickResponseResponse,
@@ -10904,7 +10903,7 @@ export const updateSession: API.OperationMethod<
   UpdateSessionRequest,
   UpdateSessionResponse,
   UpdateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSessionRequest,
   output: UpdateSessionResponse,
@@ -10932,7 +10931,7 @@ export const updateSessionData: API.OperationMethod<
   UpdateSessionDataRequest,
   UpdateSessionDataResponse,
   UpdateSessionDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSessionDataRequest,
   output: UpdateSessionDataResponse,

--- a/packages/aws/src/services/quicksight.ts
+++ b/packages/aws/src/services/quicksight.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "QuickSight",
@@ -32761,7 +32760,7 @@ export const batchCreateTopicReviewedAnswer: API.OperationMethod<
   BatchCreateTopicReviewedAnswerRequest,
   BatchCreateTopicReviewedAnswerResponse,
   BatchCreateTopicReviewedAnswerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateTopicReviewedAnswerRequest,
   output: BatchCreateTopicReviewedAnswerResponse,
@@ -32793,7 +32792,7 @@ export const batchDeleteKnowledgeBase: API.OperationMethod<
   BatchDeleteKnowledgeBaseRequest,
   BatchDeleteKnowledgeBaseResponse,
   BatchDeleteKnowledgeBaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteKnowledgeBaseRequest,
   output: BatchDeleteKnowledgeBaseResponse,
@@ -32826,7 +32825,7 @@ export const batchDeleteTopicReviewedAnswer: API.OperationMethod<
   BatchDeleteTopicReviewedAnswerRequest,
   BatchDeleteTopicReviewedAnswerResponse,
   BatchDeleteTopicReviewedAnswerError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteTopicReviewedAnswerRequest,
   output: BatchDeleteTopicReviewedAnswerResponse,
@@ -32858,7 +32857,7 @@ export const cancelIngestion: API.OperationMethod<
   CancelIngestionRequest,
   CancelIngestionResponse,
   CancelIngestionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelIngestionRequest,
   output: CancelIngestionResponse,
@@ -32915,7 +32914,7 @@ export const createAccountCustomization: API.OperationMethod<
   CreateAccountCustomizationRequest,
   CreateAccountCustomizationResponse,
   CreateAccountCustomizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountCustomizationRequest,
   output: CreateAccountCustomizationResponse,
@@ -32978,7 +32977,7 @@ export const createAccountSubscription: API.OperationMethod<
   CreateAccountSubscriptionRequest,
   CreateAccountSubscriptionResponse,
   CreateAccountSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountSubscriptionRequest,
   output: CreateAccountSubscriptionResponse,
@@ -33015,7 +33014,7 @@ export const createActionConnector: API.OperationMethod<
   CreateActionConnectorRequest,
   CreateActionConnectorResponse,
   CreateActionConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActionConnectorRequest,
   output: CreateActionConnectorResponse,
@@ -33049,7 +33048,7 @@ export const createAgent: API.OperationMethod<
   CreateAgentRequest,
   CreateAgentResponse,
   CreateAgentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentRequest,
   output: CreateAgentResponse,
@@ -33086,7 +33085,7 @@ export const createAnalysis: API.OperationMethod<
   CreateAnalysisRequest,
   CreateAnalysisResponse,
   CreateAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAnalysisRequest,
   output: CreateAnalysisResponse,
@@ -33121,7 +33120,7 @@ export const createBrand: API.OperationMethod<
   CreateBrandRequest,
   CreateBrandResponse,
   CreateBrandError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBrandRequest,
   output: CreateBrandResponse,
@@ -33157,7 +33156,7 @@ export const createCustomPermissions: API.OperationMethod<
   CreateCustomPermissionsRequest,
   CreateCustomPermissionsResponse,
   CreateCustomPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomPermissionsRequest,
   output: CreateCustomPermissionsResponse,
@@ -33205,7 +33204,7 @@ export const createDashboard: API.OperationMethod<
   CreateDashboardRequest,
   CreateDashboardResponse,
   CreateDashboardError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDashboardRequest,
   output: CreateDashboardResponse,
@@ -33246,7 +33245,7 @@ export const createDataSet: API.OperationMethod<
   CreateDataSetRequest,
   CreateDataSetResponse,
   CreateDataSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSetRequest,
   output: CreateDataSetResponse,
@@ -33287,7 +33286,7 @@ export const createDataSource: API.OperationMethod<
   CreateDataSourceRequest,
   CreateDataSourceResponse,
   CreateDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataSourceRequest,
   output: CreateDataSourceResponse,
@@ -33327,7 +33326,7 @@ export const createFlow: API.OperationMethod<
   CreateFlowRequest,
   CreateFlowResponse,
   CreateFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowRequest,
   output: CreateFlowResponse,
@@ -33364,7 +33363,7 @@ export const createFolder: API.OperationMethod<
   CreateFolderRequest,
   CreateFolderResponse,
   CreateFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFolderRequest,
   output: CreateFolderResponse,
@@ -33401,7 +33400,7 @@ export const createFolderMembership: API.OperationMethod<
   CreateFolderMembershipRequest,
   CreateFolderMembershipResponse,
   CreateFolderMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFolderMembershipRequest,
   output: CreateFolderMembershipResponse,
@@ -33444,7 +33443,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -33480,7 +33479,7 @@ export const createGroupMembership: API.OperationMethod<
   CreateGroupMembershipRequest,
   CreateGroupMembershipResponse,
   CreateGroupMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupMembershipRequest,
   output: CreateGroupMembershipResponse,
@@ -33518,7 +33517,7 @@ export const createIAMPolicyAssignment: API.OperationMethod<
   CreateIAMPolicyAssignmentRequest,
   CreateIAMPolicyAssignmentResponse,
   CreateIAMPolicyAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIAMPolicyAssignmentRequest,
   output: CreateIAMPolicyAssignmentResponse,
@@ -33559,7 +33558,7 @@ export const createIngestion: API.OperationMethod<
   CreateIngestionRequest,
   CreateIngestionResponse,
   CreateIngestionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIngestionRequest,
   output: CreateIngestionResponse,
@@ -33604,7 +33603,7 @@ export const createNamespace: API.OperationMethod<
   CreateNamespaceRequest,
   CreateNamespaceResponse,
   CreateNamespaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNamespaceRequest,
   output: CreateNamespaceResponse,
@@ -33642,7 +33641,7 @@ export const createOAuthClientApplication: API.OperationMethod<
   CreateOAuthClientApplicationRequest,
   CreateOAuthClientApplicationResponse,
   CreateOAuthClientApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOAuthClientApplicationRequest,
   output: CreateOAuthClientApplicationResponse,
@@ -33678,7 +33677,7 @@ export const createRefreshSchedule: API.OperationMethod<
   CreateRefreshScheduleRequest,
   CreateRefreshScheduleResponse,
   CreateRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRefreshScheduleRequest,
   output: CreateRefreshScheduleResponse,
@@ -33713,7 +33712,7 @@ export const createRoleMembership: API.OperationMethod<
   CreateRoleMembershipRequest,
   CreateRoleMembershipResponse,
   CreateRoleMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoleMembershipRequest,
   output: CreateRoleMembershipResponse,
@@ -33747,7 +33746,7 @@ export const createSpace: API.OperationMethod<
   CreateSpaceRequest,
   CreateSpaceResponse,
   CreateSpaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSpaceRequest,
   output: CreateSpaceResponse,
@@ -33791,7 +33790,7 @@ export const createTemplate: API.OperationMethod<
   CreateTemplateRequest,
   CreateTemplateResponse,
   CreateTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateRequest,
   output: CreateTemplateResponse,
@@ -33827,7 +33826,7 @@ export const createTemplateAlias: API.OperationMethod<
   CreateTemplateAliasRequest,
   CreateTemplateAliasResponse,
   CreateTemplateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateAliasRequest,
   output: CreateTemplateAliasResponse,
@@ -33866,7 +33865,7 @@ export const createTheme: API.OperationMethod<
   CreateThemeRequest,
   CreateThemeResponse,
   CreateThemeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThemeRequest,
   output: CreateThemeResponse,
@@ -33902,7 +33901,7 @@ export const createThemeAlias: API.OperationMethod<
   CreateThemeAliasRequest,
   CreateThemeAliasResponse,
   CreateThemeAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThemeAliasRequest,
   output: CreateThemeAliasResponse,
@@ -33938,7 +33937,7 @@ export const createTopic: API.OperationMethod<
   CreateTopicRequest,
   CreateTopicResponse,
   CreateTopicError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicRequest,
   output: CreateTopicResponse,
@@ -33974,7 +33973,7 @@ export const createTopicRefreshSchedule: API.OperationMethod<
   CreateTopicRefreshScheduleRequest,
   CreateTopicRefreshScheduleResponse,
   CreateTopicRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicRefreshScheduleRequest,
   output: CreateTopicRefreshScheduleResponse,
@@ -34010,7 +34009,7 @@ export const createVPCConnection: API.OperationMethod<
   CreateVPCConnectionRequest,
   CreateVPCConnectionResponse,
   CreateVPCConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVPCConnectionRequest,
   output: CreateVPCConnectionResponse,
@@ -34057,7 +34056,7 @@ export const deleteAccountCustomization: API.OperationMethod<
   DeleteAccountCustomizationRequest,
   DeleteAccountCustomizationResponse,
   DeleteAccountCustomizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountCustomizationRequest,
   output: DeleteAccountCustomizationResponse,
@@ -34091,7 +34090,7 @@ export const deleteAccountCustomPermission: API.OperationMethod<
   DeleteAccountCustomPermissionRequest,
   DeleteAccountCustomPermissionResponse,
   DeleteAccountCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountCustomPermissionRequest,
   output: DeleteAccountCustomPermissionResponse,
@@ -34139,7 +34138,7 @@ export const deleteAccountSubscription: API.OperationMethod<
   DeleteAccountSubscriptionRequest,
   DeleteAccountSubscriptionResponse,
   DeleteAccountSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountSubscriptionRequest,
   output: DeleteAccountSubscriptionResponse,
@@ -34171,7 +34170,7 @@ export const deleteActionConnector: API.OperationMethod<
   DeleteActionConnectorRequest,
   DeleteActionConnectorResponse,
   DeleteActionConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActionConnectorRequest,
   output: DeleteActionConnectorResponse,
@@ -34202,7 +34201,7 @@ export const deleteAgent: API.OperationMethod<
   DeleteAgentRequest,
   DeleteAgentResponse,
   DeleteAgentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentRequest,
   output: DeleteAgentResponse,
@@ -34247,7 +34246,7 @@ export const deleteAnalysis: API.OperationMethod<
   DeleteAnalysisRequest,
   DeleteAnalysisResponse,
   DeleteAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAnalysisRequest,
   output: DeleteAnalysisResponse,
@@ -34289,7 +34288,7 @@ export const deleteBrand: API.OperationMethod<
   DeleteBrandRequest,
   DeleteBrandResponse,
   DeleteBrandError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrandRequest,
   output: DeleteBrandResponse,
@@ -34321,7 +34320,7 @@ export const deleteBrandAssignment: API.OperationMethod<
   DeleteBrandAssignmentRequest,
   DeleteBrandAssignmentResponse,
   DeleteBrandAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrandAssignmentRequest,
   output: DeleteBrandAssignmentResponse,
@@ -34356,7 +34355,7 @@ export const deleteCustomPermissions: API.OperationMethod<
   DeleteCustomPermissionsRequest,
   DeleteCustomPermissionsResponse,
   DeleteCustomPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomPermissionsRequest,
   output: DeleteCustomPermissionsResponse,
@@ -34391,7 +34390,7 @@ export const deleteDashboard: API.OperationMethod<
   DeleteDashboardRequest,
   DeleteDashboardResponse,
   DeleteDashboardError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDashboardRequest,
   output: DeleteDashboardResponse,
@@ -34422,7 +34421,7 @@ export const deleteDataSet: API.OperationMethod<
   DeleteDataSetRequest,
   DeleteDataSetResponse,
   DeleteDataSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSetRequest,
   output: DeleteDataSetResponse,
@@ -34454,7 +34453,7 @@ export const deleteDataSetRefreshProperties: API.OperationMethod<
   DeleteDataSetRefreshPropertiesRequest,
   DeleteDataSetRefreshPropertiesResponse,
   DeleteDataSetRefreshPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSetRefreshPropertiesRequest,
   output: DeleteDataSetRefreshPropertiesResponse,
@@ -34487,7 +34486,7 @@ export const deleteDataSource: API.OperationMethod<
   DeleteDataSourceRequest,
   DeleteDataSourceResponse,
   DeleteDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataSourceRequest,
   output: DeleteDataSourceResponse,
@@ -34517,7 +34516,7 @@ export const deleteDefaultQBusinessApplication: API.OperationMethod<
   DeleteDefaultQBusinessApplicationRequest,
   DeleteDefaultQBusinessApplicationResponse,
   DeleteDefaultQBusinessApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDefaultQBusinessApplicationRequest,
   output: DeleteDefaultQBusinessApplicationResponse,
@@ -34548,7 +34547,7 @@ export const deleteFlow: API.OperationMethod<
   DeleteFlowRequest,
   DeleteFlowResponse,
   DeleteFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowRequest,
   output: DeleteFlowResponse,
@@ -34582,7 +34581,7 @@ export const deleteFolder: API.OperationMethod<
   DeleteFolderRequest,
   DeleteFolderResponse,
   DeleteFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFolderRequest,
   output: DeleteFolderResponse,
@@ -34616,7 +34615,7 @@ export const deleteFolderMembership: API.OperationMethod<
   DeleteFolderMembershipRequest,
   DeleteFolderMembershipResponse,
   DeleteFolderMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFolderMembershipRequest,
   output: DeleteFolderMembershipResponse,
@@ -34649,7 +34648,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -34683,7 +34682,7 @@ export const deleteGroupMembership: API.OperationMethod<
   DeleteGroupMembershipRequest,
   DeleteGroupMembershipResponse,
   DeleteGroupMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupMembershipRequest,
   output: DeleteGroupMembershipResponse,
@@ -34717,7 +34716,7 @@ export const deleteIAMPolicyAssignment: API.OperationMethod<
   DeleteIAMPolicyAssignmentRequest,
   DeleteIAMPolicyAssignmentResponse,
   DeleteIAMPolicyAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIAMPolicyAssignmentRequest,
   output: DeleteIAMPolicyAssignmentResponse,
@@ -34751,7 +34750,7 @@ export const deleteIdentityPropagationConfig: API.OperationMethod<
   DeleteIdentityPropagationConfigRequest,
   DeleteIdentityPropagationConfigResponse,
   DeleteIdentityPropagationConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityPropagationConfigRequest,
   output: DeleteIdentityPropagationConfigResponse,
@@ -34785,7 +34784,7 @@ export const deleteKnowledgeBase: API.OperationMethod<
   DeleteKnowledgeBaseRequest,
   DeleteKnowledgeBaseResponse,
   DeleteKnowledgeBaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnowledgeBaseRequest,
   output: DeleteKnowledgeBaseResponse,
@@ -34823,7 +34822,7 @@ export const deleteNamespace: API.OperationMethod<
   DeleteNamespaceRequest,
   DeleteNamespaceResponse,
   DeleteNamespaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamespaceRequest,
   output: DeleteNamespaceResponse,
@@ -34856,7 +34855,7 @@ export const deleteOAuthClientApplication: API.OperationMethod<
   DeleteOAuthClientApplicationRequest,
   DeleteOAuthClientApplicationResponse,
   DeleteOAuthClientApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOAuthClientApplicationRequest,
   output: DeleteOAuthClientApplicationResponse,
@@ -34888,7 +34887,7 @@ export const deleteRefreshSchedule: API.OperationMethod<
   DeleteRefreshScheduleRequest,
   DeleteRefreshScheduleResponse,
   DeleteRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRefreshScheduleRequest,
   output: DeleteRefreshScheduleResponse,
@@ -34921,7 +34920,7 @@ export const deleteRoleCustomPermission: API.OperationMethod<
   DeleteRoleCustomPermissionRequest,
   DeleteRoleCustomPermissionResponse,
   DeleteRoleCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoleCustomPermissionRequest,
   output: DeleteRoleCustomPermissionResponse,
@@ -34955,7 +34954,7 @@ export const deleteRoleMembership: API.OperationMethod<
   DeleteRoleMembershipRequest,
   DeleteRoleMembershipResponse,
   DeleteRoleMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoleMembershipRequest,
   output: DeleteRoleMembershipResponse,
@@ -34987,7 +34986,7 @@ export const deleteSpace: API.OperationMethod<
   DeleteSpaceRequest,
   DeleteSpaceResponse,
   DeleteSpaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpaceRequest,
   output: DeleteSpaceResponse,
@@ -35019,7 +35018,7 @@ export const deleteTemplate: API.OperationMethod<
   DeleteTemplateRequest,
   DeleteTemplateResponse,
   DeleteTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateRequest,
   output: DeleteTemplateResponse,
@@ -35052,7 +35051,7 @@ export const deleteTemplateAlias: API.OperationMethod<
   DeleteTemplateAliasRequest,
   DeleteTemplateAliasResponse,
   DeleteTemplateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateAliasRequest,
   output: DeleteTemplateAliasResponse,
@@ -35084,7 +35083,7 @@ export const deleteTheme: API.OperationMethod<
   DeleteThemeRequest,
   DeleteThemeResponse,
   DeleteThemeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThemeRequest,
   output: DeleteThemeResponse,
@@ -35119,7 +35118,7 @@ export const deleteThemeAlias: API.OperationMethod<
   DeleteThemeAliasRequest,
   DeleteThemeAliasResponse,
   DeleteThemeAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteThemeAliasRequest,
   output: DeleteThemeAliasResponse,
@@ -35151,7 +35150,7 @@ export const deleteTopic: API.OperationMethod<
   DeleteTopicRequest,
   DeleteTopicResponse,
   DeleteTopicError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicRequest,
   output: DeleteTopicResponse,
@@ -35185,7 +35184,7 @@ export const deleteTopicRefreshSchedule: API.OperationMethod<
   DeleteTopicRefreshScheduleRequest,
   DeleteTopicRefreshScheduleResponse,
   DeleteTopicRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicRefreshScheduleRequest,
   output: DeleteTopicRefreshScheduleResponse,
@@ -35222,7 +35221,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -35256,7 +35255,7 @@ export const deleteUserByPrincipalId: API.OperationMethod<
   DeleteUserByPrincipalIdRequest,
   DeleteUserByPrincipalIdResponse,
   DeleteUserByPrincipalIdError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserByPrincipalIdRequest,
   output: DeleteUserByPrincipalIdResponse,
@@ -35291,7 +35290,7 @@ export const deleteUserCustomPermission: API.OperationMethod<
   DeleteUserCustomPermissionRequest,
   DeleteUserCustomPermissionResponse,
   DeleteUserCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserCustomPermissionRequest,
   output: DeleteUserCustomPermissionResponse,
@@ -35326,7 +35325,7 @@ export const deleteVPCConnection: API.OperationMethod<
   DeleteVPCConnectionRequest,
   DeleteVPCConnectionResponse,
   DeleteVPCConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVPCConnectionRequest,
   output: DeleteVPCConnectionResponse,
@@ -35398,7 +35397,7 @@ export const describeAccountCustomization: API.OperationMethod<
   DescribeAccountCustomizationRequest,
   DescribeAccountCustomizationResponse,
   DescribeAccountCustomizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountCustomizationRequest,
   output: DescribeAccountCustomizationResponse,
@@ -35429,7 +35428,7 @@ export const describeAccountCustomPermission: API.OperationMethod<
   DescribeAccountCustomPermissionRequest,
   DescribeAccountCustomPermissionResponse,
   DescribeAccountCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountCustomPermissionRequest,
   output: DescribeAccountCustomPermissionResponse,
@@ -35461,7 +35460,7 @@ export const describeAccountSettings: API.OperationMethod<
   DescribeAccountSettingsRequest,
   DescribeAccountSettingsResponse,
   DescribeAccountSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountSettingsRequest,
   output: DescribeAccountSettingsResponse,
@@ -35493,7 +35492,7 @@ export const describeAccountSubscription: API.OperationMethod<
   DescribeAccountSubscriptionRequest,
   DescribeAccountSubscriptionResponse,
   DescribeAccountSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountSubscriptionRequest,
   output: DescribeAccountSubscriptionResponse,
@@ -35524,7 +35523,7 @@ export const describeActionConnector: API.OperationMethod<
   DescribeActionConnectorRequest,
   DescribeActionConnectorResponse,
   DescribeActionConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActionConnectorRequest,
   output: DescribeActionConnectorResponse,
@@ -35554,7 +35553,7 @@ export const describeActionConnectorPermissions: API.OperationMethod<
   DescribeActionConnectorPermissionsRequest,
   DescribeActionConnectorPermissionsResponse,
   DescribeActionConnectorPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActionConnectorPermissionsRequest,
   output: DescribeActionConnectorPermissionsResponse,
@@ -35585,7 +35584,7 @@ export const describeAgent: API.OperationMethod<
   DescribeAgentRequest,
   DescribeAgentResponse,
   DescribeAgentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgentRequest,
   output: DescribeAgentResponse,
@@ -35617,7 +35616,7 @@ export const describeAgentPermissions: API.OperationMethod<
   DescribeAgentPermissionsRequest,
   DescribeAgentPermissionsResponse,
   DescribeAgentPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgentPermissionsRequest,
   output: DescribeAgentPermissionsResponse,
@@ -35649,7 +35648,7 @@ export const describeAnalysis: API.OperationMethod<
   DescribeAnalysisRequest,
   DescribeAnalysisResponse,
   DescribeAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnalysisRequest,
   output: DescribeAnalysisResponse,
@@ -35689,7 +35688,7 @@ export const describeAnalysisDefinition: API.OperationMethod<
   DescribeAnalysisDefinitionRequest,
   DescribeAnalysisDefinitionResponse,
   DescribeAnalysisDefinitionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnalysisDefinitionRequest,
   output: DescribeAnalysisDefinitionResponse,
@@ -35722,7 +35721,7 @@ export const describeAnalysisPermissions: API.OperationMethod<
   DescribeAnalysisPermissionsRequest,
   DescribeAnalysisPermissionsResponse,
   DescribeAnalysisPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAnalysisPermissionsRequest,
   output: DescribeAnalysisPermissionsResponse,
@@ -35757,7 +35756,7 @@ export const describeAssetBundleExportJob: API.OperationMethod<
   DescribeAssetBundleExportJobRequest,
   DescribeAssetBundleExportJobResponse,
   DescribeAssetBundleExportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetBundleExportJobRequest,
   output: DescribeAssetBundleExportJobResponse,
@@ -35786,7 +35785,7 @@ export const describeAssetBundleImportJob: API.OperationMethod<
   DescribeAssetBundleImportJobRequest,
   DescribeAssetBundleImportJobResponse,
   DescribeAssetBundleImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssetBundleImportJobRequest,
   output: DescribeAssetBundleImportJobResponse,
@@ -35814,7 +35813,7 @@ export const describeAutomationJob: API.OperationMethod<
   DescribeAutomationJobRequest,
   DescribeAutomationJobResponse,
   DescribeAutomationJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutomationJobRequest,
   output: DescribeAutomationJobResponse,
@@ -35845,7 +35844,7 @@ export const describeBrand: API.OperationMethod<
   DescribeBrandRequest,
   DescribeBrandResponse,
   DescribeBrandError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrandRequest,
   output: DescribeBrandResponse,
@@ -35877,7 +35876,7 @@ export const describeBrandAssignment: API.OperationMethod<
   DescribeBrandAssignmentRequest,
   DescribeBrandAssignmentResponse,
   DescribeBrandAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrandAssignmentRequest,
   output: DescribeBrandAssignmentResponse,
@@ -35909,7 +35908,7 @@ export const describeBrandPublishedVersion: API.OperationMethod<
   DescribeBrandPublishedVersionRequest,
   DescribeBrandPublishedVersionResponse,
   DescribeBrandPublishedVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBrandPublishedVersionRequest,
   output: DescribeBrandPublishedVersionResponse,
@@ -35942,7 +35941,7 @@ export const describeCustomPermissions: API.OperationMethod<
   DescribeCustomPermissionsRequest,
   DescribeCustomPermissionsResponse,
   DescribeCustomPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomPermissionsRequest,
   output: DescribeCustomPermissionsResponse,
@@ -35975,7 +35974,7 @@ export const describeDashboard: API.OperationMethod<
   DescribeDashboardRequest,
   DescribeDashboardResponse,
   DescribeDashboardError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardRequest,
   output: DescribeDashboardResponse,
@@ -36015,7 +36014,7 @@ export const describeDashboardDefinition: API.OperationMethod<
   DescribeDashboardDefinitionRequest,
   DescribeDashboardDefinitionResponse,
   DescribeDashboardDefinitionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardDefinitionRequest,
   output: DescribeDashboardDefinitionResponse,
@@ -36048,7 +36047,7 @@ export const describeDashboardPermissions: API.OperationMethod<
   DescribeDashboardPermissionsRequest,
   DescribeDashboardPermissionsResponse,
   DescribeDashboardPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardPermissionsRequest,
   output: DescribeDashboardPermissionsResponse,
@@ -36094,7 +36093,7 @@ export const describeDashboardSnapshotJob: API.OperationMethod<
   DescribeDashboardSnapshotJobRequest,
   DescribeDashboardSnapshotJobResponse,
   DescribeDashboardSnapshotJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardSnapshotJobRequest,
   output: DescribeDashboardSnapshotJobResponse,
@@ -36160,7 +36159,7 @@ export const describeDashboardSnapshotJobResult: API.OperationMethod<
   DescribeDashboardSnapshotJobResultRequest,
   DescribeDashboardSnapshotJobResultResponse,
   DescribeDashboardSnapshotJobResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardSnapshotJobResultRequest,
   output: DescribeDashboardSnapshotJobResultResponse,
@@ -36193,7 +36192,7 @@ export const describeDashboardsQAConfiguration: API.OperationMethod<
   DescribeDashboardsQAConfigurationRequest,
   DescribeDashboardsQAConfigurationResponse,
   DescribeDashboardsQAConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDashboardsQAConfigurationRequest,
   output: DescribeDashboardsQAConfigurationResponse,
@@ -36225,7 +36224,7 @@ export const describeDataSet: API.OperationMethod<
   DescribeDataSetRequest,
   DescribeDataSetResponse,
   DescribeDataSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSetRequest,
   output: DescribeDataSetResponse,
@@ -36258,7 +36257,7 @@ export const describeDataSetPermissions: API.OperationMethod<
   DescribeDataSetPermissionsRequest,
   DescribeDataSetPermissionsResponse,
   DescribeDataSetPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSetPermissionsRequest,
   output: DescribeDataSetPermissionsResponse,
@@ -36290,7 +36289,7 @@ export const describeDataSetRefreshProperties: API.OperationMethod<
   DescribeDataSetRefreshPropertiesRequest,
   DescribeDataSetRefreshPropertiesResponse,
   DescribeDataSetRefreshPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSetRefreshPropertiesRequest,
   output: DescribeDataSetRefreshPropertiesResponse,
@@ -36322,7 +36321,7 @@ export const describeDataSource: API.OperationMethod<
   DescribeDataSourceRequest,
   DescribeDataSourceResponse,
   DescribeDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSourceRequest,
   output: DescribeDataSourceResponse,
@@ -36352,7 +36351,7 @@ export const describeDataSourcePermissions: API.OperationMethod<
   DescribeDataSourcePermissionsRequest,
   DescribeDataSourcePermissionsResponse,
   DescribeDataSourcePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataSourcePermissionsRequest,
   output: DescribeDataSourcePermissionsResponse,
@@ -36382,7 +36381,7 @@ export const describeDefaultQBusinessApplication: API.OperationMethod<
   DescribeDefaultQBusinessApplicationRequest,
   DescribeDefaultQBusinessApplicationResponse,
   DescribeDefaultQBusinessApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDefaultQBusinessApplicationRequest,
   output: DescribeDefaultQBusinessApplicationResponse,
@@ -36412,7 +36411,7 @@ export const describeFlow: API.OperationMethod<
   DescribeFlowRequest,
   DescribeFlowResponse,
   DescribeFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowRequest,
   output: DescribeFlowResponse,
@@ -36443,7 +36442,7 @@ export const describeFolder: API.OperationMethod<
   DescribeFolderRequest,
   DescribeFolderResponse,
   DescribeFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFolderRequest,
   output: DescribeFolderResponse,
@@ -36476,7 +36475,7 @@ export const describeFolderPermissions: API.PaginatedOperationMethod<
   DescribeFolderPermissionsRequest,
   DescribeFolderPermissionsResponse,
   DescribeFolderPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePermission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFolderPermissionsRequest,
@@ -36517,7 +36516,7 @@ export const describeFolderResolvedPermissions: API.PaginatedOperationMethod<
   DescribeFolderResolvedPermissionsRequest,
   DescribeFolderResolvedPermissionsResponse,
   DescribeFolderResolvedPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePermission
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFolderResolvedPermissionsRequest,
@@ -36558,7 +36557,7 @@ export const describeGroup: API.OperationMethod<
   DescribeGroupRequest,
   DescribeGroupResponse,
   DescribeGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupRequest,
   output: DescribeGroupResponse,
@@ -36594,7 +36593,7 @@ export const describeGroupMembership: API.OperationMethod<
   DescribeGroupMembershipRequest,
   DescribeGroupMembershipResponse,
   DescribeGroupMembershipError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupMembershipRequest,
   output: DescribeGroupMembershipResponse,
@@ -36628,7 +36627,7 @@ export const describeIAMPolicyAssignment: API.OperationMethod<
   DescribeIAMPolicyAssignmentRequest,
   DescribeIAMPolicyAssignmentResponse,
   DescribeIAMPolicyAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIAMPolicyAssignmentRequest,
   output: DescribeIAMPolicyAssignmentResponse,
@@ -36660,7 +36659,7 @@ export const describeIngestion: API.OperationMethod<
   DescribeIngestionRequest,
   DescribeIngestionResponse,
   DescribeIngestionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIngestionRequest,
   output: DescribeIngestionResponse,
@@ -36691,7 +36690,7 @@ export const describeIpRestriction: API.OperationMethod<
   DescribeIpRestrictionRequest,
   DescribeIpRestrictionResponse,
   DescribeIpRestrictionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIpRestrictionRequest,
   output: DescribeIpRestrictionResponse,
@@ -36720,7 +36719,7 @@ export const describeKeyRegistration: API.OperationMethod<
   DescribeKeyRegistrationRequest,
   DescribeKeyRegistrationResponse,
   DescribeKeyRegistrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKeyRegistrationRequest,
   output: DescribeKeyRegistrationResponse,
@@ -36752,7 +36751,7 @@ export const describeKnowledgeBase: API.OperationMethod<
   DescribeKnowledgeBaseRequest,
   DescribeKnowledgeBaseResponse,
   DescribeKnowledgeBaseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKnowledgeBaseRequest,
   output: DescribeKnowledgeBaseResponse,
@@ -36788,7 +36787,7 @@ export const describeKnowledgeBasePermissions: API.OperationMethod<
   DescribeKnowledgeBasePermissionsRequest,
   DescribeKnowledgeBasePermissionsResponse,
   DescribeKnowledgeBasePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeKnowledgeBasePermissionsRequest,
   output: DescribeKnowledgeBasePermissionsResponse,
@@ -36822,7 +36821,7 @@ export const describeNamespace: API.OperationMethod<
   DescribeNamespaceRequest,
   DescribeNamespaceResponse,
   DescribeNamespaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNamespaceRequest,
   output: DescribeNamespaceResponse,
@@ -36853,7 +36852,7 @@ export const describeOAuthClientApplication: API.OperationMethod<
   DescribeOAuthClientApplicationRequest,
   DescribeOAuthClientApplicationResponse,
   DescribeOAuthClientApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOAuthClientApplicationRequest,
   output: DescribeOAuthClientApplicationResponse,
@@ -36884,7 +36883,7 @@ export const describeQPersonalizationConfiguration: API.OperationMethod<
   DescribeQPersonalizationConfigurationRequest,
   DescribeQPersonalizationConfigurationResponse,
   DescribeQPersonalizationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQPersonalizationConfigurationRequest,
   output: DescribeQPersonalizationConfigurationResponse,
@@ -36916,7 +36915,7 @@ export const describeQuickSightQSearchConfiguration: API.OperationMethod<
   DescribeQuickSightQSearchConfigurationRequest,
   DescribeQuickSightQSearchConfigurationResponse,
   DescribeQuickSightQSearchConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeQuickSightQSearchConfigurationRequest,
   output: DescribeQuickSightQSearchConfigurationResponse,
@@ -36948,7 +36947,7 @@ export const describeRefreshSchedule: API.OperationMethod<
   DescribeRefreshScheduleRequest,
   DescribeRefreshScheduleResponse,
   DescribeRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRefreshScheduleRequest,
   output: DescribeRefreshScheduleResponse,
@@ -36981,7 +36980,7 @@ export const describeRoleCustomPermission: API.OperationMethod<
   DescribeRoleCustomPermissionRequest,
   DescribeRoleCustomPermissionResponse,
   DescribeRoleCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRoleCustomPermissionRequest,
   output: DescribeRoleCustomPermissionResponse,
@@ -37016,7 +37015,7 @@ export const describeSelfUpgradeConfiguration: API.OperationMethod<
   DescribeSelfUpgradeConfigurationRequest,
   DescribeSelfUpgradeConfigurationResponse,
   DescribeSelfUpgradeConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSelfUpgradeConfigurationRequest,
   output: DescribeSelfUpgradeConfigurationResponse,
@@ -37049,7 +37048,7 @@ export const describeSpace: API.OperationMethod<
   DescribeSpaceRequest,
   DescribeSpaceResponse,
   DescribeSpaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpaceRequest,
   output: DescribeSpaceResponse,
@@ -37079,7 +37078,7 @@ export const describeSpacePermissions: API.OperationMethod<
   DescribeSpacePermissionsRequest,
   DescribeSpacePermissionsResponse,
   DescribeSpacePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpacePermissionsRequest,
   output: DescribeSpacePermissionsResponse,
@@ -37112,7 +37111,7 @@ export const describeTemplate: API.OperationMethod<
   DescribeTemplateRequest,
   DescribeTemplateResponse,
   DescribeTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTemplateRequest,
   output: DescribeTemplateResponse,
@@ -37144,7 +37143,7 @@ export const describeTemplateAlias: API.OperationMethod<
   DescribeTemplateAliasRequest,
   DescribeTemplateAliasResponse,
   DescribeTemplateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTemplateAliasRequest,
   output: DescribeTemplateAliasResponse,
@@ -37182,7 +37181,7 @@ export const describeTemplateDefinition: API.OperationMethod<
   DescribeTemplateDefinitionRequest,
   DescribeTemplateDefinitionResponse,
   DescribeTemplateDefinitionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTemplateDefinitionRequest,
   output: DescribeTemplateDefinitionResponse,
@@ -37216,7 +37215,7 @@ export const describeTemplatePermissions: API.OperationMethod<
   DescribeTemplatePermissionsRequest,
   DescribeTemplatePermissionsResponse,
   DescribeTemplatePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTemplatePermissionsRequest,
   output: DescribeTemplatePermissionsResponse,
@@ -37249,7 +37248,7 @@ export const describeTheme: API.OperationMethod<
   DescribeThemeRequest,
   DescribeThemeResponse,
   DescribeThemeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThemeRequest,
   output: DescribeThemeResponse,
@@ -37282,7 +37281,7 @@ export const describeThemeAlias: API.OperationMethod<
   DescribeThemeAliasRequest,
   DescribeThemeAliasResponse,
   DescribeThemeAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThemeAliasRequest,
   output: DescribeThemeAliasResponse,
@@ -37314,7 +37313,7 @@ export const describeThemePermissions: API.OperationMethod<
   DescribeThemePermissionsRequest,
   DescribeThemePermissionsResponse,
   DescribeThemePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeThemePermissionsRequest,
   output: DescribeThemePermissionsResponse,
@@ -37345,7 +37344,7 @@ export const describeTopic: API.OperationMethod<
   DescribeTopicRequest,
   DescribeTopicResponse,
   DescribeTopicError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicRequest,
   output: DescribeTopicResponse,
@@ -37375,7 +37374,7 @@ export const describeTopicPermissions: API.OperationMethod<
   DescribeTopicPermissionsRequest,
   DescribeTopicPermissionsResponse,
   DescribeTopicPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicPermissionsRequest,
   output: DescribeTopicPermissionsResponse,
@@ -37405,7 +37404,7 @@ export const describeTopicRefresh: API.OperationMethod<
   DescribeTopicRefreshRequest,
   DescribeTopicRefreshResponse,
   DescribeTopicRefreshError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicRefreshRequest,
   output: DescribeTopicRefreshResponse,
@@ -37438,7 +37437,7 @@ export const describeTopicRefreshSchedule: API.OperationMethod<
   DescribeTopicRefreshScheduleRequest,
   DescribeTopicRefreshScheduleResponse,
   DescribeTopicRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTopicRefreshScheduleRequest,
   output: DescribeTopicRefreshScheduleResponse,
@@ -37473,7 +37472,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -37506,7 +37505,7 @@ export const describeVPCConnection: API.OperationMethod<
   DescribeVPCConnectionRequest,
   DescribeVPCConnectionResponse,
   DescribeVPCConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeVPCConnectionRequest,
   output: DescribeVPCConnectionResponse,
@@ -37563,7 +37562,7 @@ export const generateEmbedUrlForAnonymousUser: API.OperationMethod<
   GenerateEmbedUrlForAnonymousUserRequest,
   GenerateEmbedUrlForAnonymousUserResponse,
   GenerateEmbedUrlForAnonymousUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateEmbedUrlForAnonymousUserRequest,
   output: GenerateEmbedUrlForAnonymousUserResponse,
@@ -37624,7 +37623,7 @@ export const generateEmbedUrlForRegisteredUser: API.OperationMethod<
   GenerateEmbedUrlForRegisteredUserRequest,
   GenerateEmbedUrlForRegisteredUserResponse,
   GenerateEmbedUrlForRegisteredUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateEmbedUrlForRegisteredUserRequest,
   output: GenerateEmbedUrlForRegisteredUserResponse,
@@ -37673,7 +37672,7 @@ export const generateEmbedUrlForRegisteredUserWithIdentity: API.OperationMethod<
   GenerateEmbedUrlForRegisteredUserWithIdentityRequest,
   GenerateEmbedUrlForRegisteredUserWithIdentityResponse,
   GenerateEmbedUrlForRegisteredUserWithIdentityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateEmbedUrlForRegisteredUserWithIdentityRequest,
   output: GenerateEmbedUrlForRegisteredUserWithIdentityResponse,
@@ -37740,7 +37739,7 @@ export const getDashboardEmbedUrl: API.OperationMethod<
   GetDashboardEmbedUrlRequest,
   GetDashboardEmbedUrlResponse,
   GetDashboardEmbedUrlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDashboardEmbedUrlRequest,
   output: GetDashboardEmbedUrlResponse,
@@ -37776,7 +37775,7 @@ export const getFlowMetadata: API.OperationMethod<
   GetFlowMetadataInput,
   GetFlowMetadataOutput,
   GetFlowMetadataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowMetadataInput,
   output: GetFlowMetadataOutput,
@@ -37804,7 +37803,7 @@ export const getFlowPermissions: API.OperationMethod<
   GetFlowPermissionsInput,
   GetFlowPermissionsOutput,
   GetFlowPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFlowPermissionsInput,
   output: GetFlowPermissionsOutput,
@@ -37872,7 +37871,7 @@ export const getIdentityContext: API.OperationMethod<
   GetIdentityContextRequest,
   GetIdentityContextResponse,
   GetIdentityContextError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityContextRequest,
   output: GetIdentityContextResponse,
@@ -37924,7 +37923,7 @@ export const getSessionEmbedUrl: API.OperationMethod<
   GetSessionEmbedUrlRequest,
   GetSessionEmbedUrlResponse,
   GetSessionEmbedUrlError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionEmbedUrlRequest,
   output: GetSessionEmbedUrlResponse,
@@ -37958,7 +37957,7 @@ export const listActionConnectors: API.PaginatedOperationMethod<
   ListActionConnectorsRequest,
   ListActionConnectorsResponse,
   ListActionConnectorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionConnectorsRequest,
@@ -37997,7 +37996,7 @@ export const listAgents: API.OperationMethod<
   ListAgentsRequest,
   ListAgentsResponse,
   ListAgentsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAgentsRequest,
   output: ListAgentsResponse,
@@ -38028,7 +38027,7 @@ export const listAnalyses: API.PaginatedOperationMethod<
   ListAnalysesRequest,
   ListAnalysesResponse,
   ListAnalysesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnalysesRequest,
@@ -38067,7 +38066,7 @@ export const listAssetBundleExportJobs: API.PaginatedOperationMethod<
   ListAssetBundleExportJobsRequest,
   ListAssetBundleExportJobsResponse,
   ListAssetBundleExportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetBundleExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetBundleExportJobsRequest,
@@ -38107,7 +38106,7 @@ export const listAssetBundleImportJobs: API.PaginatedOperationMethod<
   ListAssetBundleImportJobsRequest,
   ListAssetBundleImportJobsResponse,
   ListAssetBundleImportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssetBundleImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssetBundleImportJobsRequest,
@@ -38143,7 +38142,7 @@ export const listBrands: API.PaginatedOperationMethod<
   ListBrandsRequest,
   ListBrandsResponse,
   ListBrandsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BrandSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBrandsRequest,
@@ -38181,7 +38180,7 @@ export const listCustomPermissions: API.PaginatedOperationMethod<
   ListCustomPermissionsRequest,
   ListCustomPermissionsResponse,
   ListCustomPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomPermissions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomPermissionsRequest,
@@ -38219,7 +38218,7 @@ export const listDashboards: API.PaginatedOperationMethod<
   ListDashboardsRequest,
   ListDashboardsResponse,
   ListDashboardsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDashboardsRequest,
@@ -38256,7 +38255,7 @@ export const listDashboardVersions: API.PaginatedOperationMethod<
   ListDashboardVersionsRequest,
   ListDashboardVersionsResponse,
   ListDashboardVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDashboardVersionsRequest,
@@ -38298,7 +38297,7 @@ export const listDataSets: API.PaginatedOperationMethod<
   ListDataSetsRequest,
   ListDataSetsResponse,
   ListDataSetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSetsRequest,
@@ -38335,7 +38334,7 @@ export const listDataSources: API.PaginatedOperationMethod<
   ListDataSourcesRequest,
   ListDataSourcesResponse,
   ListDataSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataSourcesRequest,
@@ -38371,7 +38370,7 @@ export const listFlows: API.PaginatedOperationMethod<
   ListFlowsInput,
   ListFlowsOutput,
   ListFlowsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowsInput,
@@ -38409,7 +38408,7 @@ export const listFolderMembers: API.PaginatedOperationMethod<
   ListFolderMembersRequest,
   ListFolderMembersResponse,
   ListFolderMembersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemberIdArnPair
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFolderMembersRequest,
@@ -38450,7 +38449,7 @@ export const listFolders: API.PaginatedOperationMethod<
   ListFoldersRequest,
   ListFoldersResponse,
   ListFoldersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FolderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFoldersRequest,
@@ -38491,7 +38490,7 @@ export const listFoldersForResource: API.PaginatedOperationMethod<
   ListFoldersForResourceRequest,
   ListFoldersForResourceResponse,
   ListFoldersForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Arn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFoldersForResourceRequest,
@@ -38533,7 +38532,7 @@ export const listGroupMemberships: API.PaginatedOperationMethod<
   ListGroupMembershipsRequest,
   ListGroupMembershipsResponse,
   ListGroupMembershipsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupMembershipsRequest,
@@ -38576,7 +38575,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -38619,7 +38618,7 @@ export const listIAMPolicyAssignments: API.PaginatedOperationMethod<
   ListIAMPolicyAssignmentsRequest,
   ListIAMPolicyAssignmentsResponse,
   ListIAMPolicyAssignmentsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IAMPolicyAssignmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIAMPolicyAssignmentsRequest,
@@ -38665,7 +38664,7 @@ export const listIAMPolicyAssignmentsForUser: API.PaginatedOperationMethod<
   ListIAMPolicyAssignmentsForUserRequest,
   ListIAMPolicyAssignmentsForUserResponse,
   ListIAMPolicyAssignmentsForUserError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActiveIAMPolicyAssignment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIAMPolicyAssignmentsForUserRequest,
@@ -38706,7 +38705,7 @@ export const listIdentityPropagationConfigs: API.OperationMethod<
   ListIdentityPropagationConfigsRequest,
   ListIdentityPropagationConfigsResponse,
   ListIdentityPropagationConfigsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIdentityPropagationConfigsRequest,
   output: ListIdentityPropagationConfigsResponse,
@@ -38738,7 +38737,7 @@ export const listIngestions: API.PaginatedOperationMethod<
   ListIngestionsRequest,
   ListIngestionsResponse,
   ListIngestionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Ingestion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIngestionsRequest,
@@ -38778,7 +38777,7 @@ export const listKnowledgeBases: API.PaginatedOperationMethod<
   ListKnowledgeBasesRequest,
   ListKnowledgeBasesResponse,
   ListKnowledgeBasesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKnowledgeBasesRequest,
@@ -38819,7 +38818,7 @@ export const listNamespaces: API.PaginatedOperationMethod<
   ListNamespacesRequest,
   ListNamespacesResponse,
   ListNamespacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NamespaceInfoV2
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNamespacesRequest,
@@ -38860,7 +38859,7 @@ export const listOAuthClientApplications: API.PaginatedOperationMethod<
   ListOAuthClientApplicationsRequest,
   ListOAuthClientApplicationsResponse,
   ListOAuthClientApplicationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OAuthClientApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOAuthClientApplicationsRequest,
@@ -38899,7 +38898,7 @@ export const listRefreshSchedules: API.OperationMethod<
   ListRefreshSchedulesRequest,
   ListRefreshSchedulesResponse,
   ListRefreshSchedulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRefreshSchedulesRequest,
   output: ListRefreshSchedulesResponse,
@@ -38934,7 +38933,7 @@ export const listRoleMemberships: API.PaginatedOperationMethod<
   ListRoleMembershipsRequest,
   ListRoleMembershipsResponse,
   ListRoleMembershipsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoleMembershipsRequest,
@@ -38979,7 +38978,7 @@ export const listSelfUpgrades: API.OperationMethod<
   ListSelfUpgradesRequest,
   ListSelfUpgradesResponse,
   ListSelfUpgradesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSelfUpgradesRequest,
   output: ListSelfUpgradesResponse,
@@ -39013,7 +39012,7 @@ export const listSpaceResources: API.OperationMethod<
   ListSpaceResourcesRequest,
   ListSpaceResourcesResponse,
   ListSpaceResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSpaceResourcesRequest,
   output: ListSpaceResourcesResponse,
@@ -39043,7 +39042,7 @@ export const listSpaces: API.OperationMethod<
   ListSpacesRequest,
   ListSpacesResponse,
   ListSpacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSpacesRequest,
   output: ListSpacesResponse,
@@ -39073,7 +39072,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -39103,7 +39102,7 @@ export const listTemplateAliases: API.PaginatedOperationMethod<
   ListTemplateAliasesRequest,
   ListTemplateAliasesResponse,
   ListTemplateAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateAlias
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateAliasesRequest,
@@ -39141,7 +39140,7 @@ export const listTemplates: API.PaginatedOperationMethod<
   ListTemplatesRequest,
   ListTemplatesResponse,
   ListTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplatesRequest,
@@ -39180,7 +39179,7 @@ export const listTemplateVersions: API.PaginatedOperationMethod<
   ListTemplateVersionsRequest,
   ListTemplateVersionsResponse,
   ListTemplateVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateVersionsRequest,
@@ -39220,7 +39219,7 @@ export const listThemeAliases: API.OperationMethod<
   ListThemeAliasesRequest,
   ListThemeAliasesResponse,
   ListThemeAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListThemeAliasesRequest,
   output: ListThemeAliasesResponse,
@@ -39254,7 +39253,7 @@ export const listThemes: API.PaginatedOperationMethod<
   ListThemesRequest,
   ListThemesResponse,
   ListThemesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThemeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThemesRequest,
@@ -39295,7 +39294,7 @@ export const listThemeVersions: API.PaginatedOperationMethod<
   ListThemeVersionsRequest,
   ListThemeVersionsResponse,
   ListThemeVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThemeVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThemeVersionsRequest,
@@ -39337,7 +39336,7 @@ export const listTopicRefreshSchedules: API.OperationMethod<
   ListTopicRefreshSchedulesRequest,
   ListTopicRefreshSchedulesResponse,
   ListTopicRefreshSchedulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTopicRefreshSchedulesRequest,
   output: ListTopicRefreshSchedulesResponse,
@@ -39370,7 +39369,7 @@ export const listTopicReviewedAnswers: API.OperationMethod<
   ListTopicReviewedAnswersRequest,
   ListTopicReviewedAnswersResponse,
   ListTopicReviewedAnswersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTopicReviewedAnswersRequest,
   output: ListTopicReviewedAnswersResponse,
@@ -39400,7 +39399,7 @@ export const listTopics: API.PaginatedOperationMethod<
   ListTopicsRequest,
   ListTopicsResponse,
   ListTopicsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicsRequest,
@@ -39438,7 +39437,7 @@ export const listUserGroups: API.PaginatedOperationMethod<
   ListUserGroupsRequest,
   ListUserGroupsResponse,
   ListUserGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserGroupsRequest,
@@ -39480,7 +39479,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -39521,7 +39520,7 @@ export const listUsersIndexCapacity: API.OperationMethod<
   ListUsersIndexCapacityRequest,
   ListUsersIndexCapacityResponse,
   ListUsersIndexCapacityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListUsersIndexCapacityRequest,
   output: ListUsersIndexCapacityResponse,
@@ -39554,7 +39553,7 @@ export const listVPCConnections: API.PaginatedOperationMethod<
   ListVPCConnectionsRequest,
   ListVPCConnectionsResponse,
   ListVPCConnectionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVPCConnectionsRequest,
@@ -39594,7 +39593,7 @@ export const predictQAResults: API.OperationMethod<
   PredictQAResultsRequest,
   PredictQAResultsResponse,
   PredictQAResultsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PredictQAResultsRequest,
   output: PredictQAResultsResponse,
@@ -39626,7 +39625,7 @@ export const putDataSetRefreshProperties: API.OperationMethod<
   PutDataSetRefreshPropertiesRequest,
   PutDataSetRefreshPropertiesResponse,
   PutDataSetRefreshPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataSetRefreshPropertiesRequest,
   output: PutDataSetRefreshPropertiesResponse,
@@ -39663,7 +39662,7 @@ export const registerUser: API.OperationMethod<
   RegisterUserRequest,
   RegisterUserResponse,
   RegisterUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterUserRequest,
   output: RegisterUserResponse,
@@ -39700,7 +39699,7 @@ export const restoreAnalysis: API.OperationMethod<
   RestoreAnalysisRequest,
   RestoreAnalysisResponse,
   RestoreAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreAnalysisRequest,
   output: RestoreAnalysisResponse,
@@ -39732,7 +39731,7 @@ export const searchActionConnectors: API.PaginatedOperationMethod<
   SearchActionConnectorsRequest,
   SearchActionConnectorsResponse,
   SearchActionConnectorsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionConnectorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchActionConnectorsRequest,
@@ -39769,7 +39768,7 @@ export const searchAgents: API.OperationMethod<
   SearchAgentsRequest,
   SearchAgentsResponse,
   SearchAgentsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchAgentsRequest,
   output: SearchAgentsResponse,
@@ -39803,7 +39802,7 @@ export const searchAnalyses: API.PaginatedOperationMethod<
   SearchAnalysesRequest,
   SearchAnalysesResponse,
   SearchAnalysesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnalysisSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchAnalysesRequest,
@@ -39845,7 +39844,7 @@ export const searchDashboards: API.PaginatedOperationMethod<
   SearchDashboardsRequest,
   SearchDashboardsResponse,
   SearchDashboardsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DashboardSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDashboardsRequest,
@@ -39885,7 +39884,7 @@ export const searchDataSets: API.PaginatedOperationMethod<
   SearchDataSetsRequest,
   SearchDataSetsResponse,
   SearchDataSetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDataSetsRequest,
@@ -39925,7 +39924,7 @@ export const searchDataSources: API.PaginatedOperationMethod<
   SearchDataSourcesRequest,
   SearchDataSourcesResponse,
   SearchDataSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataSourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchDataSourcesRequest,
@@ -39962,7 +39961,7 @@ export const searchFlows: API.PaginatedOperationMethod<
   SearchFlowsInput,
   SearchFlowsOutput,
   SearchFlowsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchFlowsInput,
@@ -40001,7 +40000,7 @@ export const searchFolders: API.PaginatedOperationMethod<
   SearchFoldersRequest,
   SearchFoldersResponse,
   SearchFoldersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FolderSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchFoldersRequest,
@@ -40044,7 +40043,7 @@ export const searchGroups: API.PaginatedOperationMethod<
   SearchGroupsRequest,
   SearchGroupsResponse,
   SearchGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Group
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchGroupsRequest,
@@ -40086,7 +40085,7 @@ export const searchKnowledgeBases: API.PaginatedOperationMethod<
   SearchKnowledgeBasesRequest,
   SearchKnowledgeBasesResponse,
   SearchKnowledgeBasesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchKnowledgeBasesRequest,
@@ -40125,7 +40124,7 @@ export const searchSpaces: API.OperationMethod<
   SearchSpacesRequest,
   SearchSpacesResponse,
   SearchSpacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchSpacesRequest,
   output: SearchSpacesResponse,
@@ -40156,7 +40155,7 @@ export const searchTopics: API.PaginatedOperationMethod<
   SearchTopicsRequest,
   SearchTopicsResponse,
   SearchTopicsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TopicSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchTopicsRequest,
@@ -40207,7 +40206,7 @@ export const startAssetBundleExportJob: API.OperationMethod<
   StartAssetBundleExportJobRequest,
   StartAssetBundleExportJobResponse,
   StartAssetBundleExportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssetBundleExportJobRequest,
   output: StartAssetBundleExportJobResponse,
@@ -40252,7 +40251,7 @@ export const startAssetBundleImportJob: API.OperationMethod<
   StartAssetBundleImportJobRequest,
   StartAssetBundleImportJobResponse,
   StartAssetBundleImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssetBundleImportJobRequest,
   output: StartAssetBundleImportJobResponse,
@@ -40285,7 +40284,7 @@ export const startAutomationJob: API.OperationMethod<
   StartAutomationJobRequest,
   StartAutomationJobResponse,
   StartAutomationJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutomationJobRequest,
   output: StartAutomationJobResponse,
@@ -40406,7 +40405,7 @@ export const startDashboardSnapshotJob: API.OperationMethod<
   StartDashboardSnapshotJobRequest,
   StartDashboardSnapshotJobResponse,
   StartDashboardSnapshotJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDashboardSnapshotJobRequest,
   output: StartDashboardSnapshotJobResponse,
@@ -40446,7 +40445,7 @@ export const startDashboardSnapshotJobSchedule: API.OperationMethod<
   StartDashboardSnapshotJobScheduleRequest,
   StartDashboardSnapshotJobScheduleResponse,
   StartDashboardSnapshotJobScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDashboardSnapshotJobScheduleRequest,
   output: StartDashboardSnapshotJobScheduleResponse,
@@ -40499,7 +40498,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -40530,7 +40529,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -40567,7 +40566,7 @@ export const updateAccountCustomization: API.OperationMethod<
   UpdateAccountCustomizationRequest,
   UpdateAccountCustomizationResponse,
   UpdateAccountCustomizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountCustomizationRequest,
   output: UpdateAccountCustomizationResponse,
@@ -40599,7 +40598,7 @@ export const updateAccountCustomPermission: API.OperationMethod<
   UpdateAccountCustomPermissionRequest,
   UpdateAccountCustomPermissionResponse,
   UpdateAccountCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountCustomPermissionRequest,
   output: UpdateAccountCustomPermissionResponse,
@@ -40630,7 +40629,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsRequest,
   UpdateAccountSettingsResponse,
   UpdateAccountSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsRequest,
   output: UpdateAccountSettingsResponse,
@@ -40664,7 +40663,7 @@ export const updateActionConnector: API.OperationMethod<
   UpdateActionConnectorRequest,
   UpdateActionConnectorResponse,
   UpdateActionConnectorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActionConnectorRequest,
   output: UpdateActionConnectorResponse,
@@ -40698,7 +40697,7 @@ export const updateActionConnectorPermissions: API.OperationMethod<
   UpdateActionConnectorPermissionsRequest,
   UpdateActionConnectorPermissionsResponse,
   UpdateActionConnectorPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActionConnectorPermissionsRequest,
   output: UpdateActionConnectorPermissionsResponse,
@@ -40734,7 +40733,7 @@ export const updateAgent: API.OperationMethod<
   UpdateAgentRequest,
   UpdateAgentResponse,
   UpdateAgentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentRequest,
   output: UpdateAgentResponse,
@@ -40771,7 +40770,7 @@ export const updateAgentPermissions: API.OperationMethod<
   UpdateAgentPermissionsRequest,
   UpdateAgentPermissionsResponse,
   UpdateAgentPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentPermissionsRequest,
   output: UpdateAgentPermissionsResponse,
@@ -40807,7 +40806,7 @@ export const updateAnalysis: API.OperationMethod<
   UpdateAnalysisRequest,
   UpdateAnalysisResponse,
   UpdateAnalysisError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnalysisRequest,
   output: UpdateAnalysisResponse,
@@ -40841,7 +40840,7 @@ export const updateAnalysisPermissions: API.OperationMethod<
   UpdateAnalysisPermissionsRequest,
   UpdateAnalysisPermissionsResponse,
   UpdateAnalysisPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnalysisPermissionsRequest,
   output: UpdateAnalysisPermissionsResponse,
@@ -40875,7 +40874,7 @@ export const updateApplicationWithTokenExchangeGrant: API.OperationMethod<
   UpdateApplicationWithTokenExchangeGrantRequest,
   UpdateApplicationWithTokenExchangeGrantResponse,
   UpdateApplicationWithTokenExchangeGrantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationWithTokenExchangeGrantRequest,
   output: UpdateApplicationWithTokenExchangeGrantResponse,
@@ -40908,7 +40907,7 @@ export const updateBrand: API.OperationMethod<
   UpdateBrandRequest,
   UpdateBrandResponse,
   UpdateBrandError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrandRequest,
   output: UpdateBrandResponse,
@@ -40940,7 +40939,7 @@ export const updateBrandAssignment: API.OperationMethod<
   UpdateBrandAssignmentRequest,
   UpdateBrandAssignmentResponse,
   UpdateBrandAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrandAssignmentRequest,
   output: UpdateBrandAssignmentResponse,
@@ -40972,7 +40971,7 @@ export const updateBrandPublishedVersion: API.OperationMethod<
   UpdateBrandPublishedVersionRequest,
   UpdateBrandPublishedVersionResponse,
   UpdateBrandPublishedVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrandPublishedVersionRequest,
   output: UpdateBrandPublishedVersionResponse,
@@ -41006,7 +41005,7 @@ export const updateCustomPermissions: API.OperationMethod<
   UpdateCustomPermissionsRequest,
   UpdateCustomPermissionsResponse,
   UpdateCustomPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomPermissionsRequest,
   output: UpdateCustomPermissionsResponse,
@@ -41047,7 +41046,7 @@ export const updateDashboard: API.OperationMethod<
   UpdateDashboardRequest,
   UpdateDashboardResponse,
   UpdateDashboardError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardRequest,
   output: UpdateDashboardResponse,
@@ -41081,7 +41080,7 @@ export const updateDashboardLinks: API.OperationMethod<
   UpdateDashboardLinksRequest,
   UpdateDashboardLinksResponse,
   UpdateDashboardLinksError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardLinksRequest,
   output: UpdateDashboardLinksResponse,
@@ -41115,7 +41114,7 @@ export const updateDashboardPermissions: API.OperationMethod<
   UpdateDashboardPermissionsRequest,
   UpdateDashboardPermissionsResponse,
   UpdateDashboardPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardPermissionsRequest,
   output: UpdateDashboardPermissionsResponse,
@@ -41148,7 +41147,7 @@ export const updateDashboardPublishedVersion: API.OperationMethod<
   UpdateDashboardPublishedVersionRequest,
   UpdateDashboardPublishedVersionResponse,
   UpdateDashboardPublishedVersionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardPublishedVersionRequest,
   output: UpdateDashboardPublishedVersionResponse,
@@ -41180,7 +41179,7 @@ export const updateDashboardsQAConfiguration: API.OperationMethod<
   UpdateDashboardsQAConfigurationRequest,
   UpdateDashboardsQAConfigurationResponse,
   UpdateDashboardsQAConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDashboardsQAConfigurationRequest,
   output: UpdateDashboardsQAConfigurationResponse,
@@ -41216,7 +41215,7 @@ export const updateDataSet: API.OperationMethod<
   UpdateDataSetRequest,
   UpdateDataSetResponse,
   UpdateDataSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSetRequest,
   output: UpdateDataSetResponse,
@@ -41254,7 +41253,7 @@ export const updateDataSetPermissions: API.OperationMethod<
   UpdateDataSetPermissionsRequest,
   UpdateDataSetPermissionsResponse,
   UpdateDataSetPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSetPermissionsRequest,
   output: UpdateDataSetPermissionsResponse,
@@ -41287,7 +41286,7 @@ export const updateDataSource: API.OperationMethod<
   UpdateDataSourceRequest,
   UpdateDataSourceResponse,
   UpdateDataSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourceRequest,
   output: UpdateDataSourceResponse,
@@ -41320,7 +41319,7 @@ export const updateDataSourcePermissions: API.OperationMethod<
   UpdateDataSourcePermissionsRequest,
   UpdateDataSourcePermissionsResponse,
   UpdateDataSourcePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataSourcePermissionsRequest,
   output: UpdateDataSourcePermissionsResponse,
@@ -41352,7 +41351,7 @@ export const updateDefaultQBusinessApplication: API.OperationMethod<
   UpdateDefaultQBusinessApplicationRequest,
   UpdateDefaultQBusinessApplicationResponse,
   UpdateDefaultQBusinessApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDefaultQBusinessApplicationRequest,
   output: UpdateDefaultQBusinessApplicationResponse,
@@ -41385,7 +41384,7 @@ export const updateFlow: API.OperationMethod<
   UpdateFlowRequest,
   UpdateFlowResponse,
   UpdateFlowError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowRequest,
   output: UpdateFlowResponse,
@@ -41416,7 +41415,7 @@ export const updateFlowPermissions: API.OperationMethod<
   UpdateFlowPermissionsInput,
   UpdateFlowPermissionsOutput,
   UpdateFlowPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFlowPermissionsInput,
   output: UpdateFlowPermissionsOutput,
@@ -41448,7 +41447,7 @@ export const updateFolder: API.OperationMethod<
   UpdateFolderRequest,
   UpdateFolderResponse,
   UpdateFolderError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFolderRequest,
   output: UpdateFolderResponse,
@@ -41483,7 +41482,7 @@ export const updateFolderPermissions: API.OperationMethod<
   UpdateFolderPermissionsRequest,
   UpdateFolderPermissionsResponse,
   UpdateFolderPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFolderPermissionsRequest,
   output: UpdateFolderPermissionsResponse,
@@ -41517,7 +41516,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -41553,7 +41552,7 @@ export const updateIAMPolicyAssignment: API.OperationMethod<
   UpdateIAMPolicyAssignmentRequest,
   UpdateIAMPolicyAssignmentResponse,
   UpdateIAMPolicyAssignmentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIAMPolicyAssignmentRequest,
   output: UpdateIAMPolicyAssignmentResponse,
@@ -41587,7 +41586,7 @@ export const updateIdentityPropagationConfig: API.OperationMethod<
   UpdateIdentityPropagationConfigRequest,
   UpdateIdentityPropagationConfigResponse,
   UpdateIdentityPropagationConfigError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdentityPropagationConfigRequest,
   output: UpdateIdentityPropagationConfigResponse,
@@ -41618,7 +41617,7 @@ export const updateIpRestriction: API.OperationMethod<
   UpdateIpRestrictionRequest,
   UpdateIpRestrictionResponse,
   UpdateIpRestrictionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIpRestrictionRequest,
   output: UpdateIpRestrictionResponse,
@@ -41648,7 +41647,7 @@ export const updateKeyRegistration: API.OperationMethod<
   UpdateKeyRegistrationRequest,
   UpdateKeyRegistrationResponse,
   UpdateKeyRegistrationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKeyRegistrationRequest,
   output: UpdateKeyRegistrationResponse,
@@ -41681,7 +41680,7 @@ export const updateKnowledgeBasePermissions: API.OperationMethod<
   UpdateKnowledgeBasePermissionsRequest,
   UpdateKnowledgeBasePermissionsResponse,
   UpdateKnowledgeBasePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKnowledgeBasePermissionsRequest,
   output: UpdateKnowledgeBasePermissionsResponse,
@@ -41717,7 +41716,7 @@ export const updateOAuthClientApplication: API.OperationMethod<
   UpdateOAuthClientApplicationRequest,
   UpdateOAuthClientApplicationResponse,
   UpdateOAuthClientApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOAuthClientApplicationRequest,
   output: UpdateOAuthClientApplicationResponse,
@@ -41771,7 +41770,7 @@ export const updatePublicSharingSettings: API.OperationMethod<
   UpdatePublicSharingSettingsRequest,
   UpdatePublicSharingSettingsResponse,
   UpdatePublicSharingSettingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePublicSharingSettingsRequest,
   output: UpdatePublicSharingSettingsResponse,
@@ -41804,7 +41803,7 @@ export const updateQPersonalizationConfiguration: API.OperationMethod<
   UpdateQPersonalizationConfigurationRequest,
   UpdateQPersonalizationConfigurationResponse,
   UpdateQPersonalizationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQPersonalizationConfigurationRequest,
   output: UpdateQPersonalizationConfigurationResponse,
@@ -41837,7 +41836,7 @@ export const updateQuickSightQSearchConfiguration: API.OperationMethod<
   UpdateQuickSightQSearchConfigurationRequest,
   UpdateQuickSightQSearchConfigurationResponse,
   UpdateQuickSightQSearchConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuickSightQSearchConfigurationRequest,
   output: UpdateQuickSightQSearchConfigurationResponse,
@@ -41870,7 +41869,7 @@ export const updateRefreshSchedule: API.OperationMethod<
   UpdateRefreshScheduleRequest,
   UpdateRefreshScheduleResponse,
   UpdateRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRefreshScheduleRequest,
   output: UpdateRefreshScheduleResponse,
@@ -41904,7 +41903,7 @@ export const updateRoleCustomPermission: API.OperationMethod<
   UpdateRoleCustomPermissionRequest,
   UpdateRoleCustomPermissionResponse,
   UpdateRoleCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoleCustomPermissionRequest,
   output: UpdateRoleCustomPermissionResponse,
@@ -41940,7 +41939,7 @@ export const updateSelfUpgrade: API.OperationMethod<
   UpdateSelfUpgradeRequest,
   UpdateSelfUpgradeResponse,
   UpdateSelfUpgradeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSelfUpgradeRequest,
   output: UpdateSelfUpgradeResponse,
@@ -41977,7 +41976,7 @@ export const updateSelfUpgradeConfiguration: API.OperationMethod<
   UpdateSelfUpgradeConfigurationRequest,
   UpdateSelfUpgradeConfigurationResponse,
   UpdateSelfUpgradeConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSelfUpgradeConfigurationRequest,
   output: UpdateSelfUpgradeConfigurationResponse,
@@ -42011,7 +42010,7 @@ export const updateSpace: API.OperationMethod<
   UpdateSpaceRequest,
   UpdateSpaceResponse,
   UpdateSpaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpaceRequest,
   output: UpdateSpaceResponse,
@@ -42045,7 +42044,7 @@ export const updateSpacePermissions: API.OperationMethod<
   UpdateSpacePermissionsRequest,
   UpdateSpacePermissionsResponse,
   UpdateSpacePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpacePermissionsRequest,
   output: UpdateSpacePermissionsResponse,
@@ -42081,7 +42080,7 @@ export const updateSpaceResources: API.OperationMethod<
   UpdateSpaceResourcesRequest,
   UpdateSpaceResourcesResponse,
   UpdateSpaceResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpaceResourcesRequest,
   output: UpdateSpaceResourcesResponse,
@@ -42114,7 +42113,7 @@ export const updateSPICECapacityConfiguration: API.OperationMethod<
   UpdateSPICECapacityConfigurationRequest,
   UpdateSPICECapacityConfigurationResponse,
   UpdateSPICECapacityConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSPICECapacityConfigurationRequest,
   output: UpdateSPICECapacityConfigurationResponse,
@@ -42147,7 +42146,7 @@ export const updateTemplate: API.OperationMethod<
   UpdateTemplateRequest,
   UpdateTemplateResponse,
   UpdateTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateRequest,
   output: UpdateTemplateResponse,
@@ -42180,7 +42179,7 @@ export const updateTemplateAlias: API.OperationMethod<
   UpdateTemplateAliasRequest,
   UpdateTemplateAliasResponse,
   UpdateTemplateAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateAliasRequest,
   output: UpdateTemplateAliasResponse,
@@ -42212,7 +42211,7 @@ export const updateTemplatePermissions: API.OperationMethod<
   UpdateTemplatePermissionsRequest,
   UpdateTemplatePermissionsResponse,
   UpdateTemplatePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplatePermissionsRequest,
   output: UpdateTemplatePermissionsResponse,
@@ -42247,7 +42246,7 @@ export const updateTheme: API.OperationMethod<
   UpdateThemeRequest,
   UpdateThemeResponse,
   UpdateThemeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThemeRequest,
   output: UpdateThemeResponse,
@@ -42282,7 +42281,7 @@ export const updateThemeAlias: API.OperationMethod<
   UpdateThemeAliasRequest,
   UpdateThemeAliasResponse,
   UpdateThemeAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThemeAliasRequest,
   output: UpdateThemeAliasResponse,
@@ -42356,7 +42355,7 @@ export const updateThemePermissions: API.OperationMethod<
   UpdateThemePermissionsRequest,
   UpdateThemePermissionsResponse,
   UpdateThemePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThemePermissionsRequest,
   output: UpdateThemePermissionsResponse,
@@ -42391,7 +42390,7 @@ export const updateTopic: API.OperationMethod<
   UpdateTopicRequest,
   UpdateTopicResponse,
   UpdateTopicError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTopicRequest,
   output: UpdateTopicResponse,
@@ -42427,7 +42426,7 @@ export const updateTopicPermissions: API.OperationMethod<
   UpdateTopicPermissionsRequest,
   UpdateTopicPermissionsResponse,
   UpdateTopicPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTopicPermissionsRequest,
   output: UpdateTopicPermissionsResponse,
@@ -42463,7 +42462,7 @@ export const updateTopicRefreshSchedule: API.OperationMethod<
   UpdateTopicRefreshScheduleRequest,
   UpdateTopicRefreshScheduleResponse,
   UpdateTopicRefreshScheduleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTopicRefreshScheduleRequest,
   output: UpdateTopicRefreshScheduleResponse,
@@ -42498,7 +42497,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,
@@ -42533,7 +42532,7 @@ export const updateUserCustomPermission: API.OperationMethod<
   UpdateUserCustomPermissionRequest,
   UpdateUserCustomPermissionResponse,
   UpdateUserCustomPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserCustomPermissionRequest,
   output: UpdateUserCustomPermissionResponse,
@@ -42569,7 +42568,7 @@ export const updateVPCConnection: API.OperationMethod<
   UpdateVPCConnectionRequest,
   UpdateVPCConnectionResponse,
   UpdateVPCConnectionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVPCConnectionRequest,
   output: UpdateVPCConnectionResponse,

--- a/packages/aws/src/services/ram.ts
+++ b/packages/aws/src/services/ram.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "RAM",
   serviceShapeName: "AmazonResourceSharing",
@@ -2235,7 +2234,7 @@ export const acceptResourceShareInvitation: API.OperationMethod<
   AcceptResourceShareInvitationRequest,
   AcceptResourceShareInvitationResponse,
   AcceptResourceShareInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptResourceShareInvitationRequest,
   output: AcceptResourceShareInvitationResponse,
@@ -2278,7 +2277,7 @@ export const associateResourceShare: API.OperationMethod<
   AssociateResourceShareRequest,
   AssociateResourceShareResponse,
   AssociateResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceShareRequest,
   output: AssociateResourceShareResponse,
@@ -2319,7 +2318,7 @@ export const associateResourceSharePermission: API.OperationMethod<
   AssociateResourceSharePermissionRequest,
   AssociateResourceSharePermissionResponse,
   AssociateResourceSharePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceSharePermissionRequest,
   output: AssociateResourceSharePermissionResponse,
@@ -2357,7 +2356,7 @@ export const createPermission: API.OperationMethod<
   CreatePermissionRequest,
   CreatePermissionResponse,
   CreatePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePermissionRequest,
   output: CreatePermissionResponse,
@@ -2403,7 +2402,7 @@ export const createPermissionVersion: API.OperationMethod<
   CreatePermissionVersionRequest,
   CreatePermissionVersionResponse,
   CreatePermissionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePermissionVersionRequest,
   output: CreatePermissionVersionResponse,
@@ -2452,7 +2451,7 @@ export const createResourceShare: API.OperationMethod<
   CreateResourceShareRequest,
   CreateResourceShareResponse,
   CreateResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceShareRequest,
   output: CreateResourceShareResponse,
@@ -2494,7 +2493,7 @@ export const deletePermission: API.OperationMethod<
   DeletePermissionRequest,
   DeletePermissionResponse,
   DeletePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionRequest,
   output: DeletePermissionResponse,
@@ -2533,7 +2532,7 @@ export const deletePermissionVersion: API.OperationMethod<
   DeletePermissionVersionRequest,
   DeletePermissionVersionResponse,
   DeletePermissionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionVersionRequest,
   output: DeletePermissionVersionResponse,
@@ -2574,7 +2573,7 @@ export const deleteResourceShare: API.OperationMethod<
   DeleteResourceShareRequest,
   DeleteResourceShareResponse,
   DeleteResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceShareRequest,
   output: DeleteResourceShareResponse,
@@ -2616,7 +2615,7 @@ export const disassociateResourceShare: API.OperationMethod<
   DisassociateResourceShareRequest,
   DisassociateResourceShareResponse,
   DisassociateResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceShareRequest,
   output: DisassociateResourceShareResponse,
@@ -2657,7 +2656,7 @@ export const disassociateResourceSharePermission: API.OperationMethod<
   DisassociateResourceSharePermissionRequest,
   DisassociateResourceSharePermissionResponse,
   DisassociateResourceSharePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceSharePermissionRequest,
   output: DisassociateResourceSharePermissionResponse,
@@ -2698,7 +2697,7 @@ export const enableSharingWithAwsOrganization: API.OperationMethod<
   EnableSharingWithAwsOrganizationRequest,
   EnableSharingWithAwsOrganizationResponse,
   EnableSharingWithAwsOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSharingWithAwsOrganizationRequest,
   output: EnableSharingWithAwsOrganizationResponse,
@@ -2727,7 +2726,7 @@ export const getPermission: API.OperationMethod<
   GetPermissionRequest,
   GetPermissionResponse,
   GetPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionRequest,
   output: GetPermissionResponse,
@@ -2766,7 +2765,7 @@ export const getResourcePolicies: API.PaginatedOperationMethod<
   GetResourcePoliciesRequest,
   GetResourcePoliciesResponse,
   GetResourcePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcePoliciesRequest,
@@ -2812,7 +2811,7 @@ export const getResourceShareAssociations: API.PaginatedOperationMethod<
   GetResourceShareAssociationsRequest,
   GetResourceShareAssociationsResponse,
   GetResourceShareAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceShareAssociationsRequest,
@@ -2859,7 +2858,7 @@ export const getResourceShareInvitations: API.PaginatedOperationMethod<
   GetResourceShareInvitationsRequest,
   GetResourceShareInvitationsResponse,
   GetResourceShareInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceShareInvitationsRequest,
@@ -2905,7 +2904,7 @@ export const getResourceShares: API.PaginatedOperationMethod<
   GetResourceSharesRequest,
   GetResourceSharesResponse,
   GetResourceSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceSharesRequest,
@@ -2954,7 +2953,7 @@ export const listPendingInvitationResources: API.PaginatedOperationMethod<
   ListPendingInvitationResourcesRequest,
   ListPendingInvitationResourcesResponse,
   ListPendingInvitationResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPendingInvitationResourcesRequest,
@@ -3002,7 +3001,7 @@ export const listPermissionAssociations: API.PaginatedOperationMethod<
   ListPermissionAssociationsRequest,
   ListPermissionAssociationsResponse,
   ListPermissionAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionAssociationsRequest,
@@ -3045,7 +3044,7 @@ export const listPermissions: API.PaginatedOperationMethod<
   ListPermissionsRequest,
   ListPermissionsResponse,
   ListPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionsRequest,
@@ -3089,7 +3088,7 @@ export const listPermissionVersions: API.PaginatedOperationMethod<
   ListPermissionVersionsRequest,
   ListPermissionVersionsResponse,
   ListPermissionVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionVersionsRequest,
@@ -3135,7 +3134,7 @@ export const listPrincipals: API.PaginatedOperationMethod<
   ListPrincipalsRequest,
   ListPrincipalsResponse,
   ListPrincipalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrincipalsRequest,
@@ -3178,7 +3177,7 @@ export const listReplacePermissionAssociationsWork: API.PaginatedOperationMethod
   ListReplacePermissionAssociationsWorkRequest,
   ListReplacePermissionAssociationsWorkResponse,
   ListReplacePermissionAssociationsWorkError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReplacePermissionAssociationsWorkRequest,
@@ -3222,7 +3221,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesRequest,
   ListResourcesResponse,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesRequest,
@@ -3268,7 +3267,7 @@ export const listResourceSharePermissions: API.PaginatedOperationMethod<
   ListResourceSharePermissionsRequest,
   ListResourceSharePermissionsResponse,
   ListResourceSharePermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceSharePermissionsRequest,
@@ -3305,7 +3304,7 @@ export const listResourceTypes: API.PaginatedOperationMethod<
   ListResourceTypesRequest,
   ListResourceTypesResponse,
   ListResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceTypesRequest,
@@ -3343,7 +3342,7 @@ export const listSourceAssociations: API.PaginatedOperationMethod<
   ListSourceAssociationsRequest,
   ListSourceAssociationsResponse,
   ListSourceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociatedSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSourceAssociationsRequest,
@@ -3410,7 +3409,7 @@ export const promotePermissionCreatedFromPolicy: API.OperationMethod<
   PromotePermissionCreatedFromPolicyRequest,
   PromotePermissionCreatedFromPolicyResponse,
   PromotePermissionCreatedFromPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromotePermissionCreatedFromPolicyRequest,
   output: PromotePermissionCreatedFromPolicyResponse,
@@ -3461,7 +3460,7 @@ export const promoteResourceShareCreatedFromPolicy: API.OperationMethod<
   PromoteResourceShareCreatedFromPolicyRequest,
   PromoteResourceShareCreatedFromPolicyResponse,
   PromoteResourceShareCreatedFromPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromoteResourceShareCreatedFromPolicyRequest,
   output: PromoteResourceShareCreatedFromPolicyResponse,
@@ -3501,7 +3500,7 @@ export const rejectResourceShareInvitation: API.OperationMethod<
   RejectResourceShareInvitationRequest,
   RejectResourceShareInvitationResponse,
   RejectResourceShareInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectResourceShareInvitationRequest,
   output: RejectResourceShareInvitationResponse,
@@ -3554,7 +3553,7 @@ export const replacePermissionAssociations: API.OperationMethod<
   ReplacePermissionAssociationsRequest,
   ReplacePermissionAssociationsResponse,
   ReplacePermissionAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplacePermissionAssociationsRequest,
   output: ReplacePermissionAssociationsResponse,
@@ -3591,7 +3590,7 @@ export const setDefaultPermissionVersion: API.OperationMethod<
   SetDefaultPermissionVersionRequest,
   SetDefaultPermissionVersionResponse,
   SetDefaultPermissionVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetDefaultPermissionVersionRequest,
   output: SetDefaultPermissionVersionResponse,
@@ -3629,7 +3628,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3662,7 +3661,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3696,7 +3695,7 @@ export const updateResourceShare: API.OperationMethod<
   UpdateResourceShareRequest,
   UpdateResourceShareResponse,
   UpdateResourceShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceShareRequest,
   output: UpdateResourceShareResponse,

--- a/packages/aws/src/services/rbin.ts
+++ b/packages/aws/src/services/rbin.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "rbin",
   serviceShapeName: "AmazonRecycleBin",
@@ -693,7 +692,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResponse,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
@@ -721,7 +720,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -748,7 +747,7 @@ export const getRule: API.OperationMethod<
   GetRuleRequest,
   GetRuleResponse,
   GetRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleRequest,
   output: GetRuleResponse,
@@ -773,7 +772,7 @@ export const listRules: API.PaginatedOperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesRequest,
@@ -802,7 +801,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -833,7 +832,7 @@ export const lockRule: API.OperationMethod<
   LockRuleRequest,
   LockRuleResponse,
   LockRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LockRuleRequest,
   output: LockRuleResponse,
@@ -861,7 +860,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -890,7 +889,7 @@ export const unlockRule: API.OperationMethod<
   UnlockRuleRequest,
   UnlockRuleResponse,
   UnlockRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnlockRuleRequest,
   output: UnlockRuleResponse,
@@ -917,7 +916,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -948,7 +947,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
   UpdateRuleResponse,
   UpdateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,

--- a/packages/aws/src/services/rds-data.ts
+++ b/packages/aws/src/services/rds-data.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "RDS Data",
   serviceShapeName: "RdsDataService",
@@ -893,7 +892,7 @@ export const batchExecuteStatement: API.OperationMethod<
   BatchExecuteStatementRequest,
   BatchExecuteStatementResponse,
   BatchExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchExecuteStatementRequest,
   output: BatchExecuteStatementResponse,
@@ -949,7 +948,7 @@ export const beginTransaction: API.OperationMethod<
   BeginTransactionRequest,
   BeginTransactionResponse,
   BeginTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BeginTransactionRequest,
   output: BeginTransactionResponse,
@@ -999,7 +998,7 @@ export const commitTransaction: API.OperationMethod<
   CommitTransactionRequest,
   CommitTransactionResponse,
   CommitTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CommitTransactionRequest,
   output: CommitTransactionResponse,
@@ -1041,7 +1040,7 @@ export const executeSql: API.OperationMethod<
   ExecuteSqlRequest,
   ExecuteSqlResponse,
   ExecuteSqlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteSqlRequest,
   output: ExecuteSqlResponse,
@@ -1086,7 +1085,7 @@ export const executeStatement: API.OperationMethod<
   ExecuteStatementRequest,
   ExecuteStatementResponse,
   ExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteStatementRequest,
   output: ExecuteStatementResponse,
@@ -1137,7 +1136,7 @@ export const rollbackTransaction: API.OperationMethod<
   RollbackTransactionRequest,
   RollbackTransactionResponse,
   RollbackTransactionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RollbackTransactionRequest,
   output: RollbackTransactionResponse,

--- a/packages/aws/src/services/rds.ts
+++ b/packages/aws/src/services/rds.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://rds.amazonaws.com/doc/2014-10-31/");
 const svc = T.AwsApiService({ sdkId: "RDS", serviceShapeName: "AmazonRDSv19" });
@@ -12550,7 +12549,7 @@ export const addRoleToDBCluster: API.OperationMethod<
   AddRoleToDBClusterMessage,
   AddRoleToDBClusterResponse,
   AddRoleToDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRoleToDBClusterMessage,
   output: AddRoleToDBClusterResponse,
@@ -12582,7 +12581,7 @@ export const addRoleToDBInstance: API.OperationMethod<
   AddRoleToDBInstanceMessage,
   AddRoleToDBInstanceResponse,
   AddRoleToDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRoleToDBInstanceMessage,
   output: AddRoleToDBInstanceResponse,
@@ -12608,7 +12607,7 @@ export const addSourceIdentifierToSubscription: API.OperationMethod<
   AddSourceIdentifierToSubscriptionMessage,
   AddSourceIdentifierToSubscriptionResult,
   AddSourceIdentifierToSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddSourceIdentifierToSubscriptionMessage,
   output: AddSourceIdentifierToSubscriptionResult,
@@ -12643,7 +12642,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceMessage,
   AddTagsToResourceResponse,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceMessage,
   output: AddTagsToResourceResponse,
@@ -12680,7 +12679,7 @@ export const applyPendingMaintenanceAction: API.OperationMethod<
   ApplyPendingMaintenanceActionMessage,
   ApplyPendingMaintenanceActionResult,
   ApplyPendingMaintenanceActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ApplyPendingMaintenanceActionMessage,
   output: ApplyPendingMaintenanceActionResult,
@@ -12713,7 +12712,7 @@ export const authorizeDBSecurityGroupIngress: API.OperationMethod<
   AuthorizeDBSecurityGroupIngressMessage,
   AuthorizeDBSecurityGroupIngressResult,
   AuthorizeDBSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeDBSecurityGroupIngressMessage,
   output: AuthorizeDBSecurityGroupIngressResult,
@@ -12743,7 +12742,7 @@ export const backtrackDBCluster: API.OperationMethod<
   BacktrackDBClusterMessage,
   DBClusterBacktrack,
   BacktrackDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BacktrackDBClusterMessage,
   output: DBClusterBacktrack,
@@ -12764,7 +12763,7 @@ export const cancelExportTask: API.OperationMethod<
   CancelExportTaskMessage,
   ExportTask,
   CancelExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelExportTaskMessage,
   output: ExportTask,
@@ -12788,7 +12787,7 @@ export const copyDBClusterParameterGroup: API.OperationMethod<
   CopyDBClusterParameterGroupMessage,
   CopyDBClusterParameterGroupResult,
   CopyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterParameterGroupMessage,
   output: CopyDBClusterParameterGroupResult,
@@ -12835,7 +12834,7 @@ export const copyDBClusterSnapshot: API.OperationMethod<
   CopyDBClusterSnapshotMessage,
   CopyDBClusterSnapshotResult,
   CopyDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBClusterSnapshotMessage,
   output: CopyDBClusterSnapshotResult,
@@ -12866,7 +12865,7 @@ export const copyDBParameterGroup: API.OperationMethod<
   CopyDBParameterGroupMessage,
   CopyDBParameterGroupResult,
   CopyDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBParameterGroupMessage,
   output: CopyDBParameterGroupResult,
@@ -12901,7 +12900,7 @@ export const copyDBSnapshot: API.OperationMethod<
   CopyDBSnapshotMessage,
   CopyDBSnapshotResult,
   CopyDBSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyDBSnapshotMessage,
   output: CopyDBSnapshotResult,
@@ -12930,7 +12929,7 @@ export const copyOptionGroup: API.OperationMethod<
   CopyOptionGroupMessage,
   CopyOptionGroupResult,
   CopyOptionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyOptionGroupMessage,
   output: CopyOptionGroupResult,
@@ -12971,7 +12970,7 @@ export const createBlueGreenDeployment: API.OperationMethod<
   CreateBlueGreenDeploymentRequest,
   CreateBlueGreenDeploymentResponse,
   CreateBlueGreenDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBlueGreenDeploymentRequest,
   output: CreateBlueGreenDeploymentResponse,
@@ -13010,7 +13009,7 @@ export const createCustomDBEngineVersion: API.OperationMethod<
   CreateCustomDBEngineVersionMessage,
   DBEngineVersion,
   CreateCustomDBEngineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomDBEngineVersionMessage,
   output: DBEngineVersion,
@@ -13071,7 +13070,7 @@ export const createDBCluster: API.OperationMethod<
   CreateDBClusterMessage,
   CreateDBClusterResult,
   CreateDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterMessage,
   output: CreateDBClusterResult,
@@ -13125,7 +13124,7 @@ export const createDBClusterEndpoint: API.OperationMethod<
   CreateDBClusterEndpointMessage,
   DBClusterEndpoint,
   CreateDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterEndpointMessage,
   output: DBClusterEndpoint,
@@ -13167,7 +13166,7 @@ export const createDBClusterParameterGroup: API.OperationMethod<
   CreateDBClusterParameterGroupMessage,
   CreateDBClusterParameterGroupResult,
   CreateDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterParameterGroupMessage,
   output: CreateDBClusterParameterGroupResult,
@@ -13198,7 +13197,7 @@ export const createDBClusterSnapshot: API.OperationMethod<
   CreateDBClusterSnapshotMessage,
   CreateDBClusterSnapshotResult,
   CreateDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBClusterSnapshotMessage,
   output: CreateDBClusterSnapshotResult,
@@ -13254,7 +13253,7 @@ export const createDBInstance: API.OperationMethod<
   CreateDBInstanceMessage,
   CreateDBInstanceResult,
   CreateDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBInstanceMessage,
   output: CreateDBInstanceResult,
@@ -13330,7 +13329,7 @@ export const createDBInstanceReadReplica: API.OperationMethod<
   CreateDBInstanceReadReplicaMessage,
   CreateDBInstanceReadReplicaResult,
   CreateDBInstanceReadReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBInstanceReadReplicaMessage,
   output: CreateDBInstanceReadReplicaResult,
@@ -13381,7 +13380,7 @@ export const createDBParameterGroup: API.OperationMethod<
   CreateDBParameterGroupMessage,
   CreateDBParameterGroupResult,
   CreateDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBParameterGroupMessage,
   output: CreateDBParameterGroupResult,
@@ -13406,7 +13405,7 @@ export const createDBProxy: API.OperationMethod<
   CreateDBProxyRequest,
   CreateDBProxyResponse,
   CreateDBProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBProxyRequest,
   output: CreateDBProxyResponse,
@@ -13430,7 +13429,7 @@ export const createDBProxyEndpoint: API.OperationMethod<
   CreateDBProxyEndpointRequest,
   CreateDBProxyEndpointResponse,
   CreateDBProxyEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBProxyEndpointRequest,
   output: CreateDBProxyEndpointResponse,
@@ -13462,7 +13461,7 @@ export const createDBSecurityGroup: API.OperationMethod<
   CreateDBSecurityGroupMessage,
   CreateDBSecurityGroupResult,
   CreateDBSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBSecurityGroupMessage,
   output: CreateDBSecurityGroupResult,
@@ -13494,7 +13493,7 @@ export const createDBShardGroup: API.OperationMethod<
   CreateDBShardGroupMessage,
   DBShardGroup,
   CreateDBShardGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBShardGroupMessage,
   output: DBShardGroup,
@@ -13525,7 +13524,7 @@ export const createDBSnapshot: API.OperationMethod<
   CreateDBSnapshotMessage,
   CreateDBSnapshotResult,
   CreateDBSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBSnapshotMessage,
   output: CreateDBSnapshotResult,
@@ -13554,7 +13553,7 @@ export const createDBSubnetGroup: API.OperationMethod<
   CreateDBSubnetGroupMessage,
   CreateDBSubnetGroupResult,
   CreateDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDBSubnetGroupMessage,
   output: CreateDBSubnetGroupResult,
@@ -13594,7 +13593,7 @@ export const createEventSubscription: API.OperationMethod<
   CreateEventSubscriptionMessage,
   CreateEventSubscriptionResult,
   CreateEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSubscriptionMessage,
   output: CreateEventSubscriptionResult,
@@ -13631,7 +13630,7 @@ export const createGlobalCluster: API.OperationMethod<
   CreateGlobalClusterMessage,
   CreateGlobalClusterResult,
   CreateGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalClusterMessage,
   output: CreateGlobalClusterResult,
@@ -13663,7 +13662,7 @@ export const createIntegration: API.OperationMethod<
   CreateIntegrationMessage,
   Integration,
   CreateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationMessage,
   output: Integration,
@@ -13693,7 +13692,7 @@ export const createOptionGroup: API.OperationMethod<
   CreateOptionGroupMessage,
   CreateOptionGroupResult,
   CreateOptionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOptionGroupMessage,
   output: CreateOptionGroupResult,
@@ -13717,7 +13716,7 @@ export const createTenantDatabase: API.OperationMethod<
   CreateTenantDatabaseMessage,
   CreateTenantDatabaseResult,
   CreateTenantDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTenantDatabaseMessage,
   output: CreateTenantDatabaseResult,
@@ -13746,7 +13745,7 @@ export const deleteBlueGreenDeployment: API.OperationMethod<
   DeleteBlueGreenDeploymentRequest,
   DeleteBlueGreenDeploymentResponse,
   DeleteBlueGreenDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBlueGreenDeploymentRequest,
   output: DeleteBlueGreenDeploymentResponse,
@@ -13780,7 +13779,7 @@ export const deleteCustomDBEngineVersion: API.OperationMethod<
   DeleteCustomDBEngineVersionMessage,
   DBEngineVersion,
   DeleteCustomDBEngineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomDBEngineVersionMessage,
   output: DBEngineVersion,
@@ -13816,7 +13815,7 @@ export const deleteDBCluster: API.OperationMethod<
   DeleteDBClusterMessage,
   DeleteDBClusterResult,
   DeleteDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterMessage,
   output: DeleteDBClusterResult,
@@ -13846,7 +13845,7 @@ export const deleteDBClusterAutomatedBackup: API.OperationMethod<
   DeleteDBClusterAutomatedBackupMessage,
   DeleteDBClusterAutomatedBackupResult,
   DeleteDBClusterAutomatedBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterAutomatedBackupMessage,
   output: DeleteDBClusterAutomatedBackupResult,
@@ -13873,7 +13872,7 @@ export const deleteDBClusterEndpoint: API.OperationMethod<
   DeleteDBClusterEndpointMessage,
   DBClusterEndpoint,
   DeleteDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterEndpointMessage,
   output: DBClusterEndpoint,
@@ -13902,7 +13901,7 @@ export const deleteDBClusterParameterGroup: API.OperationMethod<
   DeleteDBClusterParameterGroupMessage,
   DeleteDBClusterParameterGroupResponse,
   DeleteDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterParameterGroupMessage,
   output: DeleteDBClusterParameterGroupResponse,
@@ -13929,7 +13928,7 @@ export const deleteDBClusterSnapshot: API.OperationMethod<
   DeleteDBClusterSnapshotMessage,
   DeleteDBClusterSnapshotResult,
   DeleteDBClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBClusterSnapshotMessage,
   output: DeleteDBClusterSnapshotResult,
@@ -13969,7 +13968,7 @@ export const deleteDBInstance: API.OperationMethod<
   DeleteDBInstanceMessage,
   DeleteDBInstanceResult,
   DeleteDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBInstanceMessage,
   output: DeleteDBInstanceResult,
@@ -13998,7 +13997,7 @@ export const deleteDBInstanceAutomatedBackup: API.OperationMethod<
   DeleteDBInstanceAutomatedBackupMessage,
   DeleteDBInstanceAutomatedBackupResult,
   DeleteDBInstanceAutomatedBackupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBInstanceAutomatedBackupMessage,
   output: DeleteDBInstanceAutomatedBackupResult,
@@ -14022,7 +14021,7 @@ export const deleteDBParameterGroup: API.OperationMethod<
   DeleteDBParameterGroupMessage,
   DeleteDBParameterGroupResponse,
   DeleteDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBParameterGroupMessage,
   output: DeleteDBParameterGroupResponse,
@@ -14043,7 +14042,7 @@ export const deleteDBProxy: API.OperationMethod<
   DeleteDBProxyRequest,
   DeleteDBProxyResponse,
   DeleteDBProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBProxyRequest,
   output: DeleteDBProxyResponse,
@@ -14064,7 +14063,7 @@ export const deleteDBProxyEndpoint: API.OperationMethod<
   DeleteDBProxyEndpointRequest,
   DeleteDBProxyEndpointResponse,
   DeleteDBProxyEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBProxyEndpointRequest,
   output: DeleteDBProxyEndpointResponse,
@@ -14089,7 +14088,7 @@ export const deleteDBSecurityGroup: API.OperationMethod<
   DeleteDBSecurityGroupMessage,
   DeleteDBSecurityGroupResponse,
   DeleteDBSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBSecurityGroupMessage,
   output: DeleteDBSecurityGroupResponse,
@@ -14111,7 +14110,7 @@ export const deleteDBShardGroup: API.OperationMethod<
   DeleteDBShardGroupMessage,
   DBShardGroup,
   DeleteDBShardGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBShardGroupMessage,
   output: DBShardGroup,
@@ -14138,7 +14137,7 @@ export const deleteDBSnapshot: API.OperationMethod<
   DeleteDBSnapshotMessage,
   DeleteDBSnapshotResult,
   DeleteDBSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBSnapshotMessage,
   output: DeleteDBSnapshotResult,
@@ -14162,7 +14161,7 @@ export const deleteDBSubnetGroup: API.OperationMethod<
   DeleteDBSubnetGroupMessage,
   DeleteDBSubnetGroupResponse,
   DeleteDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDBSubnetGroupMessage,
   output: DeleteDBSubnetGroupResponse,
@@ -14187,7 +14186,7 @@ export const deleteEventSubscription: API.OperationMethod<
   DeleteEventSubscriptionMessage,
   DeleteEventSubscriptionResult,
   DeleteEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSubscriptionMessage,
   output: DeleteEventSubscriptionResult,
@@ -14210,7 +14209,7 @@ export const deleteGlobalCluster: API.OperationMethod<
   DeleteGlobalClusterMessage,
   DeleteGlobalClusterResult,
   DeleteGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalClusterMessage,
   output: DeleteGlobalClusterResult,
@@ -14232,7 +14231,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationMessage,
   Integration,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationMessage,
   output: Integration,
@@ -14257,7 +14256,7 @@ export const deleteOptionGroup: API.OperationMethod<
   DeleteOptionGroupMessage,
   DeleteOptionGroupResponse,
   DeleteOptionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOptionGroupMessage,
   output: DeleteOptionGroupResponse,
@@ -14282,7 +14281,7 @@ export const deleteTenantDatabase: API.OperationMethod<
   DeleteTenantDatabaseMessage,
   DeleteTenantDatabaseResult,
   DeleteTenantDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTenantDatabaseMessage,
   output: DeleteTenantDatabaseResult,
@@ -14310,7 +14309,7 @@ export const deregisterDBProxyTargets: API.OperationMethod<
   DeregisterDBProxyTargetsRequest,
   DeregisterDBProxyTargetsResponse,
   DeregisterDBProxyTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterDBProxyTargetsRequest,
   output: DeregisterDBProxyTargetsResponse,
@@ -14335,7 +14334,7 @@ export const describeAccountAttributes: API.OperationMethod<
   DescribeAccountAttributesMessage,
   AccountAttributesMessage,
   DescribeAccountAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAttributesMessage,
   output: AccountAttributesMessage,
@@ -14357,7 +14356,7 @@ export const describeBlueGreenDeployments: API.PaginatedOperationMethod<
   DescribeBlueGreenDeploymentsRequest,
   DescribeBlueGreenDeploymentsResponse,
   DescribeBlueGreenDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BlueGreenDeployment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeBlueGreenDeploymentsRequest,
@@ -14384,7 +14383,7 @@ export const describeCertificates: API.PaginatedOperationMethod<
   DescribeCertificatesMessage,
   CertificateMessage,
   DescribeCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Certificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCertificatesMessage,
@@ -14413,7 +14412,7 @@ export const describeDBClusterAutomatedBackups: API.PaginatedOperationMethod<
   DescribeDBClusterAutomatedBackupsMessage,
   DBClusterAutomatedBackupMessage,
   DescribeDBClusterAutomatedBackupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterAutomatedBackup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterAutomatedBackupsMessage,
@@ -14445,7 +14444,7 @@ export const describeDBClusterBacktracks: API.PaginatedOperationMethod<
   DescribeDBClusterBacktracksMessage,
   DBClusterBacktrackMessage,
   DescribeDBClusterBacktracksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterBacktrack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterBacktracksMessage,
@@ -14474,7 +14473,7 @@ export const describeDBClusterEndpoints: API.PaginatedOperationMethod<
   DescribeDBClusterEndpointsMessage,
   DBClusterEndpointMessage,
   DescribeDBClusterEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterEndpointsMessage,
@@ -14505,7 +14504,7 @@ export const describeDBClusterParameterGroups: API.PaginatedOperationMethod<
   DescribeDBClusterParameterGroupsMessage,
   DBClusterParameterGroupsMessage,
   DescribeDBClusterParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParameterGroupsMessage,
@@ -14536,7 +14535,7 @@ export const describeDBClusterParameters: API.PaginatedOperationMethod<
   DescribeDBClusterParametersMessage,
   DBClusterParameterGroupDetails,
   DescribeDBClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterParametersMessage,
@@ -14567,7 +14566,7 @@ export const describeDBClusters: API.PaginatedOperationMethod<
   DescribeDBClustersMessage,
   DBClusterMessage,
   DescribeDBClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClustersMessage,
@@ -14598,7 +14597,7 @@ export const describeDBClusterSnapshotAttributes: API.OperationMethod<
   DescribeDBClusterSnapshotAttributesMessage,
   DescribeDBClusterSnapshotAttributesResult,
   DescribeDBClusterSnapshotAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDBClusterSnapshotAttributesMessage,
   output: DescribeDBClusterSnapshotAttributesResult,
@@ -14622,7 +14621,7 @@ export const describeDBClusterSnapshots: API.PaginatedOperationMethod<
   DescribeDBClusterSnapshotsMessage,
   DBClusterSnapshotMessage,
   DescribeDBClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBClusterSnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBClusterSnapshotsMessage,
@@ -14647,7 +14646,7 @@ export const describeDBEngineVersions: API.PaginatedOperationMethod<
   DescribeDBEngineVersionsMessage,
   DBEngineVersionMessage,
   DescribeDBEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBEngineVersionsMessage,
@@ -14676,7 +14675,7 @@ export const describeDBInstanceAutomatedBackups: API.PaginatedOperationMethod<
   DescribeDBInstanceAutomatedBackupsMessage,
   DBInstanceAutomatedBackupMessage,
   DescribeDBInstanceAutomatedBackupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBInstanceAutomatedBackup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBInstanceAutomatedBackupsMessage,
@@ -14703,7 +14702,7 @@ export const describeDBInstances: API.PaginatedOperationMethod<
   DescribeDBInstancesMessage,
   DBInstanceMessage,
   DescribeDBInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBInstancesMessage,
@@ -14733,7 +14732,7 @@ export const describeDBLogFiles: API.PaginatedOperationMethod<
   DescribeDBLogFilesMessage,
   DescribeDBLogFilesResponse,
   DescribeDBLogFilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DescribeDBLogFilesDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBLogFilesMessage,
@@ -14758,7 +14757,7 @@ export const describeDBMajorEngineVersions: API.PaginatedOperationMethod<
   DescribeDBMajorEngineVersionsRequest,
   DescribeDBMajorEngineVersionsResponse,
   DescribeDBMajorEngineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBMajorEngineVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBMajorEngineVersionsRequest,
@@ -14785,7 +14784,7 @@ export const describeDBParameterGroups: API.PaginatedOperationMethod<
   DescribeDBParameterGroupsMessage,
   DBParameterGroupsMessage,
   DescribeDBParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBParameterGroupsMessage,
@@ -14812,7 +14811,7 @@ export const describeDBParameters: API.PaginatedOperationMethod<
   DescribeDBParametersMessage,
   DBParameterGroupDetails,
   DescribeDBParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBParametersMessage,
@@ -14837,7 +14836,7 @@ export const describeDBProxies: API.PaginatedOperationMethod<
   DescribeDBProxiesRequest,
   DescribeDBProxiesResponse,
   DescribeDBProxiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBProxy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBProxiesRequest,
@@ -14865,7 +14864,7 @@ export const describeDBProxyEndpoints: API.PaginatedOperationMethod<
   DescribeDBProxyEndpointsRequest,
   DescribeDBProxyEndpointsResponse,
   DescribeDBProxyEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBProxyEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBProxyEndpointsRequest,
@@ -14894,7 +14893,7 @@ export const describeDBProxyTargetGroups: API.PaginatedOperationMethod<
   DescribeDBProxyTargetGroupsRequest,
   DescribeDBProxyTargetGroupsResponse,
   DescribeDBProxyTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBProxyTargetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBProxyTargetGroupsRequest,
@@ -14928,7 +14927,7 @@ export const describeDBProxyTargets: API.PaginatedOperationMethod<
   DescribeDBProxyTargetsRequest,
   DescribeDBProxyTargetsResponse,
   DescribeDBProxyTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBProxyTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBProxyTargetsRequest,
@@ -14958,7 +14957,7 @@ export const describeDBRecommendations: API.PaginatedOperationMethod<
   DescribeDBRecommendationsMessage,
   DBRecommendationsMessage,
   DescribeDBRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBRecommendationsMessage,
@@ -14987,7 +14986,7 @@ export const describeDBSecurityGroups: API.PaginatedOperationMethod<
   DescribeDBSecurityGroupsMessage,
   DBSecurityGroupMessage,
   DescribeDBSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSecurityGroupsMessage,
@@ -15015,7 +15014,7 @@ export const describeDBShardGroups: API.OperationMethod<
   DescribeDBShardGroupsMessage,
   DescribeDBShardGroupsResponse,
   DescribeDBShardGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDBShardGroupsMessage,
   output: DescribeDBShardGroupsResponse,
@@ -15039,7 +15038,7 @@ export const describeDBSnapshotAttributes: API.OperationMethod<
   DescribeDBSnapshotAttributesMessage,
   DescribeDBSnapshotAttributesResult,
   DescribeDBSnapshotAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDBSnapshotAttributesMessage,
   output: DescribeDBSnapshotAttributesResult,
@@ -15057,7 +15056,7 @@ export const describeDBSnapshots: API.PaginatedOperationMethod<
   DescribeDBSnapshotsMessage,
   DBSnapshotMessage,
   DescribeDBSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSnapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSnapshotsMessage,
@@ -15086,7 +15085,7 @@ export const describeDBSnapshotTenantDatabases: API.PaginatedOperationMethod<
   DescribeDBSnapshotTenantDatabasesMessage,
   DBSnapshotTenantDatabasesMessage,
   DescribeDBSnapshotTenantDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSnapshotTenantDatabase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSnapshotTenantDatabasesMessage,
@@ -15115,7 +15114,7 @@ export const describeDBSubnetGroups: API.PaginatedOperationMethod<
   DescribeDBSubnetGroupsMessage,
   DBSubnetGroupMessage,
   DescribeDBSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DBSubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDBSubnetGroupsMessage,
@@ -15142,7 +15141,7 @@ export const describeEngineDefaultClusterParameters: API.PaginatedOperationMetho
   DescribeEngineDefaultClusterParametersMessage,
   DescribeEngineDefaultClusterParametersResult,
   DescribeEngineDefaultClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineDefaultClusterParametersMessage,
@@ -15167,7 +15166,7 @@ export const describeEngineDefaultParameters: API.PaginatedOperationMethod<
   DescribeEngineDefaultParametersMessage,
   DescribeEngineDefaultParametersResult,
   DescribeEngineDefaultParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEngineDefaultParametersMessage,
@@ -15192,7 +15191,7 @@ export const describeEventCategories: API.OperationMethod<
   DescribeEventCategoriesMessage,
   EventCategoriesMessage,
   DescribeEventCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventCategoriesMessage,
   output: EventCategoriesMessage,
@@ -15214,7 +15213,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -15243,7 +15242,7 @@ export const describeEventSubscriptions: API.PaginatedOperationMethod<
   DescribeEventSubscriptionsMessage,
   EventSubscriptionsMessage,
   DescribeEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventSubscriptionsMessage,
@@ -15268,7 +15267,7 @@ export const describeExportTasks: API.PaginatedOperationMethod<
   DescribeExportTasksMessage,
   ExportTasksMessage,
   DescribeExportTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeExportTasksMessage,
@@ -15299,7 +15298,7 @@ export const describeGlobalClusters: API.PaginatedOperationMethod<
   DescribeGlobalClustersMessage,
   GlobalClustersMessage,
   DescribeGlobalClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalCluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGlobalClustersMessage,
@@ -15324,7 +15323,7 @@ export const describeIntegrations: API.PaginatedOperationMethod<
   DescribeIntegrationsMessage,
   DescribeIntegrationsResponse,
   DescribeIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Integration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIntegrationsMessage,
@@ -15349,7 +15348,7 @@ export const describeOptionGroupOptions: API.PaginatedOperationMethod<
   DescribeOptionGroupOptionsMessage,
   OptionGroupOptionsMessage,
   DescribeOptionGroupOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OptionGroupOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOptionGroupOptionsMessage,
@@ -15374,7 +15373,7 @@ export const describeOptionGroups: API.PaginatedOperationMethod<
   DescribeOptionGroupsMessage,
   OptionGroups,
   DescribeOptionGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OptionGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOptionGroupsMessage,
@@ -15399,7 +15398,7 @@ export const describeOrderableDBInstanceOptions: API.PaginatedOperationMethod<
   DescribeOrderableDBInstanceOptionsMessage,
   OrderableDBInstanceOptionsMessage,
   DescribeOrderableDBInstanceOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrderableDBInstanceOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrderableDBInstanceOptionsMessage,
@@ -15428,7 +15427,7 @@ export const describePendingMaintenanceActions: API.PaginatedOperationMethod<
   DescribePendingMaintenanceActionsMessage,
   PendingMaintenanceActionsMessage,
   DescribePendingMaintenanceActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePendingMaintenanceActions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePendingMaintenanceActionsMessage,
@@ -15455,7 +15454,7 @@ export const describeReservedDBInstances: API.PaginatedOperationMethod<
   DescribeReservedDBInstancesMessage,
   ReservedDBInstanceMessage,
   DescribeReservedDBInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedDBInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedDBInstancesMessage,
@@ -15482,7 +15481,7 @@ export const describeReservedDBInstancesOfferings: API.PaginatedOperationMethod<
   DescribeReservedDBInstancesOfferingsMessage,
   ReservedDBInstancesOfferingMessage,
   DescribeReservedDBInstancesOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedDBInstancesOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedDBInstancesOfferingsMessage,
@@ -15507,7 +15506,7 @@ export const describeServerlessV2PlatformVersions: API.PaginatedOperationMethod<
   DescribeServerlessV2PlatformVersionsMessage,
   ServerlessV2PlatformVersionsMessage,
   DescribeServerlessV2PlatformVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerlessV2PlatformVersionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeServerlessV2PlatformVersionsMessage,
@@ -15536,7 +15535,7 @@ export const describeSourceRegions: API.PaginatedOperationMethod<
   DescribeSourceRegionsMessage,
   SourceRegionMessage,
   DescribeSourceRegionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SourceRegion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSourceRegionsMessage,
@@ -15563,7 +15562,7 @@ export const describeTenantDatabases: API.PaginatedOperationMethod<
   DescribeTenantDatabasesMessage,
   TenantDatabasesMessage,
   DescribeTenantDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TenantDatabase
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTenantDatabasesMessage,
@@ -15593,7 +15592,7 @@ export const describeValidDBInstanceModifications: API.OperationMethod<
   DescribeValidDBInstanceModificationsMessage,
   DescribeValidDBInstanceModificationsResult,
   DescribeValidDBInstanceModificationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeValidDBInstanceModificationsMessage,
   output: DescribeValidDBInstanceModificationsResult,
@@ -15618,7 +15617,7 @@ export const disableHttpEndpoint: API.OperationMethod<
   DisableHttpEndpointRequest,
   DisableHttpEndpointResponse,
   DisableHttpEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableHttpEndpointRequest,
   output: DisableHttpEndpointResponse,
@@ -15644,7 +15643,7 @@ export const downloadDBLogFilePortion: API.PaginatedOperationMethod<
   DownloadDBLogFilePortionMessage,
   DownloadDBLogFilePortionDetails,
   DownloadDBLogFilePortionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DownloadDBLogFilePortionMessage,
@@ -15681,7 +15680,7 @@ export const enableHttpEndpoint: API.OperationMethod<
   EnableHttpEndpointRequest,
   EnableHttpEndpointResponse,
   EnableHttpEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableHttpEndpointRequest,
   output: EnableHttpEndpointResponse,
@@ -15715,7 +15714,7 @@ export const failoverDBCluster: API.OperationMethod<
   FailoverDBClusterMessage,
   FailoverDBClusterResult,
   FailoverDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverDBClusterMessage,
   output: FailoverDBClusterResult,
@@ -15762,7 +15761,7 @@ export const failoverGlobalCluster: API.OperationMethod<
   FailoverGlobalClusterMessage,
   FailoverGlobalClusterResult,
   FailoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverGlobalClusterMessage,
   output: FailoverGlobalClusterResult,
@@ -15799,7 +15798,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceMessage,
   TagListMessage,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceMessage,
   output: TagListMessage,
@@ -15835,7 +15834,7 @@ export const modifyActivityStream: API.OperationMethod<
   ModifyActivityStreamRequest,
   ModifyActivityStreamResponse,
   ModifyActivityStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyActivityStreamRequest,
   output: ModifyActivityStreamResponse,
@@ -15869,7 +15868,7 @@ export const modifyCertificates: API.OperationMethod<
   ModifyCertificatesMessage,
   ModifyCertificatesResult,
   ModifyCertificatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCertificatesMessage,
   output: ModifyCertificatesResult,
@@ -15901,7 +15900,7 @@ export const modifyCurrentDBClusterCapacity: API.OperationMethod<
   ModifyCurrentDBClusterCapacityMessage,
   DBClusterCapacityInfo,
   ModifyCurrentDBClusterCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCurrentDBClusterCapacityMessage,
   output: DBClusterCapacityInfo,
@@ -15930,7 +15929,7 @@ export const modifyCustomDBEngineVersion: API.OperationMethod<
   ModifyCustomDBEngineVersionMessage,
   DBEngineVersion,
   ModifyCustomDBEngineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCustomDBEngineVersionMessage,
   output: DBEngineVersion,
@@ -15979,7 +15978,7 @@ export const modifyDBCluster: API.OperationMethod<
   ModifyDBClusterMessage,
   ModifyDBClusterResult,
   ModifyDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterMessage,
   output: ModifyDBClusterResult,
@@ -16029,7 +16028,7 @@ export const modifyDBClusterEndpoint: API.OperationMethod<
   ModifyDBClusterEndpointMessage,
   DBClusterEndpoint,
   ModifyDBClusterEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterEndpointMessage,
   output: DBClusterEndpoint,
@@ -16062,7 +16061,7 @@ export const modifyDBClusterParameterGroup: API.OperationMethod<
   ModifyDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ModifyDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -16092,7 +16091,7 @@ export const modifyDBClusterSnapshotAttribute: API.OperationMethod<
   ModifyDBClusterSnapshotAttributeMessage,
   ModifyDBClusterSnapshotAttributeResult,
   ModifyDBClusterSnapshotAttributeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBClusterSnapshotAttributeMessage,
   output: ModifyDBClusterSnapshotAttributeResult,
@@ -16139,7 +16138,7 @@ export const modifyDBInstance: API.OperationMethod<
   ModifyDBInstanceMessage,
   ModifyDBInstanceResult,
   ModifyDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBInstanceMessage,
   output: ModifyDBInstanceResult,
@@ -16187,7 +16186,7 @@ export const modifyDBParameterGroup: API.OperationMethod<
   ModifyDBParameterGroupMessage,
   DBParameterGroupNameMessage,
   ModifyDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBParameterGroupMessage,
   output: DBParameterGroupNameMessage,
@@ -16209,7 +16208,7 @@ export const modifyDBProxy: API.OperationMethod<
   ModifyDBProxyRequest,
   ModifyDBProxyResponse,
   ModifyDBProxyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBProxyRequest,
   output: ModifyDBProxyResponse,
@@ -16236,7 +16235,7 @@ export const modifyDBProxyEndpoint: API.OperationMethod<
   ModifyDBProxyEndpointRequest,
   ModifyDBProxyEndpointResponse,
   ModifyDBProxyEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBProxyEndpointRequest,
   output: ModifyDBProxyEndpointResponse,
@@ -16263,7 +16262,7 @@ export const modifyDBProxyTargetGroup: API.OperationMethod<
   ModifyDBProxyTargetGroupRequest,
   ModifyDBProxyTargetGroupResponse,
   ModifyDBProxyTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBProxyTargetGroupRequest,
   output: ModifyDBProxyTargetGroupResponse,
@@ -16285,7 +16284,7 @@ export const modifyDBRecommendation: API.OperationMethod<
   ModifyDBRecommendationMessage,
   DBRecommendationMessage,
   ModifyDBRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBRecommendationMessage,
   output: DBRecommendationMessage,
@@ -16307,7 +16306,7 @@ export const modifyDBShardGroup: API.OperationMethod<
   ModifyDBShardGroupMessage,
   DBShardGroup,
   ModifyDBShardGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBShardGroupMessage,
   output: DBShardGroup,
@@ -16335,7 +16334,7 @@ export const modifyDBSnapshot: API.OperationMethod<
   ModifyDBSnapshotMessage,
   ModifyDBSnapshotResult,
   ModifyDBSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBSnapshotMessage,
   output: ModifyDBSnapshotResult,
@@ -16369,7 +16368,7 @@ export const modifyDBSnapshotAttribute: API.OperationMethod<
   ModifyDBSnapshotAttributeMessage,
   ModifyDBSnapshotAttributeResult,
   ModifyDBSnapshotAttributeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBSnapshotAttributeMessage,
   output: ModifyDBSnapshotAttributeResult,
@@ -16398,7 +16397,7 @@ export const modifyDBSubnetGroup: API.OperationMethod<
   ModifyDBSubnetGroupMessage,
   ModifyDBSubnetGroupResult,
   ModifyDBSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDBSubnetGroupMessage,
   output: ModifyDBSubnetGroupResult,
@@ -16432,7 +16431,7 @@ export const modifyEventSubscription: API.OperationMethod<
   ModifyEventSubscriptionMessage,
   ModifyEventSubscriptionResult,
   ModifyEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEventSubscriptionMessage,
   output: ModifyEventSubscriptionResult,
@@ -16465,7 +16464,7 @@ export const modifyGlobalCluster: API.OperationMethod<
   ModifyGlobalClusterMessage,
   ModifyGlobalClusterResult,
   ModifyGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyGlobalClusterMessage,
   output: ModifyGlobalClusterResult,
@@ -16493,7 +16492,7 @@ export const modifyIntegration: API.OperationMethod<
   ModifyIntegrationMessage,
   Integration,
   ModifyIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIntegrationMessage,
   output: Integration,
@@ -16518,7 +16517,7 @@ export const modifyOptionGroup: API.OperationMethod<
   ModifyOptionGroupMessage,
   ModifyOptionGroupResult,
   ModifyOptionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyOptionGroupMessage,
   output: ModifyOptionGroupResult,
@@ -16542,7 +16541,7 @@ export const modifyTenantDatabase: API.OperationMethod<
   ModifyTenantDatabaseMessage,
   ModifyTenantDatabaseResult,
   ModifyTenantDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyTenantDatabaseMessage,
   output: ModifyTenantDatabaseResult,
@@ -16573,7 +16572,7 @@ export const promoteReadReplica: API.OperationMethod<
   PromoteReadReplicaMessage,
   PromoteReadReplicaResult,
   PromoteReadReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromoteReadReplicaMessage,
   output: PromoteReadReplicaResult,
@@ -16594,7 +16593,7 @@ export const promoteReadReplicaDBCluster: API.OperationMethod<
   PromoteReadReplicaDBClusterMessage,
   PromoteReadReplicaDBClusterResult,
   PromoteReadReplicaDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PromoteReadReplicaDBClusterMessage,
   output: PromoteReadReplicaDBClusterResult,
@@ -16616,7 +16615,7 @@ export const purchaseReservedDBInstancesOffering: API.OperationMethod<
   PurchaseReservedDBInstancesOfferingMessage,
   PurchaseReservedDBInstancesOfferingResult,
   PurchaseReservedDBInstancesOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedDBInstancesOfferingMessage,
   output: PurchaseReservedDBInstancesOfferingResult,
@@ -16648,7 +16647,7 @@ export const rebootDBCluster: API.OperationMethod<
   RebootDBClusterMessage,
   RebootDBClusterResult,
   RebootDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDBClusterMessage,
   output: RebootDBClusterResult,
@@ -16682,7 +16681,7 @@ export const rebootDBInstance: API.OperationMethod<
   RebootDBInstanceMessage,
   RebootDBInstanceResult,
   RebootDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDBInstanceMessage,
   output: RebootDBInstanceResult,
@@ -16709,7 +16708,7 @@ export const rebootDBShardGroup: API.OperationMethod<
   RebootDBShardGroupMessage,
   DBShardGroup,
   RebootDBShardGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDBShardGroupMessage,
   output: DBShardGroup,
@@ -16737,7 +16736,7 @@ export const registerDBProxyTargets: API.OperationMethod<
   RegisterDBProxyTargetsRequest,
   RegisterDBProxyTargetsResponse,
   RegisterDBProxyTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDBProxyTargetsRequest,
   output: RegisterDBProxyTargetsResponse,
@@ -16772,7 +16771,7 @@ export const removeFromGlobalCluster: API.OperationMethod<
   RemoveFromGlobalClusterMessage,
   RemoveFromGlobalClusterResult,
   RemoveFromGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveFromGlobalClusterMessage,
   output: RemoveFromGlobalClusterResult,
@@ -16803,7 +16802,7 @@ export const removeRoleFromDBCluster: API.OperationMethod<
   RemoveRoleFromDBClusterMessage,
   RemoveRoleFromDBClusterResponse,
   RemoveRoleFromDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRoleFromDBClusterMessage,
   output: RemoveRoleFromDBClusterResponse,
@@ -16829,7 +16828,7 @@ export const removeRoleFromDBInstance: API.OperationMethod<
   RemoveRoleFromDBInstanceMessage,
   RemoveRoleFromDBInstanceResponse,
   RemoveRoleFromDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRoleFromDBInstanceMessage,
   output: RemoveRoleFromDBInstanceResponse,
@@ -16854,7 +16853,7 @@ export const removeSourceIdentifierFromSubscription: API.OperationMethod<
   RemoveSourceIdentifierFromSubscriptionMessage,
   RemoveSourceIdentifierFromSubscriptionResult,
   RemoveSourceIdentifierFromSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveSourceIdentifierFromSubscriptionMessage,
   output: RemoveSourceIdentifierFromSubscriptionResult,
@@ -16889,7 +16888,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceMessage,
   RemoveTagsFromResourceResponse,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceMessage,
   output: RemoveTagsFromResourceResponse,
@@ -16931,7 +16930,7 @@ export const resetDBClusterParameterGroup: API.OperationMethod<
   ResetDBClusterParameterGroupMessage,
   DBClusterParameterGroupNameMessage,
   ResetDBClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDBClusterParameterGroupMessage,
   output: DBClusterParameterGroupNameMessage,
@@ -16952,7 +16951,7 @@ export const resetDBParameterGroup: API.OperationMethod<
   ResetDBParameterGroupMessage,
   DBParameterGroupNameMessage,
   ResetDBParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetDBParameterGroupMessage,
   output: DBParameterGroupNameMessage,
@@ -16993,7 +16992,7 @@ export const restoreDBClusterFromS3: API.OperationMethod<
   RestoreDBClusterFromS3Message,
   RestoreDBClusterFromS3Result,
   RestoreDBClusterFromS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterFromS3Message,
   output: RestoreDBClusterFromS3Result,
@@ -17062,7 +17061,7 @@ export const restoreDBClusterFromSnapshot: API.OperationMethod<
   RestoreDBClusterFromSnapshotMessage,
   RestoreDBClusterFromSnapshotResult,
   RestoreDBClusterFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterFromSnapshotMessage,
   output: RestoreDBClusterFromSnapshotResult,
@@ -17136,7 +17135,7 @@ export const restoreDBClusterToPointInTime: API.OperationMethod<
   RestoreDBClusterToPointInTimeMessage,
   RestoreDBClusterToPointInTimeResult,
   RestoreDBClusterToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBClusterToPointInTimeMessage,
   output: RestoreDBClusterToPointInTimeResult,
@@ -17212,7 +17211,7 @@ export const restoreDBInstanceFromDBSnapshot: API.OperationMethod<
   RestoreDBInstanceFromDBSnapshotMessage,
   RestoreDBInstanceFromDBSnapshotResult,
   RestoreDBInstanceFromDBSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBInstanceFromDBSnapshotMessage,
   output: RestoreDBInstanceFromDBSnapshotResult,
@@ -17279,7 +17278,7 @@ export const restoreDBInstanceFromS3: API.OperationMethod<
   RestoreDBInstanceFromS3Message,
   RestoreDBInstanceFromS3Result,
   RestoreDBInstanceFromS3Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBInstanceFromS3Message,
   output: RestoreDBInstanceFromS3Result,
@@ -17349,7 +17348,7 @@ export const restoreDBInstanceToPointInTime: API.OperationMethod<
   RestoreDBInstanceToPointInTimeMessage,
   RestoreDBInstanceToPointInTimeResult,
   RestoreDBInstanceToPointInTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDBInstanceToPointInTimeMessage,
   output: RestoreDBInstanceToPointInTimeResult,
@@ -17400,7 +17399,7 @@ export const revokeDBSecurityGroupIngress: API.OperationMethod<
   RevokeDBSecurityGroupIngressMessage,
   RevokeDBSecurityGroupIngressResult,
   RevokeDBSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeDBSecurityGroupIngressMessage,
   output: RevokeDBSecurityGroupIngressResult,
@@ -17429,7 +17428,7 @@ export const startActivityStream: API.OperationMethod<
   StartActivityStreamRequest,
   StartActivityStreamResponse,
   StartActivityStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartActivityStreamRequest,
   output: StartActivityStreamResponse,
@@ -17465,7 +17464,7 @@ export const startDBCluster: API.OperationMethod<
   StartDBClusterMessage,
   StartDBClusterResult,
   StartDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDBClusterMessage,
   output: StartDBClusterResult,
@@ -17507,7 +17506,7 @@ export const startDBInstance: API.OperationMethod<
   StartDBInstanceMessage,
   StartDBInstanceResult,
   StartDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDBInstanceMessage,
   output: StartDBInstanceResult,
@@ -17549,7 +17548,7 @@ export const startDBInstanceAutomatedBackupsReplication: API.OperationMethod<
   StartDBInstanceAutomatedBackupsReplicationMessage,
   StartDBInstanceAutomatedBackupsReplicationResult,
   StartDBInstanceAutomatedBackupsReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDBInstanceAutomatedBackupsReplicationMessage,
   output: StartDBInstanceAutomatedBackupsReplicationResult,
@@ -17591,7 +17590,7 @@ export const startExportTask: API.OperationMethod<
   StartExportTaskMessage,
   ExportTask,
   StartExportTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExportTaskMessage,
   output: ExportTask,
@@ -17628,7 +17627,7 @@ export const stopActivityStream: API.OperationMethod<
   StopActivityStreamRequest,
   StopActivityStreamResponse,
   StopActivityStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopActivityStreamRequest,
   output: StopActivityStreamResponse,
@@ -17661,7 +17660,7 @@ export const stopDBCluster: API.OperationMethod<
   StopDBClusterMessage,
   StopDBClusterResult,
   StopDBClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDBClusterMessage,
   output: StopDBClusterResult,
@@ -17694,7 +17693,7 @@ export const stopDBInstance: API.OperationMethod<
   StopDBInstanceMessage,
   StopDBInstanceResult,
   StopDBInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDBInstanceMessage,
   output: StopDBInstanceResult,
@@ -17725,7 +17724,7 @@ export const stopDBInstanceAutomatedBackupsReplication: API.OperationMethod<
   StopDBInstanceAutomatedBackupsReplicationMessage,
   StopDBInstanceAutomatedBackupsReplicationResult,
   StopDBInstanceAutomatedBackupsReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDBInstanceAutomatedBackupsReplicationMessage,
   output: StopDBInstanceAutomatedBackupsReplicationResult,
@@ -17750,7 +17749,7 @@ export const switchoverBlueGreenDeployment: API.OperationMethod<
   SwitchoverBlueGreenDeploymentRequest,
   SwitchoverBlueGreenDeploymentResponse,
   SwitchoverBlueGreenDeploymentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverBlueGreenDeploymentRequest,
   output: SwitchoverBlueGreenDeploymentResponse,
@@ -17780,7 +17779,7 @@ export const switchoverGlobalCluster: API.OperationMethod<
   SwitchoverGlobalClusterMessage,
   SwitchoverGlobalClusterResult,
   SwitchoverGlobalClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverGlobalClusterMessage,
   output: SwitchoverGlobalClusterResult,
@@ -17806,7 +17805,7 @@ export const switchoverReadReplica: API.OperationMethod<
   SwitchoverReadReplicaMessage,
   SwitchoverReadReplicaResult,
   SwitchoverReadReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SwitchoverReadReplicaMessage,
   output: SwitchoverReadReplicaResult,

--- a/packages/aws/src/services/redshift-data.ts
+++ b/packages/aws/src/services/redshift-data.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Redshift Data",
   serviceShapeName: "RedshiftData",
@@ -835,7 +834,7 @@ export const batchExecuteStatement: API.OperationMethod<
   BatchExecuteStatementInput,
   BatchExecuteStatementOutput,
   BatchExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchExecuteStatementInput,
   output: BatchExecuteStatementOutput,
@@ -868,7 +867,7 @@ export const cancelStatement: API.OperationMethod<
   CancelStatementRequest,
   CancelStatementResponse,
   CancelStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelStatementRequest,
   output: CancelStatementResponse,
@@ -898,7 +897,7 @@ export const describeStatement: API.OperationMethod<
   DescribeStatementRequest,
   DescribeStatementResponse,
   DescribeStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStatementRequest,
   output: DescribeStatementResponse,
@@ -938,7 +937,7 @@ export const describeTable: API.PaginatedOperationMethod<
   DescribeTableRequest,
   DescribeTableResponse,
   DescribeTableError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ColumnMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTableRequest,
@@ -988,7 +987,7 @@ export const executeStatement: API.OperationMethod<
   ExecuteStatementInput,
   ExecuteStatementOutput,
   ExecuteStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteStatementInput,
   output: ExecuteStatementOutput,
@@ -1019,7 +1018,7 @@ export const getStatementResult: API.PaginatedOperationMethod<
   GetStatementResultRequest,
   GetStatementResultResponse,
   GetStatementResultError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Field[]
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetStatementResultRequest,
@@ -1053,7 +1052,7 @@ export const getStatementResultV2: API.PaginatedOperationMethod<
   GetStatementResultV2Request,
   GetStatementResultV2Response,
   GetStatementResultV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueryRecords
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetStatementResultV2Request,
@@ -1099,7 +1098,7 @@ export const listDatabases: API.PaginatedOperationMethod<
   ListDatabasesRequest,
   ListDatabasesResponse,
   ListDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatabasesRequest,
@@ -1148,7 +1147,7 @@ export const listSchemas: API.PaginatedOperationMethod<
   ListSchemasRequest,
   ListSchemasResponse,
   ListSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemasRequest,
@@ -1187,7 +1186,7 @@ export const listStatements: API.PaginatedOperationMethod<
   ListStatementsRequest,
   ListStatementsResponse,
   ListStatementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StatementData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStatementsRequest,
@@ -1234,7 +1233,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesRequest,
   ListTablesResponse,
   ListTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableMember
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesRequest,

--- a/packages/aws/src/services/redshift-serverless.ts
+++ b/packages/aws/src/services/redshift-serverless.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Redshift Serverless",
@@ -2550,7 +2549,7 @@ export const convertRecoveryPointToSnapshot: API.OperationMethod<
   ConvertRecoveryPointToSnapshotRequest,
   ConvertRecoveryPointToSnapshotResponse,
   ConvertRecoveryPointToSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConvertRecoveryPointToSnapshotRequest,
   output: ConvertRecoveryPointToSnapshotResponse,
@@ -2582,7 +2581,7 @@ export const createCustomDomainAssociation: API.OperationMethod<
   CreateCustomDomainAssociationRequest,
   CreateCustomDomainAssociationResponse,
   CreateCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomDomainAssociationRequest,
   output: CreateCustomDomainAssociationResponse,
@@ -2614,7 +2613,7 @@ export const createEndpointAccess: API.OperationMethod<
   CreateEndpointAccessRequest,
   CreateEndpointAccessResponse,
   CreateEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointAccessRequest,
   output: CreateEndpointAccessResponse,
@@ -2644,7 +2643,7 @@ export const createNamespace: API.OperationMethod<
   CreateNamespaceRequest,
   CreateNamespaceResponse,
   CreateNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNamespaceRequest,
   output: CreateNamespaceResponse,
@@ -2675,7 +2674,7 @@ export const createReservation: API.OperationMethod<
   CreateReservationRequest,
   CreateReservationResponse,
   CreateReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReservationRequest,
   output: CreateReservationResponse,
@@ -2706,7 +2705,7 @@ export const createScheduledAction: API.OperationMethod<
   CreateScheduledActionRequest,
   CreateScheduledActionResponse,
   CreateScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledActionRequest,
   output: CreateScheduledActionResponse,
@@ -2736,7 +2735,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotRequest,
   CreateSnapshotResponse,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotRequest,
   output: CreateSnapshotResponse,
@@ -2768,7 +2767,7 @@ export const createSnapshotCopyConfiguration: API.OperationMethod<
   CreateSnapshotCopyConfigurationRequest,
   CreateSnapshotCopyConfigurationResponse,
   CreateSnapshotCopyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotCopyConfigurationRequest,
   output: CreateSnapshotCopyConfigurationResponse,
@@ -2799,7 +2798,7 @@ export const createUsageLimit: API.OperationMethod<
   CreateUsageLimitRequest,
   CreateUsageLimitResponse,
   CreateUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsageLimitRequest,
   output: CreateUsageLimitResponse,
@@ -2841,7 +2840,7 @@ export const createWorkgroup: API.OperationMethod<
   CreateWorkgroupRequest,
   CreateWorkgroupResponse,
   CreateWorkgroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkgroupRequest,
   output: CreateWorkgroupResponse,
@@ -2874,7 +2873,7 @@ export const deleteCustomDomainAssociation: API.OperationMethod<
   DeleteCustomDomainAssociationRequest,
   DeleteCustomDomainAssociationResponse,
   DeleteCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomDomainAssociationRequest,
   output: DeleteCustomDomainAssociationResponse,
@@ -2904,7 +2903,7 @@ export const deleteEndpointAccess: API.OperationMethod<
   DeleteEndpointAccessRequest,
   DeleteEndpointAccessResponse,
   DeleteEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointAccessRequest,
   output: DeleteEndpointAccessResponse,
@@ -2932,7 +2931,7 @@ export const deleteNamespace: API.OperationMethod<
   DeleteNamespaceRequest,
   DeleteNamespaceResponse,
   DeleteNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamespaceRequest,
   output: DeleteNamespaceResponse,
@@ -2959,7 +2958,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -2985,7 +2984,7 @@ export const deleteScheduledAction: API.OperationMethod<
   DeleteScheduledActionRequest,
   DeleteScheduledActionResponse,
   DeleteScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledActionRequest,
   output: DeleteScheduledActionResponse,
@@ -3012,7 +3011,7 @@ export const deleteSnapshot: API.OperationMethod<
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
   DeleteSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotRequest,
   output: DeleteSnapshotResponse,
@@ -3041,7 +3040,7 @@ export const deleteSnapshotCopyConfiguration: API.OperationMethod<
   DeleteSnapshotCopyConfigurationRequest,
   DeleteSnapshotCopyConfigurationResponse,
   DeleteSnapshotCopyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotCopyConfigurationRequest,
   output: DeleteSnapshotCopyConfigurationResponse,
@@ -3070,7 +3069,7 @@ export const deleteUsageLimit: API.OperationMethod<
   DeleteUsageLimitRequest,
   DeleteUsageLimitResponse,
   DeleteUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsageLimitRequest,
   output: DeleteUsageLimitResponse,
@@ -3098,7 +3097,7 @@ export const deleteWorkgroup: API.OperationMethod<
   DeleteWorkgroupRequest,
   DeleteWorkgroupResponse,
   DeleteWorkgroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkgroupRequest,
   output: DeleteWorkgroupResponse,
@@ -3131,7 +3130,7 @@ export const getCredentials: API.OperationMethod<
   GetCredentialsRequest,
   GetCredentialsResponse,
   GetCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCredentialsRequest,
   output: GetCredentialsResponse,
@@ -3160,7 +3159,7 @@ export const getCustomDomainAssociation: API.OperationMethod<
   GetCustomDomainAssociationRequest,
   GetCustomDomainAssociationResponse,
   GetCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomDomainAssociationRequest,
   output: GetCustomDomainAssociationResponse,
@@ -3190,7 +3189,7 @@ export const getEndpointAccess: API.OperationMethod<
   GetEndpointAccessRequest,
   GetEndpointAccessResponse,
   GetEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEndpointAccessRequest,
   output: GetEndpointAccessResponse,
@@ -3225,7 +3224,7 @@ export const getIdentityCenterAuthToken: API.OperationMethod<
   GetIdentityCenterAuthTokenRequest,
   GetIdentityCenterAuthTokenResponse,
   GetIdentityCenterAuthTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityCenterAuthTokenRequest,
   output: GetIdentityCenterAuthTokenResponse,
@@ -3255,7 +3254,7 @@ export const getNamespace: API.OperationMethod<
   GetNamespaceRequest,
   GetNamespaceResponse,
   GetNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNamespaceRequest,
   output: GetNamespaceResponse,
@@ -3282,7 +3281,7 @@ export const getRecoveryPoint: API.OperationMethod<
   GetRecoveryPointRequest,
   GetRecoveryPointResponse,
   GetRecoveryPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecoveryPointRequest,
   output: GetRecoveryPointResponse,
@@ -3310,7 +3309,7 @@ export const getReservation: API.OperationMethod<
   GetReservationRequest,
   GetReservationResponse,
   GetReservationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReservationRequest,
   output: GetReservationResponse,
@@ -3338,7 +3337,7 @@ export const getReservationOffering: API.OperationMethod<
   GetReservationOfferingRequest,
   GetReservationOfferingResponse,
   GetReservationOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReservationOfferingRequest,
   output: GetReservationOfferingResponse,
@@ -3365,7 +3364,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -3391,7 +3390,7 @@ export const getScheduledAction: API.OperationMethod<
   GetScheduledActionRequest,
   GetScheduledActionResponse,
   GetScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScheduledActionRequest,
   output: GetScheduledActionResponse,
@@ -3417,7 +3416,7 @@ export const getSnapshot: API.OperationMethod<
   GetSnapshotRequest,
   GetSnapshotResponse,
   GetSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSnapshotRequest,
   output: GetSnapshotResponse,
@@ -3442,7 +3441,7 @@ export const getTableRestoreStatus: API.OperationMethod<
   GetTableRestoreStatusRequest,
   GetTableRestoreStatusResponse,
   GetTableRestoreStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRestoreStatusRequest,
   output: GetTableRestoreStatusResponse,
@@ -3468,7 +3467,7 @@ export const getTrack: API.OperationMethod<
   GetTrackRequest,
   GetTrackResponse,
   GetTrackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrackRequest,
   output: GetTrackResponse,
@@ -3499,7 +3498,7 @@ export const getUsageLimit: API.OperationMethod<
   GetUsageLimitRequest,
   GetUsageLimitResponse,
   GetUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsageLimitRequest,
   output: GetUsageLimitResponse,
@@ -3526,7 +3525,7 @@ export const getWorkgroup: API.OperationMethod<
   GetWorkgroupRequest,
   GetWorkgroupResponse,
   GetWorkgroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkgroupRequest,
   output: GetWorkgroupResponse,
@@ -3554,7 +3553,7 @@ export const listCustomDomainAssociations: API.PaginatedOperationMethod<
   ListCustomDomainAssociationsRequest,
   ListCustomDomainAssociationsResponse,
   ListCustomDomainAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Association
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomDomainAssociationsRequest,
@@ -3590,7 +3589,7 @@ export const listEndpointAccess: API.PaginatedOperationMethod<
   ListEndpointAccessRequest,
   ListEndpointAccessResponse,
   ListEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointAccess
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointAccessRequest,
@@ -3623,7 +3622,7 @@ export const listManagedWorkgroups: API.PaginatedOperationMethod<
   ListManagedWorkgroupsRequest,
   ListManagedWorkgroupsResponse,
   ListManagedWorkgroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedWorkgroupListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedWorkgroupsRequest,
@@ -3651,7 +3650,7 @@ export const listNamespaces: API.PaginatedOperationMethod<
   ListNamespacesRequest,
   ListNamespacesResponse,
   ListNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Namespace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNamespacesRequest,
@@ -3679,7 +3678,7 @@ export const listRecoveryPoints: API.PaginatedOperationMethod<
   ListRecoveryPointsRequest,
   ListRecoveryPointsResponse,
   ListRecoveryPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecoveryPointsRequest,
@@ -3708,7 +3707,7 @@ export const listReservationOfferings: API.PaginatedOperationMethod<
   ListReservationOfferingsRequest,
   ListReservationOfferingsResponse,
   ListReservationOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservationOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReservationOfferingsRequest,
@@ -3737,7 +3736,7 @@ export const listReservations: API.PaginatedOperationMethod<
   ListReservationsRequest,
   ListReservationsResponse,
   ListReservationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Reservation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReservationsRequest,
@@ -3767,7 +3766,7 @@ export const listScheduledActions: API.PaginatedOperationMethod<
   ListScheduledActionsRequest,
   ListScheduledActionsResponse,
   ListScheduledActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledActionAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledActionsRequest,
@@ -3803,7 +3802,7 @@ export const listSnapshotCopyConfigurations: API.PaginatedOperationMethod<
   ListSnapshotCopyConfigurationsRequest,
   ListSnapshotCopyConfigurationsResponse,
   ListSnapshotCopyConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotCopyConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSnapshotCopyConfigurationsRequest,
@@ -3838,7 +3837,7 @@ export const listSnapshots: API.PaginatedOperationMethod<
   ListSnapshotsRequest,
   ListSnapshotsResponse,
   ListSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSnapshotsRequest,
@@ -3871,7 +3870,7 @@ export const listTableRestoreStatus: API.PaginatedOperationMethod<
   ListTableRestoreStatusRequest,
   ListTableRestoreStatusResponse,
   ListTableRestoreStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableRestoreStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTableRestoreStatusRequest,
@@ -3905,7 +3904,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3934,7 +3933,7 @@ export const listTracks: API.PaginatedOperationMethod<
   ListTracksRequest,
   ListTracksResponse,
   ListTracksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServerlessTrack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTracksRequest,
@@ -3971,7 +3970,7 @@ export const listUsageLimits: API.PaginatedOperationMethod<
   ListUsageLimitsRequest,
   ListUsageLimitsResponse,
   ListUsageLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsageLimit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsageLimitsRequest,
@@ -4005,7 +4004,7 @@ export const listWorkgroups: API.PaginatedOperationMethod<
   ListWorkgroupsRequest,
   ListWorkgroupsResponse,
   ListWorkgroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Workgroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkgroupsRequest,
@@ -4036,7 +4035,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -4065,7 +4064,7 @@ export const restoreFromRecoveryPoint: API.OperationMethod<
   RestoreFromRecoveryPointRequest,
   RestoreFromRecoveryPointResponse,
   RestoreFromRecoveryPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreFromRecoveryPointRequest,
   output: RestoreFromRecoveryPointResponse,
@@ -4094,7 +4093,7 @@ export const restoreFromSnapshot: API.OperationMethod<
   RestoreFromSnapshotRequest,
   RestoreFromSnapshotResponse,
   RestoreFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreFromSnapshotRequest,
   output: RestoreFromSnapshotResponse,
@@ -4123,7 +4122,7 @@ export const restoreTableFromRecoveryPoint: API.OperationMethod<
   RestoreTableFromRecoveryPointRequest,
   RestoreTableFromRecoveryPointResponse,
   RestoreTableFromRecoveryPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableFromRecoveryPointRequest,
   output: RestoreTableFromRecoveryPointResponse,
@@ -4151,7 +4150,7 @@ export const restoreTableFromSnapshot: API.OperationMethod<
   RestoreTableFromSnapshotRequest,
   RestoreTableFromSnapshotResponse,
   RestoreTableFromSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableFromSnapshotRequest,
   output: RestoreTableFromSnapshotResponse,
@@ -4180,7 +4179,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4209,7 +4208,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4239,7 +4238,7 @@ export const updateCustomDomainAssociation: API.OperationMethod<
   UpdateCustomDomainAssociationRequest,
   UpdateCustomDomainAssociationResponse,
   UpdateCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomDomainAssociationRequest,
   output: UpdateCustomDomainAssociationResponse,
@@ -4270,7 +4269,7 @@ export const updateEndpointAccess: API.OperationMethod<
   UpdateEndpointAccessRequest,
   UpdateEndpointAccessResponse,
   UpdateEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointAccessRequest,
   output: UpdateEndpointAccessResponse,
@@ -4300,7 +4299,7 @@ export const updateLakehouseConfiguration: API.OperationMethod<
   UpdateLakehouseConfigurationRequest,
   UpdateLakehouseConfigurationResponse,
   UpdateLakehouseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLakehouseConfigurationRequest,
   output: UpdateLakehouseConfigurationResponse,
@@ -4329,7 +4328,7 @@ export const updateNamespace: API.OperationMethod<
   UpdateNamespaceRequest,
   UpdateNamespaceResponse,
   UpdateNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNamespaceRequest,
   output: UpdateNamespaceResponse,
@@ -4357,7 +4356,7 @@ export const updateScheduledAction: API.OperationMethod<
   UpdateScheduledActionRequest,
   UpdateScheduledActionResponse,
   UpdateScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledActionRequest,
   output: UpdateScheduledActionResponse,
@@ -4385,7 +4384,7 @@ export const updateSnapshot: API.OperationMethod<
   UpdateSnapshotRequest,
   UpdateSnapshotResponse,
   UpdateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSnapshotRequest,
   output: UpdateSnapshotResponse,
@@ -4414,7 +4413,7 @@ export const updateSnapshotCopyConfiguration: API.OperationMethod<
   UpdateSnapshotCopyConfigurationRequest,
   UpdateSnapshotCopyConfigurationResponse,
   UpdateSnapshotCopyConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSnapshotCopyConfigurationRequest,
   output: UpdateSnapshotCopyConfigurationResponse,
@@ -4443,7 +4442,7 @@ export const updateUsageLimit: API.OperationMethod<
   UpdateUsageLimitRequest,
   UpdateUsageLimitResponse,
   UpdateUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUsageLimitRequest,
   output: UpdateUsageLimitResponse,
@@ -4483,7 +4482,7 @@ export const updateWorkgroup: API.OperationMethod<
   UpdateWorkgroupRequest,
   UpdateWorkgroupResponse,
   UpdateWorkgroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkgroupRequest,
   output: UpdateWorkgroupResponse,

--- a/packages/aws/src/services/redshift.ts
+++ b/packages/aws/src/services/redshift.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://redshift.amazonaws.com/doc/2012-12-01/");
 const svc = T.AwsApiService({
@@ -9036,7 +9035,7 @@ export const acceptReservedNodeExchange: API.OperationMethod<
   AcceptReservedNodeExchangeInputMessage,
   AcceptReservedNodeExchangeOutputMessage,
   AcceptReservedNodeExchangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptReservedNodeExchangeInputMessage,
   output: AcceptReservedNodeExchangeOutputMessage,
@@ -9069,7 +9068,7 @@ export const addPartner: API.OperationMethod<
   PartnerIntegrationInputMessage,
   PartnerIntegrationOutputMessage,
   AddPartnerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PartnerIntegrationInputMessage,
   output: PartnerIntegrationOutputMessage,
@@ -9097,7 +9096,7 @@ export const associateDataShareConsumer: API.OperationMethod<
   AssociateDataShareConsumerMessage,
   DataShare,
   AssociateDataShareConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDataShareConsumerMessage,
   output: DataShare,
@@ -9138,7 +9137,7 @@ export const authorizeClusterSecurityGroupIngress: API.OperationMethod<
   AuthorizeClusterSecurityGroupIngressMessage,
   AuthorizeClusterSecurityGroupIngressResult,
   AuthorizeClusterSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeClusterSecurityGroupIngressMessage,
   output: AuthorizeClusterSecurityGroupIngressResult,
@@ -9163,7 +9162,7 @@ export const authorizeDataShare: API.OperationMethod<
   AuthorizeDataShareMessage,
   DataShare,
   AuthorizeDataShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeDataShareMessage,
   output: DataShare,
@@ -9188,7 +9187,7 @@ export const authorizeEndpointAccess: API.OperationMethod<
   AuthorizeEndpointAccessMessage,
   EndpointAuthorization,
   AuthorizeEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeEndpointAccessMessage,
   output: EndpointAuthorization,
@@ -9226,7 +9225,7 @@ export const authorizeSnapshotAccess: API.OperationMethod<
   AuthorizeSnapshotAccessMessage,
   AuthorizeSnapshotAccessResult,
   AuthorizeSnapshotAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeSnapshotAccessMessage,
   output: AuthorizeSnapshotAccessResult,
@@ -9254,7 +9253,7 @@ export const batchDeleteClusterSnapshots: API.OperationMethod<
   BatchDeleteClusterSnapshotsRequest,
   BatchDeleteClusterSnapshotsResult,
   BatchDeleteClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteClusterSnapshotsRequest,
   output: BatchDeleteClusterSnapshotsResult,
@@ -9275,7 +9274,7 @@ export const batchModifyClusterSnapshots: API.OperationMethod<
   BatchModifyClusterSnapshotsMessage,
   BatchModifyClusterSnapshotsOutputMessage,
   BatchModifyClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchModifyClusterSnapshotsMessage,
   output: BatchModifyClusterSnapshotsOutputMessage,
@@ -9301,7 +9300,7 @@ export const cancelResize: API.OperationMethod<
   CancelResizeMessage,
   ResizeProgressMessage,
   CancelResizeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelResizeMessage,
   output: ResizeProgressMessage,
@@ -9343,7 +9342,7 @@ export const copyClusterSnapshot: API.OperationMethod<
   CopyClusterSnapshotMessage,
   CopyClusterSnapshotResult,
   CopyClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyClusterSnapshotMessage,
   output: CopyClusterSnapshotResult,
@@ -9372,7 +9371,7 @@ export const createAuthenticationProfile: API.OperationMethod<
   CreateAuthenticationProfileMessage,
   CreateAuthenticationProfileResult,
   CreateAuthenticationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAuthenticationProfileMessage,
   output: CreateAuthenticationProfileResult,
@@ -9447,7 +9446,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterMessage,
   CreateClusterResult,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterMessage,
   output: CreateClusterResult,
@@ -9508,7 +9507,7 @@ export const createClusterParameterGroup: API.OperationMethod<
   CreateClusterParameterGroupMessage,
   CreateClusterParameterGroupResult,
   CreateClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterParameterGroupMessage,
   output: CreateClusterParameterGroupResult,
@@ -9541,7 +9540,7 @@ export const createClusterSecurityGroup: API.OperationMethod<
   CreateClusterSecurityGroupMessage,
   CreateClusterSecurityGroupResult,
   CreateClusterSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterSecurityGroupMessage,
   output: CreateClusterSecurityGroupResult,
@@ -9577,7 +9576,7 @@ export const createClusterSnapshot: API.OperationMethod<
   CreateClusterSnapshotMessage,
   CreateClusterSnapshotResult,
   CreateClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterSnapshotMessage,
   output: CreateClusterSnapshotResult,
@@ -9618,7 +9617,7 @@ export const createClusterSubnetGroup: API.OperationMethod<
   CreateClusterSubnetGroupMessage,
   CreateClusterSubnetGroupResult,
   CreateClusterSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterSubnetGroupMessage,
   output: CreateClusterSubnetGroupResult,
@@ -9650,7 +9649,7 @@ export const createCustomDomainAssociation: API.OperationMethod<
   CreateCustomDomainAssociationMessage,
   CreateCustomDomainAssociationResult,
   CreateCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomDomainAssociationMessage,
   output: CreateCustomDomainAssociationResult,
@@ -9683,7 +9682,7 @@ export const createEndpointAccess: API.OperationMethod<
   CreateEndpointAccessMessage,
   EndpointAccess,
   CreateEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointAccessMessage,
   output: EndpointAccess,
@@ -9742,7 +9741,7 @@ export const createEventSubscription: API.OperationMethod<
   CreateEventSubscriptionMessage,
   CreateEventSubscriptionResult,
   CreateEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEventSubscriptionMessage,
   output: CreateEventSubscriptionResult,
@@ -9785,7 +9784,7 @@ export const createHsmClientCertificate: API.OperationMethod<
   CreateHsmClientCertificateMessage,
   CreateHsmClientCertificateResult,
   CreateHsmClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHsmClientCertificateMessage,
   output: CreateHsmClientCertificateResult,
@@ -9820,7 +9819,7 @@ export const createHsmConfiguration: API.OperationMethod<
   CreateHsmConfigurationMessage,
   CreateHsmConfigurationResult,
   CreateHsmConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHsmConfigurationMessage,
   output: CreateHsmConfigurationResult,
@@ -9853,7 +9852,7 @@ export const createIntegration: API.OperationMethod<
   CreateIntegrationMessage,
   Integration,
   CreateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationMessage,
   output: Integration,
@@ -9889,7 +9888,7 @@ export const createRedshiftIdcApplication: API.OperationMethod<
   CreateRedshiftIdcApplicationMessage,
   CreateRedshiftIdcApplicationResult,
   CreateRedshiftIdcApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRedshiftIdcApplicationMessage,
   output: CreateRedshiftIdcApplicationResult,
@@ -9925,7 +9924,7 @@ export const createScheduledAction: API.OperationMethod<
   CreateScheduledActionMessage,
   ScheduledAction,
   CreateScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledActionMessage,
   output: ScheduledAction,
@@ -9965,7 +9964,7 @@ export const createSnapshotCopyGrant: API.OperationMethod<
   CreateSnapshotCopyGrantMessage,
   CreateSnapshotCopyGrantResult,
   CreateSnapshotCopyGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotCopyGrantMessage,
   output: CreateSnapshotCopyGrantResult,
@@ -9997,7 +9996,7 @@ export const createSnapshotSchedule: API.OperationMethod<
   CreateSnapshotScheduleMessage,
   SnapshotSchedule,
   CreateSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotScheduleMessage,
   output: SnapshotSchedule,
@@ -10033,7 +10032,7 @@ export const createTags: API.OperationMethod<
   CreateTagsMessage,
   CreateTagsResponse,
   CreateTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsMessage,
   output: CreateTagsResponse,
@@ -10065,7 +10064,7 @@ export const createUsageLimit: API.OperationMethod<
   CreateUsageLimitMessage,
   UsageLimit,
   CreateUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUsageLimitMessage,
   output: UsageLimit,
@@ -10091,7 +10090,7 @@ export const deauthorizeDataShare: API.OperationMethod<
   DeauthorizeDataShareMessage,
   DataShare,
   DeauthorizeDataShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeauthorizeDataShareMessage,
   output: DataShare,
@@ -10112,7 +10111,7 @@ export const deleteAuthenticationProfile: API.OperationMethod<
   DeleteAuthenticationProfileMessage,
   DeleteAuthenticationProfileResult,
   DeleteAuthenticationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuthenticationProfileMessage,
   output: DeleteAuthenticationProfileResult,
@@ -10155,7 +10154,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterMessage,
   DeleteClusterResult,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterMessage,
   output: DeleteClusterResult,
@@ -10185,7 +10184,7 @@ export const deleteClusterParameterGroup: API.OperationMethod<
   DeleteClusterParameterGroupMessage,
   DeleteClusterParameterGroupResponse,
   DeleteClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterParameterGroupMessage,
   output: DeleteClusterParameterGroupResponse,
@@ -10216,7 +10215,7 @@ export const deleteClusterSecurityGroup: API.OperationMethod<
   DeleteClusterSecurityGroupMessage,
   DeleteClusterSecurityGroupResponse,
   DeleteClusterSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterSecurityGroupMessage,
   output: DeleteClusterSecurityGroupResponse,
@@ -10247,7 +10246,7 @@ export const deleteClusterSnapshot: API.OperationMethod<
   DeleteClusterSnapshotMessage,
   DeleteClusterSnapshotResult,
   DeleteClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterSnapshotMessage,
   output: DeleteClusterSnapshotResult,
@@ -10269,7 +10268,7 @@ export const deleteClusterSubnetGroup: API.OperationMethod<
   DeleteClusterSubnetGroupMessage,
   DeleteClusterSubnetGroupResponse,
   DeleteClusterSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterSubnetGroupMessage,
   output: DeleteClusterSubnetGroupResponse,
@@ -10296,7 +10295,7 @@ export const deleteCustomDomainAssociation: API.OperationMethod<
   DeleteCustomDomainAssociationMessage,
   DeleteCustomDomainAssociationResponse,
   DeleteCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomDomainAssociationMessage,
   output: DeleteCustomDomainAssociationResponse,
@@ -10325,7 +10324,7 @@ export const deleteEndpointAccess: API.OperationMethod<
   DeleteEndpointAccessMessage,
   EndpointAccess,
   DeleteEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointAccessMessage,
   output: EndpointAccess,
@@ -10352,7 +10351,7 @@ export const deleteEventSubscription: API.OperationMethod<
   DeleteEventSubscriptionMessage,
   DeleteEventSubscriptionResponse,
   DeleteEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEventSubscriptionMessage,
   output: DeleteEventSubscriptionResponse,
@@ -10373,7 +10372,7 @@ export const deleteHsmClientCertificate: API.OperationMethod<
   DeleteHsmClientCertificateMessage,
   DeleteHsmClientCertificateResponse,
   DeleteHsmClientCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHsmClientCertificateMessage,
   output: DeleteHsmClientCertificateResponse,
@@ -10397,7 +10396,7 @@ export const deleteHsmConfiguration: API.OperationMethod<
   DeleteHsmConfigurationMessage,
   DeleteHsmConfigurationResponse,
   DeleteHsmConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHsmConfigurationMessage,
   output: DeleteHsmConfigurationResponse,
@@ -10420,7 +10419,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationMessage,
   Integration,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationMessage,
   output: Integration,
@@ -10448,7 +10447,7 @@ export const deletePartner: API.OperationMethod<
   PartnerIntegrationInputMessage,
   PartnerIntegrationOutputMessage,
   DeletePartnerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PartnerIntegrationInputMessage,
   output: PartnerIntegrationOutputMessage,
@@ -10476,7 +10475,7 @@ export const deleteRedshiftIdcApplication: API.OperationMethod<
   DeleteRedshiftIdcApplicationMessage,
   DeleteRedshiftIdcApplicationResponse,
   DeleteRedshiftIdcApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRedshiftIdcApplicationMessage,
   output: DeleteRedshiftIdcApplicationResponse,
@@ -10502,7 +10501,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyMessage,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyMessage,
   output: DeleteResourcePolicyResponse,
@@ -10523,7 +10522,7 @@ export const deleteScheduledAction: API.OperationMethod<
   DeleteScheduledActionMessage,
   DeleteScheduledActionResponse,
   DeleteScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledActionMessage,
   output: DeleteScheduledActionResponse,
@@ -10544,7 +10543,7 @@ export const deleteSnapshotCopyGrant: API.OperationMethod<
   DeleteSnapshotCopyGrantMessage,
   DeleteSnapshotCopyGrantResponse,
   DeleteSnapshotCopyGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotCopyGrantMessage,
   output: DeleteSnapshotCopyGrantResponse,
@@ -10565,7 +10564,7 @@ export const deleteSnapshotSchedule: API.OperationMethod<
   DeleteSnapshotScheduleMessage,
   DeleteSnapshotScheduleResponse,
   DeleteSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotScheduleMessage,
   output: DeleteSnapshotScheduleResponse,
@@ -10590,7 +10589,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsMessage,
   DeleteTagsResponse,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsMessage,
   output: DeleteTagsResponse,
@@ -10611,7 +10610,7 @@ export const deleteUsageLimit: API.OperationMethod<
   DeleteUsageLimitMessage,
   DeleteUsageLimitResponse,
   DeleteUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUsageLimitMessage,
   output: DeleteUsageLimitResponse,
@@ -10633,7 +10632,7 @@ export const deregisterNamespace: API.OperationMethod<
   DeregisterNamespaceInputMessage,
   DeregisterNamespaceOutputMessage,
   DeregisterNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterNamespaceInputMessage,
   output: DeregisterNamespaceOutputMessage,
@@ -10655,7 +10654,7 @@ export const describeAccountAttributes: API.OperationMethod<
   DescribeAccountAttributesMessage,
   AccountAttributeList,
   DescribeAccountAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAttributesMessage,
   output: AccountAttributeList,
@@ -10676,7 +10675,7 @@ export const describeAuthenticationProfiles: API.OperationMethod<
   DescribeAuthenticationProfilesMessage,
   DescribeAuthenticationProfilesResult,
   DescribeAuthenticationProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAuthenticationProfilesMessage,
   output: DescribeAuthenticationProfilesResult,
@@ -10700,7 +10699,7 @@ export const describeClusterDbRevisions: API.PaginatedOperationMethod<
   DescribeClusterDbRevisionsMessage,
   ClusterDbRevisionsMessage,
   DescribeClusterDbRevisionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterDbRevision
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterDbRevisionsMessage,
@@ -10746,7 +10745,7 @@ export const describeClusterParameterGroups: API.PaginatedOperationMethod<
   DescribeClusterParameterGroupsMessage,
   ClusterParameterGroupsMessage,
   DescribeClusterParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterParameterGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterParameterGroupsMessage,
@@ -10785,7 +10784,7 @@ export const describeClusterParameters: API.PaginatedOperationMethod<
   DescribeClusterParametersMessage,
   ClusterParameterGroupDetails,
   DescribeClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterParametersMessage,
@@ -10827,7 +10826,7 @@ export const describeClusters: API.PaginatedOperationMethod<
   DescribeClustersMessage,
   ClustersMessage,
   DescribeClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Cluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClustersMessage,
@@ -10871,7 +10870,7 @@ export const describeClusterSecurityGroups: API.PaginatedOperationMethod<
   DescribeClusterSecurityGroupsMessage,
   ClusterSecurityGroupMessage,
   DescribeClusterSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterSecurityGroupsMessage,
@@ -10915,7 +10914,7 @@ export const describeClusterSnapshots: API.PaginatedOperationMethod<
   DescribeClusterSnapshotsMessage,
   SnapshotMessage,
   DescribeClusterSnapshotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Snapshot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterSnapshotsMessage,
@@ -10960,7 +10959,7 @@ export const describeClusterSubnetGroups: API.PaginatedOperationMethod<
   DescribeClusterSubnetGroupsMessage,
   ClusterSubnetGroupMessage,
   DescribeClusterSubnetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSubnetGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterSubnetGroupsMessage,
@@ -10988,7 +10987,7 @@ export const describeClusterTracks: API.PaginatedOperationMethod<
   DescribeClusterTracksMessage,
   TrackListMessage,
   DescribeClusterTracksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MaintenanceTrack
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterTracksMessage,
@@ -11018,7 +11017,7 @@ export const describeClusterVersions: API.PaginatedOperationMethod<
   DescribeClusterVersionsMessage,
   ClusterVersionsMessage,
   DescribeClusterVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeClusterVersionsMessage,
@@ -11046,7 +11045,7 @@ export const describeCustomDomainAssociations: API.PaginatedOperationMethod<
   DescribeCustomDomainAssociationsMessage,
   CustomDomainAssociationsMessage,
   DescribeCustomDomainAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Association
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCustomDomainAssociationsMessage,
@@ -11072,7 +11071,7 @@ export const describeDataShares: API.PaginatedOperationMethod<
   DescribeDataSharesMessage,
   DescribeDataSharesResult,
   DescribeDataSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataShare
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataSharesMessage,
@@ -11099,7 +11098,7 @@ export const describeDataSharesForConsumer: API.PaginatedOperationMethod<
   DescribeDataSharesForConsumerMessage,
   DescribeDataSharesForConsumerResult,
   DescribeDataSharesForConsumerError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataShare
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataSharesForConsumerMessage,
@@ -11126,7 +11125,7 @@ export const describeDataSharesForProducer: API.PaginatedOperationMethod<
   DescribeDataSharesForProducerMessage,
   DescribeDataSharesForProducerResult,
   DescribeDataSharesForProducerError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataShare
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDataSharesForProducerMessage,
@@ -11156,7 +11155,7 @@ export const describeDefaultClusterParameters: API.PaginatedOperationMethod<
   DescribeDefaultClusterParametersMessage,
   DescribeDefaultClusterParametersResult,
   DescribeDefaultClusterParametersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDefaultClusterParametersMessage,
@@ -11185,7 +11184,7 @@ export const describeEndpointAccess: API.PaginatedOperationMethod<
   DescribeEndpointAccessMessage,
   EndpointAccessList,
   DescribeEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointAccess
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointAccessMessage,
@@ -11217,7 +11216,7 @@ export const describeEndpointAuthorization: API.PaginatedOperationMethod<
   DescribeEndpointAuthorizationMessage,
   EndpointAuthorizationList,
   DescribeEndpointAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointAuthorization
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEndpointAuthorizationMessage,
@@ -11244,7 +11243,7 @@ export const describeEventCategories: API.OperationMethod<
   DescribeEventCategoriesMessage,
   EventCategoriesMessage,
   DescribeEventCategoriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEventCategoriesMessage,
   output: EventCategoriesMessage,
@@ -11265,7 +11264,7 @@ export const describeEvents: API.PaginatedOperationMethod<
   DescribeEventsMessage,
   EventsMessage,
   DescribeEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Event
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventsMessage,
@@ -11305,7 +11304,7 @@ export const describeEventSubscriptions: API.PaginatedOperationMethod<
   DescribeEventSubscriptionsMessage,
   EventSubscriptionsMessage,
   DescribeEventSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEventSubscriptionsMessage,
@@ -11344,7 +11343,7 @@ export const describeHsmClientCertificates: API.PaginatedOperationMethod<
   DescribeHsmClientCertificatesMessage,
   HsmClientCertificateMessage,
   DescribeHsmClientCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HsmClientCertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHsmClientCertificatesMessage,
@@ -11384,7 +11383,7 @@ export const describeHsmConfigurations: API.PaginatedOperationMethod<
   DescribeHsmConfigurationsMessage,
   HsmConfigurationMessage,
   DescribeHsmConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HsmConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeHsmConfigurationsMessage,
@@ -11413,7 +11412,7 @@ export const describeInboundIntegrations: API.PaginatedOperationMethod<
   DescribeInboundIntegrationsMessage,
   InboundIntegrationsMessage,
   DescribeInboundIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InboundIntegration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInboundIntegrationsMessage,
@@ -11445,7 +11444,7 @@ export const describeIntegrations: API.PaginatedOperationMethod<
   DescribeIntegrationsMessage,
   IntegrationsMessage,
   DescribeIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Integration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeIntegrationsMessage,
@@ -11474,7 +11473,7 @@ export const describeLoggingStatus: API.OperationMethod<
   DescribeLoggingStatusMessage,
   LoggingStatus,
   DescribeLoggingStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLoggingStatusMessage,
   output: LoggingStatus,
@@ -11499,7 +11498,7 @@ export const describeNodeConfigurationOptions: API.PaginatedOperationMethod<
   DescribeNodeConfigurationOptionsMessage,
   NodeConfigurationOptionsMessage,
   DescribeNodeConfigurationOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NodeConfigurationOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNodeConfigurationOptionsMessage,
@@ -11538,7 +11537,7 @@ export const describeOrderableClusterOptions: API.PaginatedOperationMethod<
   DescribeOrderableClusterOptionsMessage,
   OrderableClusterOptionsMessage,
   DescribeOrderableClusterOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrderableClusterOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOrderableClusterOptionsMessage,
@@ -11567,7 +11566,7 @@ export const describePartners: API.OperationMethod<
   DescribePartnersInputMessage,
   DescribePartnersOutputMessage,
   DescribePartnersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePartnersInputMessage,
   output: DescribePartnersOutputMessage,
@@ -11594,7 +11593,7 @@ export const describeRedshiftIdcApplications: API.PaginatedOperationMethod<
   DescribeRedshiftIdcApplicationsMessage,
   DescribeRedshiftIdcApplicationsResult,
   DescribeRedshiftIdcApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RedshiftIdcApplication
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRedshiftIdcApplicationsMessage,
@@ -11629,7 +11628,7 @@ export const describeReservedNodeExchangeStatus: API.PaginatedOperationMethod<
   DescribeReservedNodeExchangeStatusInputMessage,
   DescribeReservedNodeExchangeStatusOutputMessage,
   DescribeReservedNodeExchangeStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNodeExchangeStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedNodeExchangeStatusInputMessage,
@@ -11671,7 +11670,7 @@ export const describeReservedNodeOfferings: API.PaginatedOperationMethod<
   DescribeReservedNodeOfferingsMessage,
   ReservedNodeOfferingsMessage,
   DescribeReservedNodeOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNodeOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedNodeOfferingsMessage,
@@ -11703,7 +11702,7 @@ export const describeReservedNodes: API.PaginatedOperationMethod<
   DescribeReservedNodesMessage,
   ReservedNodesMessage,
   DescribeReservedNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNode
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeReservedNodesMessage,
@@ -11738,7 +11737,7 @@ export const describeResize: API.OperationMethod<
   DescribeResizeMessage,
   ResizeProgressMessage,
   DescribeResizeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResizeMessage,
   output: ResizeProgressMessage,
@@ -11763,7 +11762,7 @@ export const describeScheduledActions: API.PaginatedOperationMethod<
   DescribeScheduledActionsMessage,
   ScheduledActionsMessage,
   DescribeScheduledActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeScheduledActionsMessage,
@@ -11796,7 +11795,7 @@ export const describeSnapshotCopyGrants: API.PaginatedOperationMethod<
   DescribeSnapshotCopyGrantsMessage,
   SnapshotCopyGrantMessage,
   DescribeSnapshotCopyGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotCopyGrant
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotCopyGrantsMessage,
@@ -11821,7 +11820,7 @@ export const describeSnapshotSchedules: API.PaginatedOperationMethod<
   DescribeSnapshotSchedulesMessage,
   DescribeSnapshotSchedulesOutputMessage,
   DescribeSnapshotSchedulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SnapshotSchedule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSnapshotSchedulesMessage,
@@ -11846,7 +11845,7 @@ export const describeStorage: API.OperationMethod<
   DescribeStorageRequest,
   CustomerStorageMessage,
   DescribeStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStorageRequest,
   output: CustomerStorageMessage,
@@ -11872,7 +11871,7 @@ export const describeTableRestoreStatus: API.PaginatedOperationMethod<
   DescribeTableRestoreStatusMessage,
   TableRestoreStatusMessage,
   DescribeTableRestoreStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableRestoreStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTableRestoreStatusMessage,
@@ -11922,7 +11921,7 @@ export const describeTags: API.PaginatedOperationMethod<
   DescribeTagsMessage,
   TaggedResourceListMessage,
   DescribeTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaggedResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTagsMessage,
@@ -11963,7 +11962,7 @@ export const describeUsageLimits: API.PaginatedOperationMethod<
   DescribeUsageLimitsMessage,
   UsageLimitList,
   DescribeUsageLimitsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UsageLimit
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUsageLimitsMessage,
@@ -11993,7 +11992,7 @@ export const disableLogging: API.OperationMethod<
   DisableLoggingMessage,
   LoggingStatus,
   DisableLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableLoggingMessage,
   output: LoggingStatus,
@@ -12026,7 +12025,7 @@ export const disableSnapshotCopy: API.OperationMethod<
   DisableSnapshotCopyMessage,
   DisableSnapshotCopyResult,
   DisableSnapshotCopyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSnapshotCopyMessage,
   output: DisableSnapshotCopyResult,
@@ -12053,7 +12052,7 @@ export const disassociateDataShareConsumer: API.OperationMethod<
   DisassociateDataShareConsumerMessage,
   DataShare,
   DisassociateDataShareConsumerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDataShareConsumerMessage,
   output: DataShare,
@@ -12080,7 +12079,7 @@ export const enableLogging: API.OperationMethod<
   EnableLoggingMessage,
   LoggingStatus,
   EnableLoggingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableLoggingMessage,
   output: LoggingStatus,
@@ -12119,7 +12118,7 @@ export const enableSnapshotCopy: API.OperationMethod<
   EnableSnapshotCopyMessage,
   EnableSnapshotCopyResult,
   EnableSnapshotCopyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSnapshotCopyMessage,
   output: EnableSnapshotCopyResult,
@@ -12154,7 +12153,7 @@ export const failoverPrimaryCompute: API.OperationMethod<
   FailoverPrimaryComputeInputMessage,
   FailoverPrimaryComputeResult,
   FailoverPrimaryComputeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: FailoverPrimaryComputeInputMessage,
   output: FailoverPrimaryComputeResult,
@@ -12204,7 +12203,7 @@ export const getClusterCredentials: API.OperationMethod<
   GetClusterCredentialsMessage,
   ClusterCredentials,
   GetClusterCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterCredentialsMessage,
   output: ClusterCredentials,
@@ -12235,7 +12234,7 @@ export const getClusterCredentialsWithIAM: API.OperationMethod<
   GetClusterCredentialsWithIAMMessage,
   ClusterExtendedCredentials,
   GetClusterCredentialsWithIAMError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetClusterCredentialsWithIAMMessage,
   output: ClusterExtendedCredentials,
@@ -12269,7 +12268,7 @@ export const getIdentityCenterAuthToken: API.OperationMethod<
   GetIdentityCenterAuthTokenRequest,
   GetIdentityCenterAuthTokenResponse,
   GetIdentityCenterAuthTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityCenterAuthTokenRequest,
   output: GetIdentityCenterAuthTokenResponse,
@@ -12303,7 +12302,7 @@ export const getReservedNodeExchangeConfigurationOptions: API.PaginatedOperation
   GetReservedNodeExchangeConfigurationOptionsInputMessage,
   GetReservedNodeExchangeConfigurationOptionsOutputMessage,
   GetReservedNodeExchangeConfigurationOptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNodeConfigurationOption
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetReservedNodeExchangeConfigurationOptionsInputMessage,
@@ -12345,7 +12344,7 @@ export const getReservedNodeExchangeOfferings: API.PaginatedOperationMethod<
   GetReservedNodeExchangeOfferingsInputMessage,
   GetReservedNodeExchangeOfferingsOutputMessage,
   GetReservedNodeExchangeOfferingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReservedNodeOffering
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetReservedNodeExchangeOfferingsInputMessage,
@@ -12381,7 +12380,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyMessage,
   GetResourcePolicyResult,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyMessage,
   output: GetResourcePolicyResult,
@@ -12406,7 +12405,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsMessage,
   ListRecommendationsResult,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Recommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsMessage,
@@ -12435,7 +12434,7 @@ export const modifyAquaConfiguration: API.OperationMethod<
   ModifyAquaInputMessage,
   ModifyAquaOutputMessage,
   ModifyAquaConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyAquaInputMessage,
   output: ModifyAquaOutputMessage,
@@ -12461,7 +12460,7 @@ export const modifyAuthenticationProfile: API.OperationMethod<
   ModifyAuthenticationProfileMessage,
   ModifyAuthenticationProfileResult,
   ModifyAuthenticationProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyAuthenticationProfileMessage,
   output: ModifyAuthenticationProfileResult,
@@ -12534,7 +12533,7 @@ export const modifyCluster: API.OperationMethod<
   ModifyClusterMessage,
   ModifyClusterResult,
   ModifyClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterMessage,
   output: ModifyClusterResult,
@@ -12581,7 +12580,7 @@ export const modifyClusterDbRevision: API.OperationMethod<
   ModifyClusterDbRevisionMessage,
   ModifyClusterDbRevisionResult,
   ModifyClusterDbRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterDbRevisionMessage,
   output: ModifyClusterDbRevisionResult,
@@ -12612,7 +12611,7 @@ export const modifyClusterIamRoles: API.OperationMethod<
   ModifyClusterIamRolesMessage,
   ModifyClusterIamRolesResult,
   ModifyClusterIamRolesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterIamRolesMessage,
   output: ModifyClusterIamRolesResult,
@@ -12633,7 +12632,7 @@ export const modifyClusterMaintenance: API.OperationMethod<
   ModifyClusterMaintenanceMessage,
   ModifyClusterMaintenanceResult,
   ModifyClusterMaintenanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterMaintenanceMessage,
   output: ModifyClusterMaintenanceResult,
@@ -12658,7 +12657,7 @@ export const modifyClusterParameterGroup: API.OperationMethod<
   ModifyClusterParameterGroupMessage,
   ClusterParameterGroupNameMessage,
   ModifyClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterParameterGroupMessage,
   output: ClusterParameterGroupNameMessage,
@@ -12685,7 +12684,7 @@ export const modifyClusterSnapshot: API.OperationMethod<
   ModifyClusterSnapshotMessage,
   ModifyClusterSnapshotResult,
   ModifyClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterSnapshotMessage,
   output: ModifyClusterSnapshotResult,
@@ -12711,7 +12710,7 @@ export const modifyClusterSnapshotSchedule: API.OperationMethod<
   ModifyClusterSnapshotScheduleMessage,
   ModifyClusterSnapshotScheduleResponse,
   ModifyClusterSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterSnapshotScheduleMessage,
   output: ModifyClusterSnapshotScheduleResponse,
@@ -12759,7 +12758,7 @@ export const modifyClusterSubnetGroup: API.OperationMethod<
   ModifyClusterSubnetGroupMessage,
   ModifyClusterSubnetGroupResult,
   ModifyClusterSubnetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClusterSubnetGroupMessage,
   output: ModifyClusterSubnetGroupResult,
@@ -12789,7 +12788,7 @@ export const modifyCustomDomainAssociation: API.OperationMethod<
   ModifyCustomDomainAssociationMessage,
   ModifyCustomDomainAssociationResult,
   ModifyCustomDomainAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCustomDomainAssociationMessage,
   output: ModifyCustomDomainAssociationResult,
@@ -12819,7 +12818,7 @@ export const modifyEndpointAccess: API.OperationMethod<
   ModifyEndpointAccessMessage,
   EndpointAccess,
   ModifyEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEndpointAccessMessage,
   output: EndpointAccess,
@@ -12854,7 +12853,7 @@ export const modifyEventSubscription: API.OperationMethod<
   ModifyEventSubscriptionMessage,
   ModifyEventSubscriptionResult,
   ModifyEventSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEventSubscriptionMessage,
   output: ModifyEventSubscriptionResult,
@@ -12888,7 +12887,7 @@ export const modifyIntegration: API.OperationMethod<
   ModifyIntegrationMessage,
   Integration,
   ModifyIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyIntegrationMessage,
   output: Integration,
@@ -12920,7 +12919,7 @@ export const modifyLakehouseConfiguration: API.OperationMethod<
   ModifyLakehouseConfigurationMessage,
   LakehouseConfiguration,
   ModifyLakehouseConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyLakehouseConfigurationMessage,
   output: LakehouseConfiguration,
@@ -12951,7 +12950,7 @@ export const modifyRedshiftIdcApplication: API.OperationMethod<
   ModifyRedshiftIdcApplicationMessage,
   ModifyRedshiftIdcApplicationResult,
   ModifyRedshiftIdcApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyRedshiftIdcApplicationMessage,
   output: ModifyRedshiftIdcApplicationResult,
@@ -12982,7 +12981,7 @@ export const modifyScheduledAction: API.OperationMethod<
   ModifyScheduledActionMessage,
   ScheduledAction,
   ModifyScheduledActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyScheduledActionMessage,
   output: ScheduledAction,
@@ -13020,7 +13019,7 @@ export const modifySnapshotCopyRetentionPeriod: API.OperationMethod<
   ModifySnapshotCopyRetentionPeriodMessage,
   ModifySnapshotCopyRetentionPeriodResult,
   ModifySnapshotCopyRetentionPeriodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySnapshotCopyRetentionPeriodMessage,
   output: ModifySnapshotCopyRetentionPeriodResult,
@@ -13049,7 +13048,7 @@ export const modifySnapshotSchedule: API.OperationMethod<
   ModifySnapshotScheduleMessage,
   SnapshotSchedule,
   ModifySnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySnapshotScheduleMessage,
   output: SnapshotSchedule,
@@ -13076,7 +13075,7 @@ export const modifyUsageLimit: API.OperationMethod<
   ModifyUsageLimitMessage,
   UsageLimit,
   ModifyUsageLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyUsageLimitMessage,
   output: UsageLimit,
@@ -13102,7 +13101,7 @@ export const pauseCluster: API.OperationMethod<
   PauseClusterMessage,
   PauseClusterResult,
   PauseClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PauseClusterMessage,
   output: PauseClusterResult,
@@ -13137,7 +13136,7 @@ export const purchaseReservedNodeOffering: API.OperationMethod<
   PurchaseReservedNodeOfferingMessage,
   PurchaseReservedNodeOfferingResult,
   PurchaseReservedNodeOfferingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurchaseReservedNodeOfferingMessage,
   output: PurchaseReservedNodeOfferingResult,
@@ -13165,7 +13164,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyMessage,
   PutResourcePolicyResult,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyMessage,
   output: PutResourcePolicyResult,
@@ -13198,7 +13197,7 @@ export const rebootCluster: API.OperationMethod<
   RebootClusterMessage,
   RebootClusterResult,
   RebootClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootClusterMessage,
   output: RebootClusterResult,
@@ -13220,7 +13219,7 @@ export const registerNamespace: API.OperationMethod<
   RegisterNamespaceInputMessage,
   RegisterNamespaceOutputMessage,
   RegisterNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterNamespaceInputMessage,
   output: RegisterNamespaceOutputMessage,
@@ -13242,7 +13241,7 @@ export const rejectDataShare: API.OperationMethod<
   RejectDataShareMessage,
   DataShare,
   RejectDataShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectDataShareMessage,
   output: DataShare,
@@ -13266,7 +13265,7 @@ export const resetClusterParameterGroup: API.OperationMethod<
   ResetClusterParameterGroupMessage,
   ClusterParameterGroupNameMessage,
   ResetClusterParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetClusterParameterGroupMessage,
   output: ClusterParameterGroupNameMessage,
@@ -13329,7 +13328,7 @@ export const resizeCluster: API.OperationMethod<
   ResizeClusterMessage,
   ResizeClusterResult,
   ResizeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResizeClusterMessage,
   output: ResizeClusterResult,
@@ -13429,7 +13428,7 @@ export const restoreFromClusterSnapshot: API.OperationMethod<
   RestoreFromClusterSnapshotMessage,
   RestoreFromClusterSnapshotResult,
   RestoreFromClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreFromClusterSnapshotMessage,
   output: RestoreFromClusterSnapshotResult,
@@ -13506,7 +13505,7 @@ export const restoreTableFromClusterSnapshot: API.OperationMethod<
   RestoreTableFromClusterSnapshotMessage,
   RestoreTableFromClusterSnapshotResult,
   RestoreTableFromClusterSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreTableFromClusterSnapshotMessage,
   output: RestoreTableFromClusterSnapshotResult,
@@ -13537,7 +13536,7 @@ export const resumeCluster: API.OperationMethod<
   ResumeClusterMessage,
   ResumeClusterResult,
   ResumeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeClusterMessage,
   output: ResumeClusterResult,
@@ -13568,7 +13567,7 @@ export const revokeClusterSecurityGroupIngress: API.OperationMethod<
   RevokeClusterSecurityGroupIngressMessage,
   RevokeClusterSecurityGroupIngressResult,
   RevokeClusterSecurityGroupIngressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeClusterSecurityGroupIngressMessage,
   output: RevokeClusterSecurityGroupIngressResult,
@@ -13598,7 +13597,7 @@ export const revokeEndpointAccess: API.OperationMethod<
   RevokeEndpointAccessMessage,
   EndpointAuthorization,
   RevokeEndpointAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeEndpointAccessMessage,
   output: EndpointAuthorization,
@@ -13635,7 +13634,7 @@ export const revokeSnapshotAccess: API.OperationMethod<
   RevokeSnapshotAccessMessage,
   RevokeSnapshotAccessResult,
   RevokeSnapshotAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSnapshotAccessMessage,
   output: RevokeSnapshotAccessResult,
@@ -13663,7 +13662,7 @@ export const rotateEncryptionKey: API.OperationMethod<
   RotateEncryptionKeyMessage,
   RotateEncryptionKeyResult,
   RotateEncryptionKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateEncryptionKeyMessage,
   output: RotateEncryptionKeyResult,
@@ -13691,7 +13690,7 @@ export const updatePartnerStatus: API.OperationMethod<
   UpdatePartnerStatusInputMessage,
   PartnerIntegrationOutputMessage,
   UpdatePartnerStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePartnerStatusInputMessage,
   output: PartnerIntegrationOutputMessage,

--- a/packages/aws/src/services/rekognition.ts
+++ b/packages/aws/src/services/rekognition.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Rekognition",
@@ -4925,7 +4924,7 @@ export const associateFaces: API.OperationMethod<
   AssociateFacesRequest,
   AssociateFacesResponse,
   AssociateFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFacesRequest,
   output: AssociateFacesResponse,
@@ -5017,7 +5016,7 @@ export const compareFaces: API.OperationMethod<
   CompareFacesRequest,
   CompareFacesResponse,
   CompareFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompareFacesRequest,
   output: CompareFacesResponse,
@@ -5079,7 +5078,7 @@ export const copyProjectVersion: API.OperationMethod<
   CopyProjectVersionRequest,
   CopyProjectVersionResponse,
   CopyProjectVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyProjectVersionRequest,
   output: CopyProjectVersionResponse,
@@ -5131,7 +5130,7 @@ export const createCollection: API.OperationMethod<
   CreateCollectionRequest,
   CreateCollectionResponse,
   CreateCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCollectionRequest,
   output: CreateCollectionResponse,
@@ -5190,7 +5189,7 @@ export const createDataset: API.OperationMethod<
   CreateDatasetRequest,
   CreateDatasetResponse,
   CreateDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatasetRequest,
   output: CreateDatasetResponse,
@@ -5235,7 +5234,7 @@ export const createFaceLivenessSession: API.OperationMethod<
   CreateFaceLivenessSessionRequest,
   CreateFaceLivenessSessionResponse,
   CreateFaceLivenessSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFaceLivenessSessionRequest,
   output: CreateFaceLivenessSessionResponse,
@@ -5272,7 +5271,7 @@ export const createProject: API.OperationMethod<
   CreateProjectRequest,
   CreateProjectResponse,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectRequest,
   output: CreateProjectResponse,
@@ -5336,7 +5335,7 @@ export const createProjectVersion: API.OperationMethod<
   CreateProjectVersionRequest,
   CreateProjectVersionResponse,
   CreateProjectVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectVersionRequest,
   output: CreateProjectVersionResponse,
@@ -5401,7 +5400,7 @@ export const createStreamProcessor: API.OperationMethod<
   CreateStreamProcessorRequest,
   CreateStreamProcessorResponse,
   CreateStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStreamProcessorRequest,
   output: CreateStreamProcessorResponse,
@@ -5446,7 +5445,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -5486,7 +5485,7 @@ export const deleteCollection: API.OperationMethod<
   DeleteCollectionRequest,
   DeleteCollectionResponse,
   DeleteCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCollectionRequest,
   output: DeleteCollectionResponse,
@@ -5531,7 +5530,7 @@ export const deleteDataset: API.OperationMethod<
   DeleteDatasetRequest,
   DeleteDatasetResponse,
   DeleteDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatasetRequest,
   output: DeleteDatasetResponse,
@@ -5569,7 +5568,7 @@ export const deleteFaces: API.OperationMethod<
   DeleteFacesRequest,
   DeleteFacesResponse,
   DeleteFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFacesRequest,
   output: DeleteFacesResponse,
@@ -5611,7 +5610,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectRequest,
   DeleteProjectResponse,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectRequest,
   output: DeleteProjectResponse,
@@ -5651,7 +5650,7 @@ export const deleteProjectPolicy: API.OperationMethod<
   DeleteProjectPolicyRequest,
   DeleteProjectPolicyResponse,
   DeleteProjectPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectPolicyRequest,
   output: DeleteProjectPolicyResponse,
@@ -5693,7 +5692,7 @@ export const deleteProjectVersion: API.OperationMethod<
   DeleteProjectVersionRequest,
   DeleteProjectVersionResponse,
   DeleteProjectVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectVersionRequest,
   output: DeleteProjectVersionResponse,
@@ -5728,7 +5727,7 @@ export const deleteStreamProcessor: API.OperationMethod<
   DeleteStreamProcessorRequest,
   DeleteStreamProcessorResponse,
   DeleteStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStreamProcessorRequest,
   output: DeleteStreamProcessorResponse,
@@ -5767,7 +5766,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -5806,7 +5805,7 @@ export const describeCollection: API.OperationMethod<
   DescribeCollectionRequest,
   DescribeCollectionResponse,
   DescribeCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCollectionRequest,
   output: DescribeCollectionResponse,
@@ -5843,7 +5842,7 @@ export const describeDataset: API.OperationMethod<
   DescribeDatasetRequest,
   DescribeDatasetResponse,
   DescribeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatasetRequest,
   output: DescribeDatasetResponse,
@@ -5877,7 +5876,7 @@ export const describeProjects: API.PaginatedOperationMethod<
   DescribeProjectsRequest,
   DescribeProjectsResponse,
   DescribeProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeProjectsRequest,
@@ -5922,7 +5921,7 @@ export const describeProjectVersions: API.PaginatedOperationMethod<
   DescribeProjectVersionsRequest,
   DescribeProjectVersionsResponse,
   DescribeProjectVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectVersionDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeProjectVersionsRequest,
@@ -5963,7 +5962,7 @@ export const describeStreamProcessor: API.OperationMethod<
   DescribeStreamProcessorRequest,
   DescribeStreamProcessorResponse,
   DescribeStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStreamProcessorRequest,
   output: DescribeStreamProcessorResponse,
@@ -6041,7 +6040,7 @@ export const detectCustomLabels: API.OperationMethod<
   DetectCustomLabelsRequest,
   DetectCustomLabelsResponse,
   DetectCustomLabelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectCustomLabelsRequest,
   output: DetectCustomLabelsResponse,
@@ -6100,7 +6099,7 @@ export const detectFaces: API.OperationMethod<
   DetectFacesRequest,
   DetectFacesResponse,
   DetectFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectFacesRequest,
   output: DetectFacesResponse,
@@ -6239,7 +6238,7 @@ export const detectLabels: API.OperationMethod<
   DetectLabelsRequest,
   DetectLabelsResponse,
   DetectLabelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectLabelsRequest,
   output: DetectLabelsResponse,
@@ -6296,7 +6295,7 @@ export const detectModerationLabels: API.OperationMethod<
   DetectModerationLabelsRequest,
   DetectModerationLabelsResponse,
   DetectModerationLabelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectModerationLabelsRequest,
   output: DetectModerationLabelsResponse,
@@ -6366,7 +6365,7 @@ export const detectProtectiveEquipment: API.OperationMethod<
   DetectProtectiveEquipmentRequest,
   DetectProtectiveEquipmentResponse,
   DetectProtectiveEquipmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectProtectiveEquipmentRequest,
   output: DetectProtectiveEquipmentResponse,
@@ -6431,7 +6430,7 @@ export const detectText: API.OperationMethod<
   DetectTextRequest,
   DetectTextResponse,
   DetectTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectTextRequest,
   output: DetectTextResponse,
@@ -6474,7 +6473,7 @@ export const disassociateFaces: API.OperationMethod<
   DisassociateFacesRequest,
   DisassociateFacesResponse,
   DisassociateFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFacesRequest,
   output: DisassociateFacesResponse,
@@ -6523,7 +6522,7 @@ export const distributeDatasetEntries: API.OperationMethod<
   DistributeDatasetEntriesRequest,
   DistributeDatasetEntriesResponse,
   DistributeDatasetEntriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DistributeDatasetEntriesRequest,
   output: DistributeDatasetEntriesResponse,
@@ -6564,7 +6563,7 @@ export const getCelebrityInfo: API.OperationMethod<
   GetCelebrityInfoRequest,
   GetCelebrityInfoResponse,
   GetCelebrityInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCelebrityInfoRequest,
   output: GetCelebrityInfoResponse,
@@ -6640,7 +6639,7 @@ export const getCelebrityRecognition: API.PaginatedOperationMethod<
   GetCelebrityRecognitionRequest,
   GetCelebrityRecognitionResponse,
   GetCelebrityRecognitionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCelebrityRecognitionRequest,
@@ -6710,7 +6709,7 @@ export const getContentModeration: API.PaginatedOperationMethod<
   GetContentModerationRequest,
   GetContentModerationResponse,
   GetContentModerationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetContentModerationRequest,
@@ -6767,7 +6766,7 @@ export const getFaceDetection: API.PaginatedOperationMethod<
   GetFaceDetectionRequest,
   GetFaceDetectionResponse,
   GetFaceDetectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFaceDetectionRequest,
@@ -6815,7 +6814,7 @@ export const getFaceLivenessSessionResults: API.OperationMethod<
   GetFaceLivenessSessionResultsRequest,
   GetFaceLivenessSessionResultsResponse,
   GetFaceLivenessSessionResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFaceLivenessSessionResultsRequest,
   output: GetFaceLivenessSessionResultsResponse,
@@ -6878,7 +6877,7 @@ export const getFaceSearch: API.PaginatedOperationMethod<
   GetFaceSearchRequest,
   GetFaceSearchResponse,
   GetFaceSearchError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFaceSearchRequest,
@@ -6983,7 +6982,7 @@ export const getLabelDetection: API.PaginatedOperationMethod<
   GetLabelDetectionRequest,
   GetLabelDetectionResponse,
   GetLabelDetectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetLabelDetectionRequest,
@@ -7023,7 +7022,7 @@ export const getMediaAnalysisJob: API.OperationMethod<
   GetMediaAnalysisJobRequest,
   GetMediaAnalysisJobResponse,
   GetMediaAnalysisJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMediaAnalysisJobRequest,
   output: GetMediaAnalysisJobResponse,
@@ -7088,7 +7087,7 @@ export const getPersonTracking: API.PaginatedOperationMethod<
   GetPersonTrackingRequest,
   GetPersonTrackingResponse,
   GetPersonTrackingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetPersonTrackingRequest,
@@ -7153,7 +7152,7 @@ export const getSegmentDetection: API.PaginatedOperationMethod<
   GetSegmentDetectionRequest,
   GetSegmentDetectionResponse,
   GetSegmentDetectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSegmentDetectionRequest,
@@ -7214,7 +7213,7 @@ export const getTextDetection: API.PaginatedOperationMethod<
   GetTextDetectionRequest,
   GetTextDetectionResponse,
   GetTextDetectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTextDetectionRequest,
@@ -7348,7 +7347,7 @@ export const indexFaces: API.OperationMethod<
   IndexFacesRequest,
   IndexFacesResponse,
   IndexFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IndexFacesRequest,
   output: IndexFacesResponse,
@@ -7393,7 +7392,7 @@ export const listCollections: API.PaginatedOperationMethod<
   ListCollectionsRequest,
   ListCollectionsResponse,
   ListCollectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollectionId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCollectionsRequest,
@@ -7451,7 +7450,7 @@ export const listDatasetEntries: API.PaginatedOperationMethod<
   ListDatasetEntriesRequest,
   ListDatasetEntriesResponse,
   ListDatasetEntriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetEntriesRequest,
@@ -7502,7 +7501,7 @@ export const listDatasetLabels: API.PaginatedOperationMethod<
   ListDatasetLabelsRequest,
   ListDatasetLabelsResponse,
   ListDatasetLabelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatasetLabelDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatasetLabelsRequest,
@@ -7551,7 +7550,7 @@ export const listFaces: API.PaginatedOperationMethod<
   ListFacesRequest,
   ListFacesResponse,
   ListFacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Face
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFacesRequest,
@@ -7591,7 +7590,7 @@ export const listMediaAnalysisJobs: API.PaginatedOperationMethod<
   ListMediaAnalysisJobsRequest,
   ListMediaAnalysisJobsResponse,
   ListMediaAnalysisJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMediaAnalysisJobsRequest,
@@ -7636,7 +7635,7 @@ export const listProjectPolicies: API.PaginatedOperationMethod<
   ListProjectPoliciesRequest,
   ListProjectPoliciesResponse,
   ListProjectPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProjectPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectPoliciesRequest,
@@ -7676,7 +7675,7 @@ export const listStreamProcessors: API.PaginatedOperationMethod<
   ListStreamProcessorsRequest,
   ListStreamProcessorsResponse,
   ListStreamProcessorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamProcessorsRequest,
@@ -7718,7 +7717,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -7755,7 +7754,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -7820,7 +7819,7 @@ export const putProjectPolicy: API.OperationMethod<
   PutProjectPolicyRequest,
   PutProjectPolicyResponse,
   PutProjectPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutProjectPolicyRequest,
   output: PutProjectPolicyResponse,
@@ -7890,7 +7889,7 @@ export const recognizeCelebrities: API.OperationMethod<
   RecognizeCelebritiesRequest,
   RecognizeCelebritiesResponse,
   RecognizeCelebritiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecognizeCelebritiesRequest,
   output: RecognizeCelebritiesResponse,
@@ -7941,7 +7940,7 @@ export const searchFaces: API.OperationMethod<
   SearchFacesRequest,
   SearchFacesResponse,
   SearchFacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchFacesRequest,
   output: SearchFacesResponse,
@@ -8017,7 +8016,7 @@ export const searchFacesByImage: API.OperationMethod<
   SearchFacesByImageRequest,
   SearchFacesByImageResponse,
   SearchFacesByImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchFacesByImageRequest,
   output: SearchFacesByImageResponse,
@@ -8057,7 +8056,7 @@ export const searchUsers: API.OperationMethod<
   SearchUsersRequest,
   SearchUsersResponse,
   SearchUsersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchUsersRequest,
   output: SearchUsersResponse,
@@ -8102,7 +8101,7 @@ export const searchUsersByImage: API.OperationMethod<
   SearchUsersByImageRequest,
   SearchUsersByImageResponse,
   SearchUsersByImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchUsersByImageRequest,
   output: SearchUsersByImageResponse,
@@ -8152,7 +8151,7 @@ export const startCelebrityRecognition: API.OperationMethod<
   StartCelebrityRecognitionRequest,
   StartCelebrityRecognitionResponse,
   StartCelebrityRecognitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCelebrityRecognitionRequest,
   output: StartCelebrityRecognitionResponse,
@@ -8203,7 +8202,7 @@ export const startContentModeration: API.OperationMethod<
   StartContentModerationRequest,
   StartContentModerationResponse,
   StartContentModerationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContentModerationRequest,
   output: StartContentModerationResponse,
@@ -8254,7 +8253,7 @@ export const startFaceDetection: API.OperationMethod<
   StartFaceDetectionRequest,
   StartFaceDetectionResponse,
   StartFaceDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFaceDetectionRequest,
   output: StartFaceDetectionResponse,
@@ -8303,7 +8302,7 @@ export const startFaceSearch: API.OperationMethod<
   StartFaceSearchRequest,
   StartFaceSearchResponse,
   StartFaceSearchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFaceSearchRequest,
   output: StartFaceSearchResponse,
@@ -8369,7 +8368,7 @@ export const startLabelDetection: API.OperationMethod<
   StartLabelDetectionRequest,
   StartLabelDetectionResponse,
   StartLabelDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLabelDetectionRequest,
   output: StartLabelDetectionResponse,
@@ -8410,7 +8409,7 @@ export const startMediaAnalysisJob: API.OperationMethod<
   StartMediaAnalysisJobRequest,
   StartMediaAnalysisJobResponse,
   StartMediaAnalysisJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMediaAnalysisJobRequest,
   output: StartMediaAnalysisJobResponse,
@@ -8465,7 +8464,7 @@ export const startPersonTracking: API.OperationMethod<
   StartPersonTrackingRequest,
   StartPersonTrackingResponse,
   StartPersonTrackingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPersonTrackingRequest,
   output: StartPersonTrackingResponse,
@@ -8514,7 +8513,7 @@ export const startProjectVersion: API.OperationMethod<
   StartProjectVersionRequest,
   StartProjectVersionResponse,
   StartProjectVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartProjectVersionRequest,
   output: StartProjectVersionResponse,
@@ -8568,7 +8567,7 @@ export const startSegmentDetection: API.OperationMethod<
   StartSegmentDetectionRequest,
   StartSegmentDetectionResponse,
   StartSegmentDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSegmentDetectionRequest,
   output: StartSegmentDetectionResponse,
@@ -8608,7 +8607,7 @@ export const startStreamProcessor: API.OperationMethod<
   StartStreamProcessorRequest,
   StartStreamProcessorResponse,
   StartStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartStreamProcessorRequest,
   output: StartStreamProcessorResponse,
@@ -8653,7 +8652,7 @@ export const startTextDetection: API.OperationMethod<
   StartTextDetectionRequest,
   StartTextDetectionResponse,
   StartTextDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTextDetectionRequest,
   output: StartTextDetectionResponse,
@@ -8695,7 +8694,7 @@ export const stopProjectVersion: API.OperationMethod<
   StopProjectVersionRequest,
   StopProjectVersionResponse,
   StopProjectVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopProjectVersionRequest,
   output: StopProjectVersionResponse,
@@ -8729,7 +8728,7 @@ export const stopStreamProcessor: API.OperationMethod<
   StopStreamProcessorRequest,
   StopStreamProcessorResponse,
   StopStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopStreamProcessorRequest,
   output: StopStreamProcessorResponse,
@@ -8768,7 +8767,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8805,7 +8804,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -8865,7 +8864,7 @@ export const updateDatasetEntries: API.OperationMethod<
   UpdateDatasetEntriesRequest,
   UpdateDatasetEntriesResponse,
   UpdateDatasetEntriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatasetEntriesRequest,
   output: UpdateDatasetEntriesResponse,
@@ -8900,7 +8899,7 @@ export const updateStreamProcessor: API.OperationMethod<
   UpdateStreamProcessorRequest,
   UpdateStreamProcessorResponse,
   UpdateStreamProcessorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStreamProcessorRequest,
   output: UpdateStreamProcessorResponse,

--- a/packages/aws/src/services/repostspace.ts
+++ b/packages/aws/src/services/repostspace.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "repostspace",
@@ -1047,7 +1046,7 @@ export const batchAddChannelRoleToAccessors: API.OperationMethod<
   BatchAddChannelRoleToAccessorsInput,
   BatchAddChannelRoleToAccessorsOutput,
   BatchAddChannelRoleToAccessorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAddChannelRoleToAccessorsInput,
   output: BatchAddChannelRoleToAccessorsOutput,
@@ -1077,7 +1076,7 @@ export const batchAddRole: API.OperationMethod<
   BatchAddRoleInput,
   BatchAddRoleOutput,
   BatchAddRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAddRoleInput,
   output: BatchAddRoleOutput,
@@ -1107,7 +1106,7 @@ export const batchRemoveChannelRoleFromAccessors: API.OperationMethod<
   BatchRemoveChannelRoleFromAccessorsInput,
   BatchRemoveChannelRoleFromAccessorsOutput,
   BatchRemoveChannelRoleFromAccessorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchRemoveChannelRoleFromAccessorsInput,
   output: BatchRemoveChannelRoleFromAccessorsOutput,
@@ -1137,7 +1136,7 @@ export const batchRemoveRole: API.OperationMethod<
   BatchRemoveRoleInput,
   BatchRemoveRoleOutput,
   BatchRemoveRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchRemoveRoleInput,
   output: BatchRemoveRoleOutput,
@@ -1169,7 +1168,7 @@ export const createChannel: API.OperationMethod<
   CreateChannelInput,
   CreateChannelOutput,
   CreateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateChannelInput,
   output: CreateChannelOutput,
@@ -1203,7 +1202,7 @@ export const createSpace: API.OperationMethod<
   CreateSpaceInput,
   CreateSpaceOutput,
   CreateSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSpaceInput,
   output: CreateSpaceOutput,
@@ -1235,7 +1234,7 @@ export const deleteSpace: API.OperationMethod<
   DeleteSpaceInput,
   DeleteSpaceResponse,
   DeleteSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpaceInput,
   output: DeleteSpaceResponse,
@@ -1265,7 +1264,7 @@ export const deregisterAdmin: API.OperationMethod<
   DeregisterAdminInput,
   DeregisterAdminResponse,
   DeregisterAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterAdminInput,
   output: DeregisterAdminResponse,
@@ -1295,7 +1294,7 @@ export const getChannel: API.OperationMethod<
   GetChannelInput,
   GetChannelOutput,
   GetChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChannelInput,
   output: GetChannelOutput,
@@ -1325,7 +1324,7 @@ export const getSpace: API.OperationMethod<
   GetSpaceInput,
   GetSpaceOutput,
   GetSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSpaceInput,
   output: GetSpaceOutput,
@@ -1355,7 +1354,7 @@ export const listChannels: API.PaginatedOperationMethod<
   ListChannelsInput,
   ListChannelsOutput,
   ListChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ChannelData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChannelsInput,
@@ -1391,7 +1390,7 @@ export const listSpaces: API.PaginatedOperationMethod<
   ListSpacesInput,
   ListSpacesOutput,
   ListSpacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpaceData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpacesInput,
@@ -1427,7 +1426,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1457,7 +1456,7 @@ export const registerAdmin: API.OperationMethod<
   RegisterAdminInput,
   RegisterAdminResponse,
   RegisterAdminError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterAdminInput,
   output: RegisterAdminResponse,
@@ -1487,7 +1486,7 @@ export const sendInvites: API.OperationMethod<
   SendInvitesInput,
   SendInvitesResponse,
   SendInvitesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendInvitesInput,
   output: SendInvitesResponse,
@@ -1517,7 +1516,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1547,7 +1546,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1578,7 +1577,7 @@ export const updateChannel: API.OperationMethod<
   UpdateChannelInput,
   UpdateChannelOutput,
   UpdateChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChannelInput,
   output: UpdateChannelOutput,
@@ -1610,7 +1609,7 @@ export const updateSpace: API.OperationMethod<
   UpdateSpaceInput,
   UpdateSpaceResponse,
   UpdateSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpaceInput,
   output: UpdateSpaceResponse,

--- a/packages/aws/src/services/resiliencehub.ts
+++ b/packages/aws/src/services/resiliencehub.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "resiliencehub",
   serviceShapeName: "AwsResilienceHub",
@@ -4015,7 +4014,7 @@ export const acceptResourceGroupingRecommendations: API.OperationMethod<
   AcceptResourceGroupingRecommendationsRequest,
   AcceptResourceGroupingRecommendationsResponse,
   AcceptResourceGroupingRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptResourceGroupingRecommendationsRequest,
   output: AcceptResourceGroupingRecommendationsResponse,
@@ -4052,7 +4051,7 @@ export const addDraftAppVersionResourceMappings: API.OperationMethod<
   AddDraftAppVersionResourceMappingsRequest,
   AddDraftAppVersionResourceMappingsResponse,
   AddDraftAppVersionResourceMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddDraftAppVersionResourceMappingsRequest,
   output: AddDraftAppVersionResourceMappingsResponse,
@@ -4084,7 +4083,7 @@ export const batchUpdateRecommendationStatus: API.OperationMethod<
   BatchUpdateRecommendationStatusRequest,
   BatchUpdateRecommendationStatusResponse,
   BatchUpdateRecommendationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateRecommendationStatusRequest,
   output: BatchUpdateRecommendationStatusResponse,
@@ -4127,7 +4126,7 @@ export const createApp: API.OperationMethod<
   CreateAppRequest,
   CreateAppResponse,
   CreateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppRequest,
   output: CreateAppResponse,
@@ -4165,7 +4164,7 @@ export const createAppVersionAppComponent: API.OperationMethod<
   CreateAppVersionAppComponentRequest,
   CreateAppVersionAppComponentResponse,
   CreateAppVersionAppComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppVersionAppComponentRequest,
   output: CreateAppVersionAppComponentResponse,
@@ -4210,7 +4209,7 @@ export const createAppVersionResource: API.OperationMethod<
   CreateAppVersionResourceRequest,
   CreateAppVersionResourceResponse,
   CreateAppVersionResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppVersionResourceRequest,
   output: CreateAppVersionResourceResponse,
@@ -4244,7 +4243,7 @@ export const createRecommendationTemplate: API.OperationMethod<
   CreateRecommendationTemplateRequest,
   CreateRecommendationTemplateResponse,
   CreateRecommendationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecommendationTemplateRequest,
   output: CreateRecommendationTemplateResponse,
@@ -4285,7 +4284,7 @@ export const createResiliencyPolicy: API.OperationMethod<
   CreateResiliencyPolicyRequest,
   CreateResiliencyPolicyResponse,
   CreateResiliencyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResiliencyPolicyRequest,
   output: CreateResiliencyPolicyResponse,
@@ -4317,7 +4316,7 @@ export const deleteApp: API.OperationMethod<
   DeleteAppRequest,
   DeleteAppResponse,
   DeleteAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppRequest,
   output: DeleteAppResponse,
@@ -4349,7 +4348,7 @@ export const deleteAppAssessment: API.OperationMethod<
   DeleteAppAssessmentRequest,
   DeleteAppAssessmentResponse,
   DeleteAppAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppAssessmentRequest,
   output: DeleteAppAssessmentResponse,
@@ -4382,7 +4381,7 @@ export const deleteAppInputSource: API.OperationMethod<
   DeleteAppInputSourceRequest,
   DeleteAppInputSourceResponse,
   DeleteAppInputSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInputSourceRequest,
   output: DeleteAppInputSourceResponse,
@@ -4421,7 +4420,7 @@ export const deleteAppVersionAppComponent: API.OperationMethod<
   DeleteAppVersionAppComponentRequest,
   DeleteAppVersionAppComponentResponse,
   DeleteAppVersionAppComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppVersionAppComponentRequest,
   output: DeleteAppVersionAppComponentResponse,
@@ -4462,7 +4461,7 @@ export const deleteAppVersionResource: API.OperationMethod<
   DeleteAppVersionResourceRequest,
   DeleteAppVersionResourceResponse,
   DeleteAppVersionResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppVersionResourceRequest,
   output: DeleteAppVersionResourceResponse,
@@ -4494,7 +4493,7 @@ export const deleteRecommendationTemplate: API.OperationMethod<
   DeleteRecommendationTemplateRequest,
   DeleteRecommendationTemplateResponse,
   DeleteRecommendationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecommendationTemplateRequest,
   output: DeleteRecommendationTemplateResponse,
@@ -4525,7 +4524,7 @@ export const deleteResiliencyPolicy: API.OperationMethod<
   DeleteResiliencyPolicyRequest,
   DeleteResiliencyPolicyResponse,
   DeleteResiliencyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResiliencyPolicyRequest,
   output: DeleteResiliencyPolicyResponse,
@@ -4556,7 +4555,7 @@ export const describeApp: API.OperationMethod<
   DescribeAppRequest,
   DescribeAppResponse,
   DescribeAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppRequest,
   output: DescribeAppResponse,
@@ -4586,7 +4585,7 @@ export const describeAppAssessment: API.OperationMethod<
   DescribeAppAssessmentRequest,
   DescribeAppAssessmentResponse,
   DescribeAppAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppAssessmentRequest,
   output: DescribeAppAssessmentResponse,
@@ -4616,7 +4615,7 @@ export const describeAppVersion: API.OperationMethod<
   DescribeAppVersionRequest,
   DescribeAppVersionResponse,
   DescribeAppVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppVersionRequest,
   output: DescribeAppVersionResponse,
@@ -4647,7 +4646,7 @@ export const describeAppVersionAppComponent: API.OperationMethod<
   DescribeAppVersionAppComponentRequest,
   DescribeAppVersionAppComponentResponse,
   DescribeAppVersionAppComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppVersionAppComponentRequest,
   output: DescribeAppVersionAppComponentResponse,
@@ -4688,7 +4687,7 @@ export const describeAppVersionResource: API.OperationMethod<
   DescribeAppVersionResourceRequest,
   DescribeAppVersionResourceResponse,
   DescribeAppVersionResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppVersionResourceRequest,
   output: DescribeAppVersionResourceResponse,
@@ -4721,7 +4720,7 @@ export const describeAppVersionResourcesResolutionStatus: API.OperationMethod<
   DescribeAppVersionResourcesResolutionStatusRequest,
   DescribeAppVersionResourcesResolutionStatusResponse,
   DescribeAppVersionResourcesResolutionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppVersionResourcesResolutionStatusRequest,
   output: DescribeAppVersionResourcesResolutionStatusResponse,
@@ -4751,7 +4750,7 @@ export const describeAppVersionTemplate: API.OperationMethod<
   DescribeAppVersionTemplateRequest,
   DescribeAppVersionTemplateResponse,
   DescribeAppVersionTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppVersionTemplateRequest,
   output: DescribeAppVersionTemplateResponse,
@@ -4787,7 +4786,7 @@ export const describeDraftAppVersionResourcesImportStatus: API.OperationMethod<
   DescribeDraftAppVersionResourcesImportStatusRequest,
   DescribeDraftAppVersionResourcesImportStatusResponse,
   DescribeDraftAppVersionResourcesImportStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDraftAppVersionResourcesImportStatusRequest,
   output: DescribeDraftAppVersionResourcesImportStatusResponse,
@@ -4817,7 +4816,7 @@ export const describeMetricsExport: API.OperationMethod<
   DescribeMetricsExportRequest,
   DescribeMetricsExportResponse,
   DescribeMetricsExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMetricsExportRequest,
   output: DescribeMetricsExportResponse,
@@ -4849,7 +4848,7 @@ export const describeResiliencyPolicy: API.OperationMethod<
   DescribeResiliencyPolicyRequest,
   DescribeResiliencyPolicyResponse,
   DescribeResiliencyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResiliencyPolicyRequest,
   output: DescribeResiliencyPolicyResponse,
@@ -4879,7 +4878,7 @@ export const describeResourceGroupingRecommendationTask: API.OperationMethod<
   DescribeResourceGroupingRecommendationTaskRequest,
   DescribeResourceGroupingRecommendationTaskResponse,
   DescribeResourceGroupingRecommendationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceGroupingRecommendationTaskRequest,
   output: DescribeResourceGroupingRecommendationTaskResponse,
@@ -4913,7 +4912,7 @@ export const importResourcesToDraftAppVersion: API.OperationMethod<
   ImportResourcesToDraftAppVersionRequest,
   ImportResourcesToDraftAppVersionResponse,
   ImportResourcesToDraftAppVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportResourcesToDraftAppVersionRequest,
   output: ImportResourcesToDraftAppVersionResponse,
@@ -4945,7 +4944,7 @@ export const listAlarmRecommendations: API.PaginatedOperationMethod<
   ListAlarmRecommendationsRequest,
   ListAlarmRecommendationsResponse,
   ListAlarmRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAlarmRecommendationsRequest,
@@ -4981,7 +4980,7 @@ export const listAppAssessmentComplianceDrifts: API.PaginatedOperationMethod<
   ListAppAssessmentComplianceDriftsRequest,
   ListAppAssessmentComplianceDriftsResponse,
   ListAppAssessmentComplianceDriftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppAssessmentComplianceDriftsRequest,
@@ -5016,7 +5015,7 @@ export const listAppAssessmentResourceDrifts: API.PaginatedOperationMethod<
   ListAppAssessmentResourceDriftsRequest,
   ListAppAssessmentResourceDriftsResponse,
   ListAppAssessmentResourceDriftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceDrift
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppAssessmentResourceDriftsRequest,
@@ -5053,7 +5052,7 @@ export const listAppAssessments: API.PaginatedOperationMethod<
   ListAppAssessmentsRequest,
   ListAppAssessmentsResponse,
   ListAppAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppAssessmentsRequest,
@@ -5089,7 +5088,7 @@ export const listAppComponentCompliances: API.PaginatedOperationMethod<
   ListAppComponentCompliancesRequest,
   ListAppComponentCompliancesResponse,
   ListAppComponentCompliancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppComponentCompliancesRequest,
@@ -5125,7 +5124,7 @@ export const listAppComponentRecommendations: API.PaginatedOperationMethod<
   ListAppComponentRecommendationsRequest,
   ListAppComponentRecommendationsResponse,
   ListAppComponentRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppComponentRecommendationsRequest,
@@ -5163,7 +5162,7 @@ export const listAppInputSources: API.PaginatedOperationMethod<
   ListAppInputSourcesRequest,
   ListAppInputSourcesResponse,
   ListAppInputSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppInputSourcesRequest,
@@ -5205,7 +5204,7 @@ export const listApps: API.PaginatedOperationMethod<
   ListAppsRequest,
   ListAppsResponse,
   ListAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppsRequest,
@@ -5241,7 +5240,7 @@ export const listAppVersionAppComponents: API.PaginatedOperationMethod<
   ListAppVersionAppComponentsRequest,
   ListAppVersionAppComponentsResponse,
   ListAppVersionAppComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppVersionAppComponentsRequest,
@@ -5280,7 +5279,7 @@ export const listAppVersionResourceMappings: API.PaginatedOperationMethod<
   ListAppVersionResourceMappingsRequest,
   ListAppVersionResourceMappingsResponse,
   ListAppVersionResourceMappingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppVersionResourceMappingsRequest,
@@ -5317,7 +5316,7 @@ export const listAppVersionResources: API.PaginatedOperationMethod<
   ListAppVersionResourcesRequest,
   ListAppVersionResourcesResponse,
   ListAppVersionResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppVersionResourcesRequest,
@@ -5353,7 +5352,7 @@ export const listAppVersions: API.PaginatedOperationMethod<
   ListAppVersionsRequest,
   ListAppVersionsResponse,
   ListAppVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppVersionsRequest,
@@ -5387,7 +5386,7 @@ export const listMetrics: API.PaginatedOperationMethod<
   ListMetricsRequest,
   ListMetricsResponse,
   ListMetricsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   String255[]
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMetricsRequest,
@@ -5422,7 +5421,7 @@ export const listRecommendationTemplates: API.PaginatedOperationMethod<
   ListRecommendationTemplatesRequest,
   ListRecommendationTemplatesResponse,
   ListRecommendationTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationTemplatesRequest,
@@ -5457,7 +5456,7 @@ export const listResiliencyPolicies: API.PaginatedOperationMethod<
   ListResiliencyPoliciesRequest,
   ListResiliencyPoliciesResponse,
   ListResiliencyPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResiliencyPoliciesRequest,
@@ -5493,7 +5492,7 @@ export const listResourceGroupingRecommendations: API.PaginatedOperationMethod<
   ListResourceGroupingRecommendationsRequest,
   ListResourceGroupingRecommendationsResponse,
   ListResourceGroupingRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupingRecommendation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceGroupingRecommendationsRequest,
@@ -5531,7 +5530,7 @@ export const listSopRecommendations: API.PaginatedOperationMethod<
   ListSopRecommendationsRequest,
   ListSopRecommendationsResponse,
   ListSopRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSopRecommendationsRequest,
@@ -5569,7 +5568,7 @@ export const listSuggestedResiliencyPolicies: API.PaginatedOperationMethod<
   ListSuggestedResiliencyPoliciesRequest,
   ListSuggestedResiliencyPoliciesResponse,
   ListSuggestedResiliencyPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSuggestedResiliencyPoliciesRequest,
@@ -5605,7 +5604,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5636,7 +5635,7 @@ export const listTestRecommendations: API.PaginatedOperationMethod<
   ListTestRecommendationsRequest,
   ListTestRecommendationsResponse,
   ListTestRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTestRecommendationsRequest,
@@ -5676,7 +5675,7 @@ export const listUnsupportedAppVersionResources: API.PaginatedOperationMethod<
   ListUnsupportedAppVersionResourcesRequest,
   ListUnsupportedAppVersionResourcesResponse,
   ListUnsupportedAppVersionResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUnsupportedAppVersionResourcesRequest,
@@ -5714,7 +5713,7 @@ export const publishAppVersion: API.OperationMethod<
   PublishAppVersionRequest,
   PublishAppVersionResponse,
   PublishAppVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishAppVersionRequest,
   output: PublishAppVersionResponse,
@@ -5747,7 +5746,7 @@ export const putDraftAppVersionTemplate: API.OperationMethod<
   PutDraftAppVersionTemplateRequest,
   PutDraftAppVersionTemplateResponse,
   PutDraftAppVersionTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDraftAppVersionTemplateRequest,
   output: PutDraftAppVersionTemplateResponse,
@@ -5778,7 +5777,7 @@ export const rejectResourceGroupingRecommendations: API.OperationMethod<
   RejectResourceGroupingRecommendationsRequest,
   RejectResourceGroupingRecommendationsResponse,
   RejectResourceGroupingRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectResourceGroupingRecommendationsRequest,
   output: RejectResourceGroupingRecommendationsResponse,
@@ -5809,7 +5808,7 @@ export const removeDraftAppVersionResourceMappings: API.OperationMethod<
   RemoveDraftAppVersionResourceMappingsRequest,
   RemoveDraftAppVersionResourceMappingsResponse,
   RemoveDraftAppVersionResourceMappingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveDraftAppVersionResourceMappingsRequest,
   output: RemoveDraftAppVersionResourceMappingsResponse,
@@ -5841,7 +5840,7 @@ export const resolveAppVersionResources: API.OperationMethod<
   ResolveAppVersionResourcesRequest,
   ResolveAppVersionResourcesResponse,
   ResolveAppVersionResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResolveAppVersionResourcesRequest,
   output: ResolveAppVersionResourcesResponse,
@@ -5874,7 +5873,7 @@ export const startAppAssessment: API.OperationMethod<
   StartAppAssessmentRequest,
   StartAppAssessmentResponse,
   StartAppAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAppAssessmentRequest,
   output: StartAppAssessmentResponse,
@@ -5907,7 +5906,7 @@ export const startMetricsExport: API.OperationMethod<
   StartMetricsExportRequest,
   StartMetricsExportResponse,
   StartMetricsExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMetricsExportRequest,
   output: StartMetricsExportResponse,
@@ -5939,7 +5938,7 @@ export const startResourceGroupingRecommendationTask: API.OperationMethod<
   StartResourceGroupingRecommendationTaskRequest,
   StartResourceGroupingRecommendationTaskResponse,
   StartResourceGroupingRecommendationTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartResourceGroupingRecommendationTaskRequest,
   output: StartResourceGroupingRecommendationTaskResponse,
@@ -5970,7 +5969,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6000,7 +5999,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6031,7 +6030,7 @@ export const updateApp: API.OperationMethod<
   UpdateAppRequest,
   UpdateAppResponse,
   UpdateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppRequest,
   output: UpdateAppResponse,
@@ -6067,7 +6066,7 @@ export const updateAppVersion: API.OperationMethod<
   UpdateAppVersionRequest,
   UpdateAppVersionResponse,
   UpdateAppVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppVersionRequest,
   output: UpdateAppVersionResponse,
@@ -6103,7 +6102,7 @@ export const updateAppVersionAppComponent: API.OperationMethod<
   UpdateAppVersionAppComponentRequest,
   UpdateAppVersionAppComponentResponse,
   UpdateAppVersionAppComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppVersionAppComponentRequest,
   output: UpdateAppVersionAppComponentResponse,
@@ -6145,7 +6144,7 @@ export const updateAppVersionResource: API.OperationMethod<
   UpdateAppVersionResourceRequest,
   UpdateAppVersionResourceResponse,
   UpdateAppVersionResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppVersionResourceRequest,
   output: UpdateAppVersionResourceResponse,
@@ -6186,7 +6185,7 @@ export const updateResiliencyPolicy: API.OperationMethod<
   UpdateResiliencyPolicyRequest,
   UpdateResiliencyPolicyResponse,
   UpdateResiliencyPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResiliencyPolicyRequest,
   output: UpdateResiliencyPolicyResponse,

--- a/packages/aws/src/services/resiliencehubv2.ts
+++ b/packages/aws/src/services/resiliencehubv2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "resiliencehubv2",
   serviceShapeName: "NGRHServiceCore",
@@ -4088,7 +4087,7 @@ export const createAssertion: API.OperationMethod<
   CreateAssertionRequest,
   CreateAssertionResponse,
   CreateAssertionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssertionRequest,
   output: CreateAssertionResponse,
@@ -4120,7 +4119,7 @@ export const createInputSource: API.OperationMethod<
   CreateInputSourceRequest,
   CreateInputSourceResponse,
   CreateInputSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInputSourceRequest,
   output: CreateInputSourceResponse,
@@ -4152,7 +4151,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyRequest,
   CreatePolicyResponse,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyRequest,
   output: CreatePolicyResponse,
@@ -4184,7 +4183,7 @@ export const createReport: API.OperationMethod<
   CreateReportRequest,
   CreateReportResponse,
   CreateReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReportRequest,
   output: CreateReportResponse,
@@ -4216,7 +4215,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -4248,7 +4247,7 @@ export const createServiceFunction: API.OperationMethod<
   CreateServiceFunctionRequest,
   CreateServiceFunctionResponse,
   CreateServiceFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceFunctionRequest,
   output: CreateServiceFunctionResponse,
@@ -4279,7 +4278,7 @@ export const createServiceFunctionResources: API.OperationMethod<
   CreateServiceFunctionResourcesRequest,
   CreateServiceFunctionResourcesResponse,
   CreateServiceFunctionResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceFunctionResourcesRequest,
   output: CreateServiceFunctionResourcesResponse,
@@ -4310,7 +4309,7 @@ export const createSystem: API.OperationMethod<
   CreateSystemRequest,
   CreateSystemResponse,
   CreateSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSystemRequest,
   output: CreateSystemResponse,
@@ -4342,7 +4341,7 @@ export const createUserJourney: API.OperationMethod<
   CreateUserJourneyRequest,
   CreateUserJourneyResponse,
   CreateUserJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserJourneyRequest,
   output: CreateUserJourneyResponse,
@@ -4372,7 +4371,7 @@ export const deleteAssertion: API.OperationMethod<
   DeleteAssertionRequest,
   DeleteAssertionResponse,
   DeleteAssertionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssertionRequest,
   output: DeleteAssertionResponse,
@@ -4400,7 +4399,7 @@ export const deleteInputSource: API.OperationMethod<
   DeleteInputSourceRequest,
   DeleteInputSourceResponse,
   DeleteInputSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInputSourceRequest,
   output: DeleteInputSourceResponse,
@@ -4429,7 +4428,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyRequest,
   DeletePolicyResponse,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyRequest,
   output: DeletePolicyResponse,
@@ -4459,7 +4458,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -4489,7 +4488,7 @@ export const deleteServiceFunction: API.OperationMethod<
   DeleteServiceFunctionRequest,
   DeleteServiceFunctionResponse,
   DeleteServiceFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceFunctionRequest,
   output: DeleteServiceFunctionResponse,
@@ -4519,7 +4518,7 @@ export const deleteServiceFunctionResources: API.OperationMethod<
   DeleteServiceFunctionResourcesRequest,
   DeleteServiceFunctionResourcesResponse,
   DeleteServiceFunctionResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceFunctionResourcesRequest,
   output: DeleteServiceFunctionResourcesResponse,
@@ -4549,7 +4548,7 @@ export const deleteSystem: API.OperationMethod<
   DeleteSystemRequest,
   DeleteSystemResponse,
   DeleteSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSystemRequest,
   output: DeleteSystemResponse,
@@ -4579,7 +4578,7 @@ export const deleteUserJourney: API.OperationMethod<
   DeleteUserJourneyRequest,
   DeleteUserJourneyResponse,
   DeleteUserJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserJourneyRequest,
   output: DeleteUserJourneyResponse,
@@ -4608,7 +4607,7 @@ export const getFailureModeFinding: API.OperationMethod<
   GetFailureModeFindingRequest,
   GetFailureModeFindingResponse,
   GetFailureModeFindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFailureModeFindingRequest,
   output: GetFailureModeFindingResponse,
@@ -4636,7 +4635,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyRequest,
   GetPolicyResponse,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyRequest,
   output: GetPolicyResponse,
@@ -4664,7 +4663,7 @@ export const getService: API.OperationMethod<
   GetServiceRequest,
   GetServiceResponse,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRequest,
   output: GetServiceResponse,
@@ -4692,7 +4691,7 @@ export const getSystem: API.OperationMethod<
   GetSystemRequest,
   GetSystemResponse,
   GetSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSystemRequest,
   output: GetSystemResponse,
@@ -4720,7 +4719,7 @@ export const getUserJourney: API.OperationMethod<
   GetUserJourneyRequest,
   GetUserJourneyResponse,
   GetUserJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserJourneyRequest,
   output: GetUserJourneyResponse,
@@ -4749,7 +4748,7 @@ export const importApp: API.OperationMethod<
   ImportAppRequest,
   ImportAppResponse,
   ImportAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportAppRequest,
   output: ImportAppResponse,
@@ -4779,7 +4778,7 @@ export const importPolicy: API.OperationMethod<
   ImportPolicyRequest,
   ImportPolicyResponse,
   ImportPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportPolicyRequest,
   output: ImportPolicyResponse,
@@ -4808,7 +4807,7 @@ export const listAssertions: API.PaginatedOperationMethod<
   ListAssertionsRequest,
   ListAssertionsResponse,
   ListAssertionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Assertion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssertionsRequest,
@@ -4843,7 +4842,7 @@ export const listDependencies: API.PaginatedOperationMethod<
   ListDependenciesRequest,
   ListDependenciesResponse,
   ListDependenciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DependencySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDependenciesRequest,
@@ -4878,7 +4877,7 @@ export const listFailureModeAssessments: API.PaginatedOperationMethod<
   ListFailureModeAssessmentsRequest,
   ListFailureModeAssessmentsResponse,
   ListFailureModeAssessmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssessmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFailureModeAssessmentsRequest,
@@ -4913,7 +4912,7 @@ export const listFailureModeFindings: API.PaginatedOperationMethod<
   ListFailureModeFindingsRequest,
   ListFailureModeFindingsResponse,
   ListFailureModeFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFailureModeFindingsRequest,
@@ -4948,7 +4947,7 @@ export const listInputSources: API.PaginatedOperationMethod<
   ListInputSourcesRequest,
   ListInputSourcesResponse,
   ListInputSourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InputSourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInputSourcesRequest,
@@ -4982,7 +4981,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesRequest,
   ListPoliciesResponse,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesRequest,
@@ -5013,7 +5012,7 @@ export const listReports: API.PaginatedOperationMethod<
   ListReportsRequest,
   ListReportsResponse,
   ListReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReportGenerationResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReportsRequest,
@@ -5049,7 +5048,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesRequest,
   ListResourcesResponse,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesRequest,
@@ -5084,7 +5083,7 @@ export const listServiceEvents: API.PaginatedOperationMethod<
   ListServiceEventsRequest,
   ListServiceEventsResponse,
   ListServiceEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceEventsRequest,
@@ -5119,7 +5118,7 @@ export const listServiceFunctions: API.PaginatedOperationMethod<
   ListServiceFunctionsRequest,
   ListServiceFunctionsResponse,
   ListServiceFunctionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceFunction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceFunctionsRequest,
@@ -5153,7 +5152,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -5182,7 +5181,7 @@ export const listServiceTopologyEdges: API.PaginatedOperationMethod<
   ListServiceTopologyEdgesRequest,
   ListServiceTopologyEdgesResponse,
   ListServiceTopologyEdgesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceTopologyEdgeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceTopologyEdgesRequest,
@@ -5212,7 +5211,7 @@ export const listSystemEvents: API.PaginatedOperationMethod<
   ListSystemEventsRequest,
   ListSystemEventsResponse,
   ListSystemEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSystemEventsRequest,
@@ -5246,7 +5245,7 @@ export const listSystems: API.PaginatedOperationMethod<
   ListSystemsRequest,
   ListSystemsResponse,
   ListSystemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SystemSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSystemsRequest,
@@ -5277,7 +5276,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5306,7 +5305,7 @@ export const listUserJourneys: API.PaginatedOperationMethod<
   ListUserJourneysRequest,
   ListUserJourneysResponse,
   ListUserJourneysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserJourneySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserJourneysRequest,
@@ -5343,7 +5342,7 @@ export const startFailureModeAssessment: API.OperationMethod<
   StartFailureModeAssessmentRequest,
   StartFailureModeAssessmentResponse,
   StartFailureModeAssessmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFailureModeAssessmentRequest,
   output: StartFailureModeAssessmentResponse,
@@ -5374,7 +5373,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5404,7 +5403,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5434,7 +5433,7 @@ export const updateAssertion: API.OperationMethod<
   UpdateAssertionRequest,
   UpdateAssertionResponse,
   UpdateAssertionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssertionRequest,
   output: UpdateAssertionResponse,
@@ -5464,7 +5463,7 @@ export const updateDependency: API.OperationMethod<
   UpdateDependencyRequest,
   UpdateDependencyResponse,
   UpdateDependencyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDependencyRequest,
   output: UpdateDependencyResponse,
@@ -5494,7 +5493,7 @@ export const updateFailureModeFinding: API.OperationMethod<
   UpdateFailureModeFindingRequest,
   UpdateFailureModeFindingResponse,
   UpdateFailureModeFindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFailureModeFindingRequest,
   output: UpdateFailureModeFindingResponse,
@@ -5524,7 +5523,7 @@ export const updatePolicy: API.OperationMethod<
   UpdatePolicyRequest,
   UpdatePolicyResponse,
   UpdatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyRequest,
   output: UpdatePolicyResponse,
@@ -5555,7 +5554,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceRequest,
   UpdateServiceResponse,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceRequest,
   output: UpdateServiceResponse,
@@ -5586,7 +5585,7 @@ export const updateServiceFunction: API.OperationMethod<
   UpdateServiceFunctionRequest,
   UpdateServiceFunctionResponse,
   UpdateServiceFunctionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceFunctionRequest,
   output: UpdateServiceFunctionResponse,
@@ -5616,7 +5615,7 @@ export const updateSystem: API.OperationMethod<
   UpdateSystemRequest,
   UpdateSystemResponse,
   UpdateSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSystemRequest,
   output: UpdateSystemResponse,
@@ -5646,7 +5645,7 @@ export const updateUserJourney: API.OperationMethod<
   UpdateUserJourneyRequest,
   UpdateUserJourneyResponse,
   UpdateUserJourneyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserJourneyRequest,
   output: UpdateUserJourneyResponse,

--- a/packages/aws/src/services/resource-explorer-2.ts
+++ b/packages/aws/src/services/resource-explorer-2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Resource Explorer 2",
@@ -1461,7 +1460,7 @@ export const associateDefaultView: API.OperationMethod<
   AssociateDefaultViewInput,
   AssociateDefaultViewOutput,
   AssociateDefaultViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDefaultViewInput,
   output: AssociateDefaultViewOutput,
@@ -1491,7 +1490,7 @@ export const batchGetView: API.OperationMethod<
   BatchGetViewInput,
   BatchGetViewOutput,
   BatchGetViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetViewInput,
   output: BatchGetViewOutput,
@@ -1541,7 +1540,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexInput,
   CreateIndexOutput,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexInput,
   output: CreateIndexOutput,
@@ -1571,7 +1570,7 @@ export const createResourceExplorerSetup: API.OperationMethod<
   CreateResourceExplorerSetupInput,
   CreateResourceExplorerSetupOutput,
   CreateResourceExplorerSetupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceExplorerSetupInput,
   output: CreateResourceExplorerSetupOutput,
@@ -1605,7 +1604,7 @@ export const createView: API.OperationMethod<
   CreateViewInput,
   CreateViewOutput,
   CreateViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateViewInput,
   output: CreateViewOutput,
@@ -1639,7 +1638,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexInput,
   DeleteIndexOutput,
   DeleteIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexInput,
   output: DeleteIndexOutput,
@@ -1669,7 +1668,7 @@ export const deleteResourceExplorerSetup: API.OperationMethod<
   DeleteResourceExplorerSetupInput,
   DeleteResourceExplorerSetupOutput,
   DeleteResourceExplorerSetupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceExplorerSetupInput,
   output: DeleteResourceExplorerSetupOutput,
@@ -1702,7 +1701,7 @@ export const deleteView: API.OperationMethod<
   DeleteViewInput,
   DeleteViewOutput,
   DeleteViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteViewInput,
   output: DeleteViewOutput,
@@ -1735,7 +1734,7 @@ export const disassociateDefaultView: API.OperationMethod<
   DisassociateDefaultViewRequest,
   DisassociateDefaultViewResponse,
   DisassociateDefaultViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDefaultViewRequest,
   output: DisassociateDefaultViewResponse,
@@ -1764,7 +1763,7 @@ export const getAccountLevelServiceConfiguration: API.OperationMethod<
   GetAccountLevelServiceConfigurationRequest,
   GetAccountLevelServiceConfigurationOutput,
   GetAccountLevelServiceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountLevelServiceConfigurationRequest,
   output: GetAccountLevelServiceConfigurationOutput,
@@ -1793,7 +1792,7 @@ export const getDefaultView: API.OperationMethod<
   GetDefaultViewRequest,
   GetDefaultViewOutput,
   GetDefaultViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultViewRequest,
   output: GetDefaultViewOutput,
@@ -1823,7 +1822,7 @@ export const getIndex: API.OperationMethod<
   GetIndexRequest,
   GetIndexOutput,
   GetIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexRequest,
   output: GetIndexOutput,
@@ -1854,7 +1853,7 @@ export const getManagedView: API.OperationMethod<
   GetManagedViewInput,
   GetManagedViewOutput,
   GetManagedViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedViewInput,
   output: GetManagedViewOutput,
@@ -1885,7 +1884,7 @@ export const getResourceExplorerSetup: API.PaginatedOperationMethod<
   GetResourceExplorerSetupInput,
   GetResourceExplorerSetupOutput,
   GetResourceExplorerSetupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegionStatus
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourceExplorerSetupInput,
@@ -1922,7 +1921,7 @@ export const getServiceIndex: API.OperationMethod<
   GetServiceIndexRequest,
   GetServiceIndexOutput,
   GetServiceIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceIndexRequest,
   output: GetServiceIndexOutput,
@@ -1952,7 +1951,7 @@ export const getServiceView: API.OperationMethod<
   GetServiceViewInput,
   GetServiceViewOutput,
   GetServiceViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceViewInput,
   output: GetServiceViewOutput,
@@ -1983,7 +1982,7 @@ export const getView: API.OperationMethod<
   GetViewInput,
   GetViewOutput,
   GetViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetViewInput,
   output: GetViewOutput,
@@ -2013,7 +2012,7 @@ export const listIndexes: API.PaginatedOperationMethod<
   ListIndexesInput,
   ListIndexesOutput,
   ListIndexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Index
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndexesInput,
@@ -2048,7 +2047,7 @@ export const listIndexesForMembers: API.PaginatedOperationMethod<
   ListIndexesForMembersInput,
   ListIndexesForMembersOutput,
   ListIndexesForMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MemberIndex
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndexesForMembersInput,
@@ -2084,7 +2083,7 @@ export const listManagedViews: API.PaginatedOperationMethod<
   ListManagedViewsInput,
   ListManagedViewsOutput,
   ListManagedViewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedViewsInput,
@@ -2122,7 +2121,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesInput,
   ListResourcesOutput,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Resource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesInput,
@@ -2159,7 +2158,7 @@ export const listServiceIndexes: API.PaginatedOperationMethod<
   ListServiceIndexesInput,
   ListServiceIndexesOutput,
   ListServiceIndexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Index
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceIndexesInput,
@@ -2194,7 +2193,7 @@ export const listServiceViews: API.PaginatedOperationMethod<
   ListServiceViewsInput,
   ListServiceViewsOutput,
   ListServiceViewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceViewsInput,
@@ -2228,7 +2227,7 @@ export const listStreamingAccessForServices: API.PaginatedOperationMethod<
   ListStreamingAccessForServicesInput,
   ListStreamingAccessForServicesOutput,
   ListStreamingAccessForServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StreamingAccessDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStreamingAccessForServicesInput,
@@ -2258,7 +2257,7 @@ export const listSupportedResourceTypes: API.PaginatedOperationMethod<
   ListSupportedResourceTypesInput,
   ListSupportedResourceTypesOutput,
   ListSupportedResourceTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SupportedResourceType
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSupportedResourceTypesInput,
@@ -2295,7 +2294,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2327,7 +2326,7 @@ export const listViews: API.PaginatedOperationMethod<
   ListViewsInput,
   ListViewsOutput,
   ListViewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListViewsInput,
@@ -2370,7 +2369,7 @@ export const search: API.PaginatedOperationMethod<
   SearchInput,
   SearchOutput,
   SearchError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Resource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchInput,
@@ -2409,7 +2408,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2441,7 +2440,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2490,7 +2489,7 @@ export const updateIndexType: API.OperationMethod<
   UpdateIndexTypeInput,
   UpdateIndexTypeOutput,
   UpdateIndexTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexTypeInput,
   output: UpdateIndexTypeOutput,
@@ -2523,7 +2522,7 @@ export const updateView: API.OperationMethod<
   UpdateViewInput,
   UpdateViewOutput,
   UpdateViewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateViewInput,
   output: UpdateViewOutput,

--- a/packages/aws/src/services/resource-groups-tagging-api.ts
+++ b/packages/aws/src/services/resource-groups-tagging-api.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Resource Groups Tagging API",
   serviceShapeName: "ResourceGroupsTaggingAPI_20170126",
@@ -592,7 +591,7 @@ export const describeReportCreation: API.OperationMethod<
   DescribeReportCreationInput,
   DescribeReportCreationOutput,
   DescribeReportCreationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReportCreationInput,
   output: DescribeReportCreationOutput,
@@ -634,7 +633,7 @@ export const getComplianceSummary: API.PaginatedOperationMethod<
   GetComplianceSummaryInput,
   GetComplianceSummaryOutput,
   GetComplianceSummaryError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Summary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetComplianceSummaryInput,
@@ -693,7 +692,7 @@ export const getResources: API.PaginatedOperationMethod<
   GetResourcesInput,
   GetResourcesOutput,
   GetResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceTagMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcesInput,
@@ -736,7 +735,7 @@ export const getTagKeys: API.PaginatedOperationMethod<
   GetTagKeysInput,
   GetTagKeysOutput,
   GetTagKeysError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagKey
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTagKeysInput,
@@ -778,7 +777,7 @@ export const getTagValues: API.PaginatedOperationMethod<
   GetTagValuesInput,
   GetTagValuesOutput,
   GetTagValuesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagValue
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTagValuesInput,
@@ -812,7 +811,7 @@ export const listRequiredTags: API.PaginatedOperationMethod<
   ListRequiredTagsInput,
   ListRequiredTagsOutput,
   ListRequiredTagsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RequiredTag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRequiredTagsInput,
@@ -868,7 +867,7 @@ export const startReportCreation: API.OperationMethod<
   StartReportCreationInput,
   StartReportCreationOutput,
   StartReportCreationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartReportCreationInput,
   output: StartReportCreationOutput,
@@ -945,7 +944,7 @@ export const tagResources: API.OperationMethod<
   TagResourcesInput,
   TagResourcesOutput,
   TagResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourcesInput,
   output: TagResourcesOutput,
@@ -1000,7 +999,7 @@ export const untagResources: API.OperationMethod<
   UntagResourcesInput,
   UntagResourcesOutput,
   UntagResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourcesInput,
   output: UntagResourcesOutput,

--- a/packages/aws/src/services/resource-groups.ts
+++ b/packages/aws/src/services/resource-groups.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Resource Groups",
   serviceShapeName: "Ardi",
@@ -1318,7 +1317,7 @@ export const cancelTagSyncTask: API.OperationMethod<
   CancelTagSyncTaskInput,
   CancelTagSyncTaskResponse,
   CancelTagSyncTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTagSyncTaskInput,
   output: CancelTagSyncTaskResponse,
@@ -1360,7 +1359,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupInput,
   CreateGroupOutput,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupInput,
   output: CreateGroupOutput,
@@ -1399,7 +1398,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupInput,
   DeleteGroupOutput,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupInput,
   output: DeleteGroupOutput,
@@ -1430,7 +1429,7 @@ export const getAccountSettings: API.OperationMethod<
   GetAccountSettingsRequest,
   GetAccountSettingsOutput,
   GetAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSettingsRequest,
   output: GetAccountSettingsOutput,
@@ -1467,7 +1466,7 @@ export const getGroup: API.OperationMethod<
   GetGroupInput,
   GetGroupOutput,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupInput,
   output: GetGroupOutput,
@@ -1506,7 +1505,7 @@ export const getGroupConfiguration: API.OperationMethod<
   GetGroupConfigurationInput,
   GetGroupConfigurationOutput,
   GetGroupConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupConfigurationInput,
   output: GetGroupConfigurationOutput,
@@ -1546,7 +1545,7 @@ export const getGroupQuery: API.OperationMethod<
   GetGroupQueryInput,
   GetGroupQueryOutput,
   GetGroupQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupQueryInput,
   output: GetGroupQueryOutput,
@@ -1585,7 +1584,7 @@ export const getTags: API.OperationMethod<
   GetTagsInput,
   GetTagsOutput,
   GetTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagsInput,
   output: GetTagsOutput,
@@ -1624,7 +1623,7 @@ export const getTagSyncTask: API.OperationMethod<
   GetTagSyncTaskInput,
   GetTagSyncTaskOutput,
   GetTagSyncTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTagSyncTaskInput,
   output: GetTagSyncTaskOutput,
@@ -1674,7 +1673,7 @@ export const groupResources: API.OperationMethod<
   GroupResourcesInput,
   GroupResourcesOutput,
   GroupResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GroupResourcesInput,
   output: GroupResourcesOutput,
@@ -1707,7 +1706,7 @@ export const listGroupingStatuses: API.PaginatedOperationMethod<
   ListGroupingStatusesInput,
   ListGroupingStatusesOutput,
   ListGroupingStatusesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupingStatusesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupingStatusesInput,
@@ -1760,7 +1759,7 @@ export const listGroupResources: API.PaginatedOperationMethod<
   ListGroupResourcesInput,
   ListGroupResourcesOutput,
   ListGroupResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupResourcesInput,
@@ -1805,7 +1804,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsInput,
   ListGroupsOutput,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsInput,
@@ -1850,7 +1849,7 @@ export const listTagSyncTasks: API.PaginatedOperationMethod<
   ListTagSyncTasksInput,
   ListTagSyncTasksOutput,
   ListTagSyncTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TagSyncTaskItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagSyncTasksInput,
@@ -1897,7 +1896,7 @@ export const putGroupConfiguration: API.OperationMethod<
   PutGroupConfigurationInput,
   PutGroupConfigurationOutput,
   PutGroupConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutGroupConfigurationInput,
   output: PutGroupConfigurationOutput,
@@ -1943,7 +1942,7 @@ export const searchResources: API.PaginatedOperationMethod<
   SearchResourcesInput,
   SearchResourcesOutput,
   SearchResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchResourcesInput,
@@ -1999,7 +1998,7 @@ export const startTagSyncTask: API.OperationMethod<
   StartTagSyncTaskInput,
   StartTagSyncTaskOutput,
   StartTagSyncTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTagSyncTaskInput,
   output: StartTagSyncTaskOutput,
@@ -2044,7 +2043,7 @@ export const tag: API.OperationMethod<
   TagInput,
   TagOutput,
   TagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagInput,
   output: TagOutput,
@@ -2085,7 +2084,7 @@ export const ungroupResources: API.OperationMethod<
   UngroupResourcesInput,
   UngroupResourcesOutput,
   UngroupResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UngroupResourcesInput,
   output: UngroupResourcesOutput,
@@ -2123,7 +2122,7 @@ export const untag: API.OperationMethod<
   UntagInput,
   UntagOutput,
   UntagError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagInput,
   output: UntagOutput,
@@ -2159,7 +2158,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsInput,
   UpdateAccountSettingsOutput,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsInput,
   output: UpdateAccountSettingsOutput,
@@ -2197,7 +2196,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupInput,
   UpdateGroupOutput,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupInput,
   output: UpdateGroupOutput,
@@ -2236,7 +2235,7 @@ export const updateGroupQuery: API.OperationMethod<
   UpdateGroupQueryInput,
   UpdateGroupQueryOutput,
   UpdateGroupQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupQueryInput,
   output: UpdateGroupQueryOutput,

--- a/packages/aws/src/services/rolesanywhere.ts
+++ b/packages/aws/src/services/rolesanywhere.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "RolesAnywhere",
@@ -966,7 +965,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileRequest,
   ProfileDetailResponse,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileRequest,
   output: ProfileDetailResponse,
@@ -989,7 +988,7 @@ export const createTrustAnchor: API.OperationMethod<
   CreateTrustAnchorRequest,
   TrustAnchorDetailResponse,
   CreateTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustAnchorRequest,
   output: TrustAnchorDetailResponse,
@@ -1011,7 +1010,7 @@ export const deleteAttributeMapping: API.OperationMethod<
   DeleteAttributeMappingRequest,
   DeleteAttributeMappingResponse,
   DeleteAttributeMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttributeMappingRequest,
   output: DeleteAttributeMappingResponse,
@@ -1038,7 +1037,7 @@ export const deleteCrl: API.OperationMethod<
   ScalarCrlRequest,
   CrlDetailResponse,
   DeleteCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalarCrlRequest,
   output: CrlDetailResponse,
@@ -1061,7 +1060,7 @@ export const deleteProfile: API.OperationMethod<
   ScalarProfileRequest,
   ProfileDetailResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalarProfileRequest,
   output: ProfileDetailResponse,
@@ -1084,7 +1083,7 @@ export const deleteTrustAnchor: API.OperationMethod<
   ScalarTrustAnchorRequest,
   TrustAnchorDetailResponse,
   DeleteTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalarTrustAnchorRequest,
   output: TrustAnchorDetailResponse,
@@ -1113,7 +1112,7 @@ export const disableCrl: API.OperationMethod<
   DisableCrlRequest,
   CrlDetailResponse,
   DisableCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableCrlRequest,
   output: CrlDetailResponse,
@@ -1142,7 +1141,7 @@ export const disableProfile: API.OperationMethod<
   DisableProfileRequest,
   ProfileDetailResponse,
   DisableProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableProfileRequest,
   output: ProfileDetailResponse,
@@ -1172,7 +1171,7 @@ export const disableTrustAnchor: API.OperationMethod<
   DisableTrustAnchorRequest,
   TrustAnchorDetailResponse,
   DisableTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableTrustAnchorRequest,
   output: TrustAnchorDetailResponse,
@@ -1201,7 +1200,7 @@ export const enableCrl: API.OperationMethod<
   EnableCrlRequest,
   CrlDetailResponse,
   EnableCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableCrlRequest,
   output: CrlDetailResponse,
@@ -1230,7 +1229,7 @@ export const enableProfile: API.OperationMethod<
   EnableProfileRequest,
   ProfileDetailResponse,
   EnableProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableProfileRequest,
   output: ProfileDetailResponse,
@@ -1260,7 +1259,7 @@ export const enableTrustAnchor: API.OperationMethod<
   EnableTrustAnchorRequest,
   TrustAnchorDetailResponse,
   EnableTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableTrustAnchorRequest,
   output: TrustAnchorDetailResponse,
@@ -1284,7 +1283,7 @@ export const getCrl: API.OperationMethod<
   GetCrlRequest,
   CrlDetailResponse,
   GetCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCrlRequest,
   output: CrlDetailResponse,
@@ -1313,7 +1312,7 @@ export const getProfile: API.OperationMethod<
   GetProfileRequest,
   ProfileDetailResponse,
   GetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileRequest,
   output: ProfileDetailResponse,
@@ -1336,7 +1335,7 @@ export const getSubject: API.OperationMethod<
   ScalarSubjectRequest,
   SubjectDetailResponse,
   GetSubjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScalarSubjectRequest,
   output: SubjectDetailResponse,
@@ -1367,7 +1366,7 @@ export const getTrustAnchor: API.OperationMethod<
   GetTrustAnchorRequest,
   TrustAnchorDetailResponse,
   GetTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustAnchorRequest,
   output: TrustAnchorDetailResponse,
@@ -1394,7 +1393,7 @@ export const importCrl: API.OperationMethod<
   ImportCrlRequest,
   CrlDetailResponse,
   ImportCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCrlRequest,
   output: CrlDetailResponse,
@@ -1417,7 +1416,7 @@ export const listCrls: API.PaginatedOperationMethod<
   ListRequest,
   ListCrlsResponse,
   ListCrlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CrlDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRequest,
@@ -1452,7 +1451,7 @@ export const listProfiles: API.PaginatedOperationMethod<
   ListProfilesRequest,
   ListProfilesResponse,
   ListProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilesRequest,
@@ -1487,7 +1486,7 @@ export const listSubjects: API.PaginatedOperationMethod<
   ListSubjectsRequest,
   ListSubjectsResponse,
   ListSubjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubjectSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubjectsRequest,
@@ -1517,7 +1516,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1550,7 +1549,7 @@ export const listTrustAnchors: API.PaginatedOperationMethod<
   ListTrustAnchorsRequest,
   ListTrustAnchorsResponse,
   ListTrustAnchorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrustAnchorDetail
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustAnchorsRequest,
@@ -1578,7 +1577,7 @@ export const putAttributeMapping: API.OperationMethod<
   PutAttributeMappingRequest,
   PutAttributeMappingResponse,
   PutAttributeMappingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAttributeMappingRequest,
   output: PutAttributeMappingResponse,
@@ -1608,7 +1607,7 @@ export const putNotificationSettings: API.OperationMethod<
   PutNotificationSettingsRequest,
   PutNotificationSettingsResponse,
   PutNotificationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutNotificationSettingsRequest,
   output: PutNotificationSettingsResponse,
@@ -1636,7 +1635,7 @@ export const resetNotificationSettings: API.OperationMethod<
   ResetNotificationSettingsRequest,
   ResetNotificationSettingsResponse,
   ResetNotificationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetNotificationSettingsRequest,
   output: ResetNotificationSettingsResponse,
@@ -1665,7 +1664,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1694,7 +1693,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1722,7 +1721,7 @@ export const updateCrl: API.OperationMethod<
   UpdateCrlRequest,
   CrlDetailResponse,
   UpdateCrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCrlRequest,
   output: CrlDetailResponse,
@@ -1750,7 +1749,7 @@ export const updateProfile: API.OperationMethod<
   UpdateProfileRequest,
   ProfileDetailResponse,
   UpdateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileRequest,
   output: ProfileDetailResponse,
@@ -1778,7 +1777,7 @@ export const updateTrustAnchor: API.OperationMethod<
   UpdateTrustAnchorRequest,
   TrustAnchorDetailResponse,
   UpdateTrustAnchorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustAnchorRequest,
   output: TrustAnchorDetailResponse,

--- a/packages/aws/src/services/route-53-domains.ts
+++ b/packages/aws/src/services/route-53-domains.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace(
   "https://route53domains.amazonaws.com/doc/2014-05-15/",
@@ -1981,7 +1980,7 @@ export const acceptDomainTransferFromAnotherAwsAccount: API.OperationMethod<
   AcceptDomainTransferFromAnotherAwsAccountRequest,
   AcceptDomainTransferFromAnotherAwsAccountResponse,
   AcceptDomainTransferFromAnotherAwsAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptDomainTransferFromAnotherAwsAccountRequest,
   output: AcceptDomainTransferFromAnotherAwsAccountResponse,
@@ -2019,7 +2018,7 @@ export const associateDelegationSignerToDomain: API.OperationMethod<
   AssociateDelegationSignerToDomainRequest,
   AssociateDelegationSignerToDomainResponse,
   AssociateDelegationSignerToDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDelegationSignerToDomainRequest,
   output: AssociateDelegationSignerToDomainResponse,
@@ -2055,7 +2054,7 @@ export const cancelDomainTransferToAnotherAwsAccount: API.OperationMethod<
   CancelDomainTransferToAnotherAwsAccountRequest,
   CancelDomainTransferToAnotherAwsAccountResponse,
   CancelDomainTransferToAnotherAwsAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelDomainTransferToAnotherAwsAccountRequest,
   output: CancelDomainTransferToAnotherAwsAccountResponse,
@@ -2079,7 +2078,7 @@ export const checkDomainAvailability: API.OperationMethod<
   CheckDomainAvailabilityRequest,
   CheckDomainAvailabilityResponse,
   CheckDomainAvailabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckDomainAvailabilityRequest,
   output: CheckDomainAvailabilityResponse,
@@ -2101,7 +2100,7 @@ export const checkDomainTransferability: API.OperationMethod<
   CheckDomainTransferabilityRequest,
   CheckDomainTransferabilityResponse,
   CheckDomainTransferabilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckDomainTransferabilityRequest,
   output: CheckDomainTransferabilityResponse,
@@ -2141,7 +2140,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -2166,7 +2165,7 @@ export const deleteTagsForDomain: API.OperationMethod<
   DeleteTagsForDomainRequest,
   DeleteTagsForDomainResponse,
   DeleteTagsForDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsForDomainRequest,
   output: DeleteTagsForDomainResponse,
@@ -2188,7 +2187,7 @@ export const disableDomainAutoRenew: API.OperationMethod<
   DisableDomainAutoRenewRequest,
   DisableDomainAutoRenewResponse,
   DisableDomainAutoRenewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDomainAutoRenewRequest,
   output: DisableDomainAutoRenewResponse,
@@ -2217,7 +2216,7 @@ export const disableDomainTransferLock: API.OperationMethod<
   DisableDomainTransferLockRequest,
   DisableDomainTransferLockResponse,
   DisableDomainTransferLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDomainTransferLockRequest,
   output: DisableDomainTransferLockResponse,
@@ -2248,7 +2247,7 @@ export const disassociateDelegationSignerFromDomain: API.OperationMethod<
   DisassociateDelegationSignerFromDomainRequest,
   DisassociateDelegationSignerFromDomainResponse,
   DisassociateDelegationSignerFromDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDelegationSignerFromDomainRequest,
   output: DisassociateDelegationSignerFromDomainResponse,
@@ -2284,7 +2283,7 @@ export const enableDomainAutoRenew: API.OperationMethod<
   EnableDomainAutoRenewRequest,
   EnableDomainAutoRenewResponse,
   EnableDomainAutoRenewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDomainAutoRenewRequest,
   output: EnableDomainAutoRenewResponse,
@@ -2312,7 +2311,7 @@ export const enableDomainTransferLock: API.OperationMethod<
   EnableDomainTransferLockRequest,
   EnableDomainTransferLockResponse,
   EnableDomainTransferLockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDomainTransferLockRequest,
   output: EnableDomainTransferLockResponse,
@@ -2345,7 +2344,7 @@ export const getContactReachabilityStatus: API.OperationMethod<
   GetContactReachabilityStatusRequest,
   GetContactReachabilityStatusResponse,
   GetContactReachabilityStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactReachabilityStatusRequest,
   output: GetContactReachabilityStatusResponse,
@@ -2369,7 +2368,7 @@ export const getDomainDetail: API.OperationMethod<
   GetDomainDetailRequest,
   GetDomainDetailResponse,
   GetDomainDetailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainDetailRequest,
   output: GetDomainDetailResponse,
@@ -2391,7 +2390,7 @@ export const getDomainSuggestions: API.OperationMethod<
   GetDomainSuggestionsRequest,
   GetDomainSuggestionsResponse,
   GetDomainSuggestionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainSuggestionsRequest,
   output: GetDomainSuggestionsResponse,
@@ -2410,7 +2409,7 @@ export const getOperationDetail: API.OperationMethod<
   GetOperationDetailRequest,
   GetOperationDetailResponse,
   GetOperationDetailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationDetailRequest,
   output: GetOperationDetailResponse,
@@ -2429,7 +2428,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -2457,7 +2456,7 @@ export const listOperations: API.PaginatedOperationMethod<
   ListOperationsRequest,
   ListOperationsResponse,
   ListOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OperationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOperationsRequest,
@@ -2493,7 +2492,7 @@ export const listPrices: API.PaginatedOperationMethod<
   ListPricesRequest,
   ListPricesResponse,
   ListPricesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainPrice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPricesRequest,
@@ -2526,7 +2525,7 @@ export const listTagsForDomain: API.OperationMethod<
   ListTagsForDomainRequest,
   ListTagsForDomainResponse,
   ListTagsForDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForDomainRequest,
   output: ListTagsForDomainResponse,
@@ -2554,7 +2553,7 @@ export const pushDomain: API.OperationMethod<
   PushDomainRequest,
   PushDomainResponse,
   PushDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PushDomainRequest,
   output: PushDomainResponse,
@@ -2611,7 +2610,7 @@ export const registerDomain: API.OperationMethod<
   RegisterDomainRequest,
   RegisterDomainResponse,
   RegisterDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDomainRequest,
   output: RegisterDomainResponse,
@@ -2644,7 +2643,7 @@ export const rejectDomainTransferFromAnotherAwsAccount: API.OperationMethod<
   RejectDomainTransferFromAnotherAwsAccountRequest,
   RejectDomainTransferFromAnotherAwsAccountResponse,
   RejectDomainTransferFromAnotherAwsAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectDomainTransferFromAnotherAwsAccountRequest,
   output: RejectDomainTransferFromAnotherAwsAccountResponse,
@@ -2676,7 +2675,7 @@ export const renewDomain: API.OperationMethod<
   RenewDomainRequest,
   RenewDomainResponse,
   RenewDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenewDomainRequest,
   output: RenewDomainResponse,
@@ -2708,7 +2707,7 @@ export const resendContactReachabilityEmail: API.OperationMethod<
   ResendContactReachabilityEmailRequest,
   ResendContactReachabilityEmailResponse,
   ResendContactReachabilityEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResendContactReachabilityEmailRequest,
   output: ResendContactReachabilityEmailResponse,
@@ -2734,7 +2733,7 @@ export const resendOperationAuthorization: API.OperationMethod<
   ResendOperationAuthorizationRequest,
   ResendOperationAuthorizationResponse,
   ResendOperationAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResendOperationAuthorizationRequest,
   output: ResendOperationAuthorizationResponse,
@@ -2758,7 +2757,7 @@ export const retrieveDomainAuthCode: API.OperationMethod<
   RetrieveDomainAuthCodeRequest,
   RetrieveDomainAuthCodeResponse,
   RetrieveDomainAuthCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveDomainAuthCodeRequest,
   output: RetrieveDomainAuthCodeResponse,
@@ -2816,7 +2815,7 @@ export const transferDomain: API.OperationMethod<
   TransferDomainRequest,
   TransferDomainResponse,
   TransferDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransferDomainRequest,
   output: TransferDomainResponse,
@@ -2865,7 +2864,7 @@ export const transferDomainToAnotherAwsAccount: API.OperationMethod<
   TransferDomainToAnotherAwsAccountRequest,
   TransferDomainToAnotherAwsAccountResponse,
   TransferDomainToAnotherAwsAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TransferDomainToAnotherAwsAccountRequest,
   output: TransferDomainToAnotherAwsAccountResponse,
@@ -2900,7 +2899,7 @@ export const updateDomainContact: API.OperationMethod<
   UpdateDomainContactRequest,
   UpdateDomainContactResponse,
   UpdateDomainContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainContactRequest,
   output: UpdateDomainContactResponse,
@@ -2950,7 +2949,7 @@ export const updateDomainContactPrivacy: API.OperationMethod<
   UpdateDomainContactPrivacyRequest,
   UpdateDomainContactPrivacyResponse,
   UpdateDomainContactPrivacyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainContactPrivacyRequest,
   output: UpdateDomainContactPrivacyResponse,
@@ -2987,7 +2986,7 @@ export const updateDomainNameservers: API.OperationMethod<
   UpdateDomainNameserversRequest,
   UpdateDomainNameserversResponse,
   UpdateDomainNameserversError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainNameserversRequest,
   output: UpdateDomainNameserversResponse,
@@ -3019,7 +3018,7 @@ export const updateTagsForDomain: API.OperationMethod<
   UpdateTagsForDomainRequest,
   UpdateTagsForDomainResponse,
   UpdateTagsForDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTagsForDomainRequest,
   output: UpdateTagsForDomainResponse,
@@ -3037,7 +3036,7 @@ export const viewBilling: API.PaginatedOperationMethod<
   ViewBillingRequest,
   ViewBillingResponse,
   ViewBillingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BillingRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ViewBillingRequest,

--- a/packages/aws/src/services/route-53.ts
+++ b/packages/aws/src/services/route-53.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("https://route53.amazonaws.com/doc/2013-04-01/");
 const svc = T.AwsApiService({
   sdkId: "Route 53",
@@ -4291,7 +4290,7 @@ export const activateKeySigningKey: API.OperationMethod<
   ActivateKeySigningKeyRequest,
   ActivateKeySigningKeyResponse,
   ActivateKeySigningKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateKeySigningKeyRequest,
   output: ActivateKeySigningKeyResponse,
@@ -4349,7 +4348,7 @@ export const associateVPCWithHostedZone: API.OperationMethod<
   AssociateVPCWithHostedZoneRequest,
   AssociateVPCWithHostedZoneResponse,
   AssociateVPCWithHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateVPCWithHostedZoneRequest,
   output: AssociateVPCWithHostedZoneResponse,
@@ -4402,7 +4401,7 @@ export const changeCidrCollection: API.OperationMethod<
   ChangeCidrCollectionRequest,
   ChangeCidrCollectionResponse,
   ChangeCidrCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeCidrCollectionRequest,
   output: ChangeCidrCollectionResponse,
@@ -4516,7 +4515,7 @@ export const changeResourceRecordSets: API.OperationMethod<
   ChangeResourceRecordSetsRequest,
   ChangeResourceRecordSetsResponse,
   ChangeResourceRecordSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeResourceRecordSetsRequest,
   output: ChangeResourceRecordSetsResponse,
@@ -4549,7 +4548,7 @@ export const changeTagsForResource: API.OperationMethod<
   ChangeTagsForResourceRequest,
   ChangeTagsForResourceResponse,
   ChangeTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeTagsForResourceRequest,
   output: ChangeTagsForResourceResponse,
@@ -4578,7 +4577,7 @@ export const createCidrCollection: API.OperationMethod<
   CreateCidrCollectionRequest,
   CreateCidrCollectionResponse,
   CreateCidrCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCidrCollectionRequest,
   output: CreateCidrCollectionResponse,
@@ -4635,7 +4634,7 @@ export const createHealthCheck: API.OperationMethod<
   CreateHealthCheckRequest,
   CreateHealthCheckResponse,
   CreateHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHealthCheckRequest,
   output: CreateHealthCheckResponse,
@@ -4717,7 +4716,7 @@ export const createHostedZone: API.OperationMethod<
   CreateHostedZoneRequest,
   CreateHostedZoneResponse,
   CreateHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHostedZoneRequest,
   output: CreateHostedZoneResponse,
@@ -4757,7 +4756,7 @@ export const createKeySigningKey: API.OperationMethod<
   CreateKeySigningKeyRequest,
   CreateKeySigningKeyResponse,
   CreateKeySigningKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKeySigningKeyRequest,
   output: CreateKeySigningKeyResponse,
@@ -4933,7 +4932,7 @@ export const createQueryLoggingConfig: API.OperationMethod<
   CreateQueryLoggingConfigRequest,
   CreateQueryLoggingConfigResponse,
   CreateQueryLoggingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueryLoggingConfigRequest,
   output: CreateQueryLoggingConfigResponse,
@@ -5013,7 +5012,7 @@ export const createReusableDelegationSet: API.OperationMethod<
   CreateReusableDelegationSetRequest,
   CreateReusableDelegationSetResponse,
   CreateReusableDelegationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReusableDelegationSetRequest,
   output: CreateReusableDelegationSetResponse,
@@ -5046,7 +5045,7 @@ export const createTrafficPolicy: API.OperationMethod<
   CreateTrafficPolicyRequest,
   CreateTrafficPolicyResponse,
   CreateTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficPolicyRequest,
   output: CreateTrafficPolicyResponse,
@@ -5087,7 +5086,7 @@ export const createTrafficPolicyInstance: API.OperationMethod<
   CreateTrafficPolicyInstanceRequest,
   CreateTrafficPolicyInstanceResponse,
   CreateTrafficPolicyInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficPolicyInstanceRequest,
   output: CreateTrafficPolicyInstanceResponse,
@@ -5123,7 +5122,7 @@ export const createTrafficPolicyVersion: API.OperationMethod<
   CreateTrafficPolicyVersionRequest,
   CreateTrafficPolicyVersionResponse,
   CreateTrafficPolicyVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrafficPolicyVersionRequest,
   output: CreateTrafficPolicyVersionResponse,
@@ -5162,7 +5161,7 @@ export const createVPCAssociationAuthorization: API.OperationMethod<
   CreateVPCAssociationAuthorizationRequest,
   CreateVPCAssociationAuthorizationResponse,
   CreateVPCAssociationAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVPCAssociationAuthorizationRequest,
   output: CreateVPCAssociationAuthorizationResponse,
@@ -5195,7 +5194,7 @@ export const deactivateKeySigningKey: API.OperationMethod<
   DeactivateKeySigningKeyRequest,
   DeactivateKeySigningKeyResponse,
   DeactivateKeySigningKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateKeySigningKeyRequest,
   output: DeactivateKeySigningKeyResponse,
@@ -5227,7 +5226,7 @@ export const deleteCidrCollection: API.OperationMethod<
   DeleteCidrCollectionRequest,
   DeleteCidrCollectionResponse,
   DeleteCidrCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCidrCollectionRequest,
   output: DeleteCidrCollectionResponse,
@@ -5268,7 +5267,7 @@ export const deleteHealthCheck: API.OperationMethod<
   DeleteHealthCheckRequest,
   DeleteHealthCheckResponse,
   DeleteHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHealthCheckRequest,
   output: DeleteHealthCheckResponse,
@@ -5333,7 +5332,7 @@ export const deleteHostedZone: API.OperationMethod<
   DeleteHostedZoneRequest,
   DeleteHostedZoneResponse,
   DeleteHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHostedZoneRequest,
   output: DeleteHostedZoneResponse,
@@ -5371,7 +5370,7 @@ export const deleteKeySigningKey: API.OperationMethod<
   DeleteKeySigningKeyRequest,
   DeleteKeySigningKeyResponse,
   DeleteKeySigningKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKeySigningKeyRequest,
   output: DeleteKeySigningKeyResponse,
@@ -5404,7 +5403,7 @@ export const deleteQueryLoggingConfig: API.OperationMethod<
   DeleteQueryLoggingConfigRequest,
   DeleteQueryLoggingConfigResponse,
   DeleteQueryLoggingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueryLoggingConfigRequest,
   output: DeleteQueryLoggingConfigResponse,
@@ -5434,7 +5433,7 @@ export const deleteReusableDelegationSet: API.OperationMethod<
   DeleteReusableDelegationSetRequest,
   DeleteReusableDelegationSetResponse,
   DeleteReusableDelegationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReusableDelegationSetRequest,
   output: DeleteReusableDelegationSetResponse,
@@ -5473,7 +5472,7 @@ export const deleteTrafficPolicy: API.OperationMethod<
   DeleteTrafficPolicyRequest,
   DeleteTrafficPolicyResponse,
   DeleteTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficPolicyRequest,
   output: DeleteTrafficPolicyResponse,
@@ -5504,7 +5503,7 @@ export const deleteTrafficPolicyInstance: API.OperationMethod<
   DeleteTrafficPolicyInstanceRequest,
   DeleteTrafficPolicyInstanceResponse,
   DeleteTrafficPolicyInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrafficPolicyInstanceRequest,
   output: DeleteTrafficPolicyInstanceResponse,
@@ -5538,7 +5537,7 @@ export const deleteVPCAssociationAuthorization: API.OperationMethod<
   DeleteVPCAssociationAuthorizationRequest,
   DeleteVPCAssociationAuthorizationResponse,
   DeleteVPCAssociationAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVPCAssociationAuthorizationRequest,
   output: DeleteVPCAssociationAuthorizationResponse,
@@ -5572,7 +5571,7 @@ export const disableHostedZoneDNSSEC: API.OperationMethod<
   DisableHostedZoneDNSSECRequest,
   DisableHostedZoneDNSSECResponse,
   DisableHostedZoneDNSSECError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableHostedZoneDNSSECRequest,
   output: DisableHostedZoneDNSSECResponse,
@@ -5641,7 +5640,7 @@ export const disassociateVPCFromHostedZone: API.OperationMethod<
   DisassociateVPCFromHostedZoneRequest,
   DisassociateVPCFromHostedZoneResponse,
   DisassociateVPCFromHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateVPCFromHostedZoneRequest,
   output: DisassociateVPCFromHostedZoneResponse,
@@ -5675,7 +5674,7 @@ export const enableHostedZoneDNSSEC: API.OperationMethod<
   EnableHostedZoneDNSSECRequest,
   EnableHostedZoneDNSSECResponse,
   EnableHostedZoneDNSSECError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableHostedZoneDNSSECRequest,
   output: EnableHostedZoneDNSSECResponse,
@@ -5711,7 +5710,7 @@ export const getAccountLimit: API.OperationMethod<
   GetAccountLimitRequest,
   GetAccountLimitResponse,
   GetAccountLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountLimitRequest,
   output: GetAccountLimitResponse,
@@ -5737,7 +5736,7 @@ export const getChange: API.OperationMethod<
   GetChangeRequest,
   GetChangeResponse,
   GetChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangeRequest,
   output: GetChangeResponse,
@@ -5762,7 +5761,7 @@ export const getCheckerIpRanges: API.OperationMethod<
   GetCheckerIpRangesRequest,
   GetCheckerIpRangesResponse,
   GetCheckerIpRangesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCheckerIpRangesRequest,
   output: GetCheckerIpRangesResponse,
@@ -5785,7 +5784,7 @@ export const getDNSSEC: API.OperationMethod<
   GetDNSSECRequest,
   GetDNSSECResponse,
   GetDNSSECError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDNSSECRequest,
   output: GetDNSSECResponse,
@@ -5829,7 +5828,7 @@ export const getGeoLocation: API.OperationMethod<
   GetGeoLocationRequest,
   GetGeoLocationResponse,
   GetGeoLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeoLocationRequest,
   output: GetGeoLocationResponse,
@@ -5851,7 +5850,7 @@ export const getHealthCheck: API.OperationMethod<
   GetHealthCheckRequest,
   GetHealthCheckResponse,
   GetHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHealthCheckRequest,
   output: GetHealthCheckResponse,
@@ -5869,7 +5868,7 @@ export const getHealthCheckCount: API.OperationMethod<
   GetHealthCheckCountRequest,
   GetHealthCheckCountResponse,
   GetHealthCheckCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHealthCheckCountRequest,
   output: GetHealthCheckCountResponse,
@@ -5890,7 +5889,7 @@ export const getHealthCheckLastFailureReason: API.OperationMethod<
   GetHealthCheckLastFailureReasonRequest,
   GetHealthCheckLastFailureReasonResponse,
   GetHealthCheckLastFailureReasonError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHealthCheckLastFailureReasonRequest,
   output: GetHealthCheckLastFailureReasonResponse,
@@ -5915,7 +5914,7 @@ export const getHealthCheckStatus: API.OperationMethod<
   GetHealthCheckStatusRequest,
   GetHealthCheckStatusResponse,
   GetHealthCheckStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHealthCheckStatusRequest,
   output: GetHealthCheckStatusResponse,
@@ -5937,7 +5936,7 @@ export const getHostedZone: API.OperationMethod<
   GetHostedZoneRequest,
   GetHostedZoneResponse,
   GetHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostedZoneRequest,
   output: GetHostedZoneResponse,
@@ -5955,7 +5954,7 @@ export const getHostedZoneCount: API.OperationMethod<
   GetHostedZoneCountRequest,
   GetHostedZoneCountResponse,
   GetHostedZoneCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostedZoneCountRequest,
   output: GetHostedZoneCountResponse,
@@ -5982,7 +5981,7 @@ export const getHostedZoneLimit: API.OperationMethod<
   GetHostedZoneLimitRequest,
   GetHostedZoneLimitResponse,
   GetHostedZoneLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostedZoneLimitRequest,
   output: GetHostedZoneLimitResponse,
@@ -6006,7 +6005,7 @@ export const getQueryLoggingConfig: API.OperationMethod<
   GetQueryLoggingConfigRequest,
   GetQueryLoggingConfigResponse,
   GetQueryLoggingConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueryLoggingConfigRequest,
   output: GetQueryLoggingConfigResponse,
@@ -6029,7 +6028,7 @@ export const getReusableDelegationSet: API.OperationMethod<
   GetReusableDelegationSetRequest,
   GetReusableDelegationSetResponse,
   GetReusableDelegationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReusableDelegationSetRequest,
   output: GetReusableDelegationSetResponse,
@@ -6055,7 +6054,7 @@ export const getReusableDelegationSetLimit: API.OperationMethod<
   GetReusableDelegationSetLimitRequest,
   GetReusableDelegationSetLimitResponse,
   GetReusableDelegationSetLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReusableDelegationSetLimitRequest,
   output: GetReusableDelegationSetLimitResponse,
@@ -6079,7 +6078,7 @@ export const getTrafficPolicy: API.OperationMethod<
   GetTrafficPolicyRequest,
   GetTrafficPolicyResponse,
   GetTrafficPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrafficPolicyRequest,
   output: GetTrafficPolicyResponse,
@@ -6108,7 +6107,7 @@ export const getTrafficPolicyInstance: API.OperationMethod<
   GetTrafficPolicyInstanceRequest,
   GetTrafficPolicyInstanceResponse,
   GetTrafficPolicyInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrafficPolicyInstanceRequest,
   output: GetTrafficPolicyInstanceResponse,
@@ -6127,7 +6126,7 @@ export const getTrafficPolicyInstanceCount: API.OperationMethod<
   GetTrafficPolicyInstanceCountRequest,
   GetTrafficPolicyInstanceCountResponse,
   GetTrafficPolicyInstanceCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrafficPolicyInstanceCountRequest,
   output: GetTrafficPolicyInstanceCountResponse,
@@ -6149,7 +6148,7 @@ export const listCidrBlocks: API.PaginatedOperationMethod<
   ListCidrBlocksRequest,
   ListCidrBlocksResponse,
   ListCidrBlocksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CidrBlockSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCidrBlocksRequest,
@@ -6179,7 +6178,7 @@ export const listCidrCollections: API.PaginatedOperationMethod<
   ListCidrCollectionsRequest,
   ListCidrCollectionsResponse,
   ListCidrCollectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CollectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCidrCollectionsRequest,
@@ -6208,7 +6207,7 @@ export const listCidrLocations: API.PaginatedOperationMethod<
   ListCidrLocationsRequest,
   ListCidrLocationsResponse,
   ListCidrLocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LocationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCidrLocationsRequest,
@@ -6244,7 +6243,7 @@ export const listGeoLocations: API.OperationMethod<
   ListGeoLocationsRequest,
   ListGeoLocationsResponse,
   ListGeoLocationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGeoLocationsRequest,
   output: ListGeoLocationsResponse,
@@ -6265,7 +6264,7 @@ export const listHealthChecks: API.PaginatedOperationMethod<
   ListHealthChecksRequest,
   ListHealthChecksResponse,
   ListHealthChecksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HealthCheck
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHealthChecksRequest,
@@ -6300,7 +6299,7 @@ export const listHostedZones: API.PaginatedOperationMethod<
   ListHostedZonesRequest,
   ListHostedZonesResponse,
   ListHostedZonesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HostedZone
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHostedZonesRequest,
@@ -6380,7 +6379,7 @@ export const listHostedZonesByName: API.OperationMethod<
   ListHostedZonesByNameRequest,
   ListHostedZonesByNameResponse,
   ListHostedZonesByNameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHostedZonesByNameRequest,
   output: ListHostedZonesByNameResponse,
@@ -6432,7 +6431,7 @@ export const listHostedZonesByVPC: API.OperationMethod<
   ListHostedZonesByVPCRequest,
   ListHostedZonesByVPCResponse,
   ListHostedZonesByVPCError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHostedZonesByVPCRequest,
   output: ListHostedZonesByVPCResponse,
@@ -6460,7 +6459,7 @@ export const listQueryLoggingConfigs: API.PaginatedOperationMethod<
   ListQueryLoggingConfigsRequest,
   ListQueryLoggingConfigsResponse,
   ListQueryLoggingConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueryLoggingConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueryLoggingConfigsRequest,
@@ -6557,7 +6556,7 @@ export const listResourceRecordSets: API.OperationMethod<
   ListResourceRecordSetsRequest,
   ListResourceRecordSetsResponse,
   ListResourceRecordSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourceRecordSetsRequest,
   output: ListResourceRecordSetsResponse,
@@ -6576,7 +6575,7 @@ export const listReusableDelegationSets: API.OperationMethod<
   ListReusableDelegationSetsRequest,
   ListReusableDelegationSetsResponse,
   ListReusableDelegationSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReusableDelegationSetsRequest,
   output: ListReusableDelegationSetsResponse,
@@ -6603,7 +6602,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6636,7 +6635,7 @@ export const listTagsForResources: API.OperationMethod<
   ListTagsForResourcesRequest,
   ListTagsForResourcesResponse,
   ListTagsForResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourcesRequest,
   output: ListTagsForResourcesResponse,
@@ -6665,7 +6664,7 @@ export const listTrafficPolicies: API.OperationMethod<
   ListTrafficPoliciesRequest,
   ListTrafficPoliciesResponse,
   ListTrafficPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTrafficPoliciesRequest,
   output: ListTrafficPoliciesResponse,
@@ -6696,7 +6695,7 @@ export const listTrafficPolicyInstances: API.OperationMethod<
   ListTrafficPolicyInstancesRequest,
   ListTrafficPolicyInstancesResponse,
   ListTrafficPolicyInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTrafficPolicyInstancesRequest,
   output: ListTrafficPolicyInstancesResponse,
@@ -6729,7 +6728,7 @@ export const listTrafficPolicyInstancesByHostedZone: API.OperationMethod<
   ListTrafficPolicyInstancesByHostedZoneRequest,
   ListTrafficPolicyInstancesByHostedZoneResponse,
   ListTrafficPolicyInstancesByHostedZoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTrafficPolicyInstancesByHostedZoneRequest,
   output: ListTrafficPolicyInstancesByHostedZoneResponse,
@@ -6762,7 +6761,7 @@ export const listTrafficPolicyInstancesByPolicy: API.OperationMethod<
   ListTrafficPolicyInstancesByPolicyRequest,
   ListTrafficPolicyInstancesByPolicyResponse,
   ListTrafficPolicyInstancesByPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTrafficPolicyInstancesByPolicyRequest,
   output: ListTrafficPolicyInstancesByPolicyResponse,
@@ -6786,7 +6785,7 @@ export const listTrafficPolicyVersions: API.OperationMethod<
   ListTrafficPolicyVersionsRequest,
   ListTrafficPolicyVersionsResponse,
   ListTrafficPolicyVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTrafficPolicyVersionsRequest,
   output: ListTrafficPolicyVersionsResponse,
@@ -6813,7 +6812,7 @@ export const listVPCAssociationAuthorizations: API.OperationMethod<
   ListVPCAssociationAuthorizationsRequest,
   ListVPCAssociationAuthorizationsResponse,
   ListVPCAssociationAuthorizationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVPCAssociationAuthorizationsRequest,
   output: ListVPCAssociationAuthorizationsResponse,
@@ -6840,7 +6839,7 @@ export const testDNSAnswer: API.OperationMethod<
   TestDNSAnswerRequest,
   TestDNSAnswerResponse,
   TestDNSAnswerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestDNSAnswerRequest,
   output: TestDNSAnswerResponse,
@@ -6866,7 +6865,7 @@ export const updateHealthCheck: API.OperationMethod<
   UpdateHealthCheckRequest,
   UpdateHealthCheckResponse,
   UpdateHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHealthCheckRequest,
   output: UpdateHealthCheckResponse,
@@ -6888,7 +6887,7 @@ export const updateHostedZoneComment: API.OperationMethod<
   UpdateHostedZoneCommentRequest,
   UpdateHostedZoneCommentResponse,
   UpdateHostedZoneCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostedZoneCommentRequest,
   output: UpdateHostedZoneCommentResponse,
@@ -6913,7 +6912,7 @@ export const updateHostedZoneFeatures: API.OperationMethod<
   UpdateHostedZoneFeaturesRequest,
   UpdateHostedZoneFeaturesResponse,
   UpdateHostedZoneFeaturesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostedZoneFeaturesRequest,
   output: UpdateHostedZoneFeaturesResponse,
@@ -6940,7 +6939,7 @@ export const updateTrafficPolicyComment: API.OperationMethod<
   UpdateTrafficPolicyCommentRequest,
   UpdateTrafficPolicyCommentResponse,
   UpdateTrafficPolicyCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrafficPolicyCommentRequest,
   output: UpdateTrafficPolicyCommentResponse,
@@ -6986,7 +6985,7 @@ export const updateTrafficPolicyInstance: API.OperationMethod<
   UpdateTrafficPolicyInstanceRequest,
   UpdateTrafficPolicyInstanceResponse,
   UpdateTrafficPolicyInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrafficPolicyInstanceRequest,
   output: UpdateTrafficPolicyInstanceResponse,

--- a/packages/aws/src/services/route53-recovery-cluster.ts
+++ b/packages/aws/src/services/route53-recovery-cluster.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53 Recovery Cluster",
   serviceShapeName: "ToggleCustomerAPI",
@@ -366,7 +365,7 @@ export const getRoutingControlState: API.OperationMethod<
   GetRoutingControlStateRequest,
   GetRoutingControlStateResponse,
   GetRoutingControlStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoutingControlStateRequest,
   output: GetRoutingControlStateResponse,
@@ -423,7 +422,7 @@ export const listRoutingControls: API.PaginatedOperationMethod<
   ListRoutingControlsRequest,
   ListRoutingControlsResponse,
   ListRoutingControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RoutingControl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingControlsRequest,
@@ -490,7 +489,7 @@ export const updateRoutingControlState: API.OperationMethod<
   UpdateRoutingControlStateRequest,
   UpdateRoutingControlStateResponse,
   UpdateRoutingControlStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingControlStateRequest,
   output: UpdateRoutingControlStateResponse,
@@ -552,7 +551,7 @@ export const updateRoutingControlStates: API.OperationMethod<
   UpdateRoutingControlStatesRequest,
   UpdateRoutingControlStatesResponse,
   UpdateRoutingControlStatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingControlStatesRequest,
   output: UpdateRoutingControlStatesResponse,

--- a/packages/aws/src/services/route53-recovery-control-config.ts
+++ b/packages/aws/src/services/route53-recovery-control-config.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53 Recovery Control Config",
   serviceShapeName: "Route53RecoveryControlConfig",
@@ -1277,7 +1276,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -1311,7 +1310,7 @@ export const createControlPanel: API.OperationMethod<
   CreateControlPanelRequest,
   CreateControlPanelResponse,
   CreateControlPanelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateControlPanelRequest,
   output: CreateControlPanelResponse,
@@ -1349,7 +1348,7 @@ export const createRoutingControl: API.OperationMethod<
   CreateRoutingControlRequest,
   CreateRoutingControlResponse,
   CreateRoutingControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRoutingControlRequest,
   output: CreateRoutingControlResponse,
@@ -1386,7 +1385,7 @@ export const createSafetyRule: API.OperationMethod<
   CreateSafetyRuleRequest,
   CreateSafetyRuleResponse,
   CreateSafetyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSafetyRuleRequest,
   output: CreateSafetyRuleResponse,
@@ -1411,7 +1410,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -1443,7 +1442,7 @@ export const deleteControlPanel: API.OperationMethod<
   DeleteControlPanelRequest,
   DeleteControlPanelResponse,
   DeleteControlPanelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteControlPanelRequest,
   output: DeleteControlPanelResponse,
@@ -1475,7 +1474,7 @@ export const deleteRoutingControl: API.OperationMethod<
   DeleteRoutingControlRequest,
   DeleteRoutingControlResponse,
   DeleteRoutingControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRoutingControlRequest,
   output: DeleteRoutingControlResponse,
@@ -1505,7 +1504,7 @@ export const deleteSafetyRule: API.OperationMethod<
   DeleteSafetyRuleRequest,
   DeleteSafetyRuleResponse,
   DeleteSafetyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSafetyRuleRequest,
   output: DeleteSafetyRuleResponse,
@@ -1534,7 +1533,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResponse,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResponse,
@@ -1566,7 +1565,7 @@ export const describeControlPanel: API.OperationMethod<
   DescribeControlPanelRequest,
   DescribeControlPanelResponse,
   DescribeControlPanelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeControlPanelRequest,
   output: DescribeControlPanelResponse,
@@ -1600,7 +1599,7 @@ export const describeRoutingControl: API.OperationMethod<
   DescribeRoutingControlRequest,
   DescribeRoutingControlResponse,
   DescribeRoutingControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRoutingControlRequest,
   output: DescribeRoutingControlResponse,
@@ -1628,7 +1627,7 @@ export const describeSafetyRule: API.OperationMethod<
   DescribeSafetyRuleRequest,
   DescribeSafetyRuleResponse,
   DescribeSafetyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSafetyRuleRequest,
   output: DescribeSafetyRuleResponse,
@@ -1649,7 +1648,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1671,7 +1670,7 @@ export const listAssociatedRoute53HealthChecks: API.PaginatedOperationMethod<
   ListAssociatedRoute53HealthChecksRequest,
   ListAssociatedRoute53HealthChecksResponse,
   ListAssociatedRoute53HealthChecksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   __stringMax36PatternS
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedRoute53HealthChecksRequest,
@@ -1706,7 +1705,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Cluster
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -1743,7 +1742,7 @@ export const listControlPanels: API.PaginatedOperationMethod<
   ListControlPanelsRequest,
   ListControlPanelsResponse,
   ListControlPanelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ControlPanel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListControlPanelsRequest,
@@ -1780,7 +1779,7 @@ export const listRoutingControls: API.PaginatedOperationMethod<
   ListRoutingControlsRequest,
   ListRoutingControlsResponse,
   ListRoutingControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RoutingControl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRoutingControlsRequest,
@@ -1817,7 +1816,7 @@ export const listSafetyRules: API.PaginatedOperationMethod<
   ListSafetyRulesRequest,
   ListSafetyRulesResponse,
   ListSafetyRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Rule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSafetyRulesRequest,
@@ -1852,7 +1851,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1878,7 +1877,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1904,7 +1903,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1933,7 +1932,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -1965,7 +1964,7 @@ export const updateControlPanel: API.OperationMethod<
   UpdateControlPanelRequest,
   UpdateControlPanelResponse,
   UpdateControlPanelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateControlPanelRequest,
   output: UpdateControlPanelResponse,
@@ -1997,7 +1996,7 @@ export const updateRoutingControl: API.OperationMethod<
   UpdateRoutingControlRequest,
   UpdateRoutingControlResponse,
   UpdateRoutingControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRoutingControlRequest,
   output: UpdateRoutingControlResponse,
@@ -2026,7 +2025,7 @@ export const updateSafetyRule: API.OperationMethod<
   UpdateSafetyRuleRequest,
   UpdateSafetyRuleResponse,
   UpdateSafetyRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSafetyRuleRequest,
   output: UpdateSafetyRuleResponse,

--- a/packages/aws/src/services/route53-recovery-readiness.ts
+++ b/packages/aws/src/services/route53-recovery-readiness.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53 Recovery Readiness",
   serviceShapeName: "Route53RecoveryReadiness",
@@ -1778,7 +1777,7 @@ export const createCell: API.OperationMethod<
   CreateCellRequest,
   CreateCellResponse,
   CreateCellError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCellRequest,
   output: CreateCellResponse,
@@ -1808,7 +1807,7 @@ export const createCrossAccountAuthorization: API.OperationMethod<
   CreateCrossAccountAuthorizationRequest,
   CreateCrossAccountAuthorizationResponse,
   CreateCrossAccountAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCrossAccountAuthorizationRequest,
   output: CreateCrossAccountAuthorizationResponse,
@@ -1838,7 +1837,7 @@ export const createReadinessCheck: API.OperationMethod<
   CreateReadinessCheckRequest,
   CreateReadinessCheckResponse,
   CreateReadinessCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReadinessCheckRequest,
   output: CreateReadinessCheckResponse,
@@ -1868,7 +1867,7 @@ export const createRecoveryGroup: API.OperationMethod<
   CreateRecoveryGroupRequest,
   CreateRecoveryGroupResponse,
   CreateRecoveryGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRecoveryGroupRequest,
   output: CreateRecoveryGroupResponse,
@@ -1898,7 +1897,7 @@ export const createResourceSet: API.OperationMethod<
   CreateResourceSetRequest,
   CreateResourceSetResponse,
   CreateResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceSetRequest,
   output: CreateResourceSetResponse,
@@ -1928,7 +1927,7 @@ export const deleteCell: API.OperationMethod<
   DeleteCellRequest,
   DeleteCellResponse,
   DeleteCellError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCellRequest,
   output: DeleteCellResponse,
@@ -1957,7 +1956,7 @@ export const deleteCrossAccountAuthorization: API.OperationMethod<
   DeleteCrossAccountAuthorizationRequest,
   DeleteCrossAccountAuthorizationResponse,
   DeleteCrossAccountAuthorizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCrossAccountAuthorizationRequest,
   output: DeleteCrossAccountAuthorizationResponse,
@@ -1986,7 +1985,7 @@ export const deleteReadinessCheck: API.OperationMethod<
   DeleteReadinessCheckRequest,
   DeleteReadinessCheckResponse,
   DeleteReadinessCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReadinessCheckRequest,
   output: DeleteReadinessCheckResponse,
@@ -2016,7 +2015,7 @@ export const deleteRecoveryGroup: API.OperationMethod<
   DeleteRecoveryGroupRequest,
   DeleteRecoveryGroupResponse,
   DeleteRecoveryGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecoveryGroupRequest,
   output: DeleteRecoveryGroupResponse,
@@ -2046,7 +2045,7 @@ export const deleteResourceSet: API.OperationMethod<
   DeleteResourceSetRequest,
   DeleteResourceSetResponse,
   DeleteResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceSetRequest,
   output: DeleteResourceSetResponse,
@@ -2076,7 +2075,7 @@ export const getArchitectureRecommendations: API.OperationMethod<
   GetArchitectureRecommendationsRequest,
   GetArchitectureRecommendationsResponse,
   GetArchitectureRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArchitectureRecommendationsRequest,
   output: GetArchitectureRecommendationsResponse,
@@ -2106,7 +2105,7 @@ export const getCell: API.OperationMethod<
   GetCellRequest,
   GetCellResponse,
   GetCellError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCellRequest,
   output: GetCellResponse,
@@ -2136,7 +2135,7 @@ export const getCellReadinessSummary: API.PaginatedOperationMethod<
   GetCellReadinessSummaryRequest,
   GetCellReadinessSummaryResponse,
   GetCellReadinessSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReadinessCheckSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCellReadinessSummaryRequest,
@@ -2173,7 +2172,7 @@ export const getReadinessCheck: API.OperationMethod<
   GetReadinessCheckRequest,
   GetReadinessCheckResponse,
   GetReadinessCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReadinessCheckRequest,
   output: GetReadinessCheckResponse,
@@ -2203,7 +2202,7 @@ export const getReadinessCheckResourceStatus: API.PaginatedOperationMethod<
   GetReadinessCheckResourceStatusRequest,
   GetReadinessCheckResourceStatusResponse,
   GetReadinessCheckResourceStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetReadinessCheckResourceStatusRequest,
@@ -2240,7 +2239,7 @@ export const getReadinessCheckStatus: API.PaginatedOperationMethod<
   GetReadinessCheckStatusRequest,
   GetReadinessCheckStatusResponse,
   GetReadinessCheckStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetReadinessCheckStatusRequest,
@@ -2277,7 +2276,7 @@ export const getRecoveryGroup: API.OperationMethod<
   GetRecoveryGroupRequest,
   GetRecoveryGroupResponse,
   GetRecoveryGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecoveryGroupRequest,
   output: GetRecoveryGroupResponse,
@@ -2307,7 +2306,7 @@ export const getRecoveryGroupReadinessSummary: API.PaginatedOperationMethod<
   GetRecoveryGroupReadinessSummaryRequest,
   GetRecoveryGroupReadinessSummaryResponse,
   GetRecoveryGroupReadinessSummaryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReadinessCheckSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRecoveryGroupReadinessSummaryRequest,
@@ -2344,7 +2343,7 @@ export const getResourceSet: API.OperationMethod<
   GetResourceSetRequest,
   GetResourceSetResponse,
   GetResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceSetRequest,
   output: GetResourceSetResponse,
@@ -2373,7 +2372,7 @@ export const listCells: API.PaginatedOperationMethod<
   ListCellsRequest,
   ListCellsResponse,
   ListCellsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CellOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCellsRequest,
@@ -2408,7 +2407,7 @@ export const listCrossAccountAuthorizations: API.PaginatedOperationMethod<
   ListCrossAccountAuthorizationsRequest,
   ListCrossAccountAuthorizationsResponse,
   ListCrossAccountAuthorizationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CrossAccountAuthorization
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCrossAccountAuthorizationsRequest,
@@ -2443,7 +2442,7 @@ export const listReadinessChecks: API.PaginatedOperationMethod<
   ListReadinessChecksRequest,
   ListReadinessChecksResponse,
   ListReadinessChecksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReadinessCheckOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReadinessChecksRequest,
@@ -2478,7 +2477,7 @@ export const listRecoveryGroups: API.PaginatedOperationMethod<
   ListRecoveryGroupsRequest,
   ListRecoveryGroupsResponse,
   ListRecoveryGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecoveryGroupOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecoveryGroupsRequest,
@@ -2513,7 +2512,7 @@ export const listResourceSets: API.PaginatedOperationMethod<
   ListResourceSetsRequest,
   ListResourceSetsResponse,
   ListResourceSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceSetOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceSetsRequest,
@@ -2548,7 +2547,7 @@ export const listRules: API.PaginatedOperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListRulesOutput
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesRequest,
@@ -2582,7 +2581,7 @@ export const listTagsForResources: API.OperationMethod<
   ListTagsForResourcesRequest,
   ListTagsForResourcesResponse,
   ListTagsForResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourcesRequest,
   output: ListTagsForResourcesResponse,
@@ -2608,7 +2607,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2634,7 +2633,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2662,7 +2661,7 @@ export const updateCell: API.OperationMethod<
   UpdateCellRequest,
   UpdateCellResponse,
   UpdateCellError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCellRequest,
   output: UpdateCellResponse,
@@ -2692,7 +2691,7 @@ export const updateReadinessCheck: API.OperationMethod<
   UpdateReadinessCheckRequest,
   UpdateReadinessCheckResponse,
   UpdateReadinessCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReadinessCheckRequest,
   output: UpdateReadinessCheckResponse,
@@ -2722,7 +2721,7 @@ export const updateRecoveryGroup: API.OperationMethod<
   UpdateRecoveryGroupRequest,
   UpdateRecoveryGroupResponse,
   UpdateRecoveryGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecoveryGroupRequest,
   output: UpdateRecoveryGroupResponse,
@@ -2752,7 +2751,7 @@ export const updateResourceSet: API.OperationMethod<
   UpdateResourceSetRequest,
   UpdateResourceSetResponse,
   UpdateResourceSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceSetRequest,
   output: UpdateResourceSetResponse,

--- a/packages/aws/src/services/route53globalresolver.ts
+++ b/packages/aws/src/services/route53globalresolver.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53GlobalResolver",
@@ -2948,7 +2947,7 @@ export const associateHostedZone: API.OperationMethod<
   AssociateHostedZoneInput,
   AssociateHostedZoneOutput,
   AssociateHostedZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateHostedZoneInput,
   output: AssociateHostedZoneOutput,
@@ -2981,7 +2980,7 @@ export const batchCreateFirewallRule: API.OperationMethod<
   BatchCreateFirewallRuleInput,
   BatchCreateFirewallRuleOutput,
   BatchCreateFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateFirewallRuleInput,
   output: BatchCreateFirewallRuleOutput,
@@ -3011,7 +3010,7 @@ export const batchDeleteFirewallRule: API.OperationMethod<
   BatchDeleteFirewallRuleInput,
   BatchDeleteFirewallRuleOutput,
   BatchDeleteFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteFirewallRuleInput,
   output: BatchDeleteFirewallRuleOutput,
@@ -3041,7 +3040,7 @@ export const batchUpdateFirewallRule: API.OperationMethod<
   BatchUpdateFirewallRuleInput,
   BatchUpdateFirewallRuleOutput,
   BatchUpdateFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateFirewallRuleInput,
   output: BatchUpdateFirewallRuleOutput,
@@ -3074,7 +3073,7 @@ export const createAccessSource: API.OperationMethod<
   CreateAccessSourceInput,
   CreateAccessSourceOutput,
   CreateAccessSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessSourceInput,
   output: CreateAccessSourceOutput,
@@ -3110,7 +3109,7 @@ export const createAccessToken: API.OperationMethod<
   CreateAccessTokenInput,
   CreateAccessTokenOutput,
   CreateAccessTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessTokenInput,
   output: CreateAccessTokenOutput,
@@ -3146,7 +3145,7 @@ export const createDNSView: API.OperationMethod<
   CreateDNSViewInput,
   CreateDNSViewOutput,
   CreateDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDNSViewInput,
   output: CreateDNSViewOutput,
@@ -3182,7 +3181,7 @@ export const createFirewallDomainList: API.OperationMethod<
   CreateFirewallDomainListInput,
   CreateFirewallDomainListOutput,
   CreateFirewallDomainListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallDomainListInput,
   output: CreateFirewallDomainListOutput,
@@ -3218,7 +3217,7 @@ export const createFirewallRule: API.OperationMethod<
   CreateFirewallRuleInput,
   CreateFirewallRuleOutput,
   CreateFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallRuleInput,
   output: CreateFirewallRuleOutput,
@@ -3253,7 +3252,7 @@ export const createGlobalResolver: API.OperationMethod<
   CreateGlobalResolverInput,
   CreateGlobalResolverOutput,
   CreateGlobalResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGlobalResolverInput,
   output: CreateGlobalResolverOutput,
@@ -3287,7 +3286,7 @@ export const deleteAccessSource: API.OperationMethod<
   DeleteAccessSourceInput,
   DeleteAccessSourceOutput,
   DeleteAccessSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessSourceInput,
   output: DeleteAccessSourceOutput,
@@ -3321,7 +3320,7 @@ export const deleteAccessToken: API.OperationMethod<
   DeleteAccessTokenInput,
   DeleteAccessTokenOutput,
   DeleteAccessTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessTokenInput,
   output: DeleteAccessTokenOutput,
@@ -3355,7 +3354,7 @@ export const deleteDNSView: API.OperationMethod<
   DeleteDNSViewInput,
   DeleteDNSViewOutput,
   DeleteDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDNSViewInput,
   output: DeleteDNSViewOutput,
@@ -3389,7 +3388,7 @@ export const deleteFirewallDomainList: API.OperationMethod<
   DeleteFirewallDomainListInput,
   DeleteFirewallDomainListOutput,
   DeleteFirewallDomainListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallDomainListInput,
   output: DeleteFirewallDomainListOutput,
@@ -3423,7 +3422,7 @@ export const deleteFirewallRule: API.OperationMethod<
   DeleteFirewallRuleInput,
   DeleteFirewallRuleOutput,
   DeleteFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallRuleInput,
   output: DeleteFirewallRuleOutput,
@@ -3457,7 +3456,7 @@ export const deleteGlobalResolver: API.OperationMethod<
   DeleteGlobalResolverInput,
   DeleteGlobalResolverOutput,
   DeleteGlobalResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGlobalResolverInput,
   output: DeleteGlobalResolverOutput,
@@ -3492,7 +3491,7 @@ export const disableDNSView: API.OperationMethod<
   DisableDNSViewInput,
   DisableDNSViewOutput,
   DisableDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableDNSViewInput,
   output: DisableDNSViewOutput,
@@ -3527,7 +3526,7 @@ export const disassociateHostedZone: API.OperationMethod<
   DisassociateHostedZoneInput,
   DisassociateHostedZoneOutput,
   DisassociateHostedZoneError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateHostedZoneInput,
   output: DisassociateHostedZoneOutput,
@@ -3562,7 +3561,7 @@ export const enableDNSView: API.OperationMethod<
   EnableDNSViewInput,
   EnableDNSViewOutput,
   EnableDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableDNSViewInput,
   output: EnableDNSViewOutput,
@@ -3596,7 +3595,7 @@ export const getAccessSource: API.OperationMethod<
   GetAccessSourceInput,
   GetAccessSourceOutput,
   GetAccessSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessSourceInput,
   output: GetAccessSourceOutput,
@@ -3628,7 +3627,7 @@ export const getAccessToken: API.OperationMethod<
   GetAccessTokenInput,
   GetAccessTokenOutput,
   GetAccessTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessTokenInput,
   output: GetAccessTokenOutput,
@@ -3660,7 +3659,7 @@ export const getDNSView: API.OperationMethod<
   GetDNSViewInput,
   GetDNSViewOutput,
   GetDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDNSViewInput,
   output: GetDNSViewOutput,
@@ -3692,7 +3691,7 @@ export const getFirewallDomainList: API.OperationMethod<
   GetFirewallDomainListInput,
   GetFirewallDomainListOutput,
   GetFirewallDomainListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallDomainListInput,
   output: GetFirewallDomainListOutput,
@@ -3724,7 +3723,7 @@ export const getFirewallRule: API.OperationMethod<
   GetFirewallRuleInput,
   GetFirewallRuleOutput,
   GetFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallRuleInput,
   output: GetFirewallRuleOutput,
@@ -3756,7 +3755,7 @@ export const getGlobalResolver: API.OperationMethod<
   GetGlobalResolverInput,
   GetGlobalResolverOutput,
   GetGlobalResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlobalResolverInput,
   output: GetGlobalResolverOutput,
@@ -3788,7 +3787,7 @@ export const getHostedZoneAssociation: API.OperationMethod<
   GetHostedZoneAssociationInput,
   GetHostedZoneAssociationOutput,
   GetHostedZoneAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetHostedZoneAssociationInput,
   output: GetHostedZoneAssociationOutput,
@@ -3820,7 +3819,7 @@ export const getManagedFirewallDomainList: API.OperationMethod<
   GetManagedFirewallDomainListInput,
   GetManagedFirewallDomainListOutput,
   GetManagedFirewallDomainListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedFirewallDomainListInput,
   output: GetManagedFirewallDomainListOutput,
@@ -3854,7 +3853,7 @@ export const importFirewallDomains: API.OperationMethod<
   ImportFirewallDomainsInput,
   ImportFirewallDomainsOutput,
   ImportFirewallDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportFirewallDomainsInput,
   output: ImportFirewallDomainsOutput,
@@ -3887,7 +3886,7 @@ export const listAccessSources: API.PaginatedOperationMethod<
   ListAccessSourcesInput,
   ListAccessSourcesOutput,
   ListAccessSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessSourcesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessSourcesInput,
@@ -3925,7 +3924,7 @@ export const listAccessTokens: API.PaginatedOperationMethod<
   ListAccessTokensInput,
   ListAccessTokensOutput,
   ListAccessTokensError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessTokenItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessTokensInput,
@@ -3964,7 +3963,7 @@ export const listDNSViews: API.PaginatedOperationMethod<
   ListDNSViewsInput,
   ListDNSViewsOutput,
   ListDNSViewsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DNSViewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDNSViewsInput,
@@ -4003,7 +4002,7 @@ export const listFirewallDomainLists: API.PaginatedOperationMethod<
   ListFirewallDomainListsInput,
   ListFirewallDomainListsOutput,
   ListFirewallDomainListsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallDomainListsItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallDomainListsInput,
@@ -4042,7 +4041,7 @@ export const listFirewallDomains: API.PaginatedOperationMethod<
   ListFirewallDomainsInput,
   ListFirewallDomainsOutput,
   ListFirewallDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Domain
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallDomainsInput,
@@ -4081,7 +4080,7 @@ export const listFirewallRules: API.PaginatedOperationMethod<
   ListFirewallRulesInput,
   ListFirewallRulesOutput,
   ListFirewallRulesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallRulesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallRulesInput,
@@ -4119,7 +4118,7 @@ export const listGlobalResolvers: API.PaginatedOperationMethod<
   ListGlobalResolversInput,
   ListGlobalResolversOutput,
   ListGlobalResolversError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GlobalResolversItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGlobalResolversInput,
@@ -4157,7 +4156,7 @@ export const listHostedZoneAssociations: API.PaginatedOperationMethod<
   ListHostedZoneAssociationsInput,
   ListHostedZoneAssociationsOutput,
   ListHostedZoneAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HostedZoneAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHostedZoneAssociationsInput,
@@ -4195,7 +4194,7 @@ export const listManagedFirewallDomainLists: API.PaginatedOperationMethod<
   ListManagedFirewallDomainListsInput,
   ListManagedFirewallDomainListsOutput,
   ListManagedFirewallDomainListsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ManagedFirewallDomainListsItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedFirewallDomainListsInput,
@@ -4227,7 +4226,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -4251,7 +4250,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4278,7 +4277,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4306,7 +4305,7 @@ export const updateAccessSource: API.OperationMethod<
   UpdateAccessSourceInput,
   UpdateAccessSourceOutput,
   UpdateAccessSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessSourceInput,
   output: UpdateAccessSourceOutput,
@@ -4342,7 +4341,7 @@ export const updateAccessToken: API.OperationMethod<
   UpdateAccessTokenInput,
   UpdateAccessTokenOutput,
   UpdateAccessTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessTokenInput,
   output: UpdateAccessTokenOutput,
@@ -4378,7 +4377,7 @@ export const updateDNSView: API.OperationMethod<
   UpdateDNSViewInput,
   UpdateDNSViewOutput,
   UpdateDNSViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDNSViewInput,
   output: UpdateDNSViewOutput,
@@ -4414,7 +4413,7 @@ export const updateFirewallDomains: API.OperationMethod<
   UpdateFirewallDomainsInput,
   UpdateFirewallDomainsOutput,
   UpdateFirewallDomainsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallDomainsInput,
   output: UpdateFirewallDomainsOutput,
@@ -4450,7 +4449,7 @@ export const updateFirewallRule: API.OperationMethod<
   UpdateFirewallRuleInput,
   UpdateFirewallRuleOutput,
   UpdateFirewallRuleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallRuleInput,
   output: UpdateFirewallRuleOutput,
@@ -4486,7 +4485,7 @@ export const updateGlobalResolver: API.OperationMethod<
   UpdateGlobalResolverInput,
   UpdateGlobalResolverOutput,
   UpdateGlobalResolverError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalResolverInput,
   output: UpdateGlobalResolverOutput,
@@ -4522,7 +4521,7 @@ export const updateHostedZoneAssociation: API.OperationMethod<
   UpdateHostedZoneAssociationInput,
   UpdateHostedZoneAssociationOutput,
   UpdateHostedZoneAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostedZoneAssociationInput,
   output: UpdateHostedZoneAssociationOutput,

--- a/packages/aws/src/services/route53profiles.ts
+++ b/packages/aws/src/services/route53profiles.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53Profiles",
   serviceShapeName: "Route53Profiles",
@@ -833,7 +832,7 @@ export const associateProfile: API.OperationMethod<
   AssociateProfileRequest,
   AssociateProfileResponse,
   AssociateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateProfileRequest,
   output: AssociateProfileResponse,
@@ -869,7 +868,7 @@ export const associateResourceToProfile: API.OperationMethod<
   AssociateResourceToProfileRequest,
   AssociateResourceToProfileResponse,
   AssociateResourceToProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceToProfileRequest,
   output: AssociateResourceToProfileResponse,
@@ -902,7 +901,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileRequest,
   CreateProfileResponse,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileRequest,
   output: CreateProfileResponse,
@@ -932,7 +931,7 @@ export const deleteProfile: API.OperationMethod<
   DeleteProfileRequest,
   DeleteProfileResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileRequest,
   output: DeleteProfileResponse,
@@ -963,7 +962,7 @@ export const disassociateProfile: API.OperationMethod<
   DisassociateProfileRequest,
   DisassociateProfileResponse,
   DisassociateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateProfileRequest,
   output: DisassociateProfileResponse,
@@ -997,7 +996,7 @@ export const disassociateResourceFromProfile: API.OperationMethod<
   DisassociateResourceFromProfileRequest,
   DisassociateResourceFromProfileResponse,
   DisassociateResourceFromProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceFromProfileRequest,
   output: DisassociateResourceFromProfileResponse,
@@ -1029,7 +1028,7 @@ export const getProfile: API.OperationMethod<
   GetProfileRequest,
   GetProfileResponse,
   GetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileRequest,
   output: GetProfileResponse,
@@ -1057,7 +1056,7 @@ export const getProfileAssociation: API.OperationMethod<
   GetProfileAssociationRequest,
   GetProfileAssociationResponse,
   GetProfileAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileAssociationRequest,
   output: GetProfileAssociationResponse,
@@ -1086,7 +1085,7 @@ export const getProfileResourceAssociation: API.OperationMethod<
   GetProfileResourceAssociationRequest,
   GetProfileResourceAssociationResponse,
   GetProfileResourceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileResourceAssociationRequest,
   output: GetProfileResourceAssociationResponse,
@@ -1116,7 +1115,7 @@ export const listProfileAssociations: API.PaginatedOperationMethod<
   ListProfileAssociationsRequest,
   ListProfileAssociationsResponse,
   ListProfileAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfileAssociationsRequest,
@@ -1155,7 +1154,7 @@ export const listProfileResourceAssociations: API.PaginatedOperationMethod<
   ListProfileResourceAssociationsRequest,
   ListProfileResourceAssociationsResponse,
   ListProfileResourceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileResourceAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfileResourceAssociationsRequest,
@@ -1194,7 +1193,7 @@ export const listProfiles: API.PaginatedOperationMethod<
   ListProfilesRequest,
   ListProfilesResponse,
   ListProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProfileSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilesRequest,
@@ -1231,7 +1230,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1260,7 +1259,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1289,7 +1288,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1322,7 +1321,7 @@ export const updateProfileResourceAssociation: API.OperationMethod<
   UpdateProfileResourceAssociationRequest,
   UpdateProfileResourceAssociationResponse,
   UpdateProfileResourceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileResourceAssociationRequest,
   output: UpdateProfileResourceAssociationResponse,

--- a/packages/aws/src/services/route53resolver.ts
+++ b/packages/aws/src/services/route53resolver.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Route53Resolver",
   serviceShapeName: "Route53Resolver",
@@ -3123,7 +3122,7 @@ export const associateFirewallRuleGroup: API.OperationMethod<
   AssociateFirewallRuleGroupRequest,
   AssociateFirewallRuleGroupResponse,
   AssociateFirewallRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFirewallRuleGroupRequest,
   output: AssociateFirewallRuleGroupResponse,
@@ -3161,7 +3160,7 @@ export const associateResolverEndpointIpAddress: API.OperationMethod<
   AssociateResolverEndpointIpAddressRequest,
   AssociateResolverEndpointIpAddressResponse,
   AssociateResolverEndpointIpAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResolverEndpointIpAddressRequest,
   output: AssociateResolverEndpointIpAddressResponse,
@@ -3203,7 +3202,7 @@ export const associateResolverQueryLogConfig: API.OperationMethod<
   AssociateResolverQueryLogConfigRequest,
   AssociateResolverQueryLogConfigResponse,
   AssociateResolverQueryLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResolverQueryLogConfigRequest,
   output: AssociateResolverQueryLogConfigResponse,
@@ -3242,7 +3241,7 @@ export const associateResolverRule: API.OperationMethod<
   AssociateResolverRuleRequest,
   AssociateResolverRuleResponse,
   AssociateResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResolverRuleRequest,
   output: AssociateResolverRuleResponse,
@@ -3275,7 +3274,7 @@ export const batchCreateFirewallRule: API.OperationMethod<
   BatchCreateFirewallRuleRequest,
   BatchCreateFirewallRuleResponse,
   BatchCreateFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateFirewallRuleRequest,
   output: BatchCreateFirewallRuleResponse,
@@ -3305,7 +3304,7 @@ export const batchDeleteFirewallRule: API.OperationMethod<
   BatchDeleteFirewallRuleRequest,
   BatchDeleteFirewallRuleResponse,
   BatchDeleteFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteFirewallRuleRequest,
   output: BatchDeleteFirewallRuleResponse,
@@ -3335,7 +3334,7 @@ export const batchUpdateFirewallRule: API.OperationMethod<
   BatchUpdateFirewallRuleRequest,
   BatchUpdateFirewallRuleResponse,
   BatchUpdateFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateFirewallRuleRequest,
   output: BatchUpdateFirewallRuleResponse,
@@ -3365,7 +3364,7 @@ export const createFirewallDomainList: API.OperationMethod<
   CreateFirewallDomainListRequest,
   CreateFirewallDomainListResponse,
   CreateFirewallDomainListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallDomainListRequest,
   output: CreateFirewallDomainListResponse,
@@ -3404,7 +3403,7 @@ export const createFirewallRule: API.OperationMethod<
   CreateFirewallRuleRequest,
   CreateFirewallRuleResponse,
   CreateFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallRuleRequest,
   output: CreateFirewallRuleResponse,
@@ -3436,7 +3435,7 @@ export const createFirewallRuleGroup: API.OperationMethod<
   CreateFirewallRuleGroupRequest,
   CreateFirewallRuleGroupResponse,
   CreateFirewallRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFirewallRuleGroupRequest,
   output: CreateFirewallRuleGroupResponse,
@@ -3467,7 +3466,7 @@ export const createOutpostResolver: API.OperationMethod<
   CreateOutpostResolverRequest,
   CreateOutpostResolverResponse,
   CreateOutpostResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOutpostResolverRequest,
   output: CreateOutpostResolverResponse,
@@ -3507,7 +3506,7 @@ export const createResolverEndpoint: API.OperationMethod<
   CreateResolverEndpointRequest,
   CreateResolverEndpointResponse,
   CreateResolverEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResolverEndpointRequest,
   output: CreateResolverEndpointResponse,
@@ -3551,7 +3550,7 @@ export const createResolverQueryLogConfig: API.OperationMethod<
   CreateResolverQueryLogConfigRequest,
   CreateResolverQueryLogConfigResponse,
   CreateResolverQueryLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResolverQueryLogConfigRequest,
   output: CreateResolverQueryLogConfigResponse,
@@ -3589,7 +3588,7 @@ export const createResolverRule: API.OperationMethod<
   CreateResolverRuleRequest,
   CreateResolverRuleResponse,
   CreateResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResolverRuleRequest,
   output: CreateResolverRuleResponse,
@@ -3623,7 +3622,7 @@ export const deleteFirewallDomainList: API.OperationMethod<
   DeleteFirewallDomainListRequest,
   DeleteFirewallDomainListResponse,
   DeleteFirewallDomainListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallDomainListRequest,
   output: DeleteFirewallDomainListResponse,
@@ -3655,7 +3654,7 @@ export const deleteFirewallRule: API.OperationMethod<
   DeleteFirewallRuleRequest,
   DeleteFirewallRuleResponse,
   DeleteFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallRuleRequest,
   output: DeleteFirewallRuleResponse,
@@ -3686,7 +3685,7 @@ export const deleteFirewallRuleGroup: API.OperationMethod<
   DeleteFirewallRuleGroupRequest,
   DeleteFirewallRuleGroupResponse,
   DeleteFirewallRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallRuleGroupRequest,
   output: DeleteFirewallRuleGroupResponse,
@@ -3718,7 +3717,7 @@ export const deleteOutpostResolver: API.OperationMethod<
   DeleteOutpostResolverRequest,
   DeleteOutpostResolverResponse,
   DeleteOutpostResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutpostResolverRequest,
   output: DeleteOutpostResolverResponse,
@@ -3755,7 +3754,7 @@ export const deleteResolverEndpoint: API.OperationMethod<
   DeleteResolverEndpointRequest,
   DeleteResolverEndpointResponse,
   DeleteResolverEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResolverEndpointRequest,
   output: DeleteResolverEndpointResponse,
@@ -3796,7 +3795,7 @@ export const deleteResolverQueryLogConfig: API.OperationMethod<
   DeleteResolverQueryLogConfigRequest,
   DeleteResolverQueryLogConfigResponse,
   DeleteResolverQueryLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResolverQueryLogConfigRequest,
   output: DeleteResolverQueryLogConfigResponse,
@@ -3830,7 +3829,7 @@ export const deleteResolverRule: API.OperationMethod<
   DeleteResolverRuleRequest,
   DeleteResolverRuleResponse,
   DeleteResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResolverRuleRequest,
   output: DeleteResolverRuleResponse,
@@ -3862,7 +3861,7 @@ export const disassociateFirewallRuleGroup: API.OperationMethod<
   DisassociateFirewallRuleGroupRequest,
   DisassociateFirewallRuleGroupResponse,
   DisassociateFirewallRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFirewallRuleGroupRequest,
   output: DisassociateFirewallRuleGroupResponse,
@@ -3898,7 +3897,7 @@ export const disassociateResolverEndpointIpAddress: API.OperationMethod<
   DisassociateResolverEndpointIpAddressRequest,
   DisassociateResolverEndpointIpAddressResponse,
   DisassociateResolverEndpointIpAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResolverEndpointIpAddressRequest,
   output: DisassociateResolverEndpointIpAddressResponse,
@@ -3939,7 +3938,7 @@ export const disassociateResolverQueryLogConfig: API.OperationMethod<
   DisassociateResolverQueryLogConfigRequest,
   DisassociateResolverQueryLogConfigResponse,
   DisassociateResolverQueryLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResolverQueryLogConfigRequest,
   output: DisassociateResolverQueryLogConfigResponse,
@@ -3973,7 +3972,7 @@ export const disassociateResolverRule: API.OperationMethod<
   DisassociateResolverRuleRequest,
   DisassociateResolverRuleResponse,
   DisassociateResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResolverRuleRequest,
   output: DisassociateResolverRuleResponse,
@@ -4004,7 +4003,7 @@ export const getFirewallConfig: API.OperationMethod<
   GetFirewallConfigRequest,
   GetFirewallConfigResponse,
   GetFirewallConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallConfigRequest,
   output: GetFirewallConfigResponse,
@@ -4033,7 +4032,7 @@ export const getFirewallDomainList: API.OperationMethod<
   GetFirewallDomainListRequest,
   GetFirewallDomainListResponse,
   GetFirewallDomainListError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallDomainListRequest,
   output: GetFirewallDomainListResponse,
@@ -4061,7 +4060,7 @@ export const getFirewallRuleGroup: API.OperationMethod<
   GetFirewallRuleGroupRequest,
   GetFirewallRuleGroupResponse,
   GetFirewallRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallRuleGroupRequest,
   output: GetFirewallRuleGroupResponse,
@@ -4089,7 +4088,7 @@ export const getFirewallRuleGroupAssociation: API.OperationMethod<
   GetFirewallRuleGroupAssociationRequest,
   GetFirewallRuleGroupAssociationResponse,
   GetFirewallRuleGroupAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallRuleGroupAssociationRequest,
   output: GetFirewallRuleGroupAssociationResponse,
@@ -4119,7 +4118,7 @@ export const getFirewallRuleGroupPolicy: API.OperationMethod<
   GetFirewallRuleGroupPolicyRequest,
   GetFirewallRuleGroupPolicyResponse,
   GetFirewallRuleGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFirewallRuleGroupPolicyRequest,
   output: GetFirewallRuleGroupPolicyResponse,
@@ -4150,7 +4149,7 @@ export const getOutpostResolver: API.OperationMethod<
   GetOutpostResolverRequest,
   GetOutpostResolverResponse,
   GetOutpostResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOutpostResolverRequest,
   output: GetOutpostResolverResponse,
@@ -4182,7 +4181,7 @@ export const getResolverConfig: API.OperationMethod<
   GetResolverConfigRequest,
   GetResolverConfigResponse,
   GetResolverConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverConfigRequest,
   output: GetResolverConfigResponse,
@@ -4214,7 +4213,7 @@ export const getResolverDnssecConfig: API.OperationMethod<
   GetResolverDnssecConfigRequest,
   GetResolverDnssecConfigResponse,
   GetResolverDnssecConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverDnssecConfigRequest,
   output: GetResolverDnssecConfigResponse,
@@ -4245,7 +4244,7 @@ export const getResolverEndpoint: API.OperationMethod<
   GetResolverEndpointRequest,
   GetResolverEndpointResponse,
   GetResolverEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverEndpointRequest,
   output: GetResolverEndpointResponse,
@@ -4276,7 +4275,7 @@ export const getResolverQueryLogConfig: API.OperationMethod<
   GetResolverQueryLogConfigRequest,
   GetResolverQueryLogConfigResponse,
   GetResolverQueryLogConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverQueryLogConfigRequest,
   output: GetResolverQueryLogConfigResponse,
@@ -4309,7 +4308,7 @@ export const getResolverQueryLogConfigAssociation: API.OperationMethod<
   GetResolverQueryLogConfigAssociationRequest,
   GetResolverQueryLogConfigAssociationResponse,
   GetResolverQueryLogConfigAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverQueryLogConfigAssociationRequest,
   output: GetResolverQueryLogConfigAssociationResponse,
@@ -4341,7 +4340,7 @@ export const getResolverQueryLogConfigPolicy: API.OperationMethod<
   GetResolverQueryLogConfigPolicyRequest,
   GetResolverQueryLogConfigPolicyResponse,
   GetResolverQueryLogConfigPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverQueryLogConfigPolicyRequest,
   output: GetResolverQueryLogConfigPolicyResponse,
@@ -4371,7 +4370,7 @@ export const getResolverRule: API.OperationMethod<
   GetResolverRuleRequest,
   GetResolverRuleResponse,
   GetResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverRuleRequest,
   output: GetResolverRuleResponse,
@@ -4400,7 +4399,7 @@ export const getResolverRuleAssociation: API.OperationMethod<
   GetResolverRuleAssociationRequest,
   GetResolverRuleAssociationResponse,
   GetResolverRuleAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverRuleAssociationRequest,
   output: GetResolverRuleAssociationResponse,
@@ -4429,7 +4428,7 @@ export const getResolverRulePolicy: API.OperationMethod<
   GetResolverRulePolicyRequest,
   GetResolverRulePolicyResponse,
   GetResolverRulePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResolverRulePolicyRequest,
   output: GetResolverRulePolicyResponse,
@@ -4471,7 +4470,7 @@ export const importFirewallDomains: API.OperationMethod<
   ImportFirewallDomainsRequest,
   ImportFirewallDomainsResponse,
   ImportFirewallDomainsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportFirewallDomainsRequest,
   output: ImportFirewallDomainsResponse,
@@ -4504,7 +4503,7 @@ export const listFirewallConfigs: API.PaginatedOperationMethod<
   ListFirewallConfigsRequest,
   ListFirewallConfigsResponse,
   ListFirewallConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallConfigsRequest,
@@ -4541,7 +4540,7 @@ export const listFirewallDomainLists: API.PaginatedOperationMethod<
   ListFirewallDomainListsRequest,
   ListFirewallDomainListsResponse,
   ListFirewallDomainListsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallDomainListMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallDomainListsRequest,
@@ -4579,7 +4578,7 @@ export const listFirewallDomains: API.PaginatedOperationMethod<
   ListFirewallDomainsRequest,
   ListFirewallDomainsResponse,
   ListFirewallDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallDomainName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallDomainsRequest,
@@ -4617,7 +4616,7 @@ export const listFirewallRuleGroupAssociations: API.PaginatedOperationMethod<
   ListFirewallRuleGroupAssociationsRequest,
   ListFirewallRuleGroupAssociationsResponse,
   ListFirewallRuleGroupAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallRuleGroupAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallRuleGroupAssociationsRequest,
@@ -4654,7 +4653,7 @@ export const listFirewallRuleGroups: API.PaginatedOperationMethod<
   ListFirewallRuleGroupsRequest,
   ListFirewallRuleGroupsResponse,
   ListFirewallRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallRuleGroupMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallRuleGroupsRequest,
@@ -4694,7 +4693,7 @@ export const listFirewallRules: API.PaginatedOperationMethod<
   ListFirewallRulesRequest,
   ListFirewallRulesResponse,
   ListFirewallRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallRulesRequest,
@@ -4732,7 +4731,7 @@ export const listFirewallRuleTypes: API.PaginatedOperationMethod<
   ListFirewallRuleTypesRequest,
   ListFirewallRuleTypesResponse,
   ListFirewallRuleTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FirewallRuleTypeDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFirewallRuleTypesRequest,
@@ -4768,7 +4767,7 @@ export const listOutpostResolvers: API.PaginatedOperationMethod<
   ListOutpostResolversRequest,
   ListOutpostResolversResponse,
   ListOutpostResolversError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OutpostResolver
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOutpostResolversRequest,
@@ -4808,7 +4807,7 @@ export const listResolverConfigs: API.PaginatedOperationMethod<
   ListResolverConfigsRequest,
   ListResolverConfigsResponse,
   ListResolverConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverConfigsRequest,
@@ -4848,7 +4847,7 @@ export const listResolverDnssecConfigs: API.PaginatedOperationMethod<
   ListResolverDnssecConfigsRequest,
   ListResolverDnssecConfigsResponse,
   ListResolverDnssecConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverDnssecConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverDnssecConfigsRequest,
@@ -4886,7 +4885,7 @@ export const listResolverEndpointIpAddresses: API.PaginatedOperationMethod<
   ListResolverEndpointIpAddressesRequest,
   ListResolverEndpointIpAddressesResponse,
   ListResolverEndpointIpAddressesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IpAddressResponse
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverEndpointIpAddressesRequest,
@@ -4923,7 +4922,7 @@ export const listResolverEndpoints: API.PaginatedOperationMethod<
   ListResolverEndpointsRequest,
   ListResolverEndpointsResponse,
   ListResolverEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverEndpointsRequest,
@@ -4961,7 +4960,7 @@ export const listResolverQueryLogConfigAssociations: API.PaginatedOperationMetho
   ListResolverQueryLogConfigAssociationsRequest,
   ListResolverQueryLogConfigAssociationsResponse,
   ListResolverQueryLogConfigAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverQueryLogConfigAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverQueryLogConfigAssociationsRequest,
@@ -5001,7 +5000,7 @@ export const listResolverQueryLogConfigs: API.PaginatedOperationMethod<
   ListResolverQueryLogConfigsRequest,
   ListResolverQueryLogConfigsResponse,
   ListResolverQueryLogConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverQueryLogConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverQueryLogConfigsRequest,
@@ -5039,7 +5038,7 @@ export const listResolverRuleAssociations: API.PaginatedOperationMethod<
   ListResolverRuleAssociationsRequest,
   ListResolverRuleAssociationsResponse,
   ListResolverRuleAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverRuleAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverRuleAssociationsRequest,
@@ -5076,7 +5075,7 @@ export const listResolverRules: API.PaginatedOperationMethod<
   ListResolverRulesRequest,
   ListResolverRulesResponse,
   ListResolverRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolverRule
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResolverRulesRequest,
@@ -5114,7 +5113,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -5154,7 +5153,7 @@ export const putFirewallRuleGroupPolicy: API.OperationMethod<
   PutFirewallRuleGroupPolicyRequest,
   PutFirewallRuleGroupPolicyResponse,
   PutFirewallRuleGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFirewallRuleGroupPolicyRequest,
   output: PutFirewallRuleGroupPolicyResponse,
@@ -5186,7 +5185,7 @@ export const putResolverQueryLogConfigPolicy: API.OperationMethod<
   PutResolverQueryLogConfigPolicyRequest,
   PutResolverQueryLogConfigPolicyResponse,
   PutResolverQueryLogConfigPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResolverQueryLogConfigPolicyRequest,
   output: PutResolverQueryLogConfigPolicyResponse,
@@ -5218,7 +5217,7 @@ export const putResolverRulePolicy: API.OperationMethod<
   PutResolverRulePolicyRequest,
   PutResolverRulePolicyResponse,
   PutResolverRulePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResolverRulePolicyRequest,
   output: PutResolverRulePolicyResponse,
@@ -5250,7 +5249,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5282,7 +5281,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5313,7 +5312,7 @@ export const updateFirewallConfig: API.OperationMethod<
   UpdateFirewallConfigRequest,
   UpdateFirewallConfigResponse,
   UpdateFirewallConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallConfigRequest,
   output: UpdateFirewallConfigResponse,
@@ -5345,7 +5344,7 @@ export const updateFirewallDomains: API.OperationMethod<
   UpdateFirewallDomainsRequest,
   UpdateFirewallDomainsResponse,
   UpdateFirewallDomainsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallDomainsRequest,
   output: UpdateFirewallDomainsResponse,
@@ -5378,7 +5377,7 @@ export const updateFirewallRule: API.OperationMethod<
   UpdateFirewallRuleRequest,
   UpdateFirewallRuleResponse,
   UpdateFirewallRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallRuleRequest,
   output: UpdateFirewallRuleResponse,
@@ -5410,7 +5409,7 @@ export const updateFirewallRuleGroupAssociation: API.OperationMethod<
   UpdateFirewallRuleGroupAssociationRequest,
   UpdateFirewallRuleGroupAssociationResponse,
   UpdateFirewallRuleGroupAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFirewallRuleGroupAssociationRequest,
   output: UpdateFirewallRuleGroupAssociationResponse,
@@ -5443,7 +5442,7 @@ export const updateOutpostResolver: API.OperationMethod<
   UpdateOutpostResolverRequest,
   UpdateOutpostResolverResponse,
   UpdateOutpostResolverError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOutpostResolverRequest,
   output: UpdateOutpostResolverResponse,
@@ -5480,7 +5479,7 @@ export const updateResolverConfig: API.OperationMethod<
   UpdateResolverConfigRequest,
   UpdateResolverConfigResponse,
   UpdateResolverConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverConfigRequest,
   output: UpdateResolverConfigResponse,
@@ -5515,7 +5514,7 @@ export const updateResolverDnssecConfig: API.OperationMethod<
   UpdateResolverDnssecConfigRequest,
   UpdateResolverDnssecConfigResponse,
   UpdateResolverDnssecConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverDnssecConfigRequest,
   output: UpdateResolverDnssecConfigResponse,
@@ -5548,7 +5547,7 @@ export const updateResolverEndpoint: API.OperationMethod<
   UpdateResolverEndpointRequest,
   UpdateResolverEndpointResponse,
   UpdateResolverEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverEndpointRequest,
   output: UpdateResolverEndpointResponse,
@@ -5583,7 +5582,7 @@ export const updateResolverRule: API.OperationMethod<
   UpdateResolverRuleRequest,
   UpdateResolverRuleResponse,
   UpdateResolverRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverRuleRequest,
   output: UpdateResolverRuleResponse,

--- a/packages/aws/src/services/rtbfabric.ts
+++ b/packages/aws/src/services/rtbfabric.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "RTBFabric",
@@ -2166,7 +2165,7 @@ export const acceptLink: API.OperationMethod<
   AcceptLinkRequest,
   AcceptLinkResponse,
   AcceptLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptLinkRequest,
   output: AcceptLinkResponse,
@@ -2199,7 +2198,7 @@ export const associateCertificate: API.OperationMethod<
   AssociateCertificateRequest,
   AssociateCertificateResponse,
   AssociateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateCertificateRequest,
   output: AssociateCertificateResponse,
@@ -2233,7 +2232,7 @@ export const createInboundExternalLink: API.OperationMethod<
   CreateInboundExternalLinkRequest,
   CreateInboundExternalLinkResponse,
   CreateInboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInboundExternalLinkRequest,
   output: CreateInboundExternalLinkResponse,
@@ -2269,7 +2268,7 @@ export const createLink: API.OperationMethod<
   CreateLinkRequest,
   CreateLinkResponse,
   CreateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLinkRequest,
   output: CreateLinkResponse,
@@ -2305,7 +2304,7 @@ export const createLinkRoutingRule: API.OperationMethod<
   CreateLinkRoutingRuleRequest,
   CreateLinkRoutingRuleResponse,
   CreateLinkRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLinkRoutingRuleRequest,
   output: CreateLinkRoutingRuleResponse,
@@ -2339,7 +2338,7 @@ export const createOutboundExternalLink: API.OperationMethod<
   CreateOutboundExternalLinkRequest,
   CreateOutboundExternalLinkResponse,
   CreateOutboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOutboundExternalLinkRequest,
   output: CreateOutboundExternalLinkResponse,
@@ -2372,7 +2371,7 @@ export const createRequesterGateway: API.OperationMethod<
   CreateRequesterGatewayRequest,
   CreateRequesterGatewayResponse,
   CreateRequesterGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRequesterGatewayRequest,
   output: CreateRequesterGatewayResponse,
@@ -2406,7 +2405,7 @@ export const createResponderGateway: API.OperationMethod<
   CreateResponderGatewayRequest,
   CreateResponderGatewayResponse,
   CreateResponderGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResponderGatewayRequest,
   output: CreateResponderGatewayResponse,
@@ -2438,7 +2437,7 @@ export const deleteInboundExternalLink: API.OperationMethod<
   DeleteInboundExternalLinkRequest,
   DeleteInboundExternalLinkResponse,
   DeleteInboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInboundExternalLinkRequest,
   output: DeleteInboundExternalLinkResponse,
@@ -2472,7 +2471,7 @@ export const deleteLink: API.OperationMethod<
   DeleteLinkRequest,
   DeleteLinkResponse,
   DeleteLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLinkRequest,
   output: DeleteLinkResponse,
@@ -2504,7 +2503,7 @@ export const deleteLinkRoutingRule: API.OperationMethod<
   DeleteLinkRoutingRuleRequest,
   DeleteLinkRoutingRuleResponse,
   DeleteLinkRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLinkRoutingRuleRequest,
   output: DeleteLinkRoutingRuleResponse,
@@ -2536,7 +2535,7 @@ export const deleteOutboundExternalLink: API.OperationMethod<
   DeleteOutboundExternalLinkRequest,
   DeleteOutboundExternalLinkResponse,
   DeleteOutboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOutboundExternalLinkRequest,
   output: DeleteOutboundExternalLinkResponse,
@@ -2568,7 +2567,7 @@ export const deleteRequesterGateway: API.OperationMethod<
   DeleteRequesterGatewayRequest,
   DeleteRequesterGatewayResponse,
   DeleteRequesterGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRequesterGatewayRequest,
   output: DeleteRequesterGatewayResponse,
@@ -2600,7 +2599,7 @@ export const deleteResponderGateway: API.OperationMethod<
   DeleteResponderGatewayRequest,
   DeleteResponderGatewayResponse,
   DeleteResponderGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResponderGatewayRequest,
   output: DeleteResponderGatewayResponse,
@@ -2633,7 +2632,7 @@ export const disassociateCertificate: API.OperationMethod<
   DisassociateCertificateRequest,
   DisassociateCertificateResponse,
   DisassociateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateCertificateRequest,
   output: DisassociateCertificateResponse,
@@ -2665,7 +2664,7 @@ export const getCertificateAssociation: API.OperationMethod<
   GetCertificateAssociationRequest,
   GetCertificateAssociationResponse,
   GetCertificateAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCertificateAssociationRequest,
   output: GetCertificateAssociationResponse,
@@ -2695,7 +2694,7 @@ export const getInboundExternalLink: API.OperationMethod<
   GetInboundExternalLinkRequest,
   GetInboundExternalLinkResponse,
   GetInboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInboundExternalLinkRequest,
   output: GetInboundExternalLinkResponse,
@@ -2728,7 +2727,7 @@ export const getLink: API.OperationMethod<
   GetLinkRequest,
   GetLinkResponse,
   GetLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkRequest,
   output: GetLinkResponse,
@@ -2759,7 +2758,7 @@ export const getLinkRoutingRule: API.OperationMethod<
   GetLinkRoutingRuleRequest,
   GetLinkRoutingRuleResponse,
   GetLinkRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkRoutingRuleRequest,
   output: GetLinkRoutingRuleResponse,
@@ -2789,7 +2788,7 @@ export const getOutboundExternalLink: API.OperationMethod<
   GetOutboundExternalLinkRequest,
   GetOutboundExternalLinkResponse,
   GetOutboundExternalLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOutboundExternalLinkRequest,
   output: GetOutboundExternalLinkResponse,
@@ -2819,7 +2818,7 @@ export const getRequesterGateway: API.OperationMethod<
   GetRequesterGatewayRequest,
   GetRequesterGatewayResponse,
   GetRequesterGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRequesterGatewayRequest,
   output: GetRequesterGatewayResponse,
@@ -2849,7 +2848,7 @@ export const getResponderGateway: API.OperationMethod<
   GetResponderGatewayRequest,
   GetResponderGatewayResponse,
   GetResponderGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResponderGatewayRequest,
   output: GetResponderGatewayResponse,
@@ -2879,7 +2878,7 @@ export const listCertificateAssociations: API.PaginatedOperationMethod<
   ListCertificateAssociationsRequest,
   ListCertificateAssociationsResponse,
   ListCertificateAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CertificateAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificateAssociationsRequest,
@@ -2916,7 +2915,7 @@ export const listLinkRoutingRules: API.PaginatedOperationMethod<
   ListLinkRoutingRulesRequest,
   ListLinkRoutingRulesResponse,
   ListLinkRoutingRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LinkRoutingRuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinkRoutingRulesRequest,
@@ -2955,7 +2954,7 @@ export const listLinks: API.PaginatedOperationMethod<
   ListLinksRequest,
   ListLinksResponse,
   ListLinksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListLinksResponseStructure
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinksRequest,
@@ -2989,7 +2988,7 @@ export const listRequesterGateways: API.PaginatedOperationMethod<
   ListRequesterGatewaysRequest,
   ListRequesterGatewaysResponse,
   ListRequesterGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewayId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRequesterGatewaysRequest,
@@ -3017,7 +3016,7 @@ export const listResponderGateways: API.PaginatedOperationMethod<
   ListResponderGatewaysRequest,
   ListResponderGatewaysResponse,
   ListResponderGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewayId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResponderGatewaysRequest,
@@ -3048,7 +3047,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3081,7 +3080,7 @@ export const rejectLink: API.OperationMethod<
   RejectLinkRequest,
   RejectLinkResponse,
   RejectLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectLinkRequest,
   output: RejectLinkResponse,
@@ -3112,7 +3111,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3142,7 +3141,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3175,7 +3174,7 @@ export const updateLink: API.OperationMethod<
   UpdateLinkRequest,
   UpdateLinkResponse,
   UpdateLinkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkRequest,
   output: UpdateLinkResponse,
@@ -3208,7 +3207,7 @@ export const updateLinkModuleFlow: API.OperationMethod<
   UpdateLinkModuleFlowRequest,
   UpdateLinkModuleFlowResponse,
   UpdateLinkModuleFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkModuleFlowRequest,
   output: UpdateLinkModuleFlowResponse,
@@ -3241,7 +3240,7 @@ export const updateLinkRoutingRule: API.OperationMethod<
   UpdateLinkRoutingRuleRequest,
   UpdateLinkRoutingRuleResponse,
   UpdateLinkRoutingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLinkRoutingRuleRequest,
   output: UpdateLinkRoutingRuleResponse,
@@ -3273,7 +3272,7 @@ export const updateRequesterGateway: API.OperationMethod<
   UpdateRequesterGatewayRequest,
   UpdateRequesterGatewayResponse,
   UpdateRequesterGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRequesterGatewayRequest,
   output: UpdateRequesterGatewayResponse,
@@ -3305,7 +3304,7 @@ export const updateResponderGateway: API.OperationMethod<
   UpdateResponderGatewayRequest,
   UpdateResponderGatewayResponse,
   UpdateResponderGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResponderGatewayRequest,
   output: UpdateResponderGatewayResponse,

--- a/packages/aws/src/services/rum.ts
+++ b/packages/aws/src/services/rum.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "RUM", serviceShapeName: "RUM" });
 const auth = T.AwsAuthSigv4({ name: "rum" });
 const ver = T.ServiceVersion("2018-05-10");
@@ -1215,7 +1214,7 @@ export const batchCreateRumMetricDefinitions: API.OperationMethod<
   BatchCreateRumMetricDefinitionsRequest,
   BatchCreateRumMetricDefinitionsResponse,
   BatchCreateRumMetricDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateRumMetricDefinitionsRequest,
   output: BatchCreateRumMetricDefinitionsResponse,
@@ -1252,7 +1251,7 @@ export const batchDeleteRumMetricDefinitions: API.OperationMethod<
   BatchDeleteRumMetricDefinitionsRequest,
   BatchDeleteRumMetricDefinitionsResponse,
   BatchDeleteRumMetricDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteRumMetricDefinitionsRequest,
   output: BatchDeleteRumMetricDefinitionsResponse,
@@ -1282,7 +1281,7 @@ export const batchGetRumMetricDefinitions: API.PaginatedOperationMethod<
   BatchGetRumMetricDefinitionsRequest,
   BatchGetRumMetricDefinitionsResponse,
   BatchGetRumMetricDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetRumMetricDefinitionsRequest,
@@ -1324,7 +1323,7 @@ export const createAppMonitor: API.OperationMethod<
   CreateAppMonitorRequest,
   CreateAppMonitorResponse,
   CreateAppMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppMonitorRequest,
   output: CreateAppMonitorResponse,
@@ -1357,7 +1356,7 @@ export const deleteAppMonitor: API.OperationMethod<
   DeleteAppMonitorRequest,
   DeleteAppMonitorResponse,
   DeleteAppMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppMonitorRequest,
   output: DeleteAppMonitorResponse,
@@ -1391,7 +1390,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -1425,7 +1424,7 @@ export const deleteRumMetricsDestination: API.OperationMethod<
   DeleteRumMetricsDestinationRequest,
   DeleteRumMetricsDestinationResponse,
   DeleteRumMetricsDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRumMetricsDestinationRequest,
   output: DeleteRumMetricsDestinationResponse,
@@ -1456,7 +1455,7 @@ export const getAppMonitor: API.OperationMethod<
   GetAppMonitorRequest,
   GetAppMonitorResponse,
   GetAppMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAppMonitorRequest,
   output: GetAppMonitorResponse,
@@ -1486,7 +1485,7 @@ export const getAppMonitorData: API.PaginatedOperationMethod<
   GetAppMonitorDataRequest,
   GetAppMonitorDataResponse,
   GetAppMonitorDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetAppMonitorDataRequest,
@@ -1525,7 +1524,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1556,7 +1555,7 @@ export const listAppMonitors: API.PaginatedOperationMethod<
   ListAppMonitorsRequest,
   ListAppMonitorsResponse,
   ListAppMonitorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppMonitorSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppMonitorsRequest,
@@ -1593,7 +1592,7 @@ export const listRumMetricsDestinations: API.PaginatedOperationMethod<
   ListRumMetricsDestinationsRequest,
   ListRumMetricsDestinationsResponse,
   ListRumMetricsDestinationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetricDestinationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRumMetricsDestinationsRequest,
@@ -1627,7 +1626,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1659,7 +1658,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -1695,7 +1694,7 @@ export const putRumEvents: API.OperationMethod<
   PutRumEventsRequest,
   PutRumEventsResponse,
   PutRumEventsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRumEventsRequest,
   output: PutRumEventsResponse,
@@ -1729,7 +1728,7 @@ export const putRumMetricsDestination: API.OperationMethod<
   PutRumMetricsDestinationRequest,
   PutRumMetricsDestinationResponse,
   PutRumMetricsDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRumMetricsDestinationRequest,
   output: PutRumMetricsDestinationResponse,
@@ -1768,7 +1767,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1794,7 +1793,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1829,7 +1828,7 @@ export const updateAppMonitor: API.OperationMethod<
   UpdateAppMonitorRequest,
   UpdateAppMonitorResponse,
   UpdateAppMonitorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppMonitorRequest,
   output: UpdateAppMonitorResponse,
@@ -1862,7 +1861,7 @@ export const updateRumMetricDefinition: API.OperationMethod<
   UpdateRumMetricDefinitionRequest,
   UpdateRumMetricDefinitionResponse,
   UpdateRumMetricDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRumMetricDefinitionRequest,
   output: UpdateRumMetricDefinitionResponse,

--- a/packages/aws/src/services/s3-control.ts
+++ b/packages/aws/src/services/s3-control.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://awss3control.amazonaws.com/doc/2018-08-20/");
 const svc = T.AwsApiService({
@@ -7674,7 +7673,7 @@ export const associateAccessGrantsIdentityCenter: API.OperationMethod<
   AssociateAccessGrantsIdentityCenterRequest,
   AssociateAccessGrantsIdentityCenterResponse,
   AssociateAccessGrantsIdentityCenterError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAccessGrantsIdentityCenterRequest,
   output: AssociateAccessGrantsIdentityCenterResponse,
@@ -7705,7 +7704,7 @@ export const createAccessGrant: API.OperationMethod<
   CreateAccessGrantRequest,
   CreateAccessGrantResult,
   CreateAccessGrantError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessGrantRequest,
   output: CreateAccessGrantResult,
@@ -7732,7 +7731,7 @@ export const createAccessGrantsInstance: API.OperationMethod<
   CreateAccessGrantsInstanceRequest,
   CreateAccessGrantsInstanceResult,
   CreateAccessGrantsInstanceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessGrantsInstanceRequest,
   output: CreateAccessGrantsInstanceResult,
@@ -7767,7 +7766,7 @@ export const createAccessGrantsLocation: API.OperationMethod<
   CreateAccessGrantsLocationRequest,
   CreateAccessGrantsLocationResult,
   CreateAccessGrantsLocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessGrantsLocationRequest,
   output: CreateAccessGrantsLocationResult,
@@ -7814,7 +7813,7 @@ export const createAccessPoint: API.OperationMethod<
   CreateAccessPointRequest,
   CreateAccessPointResult,
   CreateAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPointRequest,
   output: CreateAccessPointResult,
@@ -7850,7 +7849,7 @@ export const createAccessPointForObjectLambda: API.OperationMethod<
   CreateAccessPointForObjectLambdaRequest,
   CreateAccessPointForObjectLambdaResult,
   CreateAccessPointForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPointForObjectLambdaRequest,
   output: CreateAccessPointForObjectLambdaResult,
@@ -7913,7 +7912,7 @@ export const createBucket: API.OperationMethod<
   CreateBucketRequest,
   CreateBucketResult,
   CreateBucketError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketRequest,
   output: CreateBucketResult,
@@ -7958,7 +7957,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResult,
   CreateJobError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResult,
@@ -8005,7 +8004,7 @@ export const createMultiRegionAccessPoint: API.OperationMethod<
   CreateMultiRegionAccessPointRequest,
   CreateMultiRegionAccessPointResult,
   CreateMultiRegionAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultiRegionAccessPointRequest,
   output: CreateMultiRegionAccessPointResult,
@@ -8038,7 +8037,7 @@ export const createStorageLensGroup: API.OperationMethod<
   CreateStorageLensGroupRequest,
   CreateStorageLensGroupResponse,
   CreateStorageLensGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorageLensGroupRequest,
   output: CreateStorageLensGroupResponse,
@@ -8061,7 +8060,7 @@ export const deleteAccessGrant: API.OperationMethod<
   DeleteAccessGrantRequest,
   DeleteAccessGrantResponse,
   DeleteAccessGrantError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessGrantRequest,
   output: DeleteAccessGrantResponse,
@@ -8084,7 +8083,7 @@ export const deleteAccessGrantsInstance: API.OperationMethod<
   DeleteAccessGrantsInstanceRequest,
   DeleteAccessGrantsInstanceResponse,
   DeleteAccessGrantsInstanceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessGrantsInstanceRequest,
   output: DeleteAccessGrantsInstanceResponse,
@@ -8107,7 +8106,7 @@ export const deleteAccessGrantsInstanceResourcePolicy: API.OperationMethod<
   DeleteAccessGrantsInstanceResourcePolicyRequest,
   DeleteAccessGrantsInstanceResourcePolicyResponse,
   DeleteAccessGrantsInstanceResourcePolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessGrantsInstanceResourcePolicyRequest,
   output: DeleteAccessGrantsInstanceResourcePolicyResponse,
@@ -8130,7 +8129,7 @@ export const deleteAccessGrantsLocation: API.OperationMethod<
   DeleteAccessGrantsLocationRequest,
   DeleteAccessGrantsLocationResponse,
   DeleteAccessGrantsLocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessGrantsLocationRequest,
   output: DeleteAccessGrantsLocationResponse,
@@ -8159,7 +8158,7 @@ export const deleteAccessPoint: API.OperationMethod<
   DeleteAccessPointRequest,
   DeleteAccessPointResponse,
   DeleteAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointRequest,
   output: DeleteAccessPointResponse,
@@ -8191,7 +8190,7 @@ export const deleteAccessPointForObjectLambda: API.OperationMethod<
   DeleteAccessPointForObjectLambdaRequest,
   DeleteAccessPointForObjectLambdaResponse,
   DeleteAccessPointForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointForObjectLambdaRequest,
   output: DeleteAccessPointForObjectLambdaResponse,
@@ -8221,7 +8220,7 @@ export const deleteAccessPointPolicy: API.OperationMethod<
   DeleteAccessPointPolicyRequest,
   DeleteAccessPointPolicyResponse,
   DeleteAccessPointPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointPolicyRequest,
   output: DeleteAccessPointPolicyResponse,
@@ -8252,7 +8251,7 @@ export const deleteAccessPointPolicyForObjectLambda: API.OperationMethod<
   DeleteAccessPointPolicyForObjectLambdaRequest,
   DeleteAccessPointPolicyForObjectLambdaResponse,
   DeleteAccessPointPolicyForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointPolicyForObjectLambdaRequest,
   output: DeleteAccessPointPolicyForObjectLambdaResponse,
@@ -8278,7 +8277,7 @@ export const deleteAccessPointScope: API.OperationMethod<
   DeleteAccessPointScopeRequest,
   DeleteAccessPointScopeResponse,
   DeleteAccessPointScopeError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointScopeRequest,
   output: DeleteAccessPointScopeResponse,
@@ -8311,7 +8310,7 @@ export const deleteBucket: API.OperationMethod<
   DeleteBucketRequest,
   DeleteBucketResponse,
   DeleteBucketError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketRequest,
   output: DeleteBucketResponse,
@@ -8353,7 +8352,7 @@ export const deleteBucketLifecycleConfiguration: API.OperationMethod<
   DeleteBucketLifecycleConfigurationRequest,
   DeleteBucketLifecycleConfigurationResponse,
   DeleteBucketLifecycleConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketLifecycleConfigurationRequest,
   output: DeleteBucketLifecycleConfigurationResponse,
@@ -8401,7 +8400,7 @@ export const deleteBucketPolicy: API.OperationMethod<
   DeleteBucketPolicyRequest,
   DeleteBucketPolicyResponse,
   DeleteBucketPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketPolicyRequest,
   output: DeleteBucketPolicyResponse,
@@ -8448,7 +8447,7 @@ export const deleteBucketReplication: API.OperationMethod<
   DeleteBucketReplicationRequest,
   DeleteBucketReplicationResponse,
   DeleteBucketReplicationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketReplicationRequest,
   output: DeleteBucketReplicationResponse,
@@ -8483,7 +8482,7 @@ export const deleteBucketTagging: API.OperationMethod<
   DeleteBucketTaggingRequest,
   DeleteBucketTaggingResponse,
   DeleteBucketTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketTaggingRequest,
   output: DeleteBucketTaggingResponse,
@@ -8522,7 +8521,7 @@ export const deleteJobTagging: API.OperationMethod<
   DeleteJobTaggingRequest,
   DeleteJobTaggingResult,
   DeleteJobTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobTaggingRequest,
   output: DeleteJobTaggingResult,
@@ -8570,7 +8569,7 @@ export const deleteMultiRegionAccessPoint: API.OperationMethod<
   DeleteMultiRegionAccessPointRequest,
   DeleteMultiRegionAccessPointResult,
   DeleteMultiRegionAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMultiRegionAccessPointRequest,
   output: DeleteMultiRegionAccessPointResult,
@@ -8603,7 +8602,7 @@ export const deletePublicAccessBlock: API.OperationMethod<
   DeletePublicAccessBlockRequest,
   DeletePublicAccessBlockResponse,
   DeletePublicAccessBlockError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublicAccessBlockRequest,
   output: DeletePublicAccessBlockResponse,
@@ -8633,7 +8632,7 @@ export const deleteStorageLensConfiguration: API.OperationMethod<
   DeleteStorageLensConfigurationRequest,
   DeleteStorageLensConfigurationResponse,
   DeleteStorageLensConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageLensConfigurationRequest,
   output: DeleteStorageLensConfigurationResponse,
@@ -8664,7 +8663,7 @@ export const deleteStorageLensConfigurationTagging: API.OperationMethod<
   DeleteStorageLensConfigurationTaggingRequest,
   DeleteStorageLensConfigurationTaggingResult,
   DeleteStorageLensConfigurationTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageLensConfigurationTaggingRequest,
   output: DeleteStorageLensConfigurationTaggingResult,
@@ -8690,7 +8689,7 @@ export const deleteStorageLensGroup: API.OperationMethod<
   DeleteStorageLensGroupRequest,
   DeleteStorageLensGroupResponse,
   DeleteStorageLensGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStorageLensGroupRequest,
   output: DeleteStorageLensGroupResponse,
@@ -8729,7 +8728,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobRequest,
   DescribeJobResult,
   DescribeJobError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRequest,
   output: DescribeJobResult,
@@ -8768,7 +8767,7 @@ export const describeMultiRegionAccessPointOperation: API.OperationMethod<
   DescribeMultiRegionAccessPointOperationRequest,
   DescribeMultiRegionAccessPointOperationResult,
   DescribeMultiRegionAccessPointOperationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMultiRegionAccessPointOperationRequest,
   output: DescribeMultiRegionAccessPointOperationResult,
@@ -8795,7 +8794,7 @@ export const dissociateAccessGrantsIdentityCenter: API.OperationMethod<
   DissociateAccessGrantsIdentityCenterRequest,
   DissociateAccessGrantsIdentityCenterResponse,
   DissociateAccessGrantsIdentityCenterError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DissociateAccessGrantsIdentityCenterRequest,
   output: DissociateAccessGrantsIdentityCenterResponse,
@@ -8818,7 +8817,7 @@ export const getAccessGrant: API.OperationMethod<
   GetAccessGrantRequest,
   GetAccessGrantResult,
   GetAccessGrantError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessGrantRequest,
   output: GetAccessGrantResult,
@@ -8843,7 +8842,7 @@ export const getAccessGrantsInstance: API.OperationMethod<
   GetAccessGrantsInstanceRequest,
   GetAccessGrantsInstanceResult,
   GetAccessGrantsInstanceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessGrantsInstanceRequest,
   output: GetAccessGrantsInstanceResult,
@@ -8870,7 +8869,7 @@ export const getAccessGrantsInstanceForPrefix: API.OperationMethod<
   GetAccessGrantsInstanceForPrefixRequest,
   GetAccessGrantsInstanceForPrefixResult,
   GetAccessGrantsInstanceForPrefixError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessGrantsInstanceForPrefixRequest,
   output: GetAccessGrantsInstanceForPrefixResult,
@@ -8893,7 +8892,7 @@ export const getAccessGrantsInstanceResourcePolicy: API.OperationMethod<
   GetAccessGrantsInstanceResourcePolicyRequest,
   GetAccessGrantsInstanceResourcePolicyResult,
   GetAccessGrantsInstanceResourcePolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessGrantsInstanceResourcePolicyRequest,
   output: GetAccessGrantsInstanceResourcePolicyResult,
@@ -8916,7 +8915,7 @@ export const getAccessGrantsLocation: API.OperationMethod<
   GetAccessGrantsLocationRequest,
   GetAccessGrantsLocationResult,
   GetAccessGrantsLocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessGrantsLocationRequest,
   output: GetAccessGrantsLocationResult,
@@ -8945,7 +8944,7 @@ export const getAccessPoint: API.OperationMethod<
   GetAccessPointRequest,
   GetAccessPointResult,
   GetAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointRequest,
   output: GetAccessPointResult,
@@ -8973,7 +8972,7 @@ export const getAccessPointConfigurationForObjectLambda: API.OperationMethod<
   GetAccessPointConfigurationForObjectLambdaRequest,
   GetAccessPointConfigurationForObjectLambdaResult,
   GetAccessPointConfigurationForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointConfigurationForObjectLambdaRequest,
   output: GetAccessPointConfigurationForObjectLambdaResult,
@@ -9004,7 +9003,7 @@ export const getAccessPointForObjectLambda: API.OperationMethod<
   GetAccessPointForObjectLambdaRequest,
   GetAccessPointForObjectLambdaResult,
   GetAccessPointForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointForObjectLambdaRequest,
   output: GetAccessPointForObjectLambdaResult,
@@ -9032,7 +9031,7 @@ export const getAccessPointPolicy: API.OperationMethod<
   GetAccessPointPolicyRequest,
   GetAccessPointPolicyResult,
   GetAccessPointPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointPolicyRequest,
   output: GetAccessPointPolicyResult,
@@ -9063,7 +9062,7 @@ export const getAccessPointPolicyForObjectLambda: API.OperationMethod<
   GetAccessPointPolicyForObjectLambdaRequest,
   GetAccessPointPolicyForObjectLambdaResult,
   GetAccessPointPolicyForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointPolicyForObjectLambdaRequest,
   output: GetAccessPointPolicyForObjectLambdaResult,
@@ -9089,7 +9088,7 @@ export const getAccessPointPolicyStatus: API.OperationMethod<
   GetAccessPointPolicyStatusRequest,
   GetAccessPointPolicyStatusResult,
   GetAccessPointPolicyStatusError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointPolicyStatusRequest,
   output: GetAccessPointPolicyStatusResult,
@@ -9110,7 +9109,7 @@ export const getAccessPointPolicyStatusForObjectLambda: API.OperationMethod<
   GetAccessPointPolicyStatusForObjectLambdaRequest,
   GetAccessPointPolicyStatusForObjectLambdaResult,
   GetAccessPointPolicyStatusForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointPolicyStatusForObjectLambdaRequest,
   output: GetAccessPointPolicyStatusForObjectLambdaResult,
@@ -9134,7 +9133,7 @@ export const getAccessPointScope: API.OperationMethod<
   GetAccessPointScopeRequest,
   GetAccessPointScopeResult,
   GetAccessPointScopeError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointScopeRequest,
   output: GetAccessPointScopeResult,
@@ -9173,7 +9172,7 @@ export const getBucket: API.OperationMethod<
   GetBucketRequest,
   GetBucketResult,
   GetBucketError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketRequest,
   output: GetBucketResult,
@@ -9223,7 +9222,7 @@ export const getBucketLifecycleConfiguration: API.OperationMethod<
   GetBucketLifecycleConfigurationRequest,
   GetBucketLifecycleConfigurationResult,
   GetBucketLifecycleConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketLifecycleConfigurationRequest,
   output: GetBucketLifecycleConfigurationResult,
@@ -9274,7 +9273,7 @@ export const getBucketPolicy: API.OperationMethod<
   GetBucketPolicyRequest,
   GetBucketPolicyResult,
   GetBucketPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketPolicyRequest,
   output: GetBucketPolicyResult,
@@ -9329,7 +9328,7 @@ export const getBucketReplication: API.OperationMethod<
   GetBucketReplicationRequest,
   GetBucketReplicationResult,
   GetBucketReplicationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketReplicationRequest,
   output: GetBucketReplicationResult,
@@ -9371,7 +9370,7 @@ export const getBucketTagging: API.OperationMethod<
   GetBucketTaggingRequest,
   GetBucketTaggingResult,
   GetBucketTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketTaggingRequest,
   output: GetBucketTaggingResult,
@@ -9419,7 +9418,7 @@ export const getBucketVersioning: API.OperationMethod<
   GetBucketVersioningRequest,
   GetBucketVersioningResult,
   GetBucketVersioningError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketVersioningRequest,
   output: GetBucketVersioningResult,
@@ -9446,7 +9445,7 @@ export const getDataAccess: API.OperationMethod<
   GetDataAccessRequest,
   GetDataAccessResult,
   GetDataAccessError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataAccessRequest,
   output: GetDataAccessResult,
@@ -9485,7 +9484,7 @@ export const getJobTagging: API.OperationMethod<
   GetJobTaggingRequest,
   GetJobTaggingResult,
   GetJobTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobTaggingRequest,
   output: GetJobTaggingResult,
@@ -9526,7 +9525,7 @@ export const getMultiRegionAccessPoint: API.OperationMethod<
   GetMultiRegionAccessPointRequest,
   GetMultiRegionAccessPointResult,
   GetMultiRegionAccessPointError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMultiRegionAccessPointRequest,
   output: GetMultiRegionAccessPointResult,
@@ -9560,7 +9559,7 @@ export const getMultiRegionAccessPointPolicy: API.OperationMethod<
   GetMultiRegionAccessPointPolicyRequest,
   GetMultiRegionAccessPointPolicyResult,
   GetMultiRegionAccessPointPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMultiRegionAccessPointPolicyRequest,
   output: GetMultiRegionAccessPointPolicyResult,
@@ -9593,7 +9592,7 @@ export const getMultiRegionAccessPointPolicyStatus: API.OperationMethod<
   GetMultiRegionAccessPointPolicyStatusRequest,
   GetMultiRegionAccessPointPolicyStatusResult,
   GetMultiRegionAccessPointPolicyStatusError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMultiRegionAccessPointPolicyStatusRequest,
   output: GetMultiRegionAccessPointPolicyStatusResult,
@@ -9628,7 +9627,7 @@ export const getMultiRegionAccessPointRoutes: API.OperationMethod<
   GetMultiRegionAccessPointRoutesRequest,
   GetMultiRegionAccessPointRoutesResult,
   GetMultiRegionAccessPointRoutesError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMultiRegionAccessPointRoutesRequest,
   output: GetMultiRegionAccessPointRoutesResult,
@@ -9660,7 +9659,7 @@ export const getPublicAccessBlock: API.OperationMethod<
   GetPublicAccessBlockRequest,
   GetPublicAccessBlockOutput,
   GetPublicAccessBlockError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicAccessBlockRequest,
   output: GetPublicAccessBlockOutput,
@@ -9689,7 +9688,7 @@ export const getStorageLensConfiguration: API.OperationMethod<
   GetStorageLensConfigurationRequest,
   GetStorageLensConfigurationResult,
   GetStorageLensConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageLensConfigurationRequest,
   output: GetStorageLensConfigurationResult,
@@ -9720,7 +9719,7 @@ export const getStorageLensConfigurationTagging: API.OperationMethod<
   GetStorageLensConfigurationTaggingRequest,
   GetStorageLensConfigurationTaggingResult,
   GetStorageLensConfigurationTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageLensConfigurationTaggingRequest,
   output: GetStorageLensConfigurationTaggingResult,
@@ -9746,7 +9745,7 @@ export const getStorageLensGroup: API.OperationMethod<
   GetStorageLensGroupRequest,
   GetStorageLensGroupResult,
   GetStorageLensGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetStorageLensGroupRequest,
   output: GetStorageLensGroupResult,
@@ -9769,7 +9768,7 @@ export const listAccessGrants: API.PaginatedOperationMethod<
   ListAccessGrantsRequest,
   ListAccessGrantsResult,
   ListAccessGrantsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessGrantsRequest,
@@ -9798,7 +9797,7 @@ export const listAccessGrantsInstances: API.PaginatedOperationMethod<
   ListAccessGrantsInstancesRequest,
   ListAccessGrantsInstancesResult,
   ListAccessGrantsInstancesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessGrantsInstancesRequest,
@@ -9827,7 +9826,7 @@ export const listAccessGrantsLocations: API.PaginatedOperationMethod<
   ListAccessGrantsLocationsRequest,
   ListAccessGrantsLocationsResult,
   ListAccessGrantsLocationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessGrantsLocationsRequest,
@@ -9870,7 +9869,7 @@ export const listAccessPoints: API.PaginatedOperationMethod<
   ListAccessPointsRequest,
   ListAccessPointsResult,
   ListAccessPointsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPointsRequest,
@@ -9902,7 +9901,7 @@ export const listAccessPointsForDirectoryBuckets: API.PaginatedOperationMethod<
   ListAccessPointsForDirectoryBucketsRequest,
   ListAccessPointsForDirectoryBucketsResult,
   ListAccessPointsForDirectoryBucketsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AccessPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPointsForDirectoryBucketsRequest,
@@ -9940,7 +9939,7 @@ export const listAccessPointsForObjectLambda: API.PaginatedOperationMethod<
   ListAccessPointsForObjectLambdaRequest,
   ListAccessPointsForObjectLambdaResult,
   ListAccessPointsForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ObjectLambdaAccessPoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPointsForObjectLambdaRequest,
@@ -9970,7 +9969,7 @@ export const listCallerAccessGrants: API.PaginatedOperationMethod<
   ListCallerAccessGrantsRequest,
   ListCallerAccessGrantsResult,
   ListCallerAccessGrantsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ListCallerAccessGrantsEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCallerAccessGrantsRequest,
@@ -10017,7 +10016,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResult,
   ListJobsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -10064,7 +10063,7 @@ export const listMultiRegionAccessPoints: API.PaginatedOperationMethod<
   ListMultiRegionAccessPointsRequest,
   ListMultiRegionAccessPointsResult,
   ListMultiRegionAccessPointsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultiRegionAccessPointsRequest,
@@ -10096,7 +10095,7 @@ export const listRegionalBuckets: API.PaginatedOperationMethod<
   ListRegionalBucketsRequest,
   ListRegionalBucketsResult,
   ListRegionalBucketsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegionalBucketsRequest,
@@ -10131,7 +10130,7 @@ export const listStorageLensConfigurations: API.PaginatedOperationMethod<
   ListStorageLensConfigurationsRequest,
   ListStorageLensConfigurationsResult,
   ListStorageLensConfigurationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStorageLensConfigurationsRequest,
@@ -10159,7 +10158,7 @@ export const listStorageLensGroups: API.PaginatedOperationMethod<
   ListStorageLensGroupsRequest,
   ListStorageLensGroupsResult,
   ListStorageLensGroupsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStorageLensGroupsRequest,
@@ -10208,7 +10207,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -10231,7 +10230,7 @@ export const putAccessGrantsInstanceResourcePolicy: API.OperationMethod<
   PutAccessGrantsInstanceResourcePolicyRequest,
   PutAccessGrantsInstanceResourcePolicyResult,
   PutAccessGrantsInstanceResourcePolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessGrantsInstanceResourcePolicyRequest,
   output: PutAccessGrantsInstanceResourcePolicyResult,
@@ -10260,7 +10259,7 @@ export const putAccessPointConfigurationForObjectLambda: API.OperationMethod<
   PutAccessPointConfigurationForObjectLambdaRequest,
   PutAccessPointConfigurationForObjectLambdaResponse,
   PutAccessPointConfigurationForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessPointConfigurationForObjectLambdaRequest,
   output: PutAccessPointConfigurationForObjectLambdaResponse,
@@ -10292,7 +10291,7 @@ export const putAccessPointPolicy: API.OperationMethod<
   PutAccessPointPolicyRequest,
   PutAccessPointPolicyResponse,
   PutAccessPointPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessPointPolicyRequest,
   output: PutAccessPointPolicyResponse,
@@ -10323,7 +10322,7 @@ export const putAccessPointPolicyForObjectLambda: API.OperationMethod<
   PutAccessPointPolicyForObjectLambdaRequest,
   PutAccessPointPolicyForObjectLambdaResponse,
   PutAccessPointPolicyForObjectLambdaError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessPointPolicyForObjectLambdaRequest,
   output: PutAccessPointPolicyForObjectLambdaResponse,
@@ -10349,7 +10348,7 @@ export const putAccessPointScope: API.OperationMethod<
   PutAccessPointScopeRequest,
   PutAccessPointScopeResponse,
   PutAccessPointScopeError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessPointScopeRequest,
   output: PutAccessPointScopeResponse,
@@ -10382,7 +10381,7 @@ export const putBucketLifecycleConfiguration: API.OperationMethod<
   PutBucketLifecycleConfigurationRequest,
   PutBucketLifecycleConfigurationResponse,
   PutBucketLifecycleConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketLifecycleConfigurationRequest,
   output: PutBucketLifecycleConfigurationResponse,
@@ -10431,7 +10430,7 @@ export const putBucketPolicy: API.OperationMethod<
   PutBucketPolicyRequest,
   PutBucketPolicyResponse,
   PutBucketPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketPolicyRequest,
   output: PutBucketPolicyResponse,
@@ -10522,7 +10521,7 @@ export const putBucketReplication: API.OperationMethod<
   PutBucketReplicationRequest,
   PutBucketReplicationResponse,
   PutBucketReplicationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketReplicationRequest,
   output: PutBucketReplicationResponse,
@@ -10595,7 +10594,7 @@ export const putBucketTagging: API.OperationMethod<
   PutBucketTaggingRequest,
   PutBucketTaggingResponse,
   PutBucketTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketTaggingRequest,
   output: PutBucketTaggingResponse,
@@ -10663,7 +10662,7 @@ export const putBucketVersioning: API.OperationMethod<
   PutBucketVersioningRequest,
   PutBucketVersioningResponse,
   PutBucketVersioningError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketVersioningRequest,
   output: PutBucketVersioningResponse,
@@ -10730,7 +10729,7 @@ export const putJobTagging: API.OperationMethod<
   PutJobTaggingRequest,
   PutJobTaggingResult,
   PutJobTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutJobTaggingRequest,
   output: PutJobTaggingResult,
@@ -10772,7 +10771,7 @@ export const putMultiRegionAccessPointPolicy: API.OperationMethod<
   PutMultiRegionAccessPointPolicyRequest,
   PutMultiRegionAccessPointPolicyResult,
   PutMultiRegionAccessPointPolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMultiRegionAccessPointPolicyRequest,
   output: PutMultiRegionAccessPointPolicyResult,
@@ -10806,7 +10805,7 @@ export const putPublicAccessBlock: API.OperationMethod<
   PutPublicAccessBlockRequest,
   PutPublicAccessBlockResponse,
   PutPublicAccessBlockError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPublicAccessBlockRequest,
   output: PutPublicAccessBlockResponse,
@@ -10835,7 +10834,7 @@ export const putStorageLensConfiguration: API.OperationMethod<
   PutStorageLensConfigurationRequest,
   PutStorageLensConfigurationResponse,
   PutStorageLensConfigurationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutStorageLensConfigurationRequest,
   output: PutStorageLensConfigurationResponse,
@@ -10865,7 +10864,7 @@ export const putStorageLensConfigurationTagging: API.OperationMethod<
   PutStorageLensConfigurationTaggingRequest,
   PutStorageLensConfigurationTaggingResult,
   PutStorageLensConfigurationTaggingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutStorageLensConfigurationTaggingRequest,
   output: PutStorageLensConfigurationTaggingResult,
@@ -10912,7 +10911,7 @@ export const submitMultiRegionAccessPointRoutes: API.OperationMethod<
   SubmitMultiRegionAccessPointRoutesRequest,
   SubmitMultiRegionAccessPointRoutesResult,
   SubmitMultiRegionAccessPointRoutesError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubmitMultiRegionAccessPointRoutesRequest,
   output: SubmitMultiRegionAccessPointRoutesResult,
@@ -10959,7 +10958,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -11007,7 +11006,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -11034,7 +11033,7 @@ export const updateAccessGrantsLocation: API.OperationMethod<
   UpdateAccessGrantsLocationRequest,
   UpdateAccessGrantsLocationResult,
   UpdateAccessGrantsLocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessGrantsLocationRequest,
   output: UpdateAccessGrantsLocationResult,
@@ -11076,7 +11075,7 @@ export const updateJobPriority: API.OperationMethod<
   UpdateJobPriorityRequest,
   UpdateJobPriorityResult,
   UpdateJobPriorityError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobPriorityRequest,
   output: UpdateJobPriorityResult,
@@ -11127,7 +11126,7 @@ export const updateJobStatus: API.OperationMethod<
   UpdateJobStatusRequest,
   UpdateJobStatusResult,
   UpdateJobStatusError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobStatusRequest,
   output: UpdateJobStatusResult,
@@ -11161,7 +11160,7 @@ export const updateStorageLensGroup: API.OperationMethod<
   UpdateStorageLensGroupRequest,
   UpdateStorageLensGroupResponse,
   UpdateStorageLensGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStorageLensGroupRequest,
   output: UpdateStorageLensGroupResponse,

--- a/packages/aws/src/services/s3.ts
+++ b/packages/aws/src/services/s3.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://s3.amazonaws.com/doc/2006-03-01/");
 const svc = T.AwsApiService({ sdkId: "S3", serviceShapeName: "AmazonS3" });
@@ -13112,7 +13111,7 @@ export const abortMultipartUpload: API.OperationMethod<
   AbortMultipartUploadRequest,
   AbortMultipartUploadOutput,
   AbortMultipartUploadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortMultipartUploadRequest,
   output: AbortMultipartUploadOutput,
@@ -13246,7 +13245,7 @@ export const completeMultipartUpload: API.OperationMethod<
   CompleteMultipartUploadRequest,
   CompleteMultipartUploadOutput,
   CompleteMultipartUploadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteMultipartUploadRequest,
   output: CompleteMultipartUploadOutput,
@@ -13428,7 +13427,7 @@ export const copyObject: API.OperationMethod<
   CopyObjectRequest,
   CopyObjectOutput,
   CopyObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyObjectRequest,
   output: CopyObjectOutput,
@@ -13572,7 +13571,7 @@ export const createBucket: API.OperationMethod<
   CreateBucketRequest,
   CreateBucketOutput,
   CreateBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketRequest,
   output: CreateBucketOutput,
@@ -13664,7 +13663,7 @@ export const createBucketMetadataConfiguration: API.OperationMethod<
   CreateBucketMetadataConfigurationRequest,
   CreateBucketMetadataConfigurationResponse,
   CreateBucketMetadataConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketMetadataConfigurationRequest,
   output: CreateBucketMetadataConfigurationResponse,
@@ -13727,7 +13726,7 @@ export const createBucketMetadataTableConfiguration: API.OperationMethod<
   CreateBucketMetadataTableConfigurationRequest,
   CreateBucketMetadataTableConfigurationResponse,
   CreateBucketMetadataTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBucketMetadataTableConfigurationRequest,
   output: CreateBucketMetadataTableConfigurationResponse,
@@ -13921,7 +13920,7 @@ export const createMultipartUpload: API.OperationMethod<
   CreateMultipartUploadRequest,
   CreateMultipartUploadOutput,
   CreateMultipartUploadError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultipartUploadRequest,
   output: CreateMultipartUploadOutput,
@@ -14031,7 +14030,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionOutput,
   CreateSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionOutput,
@@ -14088,7 +14087,7 @@ export const deleteBucket: API.OperationMethod<
   DeleteBucketRequest,
   DeleteBucketResponse,
   DeleteBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketRequest,
   output: DeleteBucketResponse,
@@ -14138,7 +14137,7 @@ export const deleteBucketAnalyticsConfiguration: API.OperationMethod<
   DeleteBucketAnalyticsConfigurationRequest,
   DeleteBucketAnalyticsConfigurationResponse,
   DeleteBucketAnalyticsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketAnalyticsConfigurationRequest,
   output: DeleteBucketAnalyticsConfigurationResponse,
@@ -14176,7 +14175,7 @@ export const deleteBucketCors: API.OperationMethod<
   DeleteBucketCorsRequest,
   DeleteBucketCorsResponse,
   DeleteBucketCorsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketCorsRequest,
   output: DeleteBucketCorsResponse,
@@ -14233,7 +14232,7 @@ export const deleteBucketEncryption: API.OperationMethod<
   DeleteBucketEncryptionRequest,
   DeleteBucketEncryptionResponse,
   DeleteBucketEncryptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketEncryptionRequest,
   output: DeleteBucketEncryptionResponse,
@@ -14273,7 +14272,7 @@ export const deleteBucketIntelligentTieringConfiguration: API.OperationMethod<
   DeleteBucketIntelligentTieringConfigurationRequest,
   DeleteBucketIntelligentTieringConfigurationResponse,
   DeleteBucketIntelligentTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketIntelligentTieringConfigurationRequest,
   output: DeleteBucketIntelligentTieringConfigurationResponse,
@@ -14337,7 +14336,7 @@ export const deleteBucketInventoryConfiguration: API.OperationMethod<
   DeleteBucketInventoryConfigurationRequest,
   DeleteBucketInventoryConfigurationResponse,
   DeleteBucketInventoryConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketInventoryConfigurationRequest,
   output: DeleteBucketInventoryConfigurationResponse,
@@ -14405,7 +14404,7 @@ export const deleteBucketLifecycle: API.OperationMethod<
   DeleteBucketLifecycleRequest,
   DeleteBucketLifecycleResponse,
   DeleteBucketLifecycleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketLifecycleRequest,
   output: DeleteBucketLifecycleResponse,
@@ -14455,7 +14454,7 @@ export const deleteBucketMetadataConfiguration: API.OperationMethod<
   DeleteBucketMetadataConfigurationRequest,
   DeleteBucketMetadataConfigurationResponse,
   DeleteBucketMetadataConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketMetadataConfigurationRequest,
   output: DeleteBucketMetadataConfigurationResponse,
@@ -14511,7 +14510,7 @@ export const deleteBucketMetadataTableConfiguration: API.OperationMethod<
   DeleteBucketMetadataTableConfigurationRequest,
   DeleteBucketMetadataTableConfigurationResponse,
   DeleteBucketMetadataTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketMetadataTableConfigurationRequest,
   output: DeleteBucketMetadataTableConfigurationResponse,
@@ -14576,7 +14575,7 @@ export const deleteBucketMetricsConfiguration: API.OperationMethod<
   DeleteBucketMetricsConfigurationRequest,
   DeleteBucketMetricsConfigurationResponse,
   DeleteBucketMetricsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketMetricsConfigurationRequest,
   output: DeleteBucketMetricsConfigurationResponse,
@@ -14613,7 +14612,7 @@ export const deleteBucketOwnershipControls: API.OperationMethod<
   DeleteBucketOwnershipControlsRequest,
   DeleteBucketOwnershipControlsResponse,
   DeleteBucketOwnershipControlsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketOwnershipControlsRequest,
   output: DeleteBucketOwnershipControlsResponse,
@@ -14683,7 +14682,7 @@ export const deleteBucketPolicy: API.OperationMethod<
   DeleteBucketPolicyRequest,
   DeleteBucketPolicyResponse,
   DeleteBucketPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketPolicyRequest,
   output: DeleteBucketPolicyResponse,
@@ -14731,7 +14730,7 @@ export const deleteBucketReplication: API.OperationMethod<
   DeleteBucketReplicationRequest,
   DeleteBucketReplicationResponse,
   DeleteBucketReplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketReplicationRequest,
   output: DeleteBucketReplicationResponse,
@@ -14766,7 +14765,7 @@ export const deleteBucketTagging: API.OperationMethod<
   DeleteBucketTaggingRequest,
   DeleteBucketTaggingResponse,
   DeleteBucketTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketTaggingRequest,
   output: DeleteBucketTaggingResponse,
@@ -14809,7 +14808,7 @@ export const deleteBucketWebsite: API.OperationMethod<
   DeleteBucketWebsiteRequest,
   DeleteBucketWebsiteResponse,
   DeleteBucketWebsiteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketWebsiteRequest,
   output: DeleteBucketWebsiteResponse,
@@ -14920,7 +14919,7 @@ export const deleteObject: API.OperationMethod<
   DeleteObjectRequest,
   DeleteObjectOutput,
   DeleteObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectRequest,
   output: DeleteObjectOutput,
@@ -14968,7 +14967,7 @@ export const deleteObjectAnnotation: API.OperationMethod<
   DeleteObjectAnnotationRequest,
   DeleteObjectAnnotationOutput,
   DeleteObjectAnnotationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectAnnotationRequest,
   output: DeleteObjectAnnotationOutput,
@@ -15080,7 +15079,7 @@ export const deleteObjects: API.OperationMethod<
   DeleteObjectsRequest,
   DeleteObjectsOutput,
   DeleteObjectsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectsRequest,
   output: DeleteObjectsOutput,
@@ -15121,7 +15120,7 @@ export const deleteObjectTagging: API.OperationMethod<
   DeleteObjectTaggingRequest,
   DeleteObjectTaggingOutput,
   DeleteObjectTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteObjectTaggingRequest,
   output: DeleteObjectTaggingOutput,
@@ -15163,7 +15162,7 @@ export const deletePublicAccessBlock: API.OperationMethod<
   DeletePublicAccessBlockRequest,
   DeletePublicAccessBlockResponse,
   DeletePublicAccessBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePublicAccessBlockRequest,
   output: DeletePublicAccessBlockResponse,
@@ -15185,7 +15184,7 @@ export const getBucketAbac: API.OperationMethod<
   GetBucketAbacRequest,
   GetBucketAbacOutput,
   GetBucketAbacError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketAbacRequest,
   output: GetBucketAbacOutput,
@@ -15234,7 +15233,7 @@ export const getBucketAccelerateConfiguration: API.OperationMethod<
   GetBucketAccelerateConfigurationRequest,
   GetBucketAccelerateConfigurationOutput,
   GetBucketAccelerateConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketAccelerateConfigurationRequest,
   output: GetBucketAccelerateConfigurationOutput,
@@ -15281,7 +15280,7 @@ export const getBucketAcl: API.OperationMethod<
   GetBucketAclRequest,
   GetBucketAclOutput,
   GetBucketAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketAclRequest,
   output: GetBucketAclOutput,
@@ -15325,7 +15324,7 @@ export const getBucketAnalyticsConfiguration: API.OperationMethod<
   GetBucketAnalyticsConfigurationRequest,
   GetBucketAnalyticsConfigurationOutput,
   GetBucketAnalyticsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketAnalyticsConfigurationRequest,
   output: GetBucketAnalyticsConfigurationOutput,
@@ -15372,7 +15371,7 @@ export const getBucketCors: API.OperationMethod<
   GetBucketCorsRequest,
   GetBucketCorsOutput,
   GetBucketCorsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketCorsRequest,
   output: GetBucketCorsOutput,
@@ -15437,7 +15436,7 @@ export const getBucketEncryption: API.OperationMethod<
   GetBucketEncryptionRequest,
   GetBucketEncryptionOutput,
   GetBucketEncryptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketEncryptionRequest,
   output: GetBucketEncryptionOutput,
@@ -15484,7 +15483,7 @@ export const getBucketIntelligentTieringConfiguration: API.OperationMethod<
   GetBucketIntelligentTieringConfigurationRequest,
   GetBucketIntelligentTieringConfigurationOutput,
   GetBucketIntelligentTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketIntelligentTieringConfigurationRequest,
   output: GetBucketIntelligentTieringConfigurationOutput,
@@ -15547,7 +15546,7 @@ export const getBucketInventoryConfiguration: API.OperationMethod<
   GetBucketInventoryConfigurationRequest,
   GetBucketInventoryConfigurationOutput,
   GetBucketInventoryConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketInventoryConfigurationRequest,
   output: GetBucketInventoryConfigurationOutput,
@@ -15634,7 +15633,7 @@ export const getBucketLifecycleConfiguration: API.OperationMethod<
   GetBucketLifecycleConfigurationRequest,
   GetBucketLifecycleConfigurationOutput,
   GetBucketLifecycleConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketLifecycleConfigurationRequest,
   output: GetBucketLifecycleConfigurationOutput,
@@ -15694,7 +15693,7 @@ export const getBucketLocation: API.OperationMethod<
   GetBucketLocationRequest,
   GetBucketLocationOutput,
   GetBucketLocationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketLocationRequest,
   output: GetBucketLocationOutput,
@@ -15728,7 +15727,7 @@ export const getBucketLogging: API.OperationMethod<
   GetBucketLoggingRequest,
   GetBucketLoggingOutput,
   GetBucketLoggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketLoggingRequest,
   output: GetBucketLoggingOutput,
@@ -15777,7 +15776,7 @@ export const getBucketMetadataConfiguration: API.OperationMethod<
   GetBucketMetadataConfigurationRequest,
   GetBucketMetadataConfigurationOutput,
   GetBucketMetadataConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketMetadataConfigurationRequest,
   output: GetBucketMetadataConfigurationOutput,
@@ -15832,7 +15831,7 @@ export const getBucketMetadataTableConfiguration: API.OperationMethod<
   GetBucketMetadataTableConfigurationRequest,
   GetBucketMetadataTableConfigurationOutput,
   GetBucketMetadataTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketMetadataTableConfigurationRequest,
   output: GetBucketMetadataTableConfigurationOutput,
@@ -15899,7 +15898,7 @@ export const getBucketMetricsConfiguration: API.OperationMethod<
   GetBucketMetricsConfigurationRequest,
   GetBucketMetricsConfigurationOutput,
   GetBucketMetricsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketMetricsConfigurationRequest,
   output: GetBucketMetricsConfigurationOutput,
@@ -15947,7 +15946,7 @@ export const getBucketNotificationConfiguration: API.OperationMethod<
   GetBucketNotificationConfigurationRequest,
   NotificationConfiguration,
   GetBucketNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketNotificationConfigurationRequest,
   output: NotificationConfiguration,
@@ -15995,7 +15994,7 @@ export const getBucketOwnershipControls: API.OperationMethod<
   GetBucketOwnershipControlsRequest,
   GetBucketOwnershipControlsOutput,
   GetBucketOwnershipControlsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketOwnershipControlsRequest,
   output: GetBucketOwnershipControlsOutput,
@@ -16077,7 +16076,7 @@ export const getBucketPolicy: API.OperationMethod<
   GetBucketPolicyRequest,
   GetBucketPolicyOutput,
   GetBucketPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketPolicyRequest,
   output: GetBucketPolicyOutput,
@@ -16126,7 +16125,7 @@ export const getBucketPolicyStatus: API.OperationMethod<
   GetBucketPolicyStatusRequest,
   GetBucketPolicyStatusOutput,
   GetBucketPolicyStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketPolicyStatusRequest,
   output: GetBucketPolicyStatusOutput,
@@ -16176,7 +16175,7 @@ export const getBucketReplication: API.OperationMethod<
   GetBucketReplicationRequest,
   GetBucketReplicationOutput,
   GetBucketReplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketReplicationRequest,
   output: GetBucketReplicationOutput,
@@ -16213,7 +16212,7 @@ export const getBucketRequestPayment: API.OperationMethod<
   GetBucketRequestPaymentRequest,
   GetBucketRequestPaymentOutput,
   GetBucketRequestPaymentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketRequestPaymentRequest,
   output: GetBucketRequestPaymentOutput,
@@ -16256,7 +16255,7 @@ export const getBucketTagging: API.OperationMethod<
   GetBucketTaggingRequest,
   GetBucketTaggingOutput,
   GetBucketTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketTaggingRequest,
   output: GetBucketTaggingOutput,
@@ -16303,7 +16302,7 @@ export const getBucketVersioning: API.OperationMethod<
   GetBucketVersioningRequest,
   GetBucketVersioningOutput,
   GetBucketVersioningError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketVersioningRequest,
   output: GetBucketVersioningOutput,
@@ -16343,7 +16342,7 @@ export const getBucketWebsite: API.OperationMethod<
   GetBucketWebsiteRequest,
   GetBucketWebsiteOutput,
   GetBucketWebsiteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBucketWebsiteRequest,
   output: GetBucketWebsiteOutput,
@@ -16503,7 +16502,7 @@ export const getObject: API.OperationMethod<
   GetObjectRequest,
   GetObjectOutput,
   GetObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectRequest,
   output: GetObjectOutput,
@@ -16561,7 +16560,7 @@ export const getObjectAcl: API.OperationMethod<
   GetObjectAclRequest,
   GetObjectAclOutput,
   GetObjectAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectAclRequest,
   output: GetObjectAclOutput,
@@ -16605,7 +16604,7 @@ export const getObjectAnnotation: API.OperationMethod<
   GetObjectAnnotationRequest,
   GetObjectAnnotationOutput,
   GetObjectAnnotationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectAnnotationRequest,
   output: GetObjectAnnotationOutput,
@@ -16760,7 +16759,7 @@ export const getObjectAttributes: API.OperationMethod<
   GetObjectAttributesRequest,
   GetObjectAttributesOutput,
   GetObjectAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectAttributesRequest,
   output: GetObjectAttributesOutput,
@@ -16792,7 +16791,7 @@ export const getObjectLegalHold: API.OperationMethod<
   GetObjectLegalHoldRequest,
   GetObjectLegalHoldOutput,
   GetObjectLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectLegalHoldRequest,
   output: GetObjectLegalHoldOutput,
@@ -16826,7 +16825,7 @@ export const getObjectLockConfiguration: API.OperationMethod<
   GetObjectLockConfigurationRequest,
   GetObjectLockConfigurationOutput,
   GetObjectLockConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectLockConfigurationRequest,
   output: GetObjectLockConfigurationOutput,
@@ -16864,7 +16863,7 @@ export const getObjectRetention: API.OperationMethod<
   GetObjectRetentionRequest,
   GetObjectRetentionOutput,
   GetObjectRetentionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectRetentionRequest,
   output: GetObjectRetentionOutput,
@@ -16911,7 +16910,7 @@ export const getObjectTagging: API.OperationMethod<
   GetObjectTaggingRequest,
   GetObjectTaggingOutput,
   GetObjectTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectTaggingRequest,
   output: GetObjectTaggingOutput,
@@ -16951,7 +16950,7 @@ export const getObjectTorrent: API.OperationMethod<
   GetObjectTorrentRequest,
   GetObjectTorrentOutput,
   GetObjectTorrentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetObjectTorrentRequest,
   output: GetObjectTorrentOutput,
@@ -17005,7 +17004,7 @@ export const getPublicAccessBlock: API.OperationMethod<
   GetPublicAccessBlockRequest,
   GetPublicAccessBlockOutput,
   GetPublicAccessBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPublicAccessBlockRequest,
   output: GetPublicAccessBlockOutput,
@@ -17095,7 +17094,7 @@ export const headBucket: API.OperationMethod<
   HeadBucketRequest,
   HeadBucketOutput,
   HeadBucketError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: HeadBucketRequest,
   output: HeadBucketOutput,
@@ -17224,7 +17223,7 @@ export const headObject: API.OperationMethod<
   HeadObjectRequest,
   HeadObjectOutput,
   HeadObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: HeadObjectRequest,
   output: HeadObjectOutput,
@@ -17275,7 +17274,7 @@ export const listBucketAnalyticsConfigurations: API.OperationMethod<
   ListBucketAnalyticsConfigurationsRequest,
   ListBucketAnalyticsConfigurationsOutput,
   ListBucketAnalyticsConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBucketAnalyticsConfigurationsRequest,
   output: ListBucketAnalyticsConfigurationsOutput,
@@ -17315,7 +17314,7 @@ export const listBucketIntelligentTieringConfigurations: API.OperationMethod<
   ListBucketIntelligentTieringConfigurationsRequest,
   ListBucketIntelligentTieringConfigurationsOutput,
   ListBucketIntelligentTieringConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBucketIntelligentTieringConfigurationsRequest,
   output: ListBucketIntelligentTieringConfigurationsOutput,
@@ -17384,7 +17383,7 @@ export const listBucketInventoryConfigurations: API.OperationMethod<
   ListBucketInventoryConfigurationsRequest,
   ListBucketInventoryConfigurationsOutput,
   ListBucketInventoryConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBucketInventoryConfigurationsRequest,
   output: ListBucketInventoryConfigurationsOutput,
@@ -17455,7 +17454,7 @@ export const listBucketMetricsConfigurations: API.OperationMethod<
   ListBucketMetricsConfigurationsRequest,
   ListBucketMetricsConfigurationsOutput,
   ListBucketMetricsConfigurationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListBucketMetricsConfigurationsRequest,
   output: ListBucketMetricsConfigurationsOutput,
@@ -17492,7 +17491,7 @@ export const listBuckets: API.PaginatedOperationMethod<
   ListBucketsRequest,
   ListBucketsOutput,
   ListBucketsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Bucket
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBucketsRequest,
@@ -17541,7 +17540,7 @@ export const listDirectoryBuckets: API.PaginatedOperationMethod<
   ListDirectoryBucketsRequest,
   ListDirectoryBucketsOutput,
   ListDirectoryBucketsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Bucket
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDirectoryBucketsRequest,
@@ -17655,7 +17654,7 @@ export const listMultipartUploads: API.OperationMethod<
   ListMultipartUploadsRequest,
   ListMultipartUploadsOutput,
   ListMultipartUploadsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMultipartUploadsRequest,
   output: ListMultipartUploadsOutput,
@@ -17693,7 +17692,7 @@ export const listObjectAnnotations: API.PaginatedOperationMethod<
   ListObjectAnnotationsRequest,
   ListObjectAnnotationsOutput,
   ListObjectAnnotationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AnnotationEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectAnnotationsRequest,
@@ -17746,7 +17745,7 @@ export const listObjects: API.OperationMethod<
   ListObjectsRequest,
   ListObjectsOutput,
   ListObjectsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListObjectsRequest,
   output: ListObjectsOutput,
@@ -17832,7 +17831,7 @@ export const listObjectsV2: API.PaginatedOperationMethod<
   ListObjectsV2Request,
   ListObjectsV2Output,
   ListObjectsV2Error,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListObjectsV2Request,
@@ -17884,7 +17883,7 @@ export const listObjectVersions: API.OperationMethod<
   ListObjectVersionsRequest,
   ListObjectVersionsOutput,
   ListObjectVersionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListObjectVersionsRequest,
   output: ListObjectVersionsOutput,
@@ -17965,7 +17964,7 @@ export const listParts: API.PaginatedOperationMethod<
   ListPartsRequest,
   ListPartsOutput,
   ListPartsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Part
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPartsRequest,
@@ -17990,7 +17989,7 @@ export const putBucketAbac: API.OperationMethod<
   PutBucketAbacRequest,
   PutBucketAbacResponse,
   PutBucketAbacError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketAbacRequest,
   output: PutBucketAbacResponse,
@@ -18046,7 +18045,7 @@ export const putBucketAccelerateConfiguration: API.OperationMethod<
   PutBucketAccelerateConfigurationRequest,
   PutBucketAccelerateConfigurationResponse,
   PutBucketAccelerateConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketAccelerateConfigurationRequest,
   output: PutBucketAccelerateConfigurationResponse,
@@ -18211,7 +18210,7 @@ export const putBucketAcl: API.OperationMethod<
   PutBucketAclRequest,
   PutBucketAclResponse,
   PutBucketAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketAclRequest,
   output: PutBucketAclResponse,
@@ -18289,7 +18288,7 @@ export const putBucketAnalyticsConfiguration: API.OperationMethod<
   PutBucketAnalyticsConfigurationRequest,
   PutBucketAnalyticsConfigurationResponse,
   PutBucketAnalyticsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketAnalyticsConfigurationRequest,
   output: PutBucketAnalyticsConfigurationResponse,
@@ -18355,7 +18354,7 @@ export const putBucketCors: API.OperationMethod<
   PutBucketCorsRequest,
   PutBucketCorsResponse,
   PutBucketCorsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketCorsRequest,
   output: PutBucketCorsResponse,
@@ -18460,7 +18459,7 @@ export const putBucketEncryption: API.OperationMethod<
   PutBucketEncryptionRequest,
   PutBucketEncryptionResponse,
   PutBucketEncryptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketEncryptionRequest,
   output: PutBucketEncryptionResponse,
@@ -18526,7 +18525,7 @@ export const putBucketIntelligentTieringConfiguration: API.OperationMethod<
   PutBucketIntelligentTieringConfigurationRequest,
   PutBucketIntelligentTieringConfigurationResponse,
   PutBucketIntelligentTieringConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketIntelligentTieringConfigurationRequest,
   output: PutBucketIntelligentTieringConfigurationResponse,
@@ -18635,7 +18634,7 @@ export const putBucketInventoryConfiguration: API.OperationMethod<
   PutBucketInventoryConfigurationRequest,
   PutBucketInventoryConfigurationResponse,
   PutBucketInventoryConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketInventoryConfigurationRequest,
   output: PutBucketInventoryConfigurationResponse,
@@ -18753,7 +18752,7 @@ export const putBucketLifecycleConfiguration: API.OperationMethod<
   PutBucketLifecycleConfigurationRequest,
   PutBucketLifecycleConfigurationOutput,
   PutBucketLifecycleConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketLifecycleConfigurationRequest,
   output: PutBucketLifecycleConfigurationOutput,
@@ -18848,7 +18847,7 @@ export const putBucketLogging: API.OperationMethod<
   PutBucketLoggingRequest,
   PutBucketLoggingResponse,
   PutBucketLoggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketLoggingRequest,
   output: PutBucketLoggingResponse,
@@ -18922,7 +18921,7 @@ export const putBucketMetricsConfiguration: API.OperationMethod<
   PutBucketMetricsConfigurationRequest,
   PutBucketMetricsConfigurationResponse,
   PutBucketMetricsConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketMetricsConfigurationRequest,
   output: PutBucketMetricsConfigurationResponse,
@@ -18994,7 +18993,7 @@ export const putBucketNotificationConfiguration: API.OperationMethod<
   PutBucketNotificationConfigurationRequest,
   PutBucketNotificationConfigurationResponse,
   PutBucketNotificationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketNotificationConfigurationRequest,
   output: PutBucketNotificationConfigurationResponse,
@@ -19030,7 +19029,7 @@ export const putBucketOwnershipControls: API.OperationMethod<
   PutBucketOwnershipControlsRequest,
   PutBucketOwnershipControlsResponse,
   PutBucketOwnershipControlsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketOwnershipControlsRequest,
   output: PutBucketOwnershipControlsResponse,
@@ -19113,7 +19112,7 @@ export const putBucketPolicy: API.OperationMethod<
   PutBucketPolicyRequest,
   PutBucketPolicyResponse,
   PutBucketPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketPolicyRequest,
   output: PutBucketPolicyResponse,
@@ -19205,7 +19204,7 @@ export const putBucketReplication: API.OperationMethod<
   PutBucketReplicationRequest,
   PutBucketReplicationResponse,
   PutBucketReplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketReplicationRequest,
   output: PutBucketReplicationResponse,
@@ -19241,7 +19240,7 @@ export const putBucketRequestPayment: API.OperationMethod<
   PutBucketRequestPaymentRequest,
   PutBucketRequestPaymentResponse,
   PutBucketRequestPaymentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketRequestPaymentRequest,
   output: PutBucketRequestPaymentResponse,
@@ -19303,7 +19302,7 @@ export const putBucketTagging: API.OperationMethod<
   PutBucketTaggingRequest,
   PutBucketTaggingResponse,
   PutBucketTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketTaggingRequest,
   output: PutBucketTaggingResponse,
@@ -19366,7 +19365,7 @@ export const putBucketVersioning: API.OperationMethod<
   PutBucketVersioningRequest,
   PutBucketVersioningResponse,
   PutBucketVersioningError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketVersioningRequest,
   output: PutBucketVersioningResponse,
@@ -19457,7 +19456,7 @@ export const putBucketWebsite: API.OperationMethod<
   PutBucketWebsiteRequest,
   PutBucketWebsiteResponse,
   PutBucketWebsiteError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutBucketWebsiteRequest,
   output: PutBucketWebsiteResponse,
@@ -19606,7 +19605,7 @@ export const putObject: API.OperationMethod<
   PutObjectRequest,
   PutObjectOutput,
   PutObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectRequest,
   output: PutObjectOutput,
@@ -19780,7 +19779,7 @@ export const putObjectAcl: API.OperationMethod<
   PutObjectAclRequest,
   PutObjectAclOutput,
   PutObjectAclError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectAclRequest,
   output: PutObjectAclOutput,
@@ -19830,7 +19829,7 @@ export const putObjectAnnotation: API.OperationMethod<
   PutObjectAnnotationRequest,
   PutObjectAnnotationOutput,
   PutObjectAnnotationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectAnnotationRequest,
   output: PutObjectAnnotationOutput,
@@ -19867,7 +19866,7 @@ export const putObjectLegalHold: API.OperationMethod<
   PutObjectLegalHoldRequest,
   PutObjectLegalHoldOutput,
   PutObjectLegalHoldError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectLegalHoldRequest,
   output: PutObjectLegalHoldOutput,
@@ -19907,7 +19906,7 @@ export const putObjectLockConfiguration: API.OperationMethod<
   PutObjectLockConfigurationRequest,
   PutObjectLockConfigurationOutput,
   PutObjectLockConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectLockConfigurationRequest,
   output: PutObjectLockConfigurationOutput,
@@ -19944,7 +19943,7 @@ export const putObjectRetention: API.OperationMethod<
   PutObjectRetentionRequest,
   PutObjectRetentionOutput,
   PutObjectRetentionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectRetentionRequest,
   output: PutObjectRetentionOutput,
@@ -20004,7 +20003,7 @@ export const putObjectTagging: API.OperationMethod<
   PutObjectTaggingRequest,
   PutObjectTaggingOutput,
   PutObjectTaggingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutObjectTaggingRequest,
   output: PutObjectTaggingOutput,
@@ -20054,7 +20053,7 @@ export const putPublicAccessBlock: API.OperationMethod<
   PutPublicAccessBlockRequest,
   PutPublicAccessBlockResponse,
   PutPublicAccessBlockError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPublicAccessBlockRequest,
   output: PutPublicAccessBlockResponse,
@@ -20114,7 +20113,7 @@ export const renameObject: API.OperationMethod<
   RenameObjectRequest,
   RenameObjectOutput,
   RenameObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenameObjectRequest,
   output: RenameObjectOutput,
@@ -20276,7 +20275,7 @@ export const restoreObject: API.OperationMethod<
   RestoreObjectRequest,
   RestoreObjectOutput,
   RestoreObjectError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreObjectRequest,
   output: RestoreObjectOutput,
@@ -20393,7 +20392,7 @@ export const selectObjectContent: API.OperationMethod<
   SelectObjectContentRequest,
   SelectObjectContentOutput,
   SelectObjectContentError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SelectObjectContentRequest,
   output: SelectObjectContentOutput,
@@ -20433,7 +20432,7 @@ export const updateBucketMetadataAnnotationTableConfiguration: API.OperationMeth
   UpdateBucketMetadataAnnotationTableConfigurationRequest,
   UpdateBucketMetadataAnnotationTableConfigurationResponse,
   UpdateBucketMetadataAnnotationTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBucketMetadataAnnotationTableConfigurationRequest,
   output: UpdateBucketMetadataAnnotationTableConfigurationResponse,
@@ -20494,7 +20493,7 @@ export const updateBucketMetadataInventoryTableConfiguration: API.OperationMetho
   UpdateBucketMetadataInventoryTableConfigurationRequest,
   UpdateBucketMetadataInventoryTableConfigurationResponse,
   UpdateBucketMetadataInventoryTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBucketMetadataInventoryTableConfigurationRequest,
   output: UpdateBucketMetadataInventoryTableConfigurationResponse,
@@ -20533,7 +20532,7 @@ export const updateBucketMetadataJournalTableConfiguration: API.OperationMethod<
   UpdateBucketMetadataJournalTableConfigurationRequest,
   UpdateBucketMetadataJournalTableConfigurationResponse,
   UpdateBucketMetadataJournalTableConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBucketMetadataJournalTableConfigurationRequest,
   output: UpdateBucketMetadataJournalTableConfigurationResponse,
@@ -20663,7 +20662,7 @@ export const updateObjectEncryption: API.OperationMethod<
   UpdateObjectEncryptionRequest,
   UpdateObjectEncryptionResponse,
   UpdateObjectEncryptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateObjectEncryptionRequest,
   output: UpdateObjectEncryptionResponse,
@@ -20823,7 +20822,7 @@ export const uploadPart: API.OperationMethod<
   UploadPartRequest,
   UploadPartOutput,
   UploadPartError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadPartRequest,
   output: UploadPartOutput,
@@ -21003,7 +21002,7 @@ export const uploadPartCopy: API.OperationMethod<
   UploadPartCopyRequest,
   UploadPartCopyOutput,
   UploadPartCopyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadPartCopyRequest,
   output: UploadPartCopyOutput,
@@ -21061,7 +21060,7 @@ export const writeGetObjectResponse: API.OperationMethod<
   WriteGetObjectResponseRequest,
   WriteGetObjectResponseResponse,
   WriteGetObjectResponseError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: WriteGetObjectResponseRequest,
   output: WriteGetObjectResponseResponse,

--- a/packages/aws/src/services/s3files.ts
+++ b/packages/aws/src/services/s3files.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("s3files");
 const svc = T.AwsApiService({ sdkId: "S3Files", serviceShapeName: "S3Files" });
 const auth = T.AwsAuthSigv4({ name: "s3files" });
@@ -1133,7 +1132,7 @@ export const createAccessPoint: API.OperationMethod<
   CreateAccessPointRequest,
   CreateAccessPointResponse,
   CreateAccessPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessPointRequest,
   output: CreateAccessPointResponse,
@@ -1163,7 +1162,7 @@ export const createFileSystem: API.OperationMethod<
   CreateFileSystemRequest,
   CreateFileSystemResponse,
   CreateFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFileSystemRequest,
   output: CreateFileSystemResponse,
@@ -1193,7 +1192,7 @@ export const createMountTarget: API.OperationMethod<
   CreateMountTargetRequest,
   CreateMountTargetResponse,
   CreateMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMountTargetRequest,
   output: CreateMountTargetResponse,
@@ -1222,7 +1221,7 @@ export const deleteAccessPoint: API.OperationMethod<
   DeleteAccessPointRequest,
   DeleteAccessPointResponse,
   DeleteAccessPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessPointRequest,
   output: DeleteAccessPointResponse,
@@ -1250,7 +1249,7 @@ export const deleteFileSystem: API.OperationMethod<
   DeleteFileSystemRequest,
   DeleteFileSystemResponse,
   DeleteFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileSystemRequest,
   output: DeleteFileSystemResponse,
@@ -1277,7 +1276,7 @@ export const deleteFileSystemPolicy: API.OperationMethod<
   DeleteFileSystemPolicyRequest,
   DeleteFileSystemPolicyResponse,
   DeleteFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileSystemPolicyRequest,
   output: DeleteFileSystemPolicyResponse,
@@ -1304,7 +1303,7 @@ export const deleteMountTarget: API.OperationMethod<
   DeleteMountTargetRequest,
   DeleteMountTargetResponse,
   DeleteMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMountTargetRequest,
   output: DeleteMountTargetResponse,
@@ -1331,7 +1330,7 @@ export const getAccessPoint: API.OperationMethod<
   GetAccessPointRequest,
   GetAccessPointResponse,
   GetAccessPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessPointRequest,
   output: GetAccessPointResponse,
@@ -1357,7 +1356,7 @@ export const getFileSystem: API.OperationMethod<
   GetFileSystemRequest,
   GetFileSystemResponse,
   GetFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFileSystemRequest,
   output: GetFileSystemResponse,
@@ -1383,7 +1382,7 @@ export const getFileSystemPolicy: API.OperationMethod<
   GetFileSystemPolicyRequest,
   GetFileSystemPolicyResponse,
   GetFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFileSystemPolicyRequest,
   output: GetFileSystemPolicyResponse,
@@ -1409,7 +1408,7 @@ export const getMountTarget: API.OperationMethod<
   GetMountTargetRequest,
   GetMountTargetResponse,
   GetMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMountTargetRequest,
   output: GetMountTargetResponse,
@@ -1435,7 +1434,7 @@ export const getSynchronizationConfiguration: API.OperationMethod<
   GetSynchronizationConfigurationRequest,
   GetSynchronizationConfigurationResponse,
   GetSynchronizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSynchronizationConfigurationRequest,
   output: GetSynchronizationConfigurationResponse,
@@ -1461,7 +1460,7 @@ export const listAccessPoints: API.PaginatedOperationMethod<
   ListAccessPointsRequest,
   ListAccessPointsResponse,
   ListAccessPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListAccessPointsDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessPointsRequest,
@@ -1493,7 +1492,7 @@ export const listFileSystems: API.PaginatedOperationMethod<
   ListFileSystemsRequest,
   ListFileSystemsResponse,
   ListFileSystemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListFileSystemsDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFileSystemsRequest,
@@ -1522,7 +1521,7 @@ export const listMountTargets: API.PaginatedOperationMethod<
   ListMountTargetsRequest,
   ListMountTargetsResponse,
   ListMountTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListMountTargetsDescription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMountTargetsRequest,
@@ -1555,7 +1554,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -1588,7 +1587,7 @@ export const putFileSystemPolicy: API.OperationMethod<
   PutFileSystemPolicyRequest,
   PutFileSystemPolicyResponse,
   PutFileSystemPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutFileSystemPolicyRequest,
   output: PutFileSystemPolicyResponse,
@@ -1615,7 +1614,7 @@ export const putSynchronizationConfiguration: API.OperationMethod<
   PutSynchronizationConfigurationRequest,
   PutSynchronizationConfigurationResponse,
   PutSynchronizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSynchronizationConfigurationRequest,
   output: PutSynchronizationConfigurationResponse,
@@ -1642,7 +1641,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1668,7 +1667,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1694,7 +1693,7 @@ export const updateMountTarget: API.OperationMethod<
   UpdateMountTargetRequest,
   UpdateMountTargetResponse,
   UpdateMountTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMountTargetRequest,
   output: UpdateMountTargetResponse,

--- a/packages/aws/src/services/s3outposts.ts
+++ b/packages/aws/src/services/s3outposts.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "S3Outposts",
   serviceShapeName: "S3Outposts",
@@ -408,7 +407,7 @@ export const createEndpoint: API.OperationMethod<
   CreateEndpointRequest,
   CreateEndpointResult,
   CreateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointRequest,
   output: CreateEndpointResult,
@@ -449,7 +448,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointRequest,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointRequest,
   output: DeleteEndpointResponse,
@@ -486,7 +485,7 @@ export const listEndpoints: API.PaginatedOperationMethod<
   ListEndpointsRequest,
   ListEndpointsResult,
   ListEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Endpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointsRequest,
@@ -524,7 +523,7 @@ export const listOutpostsWithS3: API.PaginatedOperationMethod<
   ListOutpostsWithS3Request,
   ListOutpostsWithS3Result,
   ListOutpostsWithS3Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Outpost
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOutpostsWithS3Request,
@@ -566,7 +565,7 @@ export const listSharedEndpoints: API.PaginatedOperationMethod<
   ListSharedEndpointsRequest,
   ListSharedEndpointsResult,
   ListSharedEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Endpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSharedEndpointsRequest,

--- a/packages/aws/src/services/s3tables.ts
+++ b/packages/aws/src/services/s3tables.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "S3Tables",
   serviceShapeName: "S3TableBuckets",
@@ -2365,7 +2364,7 @@ export const createNamespace: API.OperationMethod<
   CreateNamespaceRequest,
   CreateNamespaceResponse,
   CreateNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNamespaceRequest,
   output: CreateNamespaceResponse,
@@ -2411,7 +2410,7 @@ export const createTable: API.OperationMethod<
   CreateTableRequest,
   CreateTableResponse,
   CreateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableRequest,
   output: CreateTableResponse,
@@ -2453,7 +2452,7 @@ export const createTableBucket: API.OperationMethod<
   CreateTableBucketRequest,
   CreateTableBucketResponse,
   CreateTableBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableBucketRequest,
   output: CreateTableBucketResponse,
@@ -2489,7 +2488,7 @@ export const deleteNamespace: API.OperationMethod<
   DeleteNamespaceRequest,
   DeleteNamespaceResponse,
   DeleteNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamespaceRequest,
   output: DeleteNamespaceResponse,
@@ -2525,7 +2524,7 @@ export const deleteTable: API.OperationMethod<
   DeleteTableRequest,
   DeleteTableResponse,
   DeleteTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableRequest,
   output: DeleteTableResponse,
@@ -2561,7 +2560,7 @@ export const deleteTableBucket: API.OperationMethod<
   DeleteTableBucketRequest,
   DeleteTableBucketResponse,
   DeleteTableBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableBucketRequest,
   output: DeleteTableBucketResponse,
@@ -2597,7 +2596,7 @@ export const deleteTableBucketEncryption: API.OperationMethod<
   DeleteTableBucketEncryptionRequest,
   DeleteTableBucketEncryptionResponse,
   DeleteTableBucketEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableBucketEncryptionRequest,
   output: DeleteTableBucketEncryptionResponse,
@@ -2633,7 +2632,7 @@ export const deleteTableBucketMetricsConfiguration: API.OperationMethod<
   DeleteTableBucketMetricsConfigurationRequest,
   DeleteTableBucketMetricsConfigurationResponse,
   DeleteTableBucketMetricsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableBucketMetricsConfigurationRequest,
   output: DeleteTableBucketMetricsConfigurationResponse,
@@ -2669,7 +2668,7 @@ export const deleteTableBucketPolicy: API.OperationMethod<
   DeleteTableBucketPolicyRequest,
   DeleteTableBucketPolicyResponse,
   DeleteTableBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableBucketPolicyRequest,
   output: DeleteTableBucketPolicyResponse,
@@ -2706,7 +2705,7 @@ export const deleteTableBucketReplication: API.OperationMethod<
   DeleteTableBucketReplicationRequest,
   DeleteTableBucketReplicationResponse,
   DeleteTableBucketReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableBucketReplicationRequest,
   output: DeleteTableBucketReplicationResponse,
@@ -2743,7 +2742,7 @@ export const deleteTablePolicy: API.OperationMethod<
   DeleteTablePolicyRequest,
   DeleteTablePolicyResponse,
   DeleteTablePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTablePolicyRequest,
   output: DeleteTablePolicyResponse,
@@ -2780,7 +2779,7 @@ export const deleteTableReplication: API.OperationMethod<
   DeleteTableReplicationRequest,
   DeleteTableReplicationResponse,
   DeleteTableReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableReplicationRequest,
   output: DeleteTableReplicationResponse,
@@ -2818,7 +2817,7 @@ export const getNamespace: API.OperationMethod<
   GetNamespaceRequest,
   GetNamespaceResponse,
   GetNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNamespaceRequest,
   output: GetNamespaceResponse,
@@ -2856,7 +2855,7 @@ export const getTable: API.OperationMethod<
   GetTableRequest,
   GetTableResponse,
   GetTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRequest,
   output: GetTableResponse,
@@ -2894,7 +2893,7 @@ export const getTableBucket: API.OperationMethod<
   GetTableBucketRequest,
   GetTableBucketResponse,
   GetTableBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketRequest,
   output: GetTableBucketResponse,
@@ -2931,7 +2930,7 @@ export const getTableBucketEncryption: API.OperationMethod<
   GetTableBucketEncryptionRequest,
   GetTableBucketEncryptionResponse,
   GetTableBucketEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketEncryptionRequest,
   output: GetTableBucketEncryptionResponse,
@@ -2967,7 +2966,7 @@ export const getTableBucketMaintenanceConfiguration: API.OperationMethod<
   GetTableBucketMaintenanceConfigurationRequest,
   GetTableBucketMaintenanceConfigurationResponse,
   GetTableBucketMaintenanceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketMaintenanceConfigurationRequest,
   output: GetTableBucketMaintenanceConfigurationResponse,
@@ -3003,7 +3002,7 @@ export const getTableBucketMetricsConfiguration: API.OperationMethod<
   GetTableBucketMetricsConfigurationRequest,
   GetTableBucketMetricsConfigurationResponse,
   GetTableBucketMetricsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketMetricsConfigurationRequest,
   output: GetTableBucketMetricsConfigurationResponse,
@@ -3039,7 +3038,7 @@ export const getTableBucketPolicy: API.OperationMethod<
   GetTableBucketPolicyRequest,
   GetTableBucketPolicyResponse,
   GetTableBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketPolicyRequest,
   output: GetTableBucketPolicyResponse,
@@ -3076,7 +3075,7 @@ export const getTableBucketReplication: API.OperationMethod<
   GetTableBucketReplicationRequest,
   GetTableBucketReplicationResponse,
   GetTableBucketReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketReplicationRequest,
   output: GetTableBucketReplicationResponse,
@@ -3113,7 +3112,7 @@ export const getTableBucketStorageClass: API.OperationMethod<
   GetTableBucketStorageClassRequest,
   GetTableBucketStorageClassResponse,
   GetTableBucketStorageClassError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableBucketStorageClassRequest,
   output: GetTableBucketStorageClassResponse,
@@ -3149,7 +3148,7 @@ export const getTableEncryption: API.OperationMethod<
   GetTableEncryptionRequest,
   GetTableEncryptionResponse,
   GetTableEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableEncryptionRequest,
   output: GetTableEncryptionResponse,
@@ -3187,7 +3186,7 @@ export const getTableMaintenanceConfiguration: API.OperationMethod<
   GetTableMaintenanceConfigurationRequest,
   GetTableMaintenanceConfigurationResponse,
   GetTableMaintenanceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableMaintenanceConfigurationRequest,
   output: GetTableMaintenanceConfigurationResponse,
@@ -3223,7 +3222,7 @@ export const getTableMaintenanceJobStatus: API.OperationMethod<
   GetTableMaintenanceJobStatusRequest,
   GetTableMaintenanceJobStatusResponse,
   GetTableMaintenanceJobStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableMaintenanceJobStatusRequest,
   output: GetTableMaintenanceJobStatusResponse,
@@ -3259,7 +3258,7 @@ export const getTableMetadataLocation: API.OperationMethod<
   GetTableMetadataLocationRequest,
   GetTableMetadataLocationResponse,
   GetTableMetadataLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableMetadataLocationRequest,
   output: GetTableMetadataLocationResponse,
@@ -3295,7 +3294,7 @@ export const getTablePolicy: API.OperationMethod<
   GetTablePolicyRequest,
   GetTablePolicyResponse,
   GetTablePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTablePolicyRequest,
   output: GetTablePolicyResponse,
@@ -3331,7 +3330,7 @@ export const getTableRecordExpirationConfiguration: API.OperationMethod<
   GetTableRecordExpirationConfigurationRequest,
   GetTableRecordExpirationConfigurationResponse,
   GetTableRecordExpirationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRecordExpirationConfigurationRequest,
   output: GetTableRecordExpirationConfigurationResponse,
@@ -3367,7 +3366,7 @@ export const getTableRecordExpirationJobStatus: API.OperationMethod<
   GetTableRecordExpirationJobStatusRequest,
   GetTableRecordExpirationJobStatusResponse,
   GetTableRecordExpirationJobStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableRecordExpirationJobStatusRequest,
   output: GetTableRecordExpirationJobStatusResponse,
@@ -3404,7 +3403,7 @@ export const getTableReplication: API.OperationMethod<
   GetTableReplicationRequest,
   GetTableReplicationResponse,
   GetTableReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableReplicationRequest,
   output: GetTableReplicationResponse,
@@ -3441,7 +3440,7 @@ export const getTableReplicationStatus: API.OperationMethod<
   GetTableReplicationStatusRequest,
   GetTableReplicationStatusResponse,
   GetTableReplicationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableReplicationStatusRequest,
   output: GetTableReplicationStatusResponse,
@@ -3477,7 +3476,7 @@ export const getTableStorageClass: API.OperationMethod<
   GetTableStorageClassRequest,
   GetTableStorageClassResponse,
   GetTableStorageClassError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTableStorageClassRequest,
   output: GetTableStorageClassResponse,
@@ -3514,7 +3513,7 @@ export const listNamespaces: API.PaginatedOperationMethod<
   ListNamespacesRequest,
   ListNamespacesResponse,
   ListNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NamespaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNamespacesRequest,
@@ -3559,7 +3558,7 @@ export const listTableBuckets: API.PaginatedOperationMethod<
   ListTableBucketsRequest,
   ListTableBucketsResponse,
   ListTableBucketsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableBucketSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTableBucketsRequest,
@@ -3603,7 +3602,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesRequest,
   ListTablesResponse,
   ListTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TableSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesRequest,
@@ -3648,7 +3647,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3686,7 +3685,7 @@ export const putTableBucketEncryption: API.OperationMethod<
   PutTableBucketEncryptionRequest,
   PutTableBucketEncryptionResponse,
   PutTableBucketEncryptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketEncryptionRequest,
   output: PutTableBucketEncryptionResponse,
@@ -3722,7 +3721,7 @@ export const putTableBucketMaintenanceConfiguration: API.OperationMethod<
   PutTableBucketMaintenanceConfigurationRequest,
   PutTableBucketMaintenanceConfigurationResponse,
   PutTableBucketMaintenanceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketMaintenanceConfigurationRequest,
   output: PutTableBucketMaintenanceConfigurationResponse,
@@ -3758,7 +3757,7 @@ export const putTableBucketMetricsConfiguration: API.OperationMethod<
   PutTableBucketMetricsConfigurationRequest,
   PutTableBucketMetricsConfigurationResponse,
   PutTableBucketMetricsConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketMetricsConfigurationRequest,
   output: PutTableBucketMetricsConfigurationResponse,
@@ -3794,7 +3793,7 @@ export const putTableBucketPolicy: API.OperationMethod<
   PutTableBucketPolicyRequest,
   PutTableBucketPolicyResponse,
   PutTableBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketPolicyRequest,
   output: PutTableBucketPolicyResponse,
@@ -3847,7 +3846,7 @@ export const putTableBucketReplication: API.OperationMethod<
   PutTableBucketReplicationRequest,
   PutTableBucketReplicationResponse,
   PutTableBucketReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketReplicationRequest,
   output: PutTableBucketReplicationResponse,
@@ -3884,7 +3883,7 @@ export const putTableBucketStorageClass: API.OperationMethod<
   PutTableBucketStorageClassRequest,
   PutTableBucketStorageClassResponse,
   PutTableBucketStorageClassError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableBucketStorageClassRequest,
   output: PutTableBucketStorageClassResponse,
@@ -3920,7 +3919,7 @@ export const putTableMaintenanceConfiguration: API.OperationMethod<
   PutTableMaintenanceConfigurationRequest,
   PutTableMaintenanceConfigurationResponse,
   PutTableMaintenanceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableMaintenanceConfigurationRequest,
   output: PutTableMaintenanceConfigurationResponse,
@@ -3956,7 +3955,7 @@ export const putTablePolicy: API.OperationMethod<
   PutTablePolicyRequest,
   PutTablePolicyResponse,
   PutTablePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTablePolicyRequest,
   output: PutTablePolicyResponse,
@@ -3992,7 +3991,7 @@ export const putTableRecordExpirationConfiguration: API.OperationMethod<
   PutTableRecordExpirationConfigurationRequest,
   PutTableRecordExpirationConfigurationResponse,
   PutTableRecordExpirationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableRecordExpirationConfigurationRequest,
   output: PutTableRecordExpirationConfigurationResponse,
@@ -4043,7 +4042,7 @@ export const putTableReplication: API.OperationMethod<
   PutTableReplicationRequest,
   PutTableReplicationResponse,
   PutTableReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTableReplicationRequest,
   output: PutTableReplicationResponse,
@@ -4080,7 +4079,7 @@ export const renameTable: API.OperationMethod<
   RenameTableRequest,
   RenameTableResponse,
   RenameTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenameTableRequest,
   output: RenameTableResponse,
@@ -4118,7 +4117,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4156,7 +4155,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4192,7 +4191,7 @@ export const updateTableMetadataLocation: API.OperationMethod<
   UpdateTableMetadataLocationRequest,
   UpdateTableMetadataLocationResponse,
   UpdateTableMetadataLocationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableMetadataLocationRequest,
   output: UpdateTableMetadataLocationResponse,

--- a/packages/aws/src/services/s3vectors.ts
+++ b/packages/aws/src/services/s3vectors.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "S3Vectors",
   serviceShapeName: "S3Vectors",
@@ -937,7 +936,7 @@ export const createIndex: API.OperationMethod<
   CreateIndexInput,
   CreateIndexOutput,
   CreateIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIndexInput,
   output: CreateIndexOutput,
@@ -970,7 +969,7 @@ export const createVectorBucket: API.OperationMethod<
   CreateVectorBucketInput,
   CreateVectorBucketOutput,
   CreateVectorBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVectorBucketInput,
   output: CreateVectorBucketOutput,
@@ -999,7 +998,7 @@ export const deleteIndex: API.OperationMethod<
   DeleteIndexInput,
   DeleteIndexOutput,
   DeleteIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIndexInput,
   output: DeleteIndexOutput,
@@ -1025,7 +1024,7 @@ export const deleteVectorBucket: API.OperationMethod<
   DeleteVectorBucketInput,
   DeleteVectorBucketOutput,
   DeleteVectorBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVectorBucketInput,
   output: DeleteVectorBucketOutput,
@@ -1050,7 +1049,7 @@ export const deleteVectorBucketPolicy: API.OperationMethod<
   DeleteVectorBucketPolicyInput,
   DeleteVectorBucketPolicyOutput,
   DeleteVectorBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVectorBucketPolicyInput,
   output: DeleteVectorBucketPolicyOutput,
@@ -1080,7 +1079,7 @@ export const deleteVectors: API.OperationMethod<
   DeleteVectorsInput,
   DeleteVectorsOutput,
   DeleteVectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVectorsInput,
   output: DeleteVectorsOutput,
@@ -1113,7 +1112,7 @@ export const getIndex: API.OperationMethod<
   GetIndexInput,
   GetIndexOutput,
   GetIndexError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexInput,
   output: GetIndexOutput,
@@ -1138,7 +1137,7 @@ export const getVectorBucket: API.OperationMethod<
   GetVectorBucketInput,
   GetVectorBucketOutput,
   GetVectorBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVectorBucketInput,
   output: GetVectorBucketOutput,
@@ -1163,7 +1162,7 @@ export const getVectorBucketPolicy: API.OperationMethod<
   GetVectorBucketPolicyInput,
   GetVectorBucketPolicyOutput,
   GetVectorBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVectorBucketPolicyInput,
   output: GetVectorBucketPolicyOutput,
@@ -1192,7 +1191,7 @@ export const getVectors: API.OperationMethod<
   GetVectorsInput,
   GetVectorsOutput,
   GetVectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVectorsInput,
   output: GetVectorsOutput,
@@ -1224,7 +1223,7 @@ export const listIndexes: API.PaginatedOperationMethod<
   ListIndexesInput,
   ListIndexesOutput,
   ListIndexesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IndexSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIndexesInput,
@@ -1258,7 +1257,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1280,7 +1279,7 @@ export const listVectorBuckets: API.PaginatedOperationMethod<
   ListVectorBucketsInput,
   ListVectorBucketsOutput,
   ListVectorBucketsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VectorBucketSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVectorBucketsInput,
@@ -1319,7 +1318,7 @@ export const listVectors: API.PaginatedOperationMethod<
   ListVectorsInput,
   ListVectorsOutput,
   ListVectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListOutputVector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVectorsInput,
@@ -1355,7 +1354,7 @@ export const putVectorBucketPolicy: API.OperationMethod<
   PutVectorBucketPolicyInput,
   PutVectorBucketPolicyOutput,
   PutVectorBucketPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVectorBucketPolicyInput,
   output: PutVectorBucketPolicyOutput,
@@ -1390,7 +1389,7 @@ export const putVectors: API.OperationMethod<
   PutVectorsInput,
   PutVectorsOutput,
   PutVectorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutVectorsInput,
   output: PutVectorsOutput,
@@ -1434,7 +1433,7 @@ export const queryVectors: API.PaginatedOperationMethod<
   QueryVectorsInput,
   QueryVectorsOutput,
   QueryVectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QueryOutputVector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryVectorsInput,
@@ -1475,7 +1474,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1503,7 +1502,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,

--- a/packages/aws/src/services/sagemaker-a2i-runtime.ts
+++ b/packages/aws/src/services/sagemaker-a2i-runtime.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker A2I Runtime",
   serviceShapeName: "AmazonSageMakerA2IRuntime",
@@ -376,7 +375,7 @@ export const deleteHumanLoop: API.OperationMethod<
   DeleteHumanLoopRequest,
   DeleteHumanLoopResponse,
   DeleteHumanLoopError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHumanLoopRequest,
   output: DeleteHumanLoopResponse,
@@ -405,7 +404,7 @@ export const describeHumanLoop: API.OperationMethod<
   DescribeHumanLoopRequest,
   DescribeHumanLoopResponse,
   DescribeHumanLoopError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHumanLoopRequest,
   output: DescribeHumanLoopResponse,
@@ -433,7 +432,7 @@ export const listHumanLoops: API.PaginatedOperationMethod<
   ListHumanLoopsRequest,
   ListHumanLoopsResponse,
   ListHumanLoopsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HumanLoopSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHumanLoopsRequest,
@@ -469,7 +468,7 @@ export const startHumanLoop: API.OperationMethod<
   StartHumanLoopRequest,
   StartHumanLoopResponse,
   StartHumanLoopError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartHumanLoopRequest,
   output: StartHumanLoopResponse,
@@ -498,7 +497,7 @@ export const stopHumanLoop: API.OperationMethod<
   StopHumanLoopRequest,
   StopHumanLoopResponse,
   StopHumanLoopError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopHumanLoopRequest,
   output: StopHumanLoopResponse,

--- a/packages/aws/src/services/sagemaker-edge.ts
+++ b/packages/aws/src/services/sagemaker-edge.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Sagemaker Edge",
   serviceShapeName: "AmazonSageMakerEdge",
@@ -351,7 +350,7 @@ export const getDeployments: API.OperationMethod<
   GetDeploymentsRequest,
   GetDeploymentsResult,
   GetDeploymentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeploymentsRequest,
   output: GetDeploymentsResult,
@@ -371,7 +370,7 @@ export const getDeviceRegistration: API.OperationMethod<
   GetDeviceRegistrationRequest,
   GetDeviceRegistrationResult,
   GetDeviceRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceRegistrationRequest,
   output: GetDeviceRegistrationResult,
@@ -389,7 +388,7 @@ export const sendHeartbeat: API.OperationMethod<
   SendHeartbeatRequest,
   SendHeartbeatResponse,
   SendHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendHeartbeatRequest,
   output: SendHeartbeatResponse,

--- a/packages/aws/src/services/sagemaker-featurestore-runtime.ts
+++ b/packages/aws/src/services/sagemaker-featurestore-runtime.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker FeatureStore Runtime",
   serviceShapeName: "AmazonSageMakerFeatureStoreRuntime",
@@ -537,7 +536,7 @@ export const batchGetRecord: API.OperationMethod<
   BatchGetRecordRequest,
   BatchGetRecordResponse,
   BatchGetRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetRecordRequest,
   output: BatchGetRecordResponse,
@@ -573,7 +572,7 @@ export const batchWriteRecord: API.OperationMethod<
   BatchWriteRecordRequest,
   BatchWriteRecordResponse,
   BatchWriteRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchWriteRecordRequest,
   output: BatchWriteRecordResponse,
@@ -633,7 +632,7 @@ export const deleteRecord: API.OperationMethod<
   DeleteRecordRequest,
   DeleteRecordResponse,
   DeleteRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRecordRequest,
   output: DeleteRecordResponse,
@@ -666,7 +665,7 @@ export const getRecord: API.OperationMethod<
   GetRecordRequest,
   GetRecordResponse,
   GetRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecordRequest,
   output: GetRecordResponse,
@@ -699,7 +698,7 @@ export const listRecords: API.PaginatedOperationMethod<
   ListRecordsRequest,
   ListRecordsResponse,
   ListRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ValueAsString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecordsRequest,
@@ -754,7 +753,7 @@ export const putRecord: API.OperationMethod<
   PutRecordRequest,
   PutRecordResponse,
   PutRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRecordRequest,
   output: PutRecordResponse,

--- a/packages/aws/src/services/sagemaker-geospatial.ts
+++ b/packages/aws/src/services/sagemaker-geospatial.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker Geospatial",
@@ -1755,7 +1754,7 @@ export const deleteEarthObservationJob: API.OperationMethod<
   DeleteEarthObservationJobInput,
   DeleteEarthObservationJobOutput,
   DeleteEarthObservationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEarthObservationJobInput,
   output: DeleteEarthObservationJobOutput,
@@ -1787,7 +1786,7 @@ export const deleteVectorEnrichmentJob: API.OperationMethod<
   DeleteVectorEnrichmentJobInput,
   DeleteVectorEnrichmentJobOutput,
   DeleteVectorEnrichmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVectorEnrichmentJobInput,
   output: DeleteVectorEnrichmentJobOutput,
@@ -1820,7 +1819,7 @@ export const exportEarthObservationJob: API.OperationMethod<
   ExportEarthObservationJobInput,
   ExportEarthObservationJobOutput,
   ExportEarthObservationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportEarthObservationJobInput,
   output: ExportEarthObservationJobOutput,
@@ -1854,7 +1853,7 @@ export const exportVectorEnrichmentJob: API.OperationMethod<
   ExportVectorEnrichmentJobInput,
   ExportVectorEnrichmentJobOutput,
   ExportVectorEnrichmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportVectorEnrichmentJobInput,
   output: ExportVectorEnrichmentJobOutput,
@@ -1886,7 +1885,7 @@ export const getEarthObservationJob: API.OperationMethod<
   GetEarthObservationJobInput,
   GetEarthObservationJobOutput,
   GetEarthObservationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEarthObservationJobInput,
   output: GetEarthObservationJobOutput,
@@ -1916,7 +1915,7 @@ export const getRasterDataCollection: API.OperationMethod<
   GetRasterDataCollectionInput,
   GetRasterDataCollectionOutput,
   GetRasterDataCollectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRasterDataCollectionInput,
   output: GetRasterDataCollectionOutput,
@@ -1946,7 +1945,7 @@ export const getTile: API.OperationMethod<
   GetTileInput,
   GetTileOutput,
   GetTileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTileInput,
   output: GetTileOutput,
@@ -1976,7 +1975,7 @@ export const getVectorEnrichmentJob: API.OperationMethod<
   GetVectorEnrichmentJobInput,
   GetVectorEnrichmentJobOutput,
   GetVectorEnrichmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVectorEnrichmentJobInput,
   output: GetVectorEnrichmentJobOutput,
@@ -2006,7 +2005,7 @@ export const listEarthObservationJobs: API.PaginatedOperationMethod<
   ListEarthObservationJobInput,
   ListEarthObservationJobOutput,
   ListEarthObservationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListEarthObservationJobOutputConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEarthObservationJobInput,
@@ -2042,7 +2041,7 @@ export const listRasterDataCollections: API.PaginatedOperationMethod<
   ListRasterDataCollectionsInput,
   ListRasterDataCollectionsOutput,
   ListRasterDataCollectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RasterDataCollectionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRasterDataCollectionsInput,
@@ -2078,7 +2077,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2108,7 +2107,7 @@ export const listVectorEnrichmentJobs: API.PaginatedOperationMethod<
   ListVectorEnrichmentJobInput,
   ListVectorEnrichmentJobOutput,
   ListVectorEnrichmentJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListVectorEnrichmentJobOutputConfig
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVectorEnrichmentJobInput,
@@ -2144,7 +2143,7 @@ export const searchRasterDataCollection: API.PaginatedOperationMethod<
   SearchRasterDataCollectionInput,
   SearchRasterDataCollectionOutput,
   SearchRasterDataCollectionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchRasterDataCollectionInput,
@@ -2178,7 +2177,7 @@ export const startEarthObservationJob: API.OperationMethod<
   StartEarthObservationJobInput,
   StartEarthObservationJobOutput,
   StartEarthObservationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEarthObservationJobInput,
   output: StartEarthObservationJobOutput,
@@ -2212,7 +2211,7 @@ export const startVectorEnrichmentJob: API.OperationMethod<
   StartVectorEnrichmentJobInput,
   StartVectorEnrichmentJobOutput,
   StartVectorEnrichmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartVectorEnrichmentJobInput,
   output: StartVectorEnrichmentJobOutput,
@@ -2245,7 +2244,7 @@ export const stopEarthObservationJob: API.OperationMethod<
   StopEarthObservationJobInput,
   StopEarthObservationJobOutput,
   StopEarthObservationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEarthObservationJobInput,
   output: StopEarthObservationJobOutput,
@@ -2277,7 +2276,7 @@ export const stopVectorEnrichmentJob: API.OperationMethod<
   StopVectorEnrichmentJobInput,
   StopVectorEnrichmentJobOutput,
   StopVectorEnrichmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopVectorEnrichmentJobInput,
   output: StopVectorEnrichmentJobOutput,
@@ -2308,7 +2307,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2338,7 +2337,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/sagemaker-metrics.ts
+++ b/packages/aws/src/services/sagemaker-metrics.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker Metrics",
   serviceShapeName: "SageMakerMetricsService",
@@ -272,7 +271,7 @@ export const batchGetMetrics: API.OperationMethod<
   BatchGetMetricsRequest,
   BatchGetMetricsResponse,
   BatchGetMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetMetricsRequest,
   output: BatchGetMetricsResponse,
@@ -290,7 +289,7 @@ export const batchPutMetrics: API.OperationMethod<
   BatchPutMetricsRequest,
   BatchPutMetricsResponse,
   BatchPutMetricsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutMetricsRequest,
   output: BatchPutMetricsResponse,

--- a/packages/aws/src/services/sagemaker-runtime-http2.ts
+++ b/packages/aws/src/services/sagemaker-runtime-http2.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker Runtime HTTP2",
@@ -538,7 +537,7 @@ export const invokeEndpointWithBidirectionalStream: API.OperationMethod<
   InvokeEndpointWithBidirectionalStreamInput,
   InvokeEndpointWithBidirectionalStreamOutput,
   InvokeEndpointWithBidirectionalStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeEndpointWithBidirectionalStreamInput,
   output: InvokeEndpointWithBidirectionalStreamOutput,

--- a/packages/aws/src/services/sagemaker-runtime.ts
+++ b/packages/aws/src/services/sagemaker-runtime.ts
@@ -9,7 +9,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SageMaker Runtime",
@@ -489,7 +488,7 @@ export const invokeEndpoint: API.OperationMethod<
   InvokeEndpointInput,
   InvokeEndpointOutput,
   InvokeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeEndpointInput,
   output: InvokeEndpointOutput,
@@ -532,7 +531,7 @@ export const invokeEndpointAsync: API.OperationMethod<
   InvokeEndpointAsyncInput,
   InvokeEndpointAsyncOutput,
   InvokeEndpointAsyncError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeEndpointAsyncInput,
   output: InvokeEndpointAsyncOutput,
@@ -580,7 +579,7 @@ export const invokeEndpointWithResponseStream: API.OperationMethod<
   InvokeEndpointWithResponseStreamInput,
   InvokeEndpointWithResponseStreamOutput,
   InvokeEndpointWithResponseStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InvokeEndpointWithResponseStreamInput,
   output: InvokeEndpointWithResponseStreamOutput,

--- a/packages/aws/src/services/sagemaker.ts
+++ b/packages/aws/src/services/sagemaker.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://sagemaker.amazonaws.com/doc/2017-05-13/");
 const svc = T.AwsApiService({
@@ -38290,7 +38289,7 @@ export const addAssociation: API.OperationMethod<
   AddAssociationRequest,
   AddAssociationResponse,
   AddAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddAssociationRequest,
   output: AddAssociationResponse,
@@ -38314,7 +38313,7 @@ export const addTags: API.OperationMethod<
   AddTagsInput,
   AddTagsOutput,
   AddTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsInput,
   output: AddTagsOutput,
@@ -38335,7 +38334,7 @@ export const associateTrialComponent: API.OperationMethod<
   AssociateTrialComponentRequest,
   AssociateTrialComponentResponse,
   AssociateTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTrialComponentRequest,
   output: AssociateTrialComponentResponse,
@@ -38355,7 +38354,7 @@ export const attachClusterNodeVolume: API.OperationMethod<
   AttachClusterNodeVolumeRequest,
   AttachClusterNodeVolumeResponse,
   AttachClusterNodeVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachClusterNodeVolumeRequest,
   output: AttachClusterNodeVolumeResponse,
@@ -38378,7 +38377,7 @@ export const batchAddClusterNodes: API.OperationMethod<
   BatchAddClusterNodesRequest,
   BatchAddClusterNodesResponse,
   BatchAddClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAddClusterNodesRequest,
   output: BatchAddClusterNodesResponse,
@@ -38400,7 +38399,7 @@ export const batchDeleteClusterNodes: API.OperationMethod<
   BatchDeleteClusterNodesRequest,
   BatchDeleteClusterNodesResponse,
   BatchDeleteClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteClusterNodesRequest,
   output: BatchDeleteClusterNodesResponse,
@@ -38418,7 +38417,7 @@ export const batchDescribeModelPackage: API.OperationMethod<
   BatchDescribeModelPackageInput,
   BatchDescribeModelPackageOutput,
   BatchDescribeModelPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDescribeModelPackageInput,
   output: BatchDescribeModelPackageOutput,
@@ -38444,7 +38443,7 @@ export const batchRebootClusterNodes: API.OperationMethod<
   BatchRebootClusterNodesRequest,
   BatchRebootClusterNodesResponse,
   BatchRebootClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchRebootClusterNodesRequest,
   output: BatchRebootClusterNodesResponse,
@@ -38472,7 +38471,7 @@ export const batchReplaceClusterNodes: API.OperationMethod<
   BatchReplaceClusterNodesRequest,
   BatchReplaceClusterNodesResponse,
   BatchReplaceClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchReplaceClusterNodesRequest,
   output: BatchReplaceClusterNodesResponse,
@@ -38490,7 +38489,7 @@ export const createAction: API.OperationMethod<
   CreateActionRequest,
   CreateActionResponse,
   CreateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActionRequest,
   output: CreateActionResponse,
@@ -38512,7 +38511,7 @@ export const createAIBenchmarkJob: API.OperationMethod<
   CreateAIBenchmarkJobRequest,
   CreateAIBenchmarkJobResponse,
   CreateAIBenchmarkJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIBenchmarkJobRequest,
   output: CreateAIBenchmarkJobResponse,
@@ -38534,7 +38533,7 @@ export const createAIRecommendationJob: API.OperationMethod<
   CreateAIRecommendationJobRequest,
   CreateAIRecommendationJobResponse,
   CreateAIRecommendationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIRecommendationJobRequest,
   output: CreateAIRecommendationJobResponse,
@@ -38555,7 +38554,7 @@ export const createAIWorkloadConfig: API.OperationMethod<
   CreateAIWorkloadConfigRequest,
   CreateAIWorkloadConfigResponse,
   CreateAIWorkloadConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAIWorkloadConfigRequest,
   output: CreateAIWorkloadConfigResponse,
@@ -38573,7 +38572,7 @@ export const createAlgorithm: API.OperationMethod<
   CreateAlgorithmInput,
   CreateAlgorithmOutput,
   CreateAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAlgorithmInput,
   output: CreateAlgorithmOutput,
@@ -38594,7 +38593,7 @@ export const createApp: API.OperationMethod<
   CreateAppRequest,
   CreateAppResponse,
   CreateAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppRequest,
   output: CreateAppResponse,
@@ -38612,7 +38611,7 @@ export const createAppImageConfig: API.OperationMethod<
   CreateAppImageConfigRequest,
   CreateAppImageConfigResponse,
   CreateAppImageConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppImageConfigRequest,
   output: CreateAppImageConfigResponse,
@@ -38630,7 +38629,7 @@ export const createArtifact: API.OperationMethod<
   CreateArtifactRequest,
   CreateArtifactResponse,
   CreateArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateArtifactRequest,
   output: CreateArtifactResponse,
@@ -38663,7 +38662,7 @@ export const createAutoMLJob: API.OperationMethod<
   CreateAutoMLJobRequest,
   CreateAutoMLJobResponse,
   CreateAutoMLJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutoMLJobRequest,
   output: CreateAutoMLJobResponse,
@@ -38700,7 +38699,7 @@ export const createAutoMLJobV2: API.OperationMethod<
   CreateAutoMLJobV2Request,
   CreateAutoMLJobV2Response,
   CreateAutoMLJobV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutoMLJobV2Request,
   output: CreateAutoMLJobV2Response,
@@ -38721,7 +38720,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResponse,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResponse,
@@ -38742,7 +38741,7 @@ export const createClusterSchedulerConfig: API.OperationMethod<
   CreateClusterSchedulerConfigRequest,
   CreateClusterSchedulerConfigResponse,
   CreateClusterSchedulerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterSchedulerConfigRequest,
   output: CreateClusterSchedulerConfigResponse,
@@ -38762,7 +38761,7 @@ export const createCodeRepository: API.OperationMethod<
   CreateCodeRepositoryInput,
   CreateCodeRepositoryOutput,
   CreateCodeRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeRepositoryInput,
   output: CreateCodeRepositoryOutput,
@@ -38799,7 +38798,7 @@ export const createCompilationJob: API.OperationMethod<
   CreateCompilationJobRequest,
   CreateCompilationJobResponse,
   CreateCompilationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCompilationJobRequest,
   output: CreateCompilationJobResponse,
@@ -38820,7 +38819,7 @@ export const createComputeQuota: API.OperationMethod<
   CreateComputeQuotaRequest,
   CreateComputeQuotaResponse,
   CreateComputeQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateComputeQuotaRequest,
   output: CreateComputeQuotaResponse,
@@ -38838,7 +38837,7 @@ export const createContext: API.OperationMethod<
   CreateContextRequest,
   CreateContextResponse,
   CreateContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContextRequest,
   output: CreateContextResponse,
@@ -38859,7 +38858,7 @@ export const createDataQualityJobDefinition: API.OperationMethod<
   CreateDataQualityJobDefinitionRequest,
   CreateDataQualityJobDefinitionResponse,
   CreateDataQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataQualityJobDefinitionRequest,
   output: CreateDataQualityJobDefinitionResponse,
@@ -38880,7 +38879,7 @@ export const createDeviceFleet: API.OperationMethod<
   CreateDeviceFleetRequest,
   CreateDeviceFleetResponse,
   CreateDeviceFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeviceFleetRequest,
   output: CreateDeviceFleetResponse,
@@ -38921,7 +38920,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -38941,7 +38940,7 @@ export const createEdgeDeploymentPlan: API.OperationMethod<
   CreateEdgeDeploymentPlanRequest,
   CreateEdgeDeploymentPlanResponse,
   CreateEdgeDeploymentPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEdgeDeploymentPlanRequest,
   output: CreateEdgeDeploymentPlanResponse,
@@ -38961,7 +38960,7 @@ export const createEdgeDeploymentStage: API.OperationMethod<
   CreateEdgeDeploymentStageRequest,
   CreateEdgeDeploymentStageResponse,
   CreateEdgeDeploymentStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEdgeDeploymentStageRequest,
   output: CreateEdgeDeploymentStageResponse,
@@ -38979,7 +38978,7 @@ export const createEdgePackagingJob: API.OperationMethod<
   CreateEdgePackagingJobRequest,
   CreateEdgePackagingJobResponse,
   CreateEdgePackagingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEdgePackagingJobRequest,
   output: CreateEdgePackagingJobResponse,
@@ -39033,7 +39032,7 @@ export const createEndpoint: API.OperationMethod<
   CreateEndpointInput,
   CreateEndpointOutput,
   CreateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointInput,
   output: CreateEndpointOutput,
@@ -39066,7 +39065,7 @@ export const createEndpointConfig: API.OperationMethod<
   CreateEndpointConfigInput,
   CreateEndpointConfigOutput,
   CreateEndpointConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEndpointConfigInput,
   output: CreateEndpointConfigOutput,
@@ -39096,7 +39095,7 @@ export const createExperiment: API.OperationMethod<
   CreateExperimentRequest,
   CreateExperimentResponse,
   CreateExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExperimentRequest,
   output: CreateExperimentResponse,
@@ -39123,7 +39122,7 @@ export const createFeatureGroup: API.OperationMethod<
   CreateFeatureGroupRequest,
   CreateFeatureGroupResponse,
   CreateFeatureGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFeatureGroupRequest,
   output: CreateFeatureGroupResponse,
@@ -39144,7 +39143,7 @@ export const createFlowDefinition: API.OperationMethod<
   CreateFlowDefinitionRequest,
   CreateFlowDefinitionResponse,
   CreateFlowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFlowDefinitionRequest,
   output: CreateFlowDefinitionResponse,
@@ -39165,7 +39164,7 @@ export const createHub: API.OperationMethod<
   CreateHubRequest,
   CreateHubResponse,
   CreateHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHubRequest,
   output: CreateHubResponse,
@@ -39183,7 +39182,7 @@ export const createHubContentPresignedUrls: API.PaginatedOperationMethod<
   CreateHubContentPresignedUrlsRequest,
   CreateHubContentPresignedUrlsResponse,
   CreateHubContentPresignedUrlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuthorizedUrl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: CreateHubContentPresignedUrlsRequest,
@@ -39212,7 +39211,7 @@ export const createHubContentReference: API.OperationMethod<
   CreateHubContentReferenceRequest,
   CreateHubContentReferenceResponse,
   CreateHubContentReferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHubContentReferenceRequest,
   output: CreateHubContentReferenceResponse,
@@ -39233,7 +39232,7 @@ export const createHumanTaskUi: API.OperationMethod<
   CreateHumanTaskUiRequest,
   CreateHumanTaskUiResponse,
   CreateHumanTaskUiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHumanTaskUiRequest,
   output: CreateHumanTaskUiResponse,
@@ -39258,7 +39257,7 @@ export const createHyperParameterTuningJob: API.OperationMethod<
   CreateHyperParameterTuningJobRequest,
   CreateHyperParameterTuningJobResponse,
   CreateHyperParameterTuningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHyperParameterTuningJobRequest,
   output: CreateHyperParameterTuningJobResponse,
@@ -39279,7 +39278,7 @@ export const createImage: API.OperationMethod<
   CreateImageRequest,
   CreateImageResponse,
   CreateImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageRequest,
   output: CreateImageResponse,
@@ -39301,7 +39300,7 @@ export const createImageVersion: API.OperationMethod<
   CreateImageVersionRequest,
   CreateImageVersionResponse,
   CreateImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImageVersionRequest,
   output: CreateImageVersionResponse,
@@ -39321,7 +39320,7 @@ export const createInferenceComponent: API.OperationMethod<
   CreateInferenceComponentInput,
   CreateInferenceComponentOutput,
   CreateInferenceComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInferenceComponentInput,
   output: CreateInferenceComponentOutput,
@@ -39348,7 +39347,7 @@ export const createInferenceExperiment: API.OperationMethod<
   CreateInferenceExperimentRequest,
   CreateInferenceExperimentResponse,
   CreateInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInferenceExperimentRequest,
   output: CreateInferenceExperimentResponse,
@@ -39369,7 +39368,7 @@ export const createInferenceRecommendationsJob: API.OperationMethod<
   CreateInferenceRecommendationsJobRequest,
   CreateInferenceRecommendationsJobResponse,
   CreateInferenceRecommendationsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInferenceRecommendationsJobRequest,
   output: CreateInferenceRecommendationsJobResponse,
@@ -39409,7 +39408,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResponse,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResponse,
@@ -39446,7 +39445,7 @@ export const createLabelingJob: API.OperationMethod<
   CreateLabelingJobRequest,
   CreateLabelingJobResponse,
   CreateLabelingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLabelingJobRequest,
   output: CreateLabelingJobResponse,
@@ -39464,7 +39463,7 @@ export const createMlflowApp: API.OperationMethod<
   CreateMlflowAppRequest,
   CreateMlflowAppResponse,
   CreateMlflowAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMlflowAppRequest,
   output: CreateMlflowAppResponse,
@@ -39484,7 +39483,7 @@ export const createMlflowTrackingServer: API.OperationMethod<
   CreateMlflowTrackingServerRequest,
   CreateMlflowTrackingServerResponse,
   CreateMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMlflowTrackingServerRequest,
   output: CreateMlflowTrackingServerResponse,
@@ -39513,7 +39512,7 @@ export const createModel: API.OperationMethod<
   CreateModelInput,
   CreateModelOutput,
   CreateModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelInput,
   output: CreateModelOutput,
@@ -39534,7 +39533,7 @@ export const createModelBiasJobDefinition: API.OperationMethod<
   CreateModelBiasJobDefinitionRequest,
   CreateModelBiasJobDefinitionResponse,
   CreateModelBiasJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelBiasJobDefinitionRequest,
   output: CreateModelBiasJobDefinitionResponse,
@@ -39557,7 +39556,7 @@ export const createModelCard: API.OperationMethod<
   CreateModelCardRequest,
   CreateModelCardResponse,
   CreateModelCardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelCardRequest,
   output: CreateModelCardResponse,
@@ -39579,7 +39578,7 @@ export const createModelCardExportJob: API.OperationMethod<
   CreateModelCardExportJobRequest,
   CreateModelCardExportJobResponse,
   CreateModelCardExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelCardExportJobRequest,
   output: CreateModelCardExportJobResponse,
@@ -39600,7 +39599,7 @@ export const createModelExplainabilityJobDefinition: API.OperationMethod<
   CreateModelExplainabilityJobDefinitionRequest,
   CreateModelExplainabilityJobDefinitionResponse,
   CreateModelExplainabilityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelExplainabilityJobDefinitionRequest,
   output: CreateModelExplainabilityJobDefinitionResponse,
@@ -39629,7 +39628,7 @@ export const createModelPackage: API.OperationMethod<
   CreateModelPackageInput,
   CreateModelPackageOutput,
   CreateModelPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelPackageInput,
   output: CreateModelPackageOutput,
@@ -39647,7 +39646,7 @@ export const createModelPackageGroup: API.OperationMethod<
   CreateModelPackageGroupInput,
   CreateModelPackageGroupOutput,
   CreateModelPackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelPackageGroupInput,
   output: CreateModelPackageGroupOutput,
@@ -39668,7 +39667,7 @@ export const createModelQualityJobDefinition: API.OperationMethod<
   CreateModelQualityJobDefinitionRequest,
   CreateModelQualityJobDefinitionResponse,
   CreateModelQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateModelQualityJobDefinitionRequest,
   output: CreateModelQualityJobDefinitionResponse,
@@ -39689,7 +39688,7 @@ export const createMonitoringSchedule: API.OperationMethod<
   CreateMonitoringScheduleRequest,
   CreateMonitoringScheduleResponse,
   CreateMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMonitoringScheduleRequest,
   output: CreateMonitoringScheduleResponse,
@@ -39725,7 +39724,7 @@ export const createNotebookInstance: API.OperationMethod<
   CreateNotebookInstanceInput,
   CreateNotebookInstanceOutput,
   CreateNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotebookInstanceInput,
   output: CreateNotebookInstanceOutput,
@@ -39757,7 +39756,7 @@ export const createNotebookInstanceLifecycleConfig: API.OperationMethod<
   CreateNotebookInstanceLifecycleConfigInput,
   CreateNotebookInstanceLifecycleConfigOutput,
   CreateNotebookInstanceLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotebookInstanceLifecycleConfigInput,
   output: CreateNotebookInstanceLifecycleConfigOutput,
@@ -39780,7 +39779,7 @@ export const createOptimizationJob: API.OperationMethod<
   CreateOptimizationJobRequest,
   CreateOptimizationJobResponse,
   CreateOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOptimizationJobRequest,
   output: CreateOptimizationJobResponse,
@@ -39801,7 +39800,7 @@ export const createPartnerApp: API.OperationMethod<
   CreatePartnerAppRequest,
   CreatePartnerAppResponse,
   CreatePartnerAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerAppRequest,
   output: CreatePartnerAppResponse,
@@ -39819,7 +39818,7 @@ export const createPartnerAppPresignedUrl: API.OperationMethod<
   CreatePartnerAppPresignedUrlRequest,
   CreatePartnerAppPresignedUrlResponse,
   CreatePartnerAppPresignedUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePartnerAppPresignedUrlRequest,
   output: CreatePartnerAppPresignedUrlResponse,
@@ -39841,7 +39840,7 @@ export const createPipeline: API.OperationMethod<
   CreatePipelineRequest,
   CreatePipelineResponse,
   CreatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePipelineRequest,
   output: CreatePipelineResponse,
@@ -39867,7 +39866,7 @@ export const createPresignedDomainUrl: API.OperationMethod<
   CreatePresignedDomainUrlRequest,
   CreatePresignedDomainUrlResponse,
   CreatePresignedDomainUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedDomainUrlRequest,
   output: CreatePresignedDomainUrlResponse,
@@ -39885,7 +39884,7 @@ export const createPresignedMlflowAppUrl: API.OperationMethod<
   CreatePresignedMlflowAppUrlRequest,
   CreatePresignedMlflowAppUrlResponse,
   CreatePresignedMlflowAppUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedMlflowAppUrlRequest,
   output: CreatePresignedMlflowAppUrlResponse,
@@ -39905,7 +39904,7 @@ export const createPresignedMlflowTrackingServerUrl: API.OperationMethod<
   CreatePresignedMlflowTrackingServerUrlRequest,
   CreatePresignedMlflowTrackingServerUrlResponse,
   CreatePresignedMlflowTrackingServerUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedMlflowTrackingServerUrlRequest,
   output: CreatePresignedMlflowTrackingServerUrlResponse,
@@ -39929,7 +39928,7 @@ export const createPresignedNotebookInstanceUrl: API.OperationMethod<
   CreatePresignedNotebookInstanceUrlInput,
   CreatePresignedNotebookInstanceUrlOutput,
   CreatePresignedNotebookInstanceUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePresignedNotebookInstanceUrlInput,
   output: CreatePresignedNotebookInstanceUrlOutput,
@@ -39951,7 +39950,7 @@ export const createProcessingJob: API.OperationMethod<
   CreateProcessingJobRequest,
   CreateProcessingJobResponse,
   CreateProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProcessingJobRequest,
   output: CreateProcessingJobResponse,
@@ -39969,7 +39968,7 @@ export const createProject: API.OperationMethod<
   CreateProjectInput,
   CreateProjectOutput,
   CreateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProjectInput,
   output: CreateProjectOutput,
@@ -39990,7 +39989,7 @@ export const createSpace: API.OperationMethod<
   CreateSpaceRequest,
   CreateSpaceResponse,
   CreateSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSpaceRequest,
   output: CreateSpaceResponse,
@@ -40008,7 +40007,7 @@ export const createStudioLifecycleConfig: API.OperationMethod<
   CreateStudioLifecycleConfigRequest,
   CreateStudioLifecycleConfigResponse,
   CreateStudioLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStudioLifecycleConfigRequest,
   output: CreateStudioLifecycleConfigResponse,
@@ -40060,7 +40059,7 @@ export const createTrainingJob: API.OperationMethod<
   CreateTrainingJobRequest,
   CreateTrainingJobResponse,
   CreateTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrainingJobRequest,
   output: CreateTrainingJobResponse,
@@ -40112,7 +40111,7 @@ export const createTrainingPlan: API.OperationMethod<
   CreateTrainingPlanRequest,
   CreateTrainingPlanResponse,
   CreateTrainingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrainingPlanRequest,
   output: CreateTrainingPlanResponse,
@@ -40150,7 +40149,7 @@ export const createTransformJob: API.OperationMethod<
   CreateTransformJobRequest,
   CreateTransformJobResponse,
   CreateTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTransformJobRequest,
   output: CreateTransformJobResponse,
@@ -40177,7 +40176,7 @@ export const createTrial: API.OperationMethod<
   CreateTrialRequest,
   CreateTrialResponse,
   CreateTrialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrialRequest,
   output: CreateTrialResponse,
@@ -40201,7 +40200,7 @@ export const createTrialComponent: API.OperationMethod<
   CreateTrialComponentRequest,
   CreateTrialComponentResponse,
   CreateTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrialComponentRequest,
   output: CreateTrialComponentResponse,
@@ -40222,7 +40221,7 @@ export const createUserProfile: API.OperationMethod<
   CreateUserProfileRequest,
   CreateUserProfileResponse,
   CreateUserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserProfileRequest,
   output: CreateUserProfileResponse,
@@ -40246,7 +40245,7 @@ export const createWorkforce: API.OperationMethod<
   CreateWorkforceRequest,
   CreateWorkforceResponse,
   CreateWorkforceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkforceRequest,
   output: CreateWorkforceResponse,
@@ -40269,7 +40268,7 @@ export const createWorkteam: API.OperationMethod<
   CreateWorkteamRequest,
   CreateWorkteamResponse,
   CreateWorkteamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkteamRequest,
   output: CreateWorkteamResponse,
@@ -40287,7 +40286,7 @@ export const deleteAction: API.OperationMethod<
   DeleteActionRequest,
   DeleteActionResponse,
   DeleteActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActionRequest,
   output: DeleteActionResponse,
@@ -40305,7 +40304,7 @@ export const deleteAIBenchmarkJob: API.OperationMethod<
   DeleteAIBenchmarkJobRequest,
   DeleteAIBenchmarkJobResponse,
   DeleteAIBenchmarkJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIBenchmarkJobRequest,
   output: DeleteAIBenchmarkJobResponse,
@@ -40323,7 +40322,7 @@ export const deleteAIRecommendationJob: API.OperationMethod<
   DeleteAIRecommendationJobRequest,
   DeleteAIRecommendationJobResponse,
   DeleteAIRecommendationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIRecommendationJobRequest,
   output: DeleteAIRecommendationJobResponse,
@@ -40344,7 +40343,7 @@ export const deleteAIWorkloadConfig: API.OperationMethod<
   DeleteAIWorkloadConfigRequest,
   DeleteAIWorkloadConfigResponse,
   DeleteAIWorkloadConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAIWorkloadConfigRequest,
   output: DeleteAIWorkloadConfigResponse,
@@ -40362,7 +40361,7 @@ export const deleteAlgorithm: API.OperationMethod<
   DeleteAlgorithmInput,
   DeleteAlgorithmResponse,
   DeleteAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAlgorithmInput,
   output: DeleteAlgorithmResponse,
@@ -40380,7 +40379,7 @@ export const deleteApp: API.OperationMethod<
   DeleteAppRequest,
   DeleteAppResponse,
   DeleteAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppRequest,
   output: DeleteAppResponse,
@@ -40398,7 +40397,7 @@ export const deleteAppImageConfig: API.OperationMethod<
   DeleteAppImageConfigRequest,
   DeleteAppImageConfigResponse,
   DeleteAppImageConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppImageConfigRequest,
   output: DeleteAppImageConfigResponse,
@@ -40416,7 +40415,7 @@ export const deleteArtifact: API.OperationMethod<
   DeleteArtifactRequest,
   DeleteArtifactResponse,
   DeleteArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArtifactRequest,
   output: DeleteArtifactResponse,
@@ -40434,7 +40433,7 @@ export const deleteAssociation: API.OperationMethod<
   DeleteAssociationRequest,
   DeleteAssociationResponse,
   DeleteAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssociationRequest,
   output: DeleteAssociationResponse,
@@ -40455,7 +40454,7 @@ export const deleteCluster: API.OperationMethod<
   DeleteClusterRequest,
   DeleteClusterResponse,
   DeleteClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterRequest,
   output: DeleteClusterResponse,
@@ -40473,7 +40472,7 @@ export const deleteClusterSchedulerConfig: API.OperationMethod<
   DeleteClusterSchedulerConfigRequest,
   DeleteClusterSchedulerConfigResponse,
   DeleteClusterSchedulerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClusterSchedulerConfigRequest,
   output: DeleteClusterSchedulerConfigResponse,
@@ -40491,7 +40490,7 @@ export const deleteCodeRepository: API.OperationMethod<
   DeleteCodeRepositoryInput,
   DeleteCodeRepositoryResponse,
   DeleteCodeRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCodeRepositoryInput,
   output: DeleteCodeRepositoryResponse,
@@ -40511,7 +40510,7 @@ export const deleteCompilationJob: API.OperationMethod<
   DeleteCompilationJobRequest,
   DeleteCompilationJobResponse,
   DeleteCompilationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCompilationJobRequest,
   output: DeleteCompilationJobResponse,
@@ -40529,7 +40528,7 @@ export const deleteComputeQuota: API.OperationMethod<
   DeleteComputeQuotaRequest,
   DeleteComputeQuotaResponse,
   DeleteComputeQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteComputeQuotaRequest,
   output: DeleteComputeQuotaResponse,
@@ -40547,7 +40546,7 @@ export const deleteContext: API.OperationMethod<
   DeleteContextRequest,
   DeleteContextResponse,
   DeleteContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContextRequest,
   output: DeleteContextResponse,
@@ -40567,7 +40566,7 @@ export const deleteDataQualityJobDefinition: API.OperationMethod<
   DeleteDataQualityJobDefinitionRequest,
   DeleteDataQualityJobDefinitionResponse,
   DeleteDataQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataQualityJobDefinitionRequest,
   output: DeleteDataQualityJobDefinitionResponse,
@@ -40585,7 +40584,7 @@ export const deleteDeviceFleet: API.OperationMethod<
   DeleteDeviceFleetRequest,
   DeleteDeviceFleetResponse,
   DeleteDeviceFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceFleetRequest,
   output: DeleteDeviceFleetResponse,
@@ -40603,7 +40602,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -40621,7 +40620,7 @@ export const deleteEdgeDeploymentPlan: API.OperationMethod<
   DeleteEdgeDeploymentPlanRequest,
   DeleteEdgeDeploymentPlanResponse,
   DeleteEdgeDeploymentPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEdgeDeploymentPlanRequest,
   output: DeleteEdgeDeploymentPlanResponse,
@@ -40639,7 +40638,7 @@ export const deleteEdgeDeploymentStage: API.OperationMethod<
   DeleteEdgeDeploymentStageRequest,
   DeleteEdgeDeploymentStageResponse,
   DeleteEdgeDeploymentStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEdgeDeploymentStageRequest,
   output: DeleteEdgeDeploymentStageResponse,
@@ -40661,7 +40660,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointInput,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointInput,
   output: DeleteEndpointResponse,
@@ -40681,7 +40680,7 @@ export const deleteEndpointConfig: API.OperationMethod<
   DeleteEndpointConfigInput,
   DeleteEndpointConfigResponse,
   DeleteEndpointConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointConfigInput,
   output: DeleteEndpointConfigResponse,
@@ -40699,7 +40698,7 @@ export const deleteExperiment: API.OperationMethod<
   DeleteExperimentRequest,
   DeleteExperimentResponse,
   DeleteExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteExperimentRequest,
   output: DeleteExperimentResponse,
@@ -40721,7 +40720,7 @@ export const deleteFeatureGroup: API.OperationMethod<
   DeleteFeatureGroupRequest,
   DeleteFeatureGroupResponse,
   DeleteFeatureGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFeatureGroupRequest,
   output: DeleteFeatureGroupResponse,
@@ -40742,7 +40741,7 @@ export const deleteFlowDefinition: API.OperationMethod<
   DeleteFlowDefinitionRequest,
   DeleteFlowDefinitionResponse,
   DeleteFlowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFlowDefinitionRequest,
   output: DeleteFlowDefinitionResponse,
@@ -40760,7 +40759,7 @@ export const deleteHub: API.OperationMethod<
   DeleteHubRequest,
   DeleteHubResponse,
   DeleteHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHubRequest,
   output: DeleteHubResponse,
@@ -40781,7 +40780,7 @@ export const deleteHubContent: API.OperationMethod<
   DeleteHubContentRequest,
   DeleteHubContentResponse,
   DeleteHubContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHubContentRequest,
   output: DeleteHubContentResponse,
@@ -40799,7 +40798,7 @@ export const deleteHubContentReference: API.OperationMethod<
   DeleteHubContentReferenceRequest,
   DeleteHubContentReferenceResponse,
   DeleteHubContentReferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHubContentReferenceRequest,
   output: DeleteHubContentReferenceResponse,
@@ -40819,7 +40818,7 @@ export const deleteHumanTaskUi: API.OperationMethod<
   DeleteHumanTaskUiRequest,
   DeleteHumanTaskUiResponse,
   DeleteHumanTaskUiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHumanTaskUiRequest,
   output: DeleteHumanTaskUiResponse,
@@ -40837,7 +40836,7 @@ export const deleteHyperParameterTuningJob: API.OperationMethod<
   DeleteHyperParameterTuningJobRequest,
   DeleteHyperParameterTuningJobResponse,
   DeleteHyperParameterTuningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHyperParameterTuningJobRequest,
   output: DeleteHyperParameterTuningJobResponse,
@@ -40855,7 +40854,7 @@ export const deleteImage: API.OperationMethod<
   DeleteImageRequest,
   DeleteImageResponse,
   DeleteImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageRequest,
   output: DeleteImageResponse,
@@ -40876,7 +40875,7 @@ export const deleteImageVersion: API.OperationMethod<
   DeleteImageVersionRequest,
   DeleteImageVersionResponse,
   DeleteImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImageVersionRequest,
   output: DeleteImageVersionResponse,
@@ -40894,7 +40893,7 @@ export const deleteInferenceComponent: API.OperationMethod<
   DeleteInferenceComponentInput,
   DeleteInferenceComponentResponse,
   DeleteInferenceComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInferenceComponentInput,
   output: DeleteInferenceComponentResponse,
@@ -40917,7 +40916,7 @@ export const deleteInferenceExperiment: API.OperationMethod<
   DeleteInferenceExperimentRequest,
   DeleteInferenceExperimentResponse,
   DeleteInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInferenceExperimentRequest,
   output: DeleteInferenceExperimentResponse,
@@ -40943,7 +40942,7 @@ export const deleteJob: API.OperationMethod<
   DeleteJobRequest,
   DeleteJobResponse,
   DeleteJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteJobRequest,
   output: DeleteJobResponse,
@@ -40961,7 +40960,7 @@ export const deleteMlflowApp: API.OperationMethod<
   DeleteMlflowAppRequest,
   DeleteMlflowAppResponse,
   DeleteMlflowAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMlflowAppRequest,
   output: DeleteMlflowAppResponse,
@@ -40979,7 +40978,7 @@ export const deleteMlflowTrackingServer: API.OperationMethod<
   DeleteMlflowTrackingServerRequest,
   DeleteMlflowTrackingServerResponse,
   DeleteMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMlflowTrackingServerRequest,
   output: DeleteMlflowTrackingServerResponse,
@@ -40997,7 +40996,7 @@ export const deleteModel: API.OperationMethod<
   DeleteModelInput,
   DeleteModelResponse,
   DeleteModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelInput,
   output: DeleteModelResponse,
@@ -41015,7 +41014,7 @@ export const deleteModelBiasJobDefinition: API.OperationMethod<
   DeleteModelBiasJobDefinitionRequest,
   DeleteModelBiasJobDefinitionResponse,
   DeleteModelBiasJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelBiasJobDefinitionRequest,
   output: DeleteModelBiasJobDefinitionResponse,
@@ -41036,7 +41035,7 @@ export const deleteModelCard: API.OperationMethod<
   DeleteModelCardRequest,
   DeleteModelCardResponse,
   DeleteModelCardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelCardRequest,
   output: DeleteModelCardResponse,
@@ -41056,7 +41055,7 @@ export const deleteModelExplainabilityJobDefinition: API.OperationMethod<
   DeleteModelExplainabilityJobDefinitionRequest,
   DeleteModelExplainabilityJobDefinitionResponse,
   DeleteModelExplainabilityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelExplainabilityJobDefinitionRequest,
   output: DeleteModelExplainabilityJobDefinitionResponse,
@@ -41076,7 +41075,7 @@ export const deleteModelPackage: API.OperationMethod<
   DeleteModelPackageInput,
   DeleteModelPackageResponse,
   DeleteModelPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelPackageInput,
   output: DeleteModelPackageResponse,
@@ -41094,7 +41093,7 @@ export const deleteModelPackageGroup: API.OperationMethod<
   DeleteModelPackageGroupInput,
   DeleteModelPackageGroupResponse,
   DeleteModelPackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelPackageGroupInput,
   output: DeleteModelPackageGroupResponse,
@@ -41112,7 +41111,7 @@ export const deleteModelPackageGroupPolicy: API.OperationMethod<
   DeleteModelPackageGroupPolicyInput,
   DeleteModelPackageGroupPolicyResponse,
   DeleteModelPackageGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelPackageGroupPolicyInput,
   output: DeleteModelPackageGroupPolicyResponse,
@@ -41132,7 +41131,7 @@ export const deleteModelQualityJobDefinition: API.OperationMethod<
   DeleteModelQualityJobDefinitionRequest,
   DeleteModelQualityJobDefinitionResponse,
   DeleteModelQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteModelQualityJobDefinitionRequest,
   output: DeleteModelQualityJobDefinitionResponse,
@@ -41150,7 +41149,7 @@ export const deleteMonitoringSchedule: API.OperationMethod<
   DeleteMonitoringScheduleRequest,
   DeleteMonitoringScheduleResponse,
   DeleteMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMonitoringScheduleRequest,
   output: DeleteMonitoringScheduleResponse,
@@ -41170,7 +41169,7 @@ export const deleteNotebookInstance: API.OperationMethod<
   DeleteNotebookInstanceInput,
   DeleteNotebookInstanceResponse,
   DeleteNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotebookInstanceInput,
   output: DeleteNotebookInstanceResponse,
@@ -41188,7 +41187,7 @@ export const deleteNotebookInstanceLifecycleConfig: API.OperationMethod<
   DeleteNotebookInstanceLifecycleConfigInput,
   DeleteNotebookInstanceLifecycleConfigResponse,
   DeleteNotebookInstanceLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotebookInstanceLifecycleConfigInput,
   output: DeleteNotebookInstanceLifecycleConfigResponse,
@@ -41206,7 +41205,7 @@ export const deleteOptimizationJob: API.OperationMethod<
   DeleteOptimizationJobRequest,
   DeleteOptimizationJobResponse,
   DeleteOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOptimizationJobRequest,
   output: DeleteOptimizationJobResponse,
@@ -41227,7 +41226,7 @@ export const deletePartnerApp: API.OperationMethod<
   DeletePartnerAppRequest,
   DeletePartnerAppResponse,
   DeletePartnerAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePartnerAppRequest,
   output: DeletePartnerAppResponse,
@@ -41248,7 +41247,7 @@ export const deletePipeline: API.OperationMethod<
   DeletePipelineRequest,
   DeletePipelineResponse,
   DeletePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePipelineRequest,
   output: DeletePipelineResponse,
@@ -41269,7 +41268,7 @@ export const deleteProcessingJob: API.OperationMethod<
   DeleteProcessingJobRequest,
   DeleteProcessingJobResponse,
   DeleteProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProcessingJobRequest,
   output: DeleteProcessingJobResponse,
@@ -41287,7 +41286,7 @@ export const deleteProject: API.OperationMethod<
   DeleteProjectInput,
   DeleteProjectResponse,
   DeleteProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProjectInput,
   output: DeleteProjectResponse,
@@ -41305,7 +41304,7 @@ export const deleteSpace: API.OperationMethod<
   DeleteSpaceRequest,
   DeleteSpaceResponse,
   DeleteSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpaceRequest,
   output: DeleteSpaceResponse,
@@ -41326,7 +41325,7 @@ export const deleteStudioLifecycleConfig: API.OperationMethod<
   DeleteStudioLifecycleConfigRequest,
   DeleteStudioLifecycleConfigResponse,
   DeleteStudioLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStudioLifecycleConfigRequest,
   output: DeleteStudioLifecycleConfigResponse,
@@ -41350,7 +41349,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsInput,
   DeleteTagsOutput,
   DeleteTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsInput,
   output: DeleteTagsOutput,
@@ -41371,7 +41370,7 @@ export const deleteTrainingJob: API.OperationMethod<
   DeleteTrainingJobRequest,
   DeleteTrainingJobResponse,
   DeleteTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrainingJobRequest,
   output: DeleteTrainingJobResponse,
@@ -41389,7 +41388,7 @@ export const deleteTrial: API.OperationMethod<
   DeleteTrialRequest,
   DeleteTrialResponse,
   DeleteTrialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrialRequest,
   output: DeleteTrialResponse,
@@ -41407,7 +41406,7 @@ export const deleteTrialComponent: API.OperationMethod<
   DeleteTrialComponentRequest,
   DeleteTrialComponentResponse,
   DeleteTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrialComponentRequest,
   output: DeleteTrialComponentResponse,
@@ -41428,7 +41427,7 @@ export const deleteUserProfile: API.OperationMethod<
   DeleteUserProfileRequest,
   DeleteUserProfileResponse,
   DeleteUserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserProfileRequest,
   output: DeleteUserProfileResponse,
@@ -41450,7 +41449,7 @@ export const deleteWorkforce: API.OperationMethod<
   DeleteWorkforceRequest,
   DeleteWorkforceResponse,
   DeleteWorkforceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkforceRequest,
   output: DeleteWorkforceResponse,
@@ -41468,7 +41467,7 @@ export const deleteWorkteam: API.OperationMethod<
   DeleteWorkteamRequest,
   DeleteWorkteamResponse,
   DeleteWorkteamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkteamRequest,
   output: DeleteWorkteamResponse,
@@ -41486,7 +41485,7 @@ export const deregisterDevices: API.OperationMethod<
   DeregisterDevicesRequest,
   DeregisterDevicesResponse,
   DeregisterDevicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterDevicesRequest,
   output: DeregisterDevicesResponse,
@@ -41504,7 +41503,7 @@ export const describeAction: API.OperationMethod<
   DescribeActionRequest,
   DescribeActionResponse,
   DescribeActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActionRequest,
   output: DescribeActionResponse,
@@ -41522,7 +41521,7 @@ export const describeAIBenchmarkJob: API.OperationMethod<
   DescribeAIBenchmarkJobRequest,
   DescribeAIBenchmarkJobResponse,
   DescribeAIBenchmarkJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAIBenchmarkJobRequest,
   output: DescribeAIBenchmarkJobResponse,
@@ -41540,7 +41539,7 @@ export const describeAIRecommendationJob: API.OperationMethod<
   DescribeAIRecommendationJobRequest,
   DescribeAIRecommendationJobResponse,
   DescribeAIRecommendationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAIRecommendationJobRequest,
   output: DescribeAIRecommendationJobResponse,
@@ -41558,7 +41557,7 @@ export const describeAIWorkloadConfig: API.OperationMethod<
   DescribeAIWorkloadConfigRequest,
   DescribeAIWorkloadConfigResponse,
   DescribeAIWorkloadConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAIWorkloadConfigRequest,
   output: DescribeAIWorkloadConfigResponse,
@@ -41576,7 +41575,7 @@ export const describeAlgorithm: API.OperationMethod<
   DescribeAlgorithmInput,
   DescribeAlgorithmOutput,
   DescribeAlgorithmError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAlgorithmInput,
   output: DescribeAlgorithmOutput,
@@ -41594,7 +41593,7 @@ export const describeApp: API.OperationMethod<
   DescribeAppRequest,
   DescribeAppResponse,
   DescribeAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppRequest,
   output: DescribeAppResponse,
@@ -41612,7 +41611,7 @@ export const describeAppImageConfig: API.OperationMethod<
   DescribeAppImageConfigRequest,
   DescribeAppImageConfigResponse,
   DescribeAppImageConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppImageConfigRequest,
   output: DescribeAppImageConfigResponse,
@@ -41630,7 +41629,7 @@ export const describeArtifact: API.OperationMethod<
   DescribeArtifactRequest,
   DescribeArtifactResponse,
   DescribeArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeArtifactRequest,
   output: DescribeArtifactResponse,
@@ -41650,7 +41649,7 @@ export const describeAutoMLJob: API.OperationMethod<
   DescribeAutoMLJobRequest,
   DescribeAutoMLJobResponse,
   DescribeAutoMLJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutoMLJobRequest,
   output: DescribeAutoMLJobResponse,
@@ -41668,7 +41667,7 @@ export const describeAutoMLJobV2: API.OperationMethod<
   DescribeAutoMLJobV2Request,
   DescribeAutoMLJobV2Response,
   DescribeAutoMLJobV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAutoMLJobV2Request,
   output: DescribeAutoMLJobV2Response,
@@ -41686,7 +41685,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResponse,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResponse,
@@ -41704,7 +41703,7 @@ export const describeClusterEvent: API.OperationMethod<
   DescribeClusterEventRequest,
   DescribeClusterEventResponse,
   DescribeClusterEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterEventRequest,
   output: DescribeClusterEventResponse,
@@ -41722,7 +41721,7 @@ export const describeClusterNode: API.OperationMethod<
   DescribeClusterNodeRequest,
   DescribeClusterNodeResponse,
   DescribeClusterNodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterNodeRequest,
   output: DescribeClusterNodeResponse,
@@ -41742,7 +41741,7 @@ export const describeClusterSchedulerConfig: API.OperationMethod<
   DescribeClusterSchedulerConfigRequest,
   DescribeClusterSchedulerConfigResponse,
   DescribeClusterSchedulerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterSchedulerConfigRequest,
   output: DescribeClusterSchedulerConfigResponse,
@@ -41760,7 +41759,7 @@ export const describeCodeRepository: API.OperationMethod<
   DescribeCodeRepositoryInput,
   DescribeCodeRepositoryOutput,
   DescribeCodeRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCodeRepositoryInput,
   output: DescribeCodeRepositoryOutput,
@@ -41780,7 +41779,7 @@ export const describeCompilationJob: API.OperationMethod<
   DescribeCompilationJobRequest,
   DescribeCompilationJobResponse,
   DescribeCompilationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCompilationJobRequest,
   output: DescribeCompilationJobResponse,
@@ -41798,7 +41797,7 @@ export const describeComputeQuota: API.OperationMethod<
   DescribeComputeQuotaRequest,
   DescribeComputeQuotaResponse,
   DescribeComputeQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeComputeQuotaRequest,
   output: DescribeComputeQuotaResponse,
@@ -41816,7 +41815,7 @@ export const describeContext: API.OperationMethod<
   DescribeContextRequest,
   DescribeContextResponse,
   DescribeContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeContextRequest,
   output: DescribeContextResponse,
@@ -41836,7 +41835,7 @@ export const describeDataQualityJobDefinition: API.OperationMethod<
   DescribeDataQualityJobDefinitionRequest,
   DescribeDataQualityJobDefinitionResponse,
   DescribeDataQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDataQualityJobDefinitionRequest,
   output: DescribeDataQualityJobDefinitionResponse,
@@ -41854,7 +41853,7 @@ export const describeDevice: API.OperationMethod<
   DescribeDeviceRequest,
   DescribeDeviceResponse,
   DescribeDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceRequest,
   output: DescribeDeviceResponse,
@@ -41872,7 +41871,7 @@ export const describeDeviceFleet: API.OperationMethod<
   DescribeDeviceFleetRequest,
   DescribeDeviceFleetResponse,
   DescribeDeviceFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceFleetRequest,
   output: DescribeDeviceFleetResponse,
@@ -41890,7 +41889,7 @@ export const describeDomain: API.OperationMethod<
   DescribeDomainRequest,
   DescribeDomainResponse,
   DescribeDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainRequest,
   output: DescribeDomainResponse,
@@ -41908,7 +41907,7 @@ export const describeEdgeDeploymentPlan: API.OperationMethod<
   DescribeEdgeDeploymentPlanRequest,
   DescribeEdgeDeploymentPlanResponse,
   DescribeEdgeDeploymentPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEdgeDeploymentPlanRequest,
   output: DescribeEdgeDeploymentPlanResponse,
@@ -41926,7 +41925,7 @@ export const describeEdgePackagingJob: API.OperationMethod<
   DescribeEdgePackagingJobRequest,
   DescribeEdgePackagingJobResponse,
   DescribeEdgePackagingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEdgePackagingJobRequest,
   output: DescribeEdgePackagingJobResponse,
@@ -41944,7 +41943,7 @@ export const describeEndpoint: API.OperationMethod<
   DescribeEndpointInput,
   DescribeEndpointOutput,
   DescribeEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointInput,
   output: DescribeEndpointOutput,
@@ -41962,7 +41961,7 @@ export const describeEndpointConfig: API.OperationMethod<
   DescribeEndpointConfigInput,
   DescribeEndpointConfigOutput,
   DescribeEndpointConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointConfigInput,
   output: DescribeEndpointConfigOutput,
@@ -41980,7 +41979,7 @@ export const describeExperiment: API.OperationMethod<
   DescribeExperimentRequest,
   DescribeExperimentResponse,
   DescribeExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExperimentRequest,
   output: DescribeExperimentResponse,
@@ -41998,7 +41997,7 @@ export const describeFeatureGroup: API.OperationMethod<
   DescribeFeatureGroupRequest,
   DescribeFeatureGroupResponse,
   DescribeFeatureGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFeatureGroupRequest,
   output: DescribeFeatureGroupResponse,
@@ -42016,7 +42015,7 @@ export const describeFeatureMetadata: API.OperationMethod<
   DescribeFeatureMetadataRequest,
   DescribeFeatureMetadataResponse,
   DescribeFeatureMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFeatureMetadataRequest,
   output: DescribeFeatureMetadataResponse,
@@ -42034,7 +42033,7 @@ export const describeFlowDefinition: API.OperationMethod<
   DescribeFlowDefinitionRequest,
   DescribeFlowDefinitionResponse,
   DescribeFlowDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFlowDefinitionRequest,
   output: DescribeFlowDefinitionResponse,
@@ -42052,7 +42051,7 @@ export const describeHub: API.OperationMethod<
   DescribeHubRequest,
   DescribeHubResponse,
   DescribeHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHubRequest,
   output: DescribeHubResponse,
@@ -42070,7 +42069,7 @@ export const describeHubContent: API.OperationMethod<
   DescribeHubContentRequest,
   DescribeHubContentResponse,
   DescribeHubContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHubContentRequest,
   output: DescribeHubContentResponse,
@@ -42088,7 +42087,7 @@ export const describeHumanTaskUi: API.OperationMethod<
   DescribeHumanTaskUiRequest,
   DescribeHumanTaskUiResponse,
   DescribeHumanTaskUiError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHumanTaskUiRequest,
   output: DescribeHumanTaskUiResponse,
@@ -42108,7 +42107,7 @@ export const describeHyperParameterTuningJob: API.OperationMethod<
   DescribeHyperParameterTuningJobRequest,
   DescribeHyperParameterTuningJobResponse,
   DescribeHyperParameterTuningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHyperParameterTuningJobRequest,
   output: DescribeHyperParameterTuningJobResponse,
@@ -42126,7 +42125,7 @@ export const describeImage: API.OperationMethod<
   DescribeImageRequest,
   DescribeImageResponse,
   DescribeImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageRequest,
   output: DescribeImageResponse,
@@ -42144,7 +42143,7 @@ export const describeImageVersion: API.OperationMethod<
   DescribeImageVersionRequest,
   DescribeImageVersionResponse,
   DescribeImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageVersionRequest,
   output: DescribeImageVersionResponse,
@@ -42162,7 +42161,7 @@ export const describeInferenceComponent: API.OperationMethod<
   DescribeInferenceComponentInput,
   DescribeInferenceComponentOutput,
   DescribeInferenceComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInferenceComponentInput,
   output: DescribeInferenceComponentOutput,
@@ -42180,7 +42179,7 @@ export const describeInferenceExperiment: API.OperationMethod<
   DescribeInferenceExperimentRequest,
   DescribeInferenceExperimentResponse,
   DescribeInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInferenceExperimentRequest,
   output: DescribeInferenceExperimentResponse,
@@ -42200,7 +42199,7 @@ export const describeInferenceRecommendationsJob: API.OperationMethod<
   DescribeInferenceRecommendationsJobRequest,
   DescribeInferenceRecommendationsJobResponse,
   DescribeInferenceRecommendationsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInferenceRecommendationsJobRequest,
   output: DescribeInferenceRecommendationsJobResponse,
@@ -42228,7 +42227,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobRequest,
   DescribeJobResponse,
   DescribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRequest,
   output: DescribeJobResponse,
@@ -42252,7 +42251,7 @@ export const describeJobSchemaVersion: API.OperationMethod<
   DescribeJobSchemaVersionRequest,
   DescribeJobSchemaVersionResponse,
   DescribeJobSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobSchemaVersionRequest,
   output: DescribeJobSchemaVersionResponse,
@@ -42270,7 +42269,7 @@ export const describeLabelingJob: API.OperationMethod<
   DescribeLabelingJobRequest,
   DescribeLabelingJobResponse,
   DescribeLabelingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLabelingJobRequest,
   output: DescribeLabelingJobResponse,
@@ -42288,7 +42287,7 @@ export const describeLineageGroup: API.OperationMethod<
   DescribeLineageGroupRequest,
   DescribeLineageGroupResponse,
   DescribeLineageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLineageGroupRequest,
   output: DescribeLineageGroupResponse,
@@ -42306,7 +42305,7 @@ export const describeMlflowApp: API.OperationMethod<
   DescribeMlflowAppRequest,
   DescribeMlflowAppResponse,
   DescribeMlflowAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMlflowAppRequest,
   output: DescribeMlflowAppResponse,
@@ -42324,7 +42323,7 @@ export const describeMlflowTrackingServer: API.OperationMethod<
   DescribeMlflowTrackingServerRequest,
   DescribeMlflowTrackingServerResponse,
   DescribeMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMlflowTrackingServerRequest,
   output: DescribeMlflowTrackingServerResponse,
@@ -42342,7 +42341,7 @@ export const describeModel: API.OperationMethod<
   DescribeModelInput,
   DescribeModelOutput,
   DescribeModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelInput,
   output: DescribeModelOutput,
@@ -42362,7 +42361,7 @@ export const describeModelBiasJobDefinition: API.OperationMethod<
   DescribeModelBiasJobDefinitionRequest,
   DescribeModelBiasJobDefinitionResponse,
   DescribeModelBiasJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelBiasJobDefinitionRequest,
   output: DescribeModelBiasJobDefinitionResponse,
@@ -42382,7 +42381,7 @@ export const describeModelCard: API.OperationMethod<
   DescribeModelCardRequest,
   DescribeModelCardResponse,
   DescribeModelCardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelCardRequest,
   output: DescribeModelCardResponse,
@@ -42400,7 +42399,7 @@ export const describeModelCardExportJob: API.OperationMethod<
   DescribeModelCardExportJobRequest,
   DescribeModelCardExportJobResponse,
   DescribeModelCardExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelCardExportJobRequest,
   output: DescribeModelCardExportJobResponse,
@@ -42420,7 +42419,7 @@ export const describeModelExplainabilityJobDefinition: API.OperationMethod<
   DescribeModelExplainabilityJobDefinitionRequest,
   DescribeModelExplainabilityJobDefinitionResponse,
   DescribeModelExplainabilityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelExplainabilityJobDefinitionRequest,
   output: DescribeModelExplainabilityJobDefinitionResponse,
@@ -42442,7 +42441,7 @@ export const describeModelPackage: API.OperationMethod<
   DescribeModelPackageInput,
   DescribeModelPackageOutput,
   DescribeModelPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelPackageInput,
   output: DescribeModelPackageOutput,
@@ -42460,7 +42459,7 @@ export const describeModelPackageGroup: API.OperationMethod<
   DescribeModelPackageGroupInput,
   DescribeModelPackageGroupOutput,
   DescribeModelPackageGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelPackageGroupInput,
   output: DescribeModelPackageGroupOutput,
@@ -42480,7 +42479,7 @@ export const describeModelQualityJobDefinition: API.OperationMethod<
   DescribeModelQualityJobDefinitionRequest,
   DescribeModelQualityJobDefinitionResponse,
   DescribeModelQualityJobDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeModelQualityJobDefinitionRequest,
   output: DescribeModelQualityJobDefinitionResponse,
@@ -42498,7 +42497,7 @@ export const describeMonitoringSchedule: API.OperationMethod<
   DescribeMonitoringScheduleRequest,
   DescribeMonitoringScheduleResponse,
   DescribeMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMonitoringScheduleRequest,
   output: DescribeMonitoringScheduleResponse,
@@ -42516,7 +42515,7 @@ export const describeNotebookInstance: API.OperationMethod<
   DescribeNotebookInstanceInput,
   DescribeNotebookInstanceOutput,
   DescribeNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotebookInstanceInput,
   output: DescribeNotebookInstanceOutput,
@@ -42536,7 +42535,7 @@ export const describeNotebookInstanceLifecycleConfig: API.OperationMethod<
   DescribeNotebookInstanceLifecycleConfigInput,
   DescribeNotebookInstanceLifecycleConfigOutput,
   DescribeNotebookInstanceLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNotebookInstanceLifecycleConfigInput,
   output: DescribeNotebookInstanceLifecycleConfigOutput,
@@ -42554,7 +42553,7 @@ export const describeOptimizationJob: API.OperationMethod<
   DescribeOptimizationJobRequest,
   DescribeOptimizationJobResponse,
   DescribeOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOptimizationJobRequest,
   output: DescribeOptimizationJobResponse,
@@ -42572,7 +42571,7 @@ export const describePartnerApp: API.OperationMethod<
   DescribePartnerAppRequest,
   DescribePartnerAppResponse,
   DescribePartnerAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePartnerAppRequest,
   output: DescribePartnerAppResponse,
@@ -42590,7 +42589,7 @@ export const describePipeline: API.OperationMethod<
   DescribePipelineRequest,
   DescribePipelineResponse,
   DescribePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePipelineRequest,
   output: DescribePipelineResponse,
@@ -42610,7 +42609,7 @@ export const describePipelineDefinitionForExecution: API.OperationMethod<
   DescribePipelineDefinitionForExecutionRequest,
   DescribePipelineDefinitionForExecutionResponse,
   DescribePipelineDefinitionForExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePipelineDefinitionForExecutionRequest,
   output: DescribePipelineDefinitionForExecutionResponse,
@@ -42628,7 +42627,7 @@ export const describePipelineExecution: API.OperationMethod<
   DescribePipelineExecutionRequest,
   DescribePipelineExecutionResponse,
   DescribePipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePipelineExecutionRequest,
   output: DescribePipelineExecutionResponse,
@@ -42646,7 +42645,7 @@ export const describeProcessingJob: API.OperationMethod<
   DescribeProcessingJobRequest,
   DescribeProcessingJobResponse,
   DescribeProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProcessingJobRequest,
   output: DescribeProcessingJobResponse,
@@ -42664,7 +42663,7 @@ export const describeProject: API.OperationMethod<
   DescribeProjectInput,
   DescribeProjectOutput,
   DescribeProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProjectInput,
   output: DescribeProjectOutput,
@@ -42682,7 +42681,7 @@ export const describeReservedCapacity: API.OperationMethod<
   DescribeReservedCapacityRequest,
   DescribeReservedCapacityResponse,
   DescribeReservedCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReservedCapacityRequest,
   output: DescribeReservedCapacityResponse,
@@ -42700,7 +42699,7 @@ export const describeSpace: API.OperationMethod<
   DescribeSpaceRequest,
   DescribeSpaceResponse,
   DescribeSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpaceRequest,
   output: DescribeSpaceResponse,
@@ -42720,7 +42719,7 @@ export const describeStudioLifecycleConfig: API.OperationMethod<
   DescribeStudioLifecycleConfigRequest,
   DescribeStudioLifecycleConfigResponse,
   DescribeStudioLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStudioLifecycleConfigRequest,
   output: DescribeStudioLifecycleConfigResponse,
@@ -42738,7 +42737,7 @@ export const describeSubscribedWorkteam: API.OperationMethod<
   DescribeSubscribedWorkteamRequest,
   DescribeSubscribedWorkteamResponse,
   DescribeSubscribedWorkteamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSubscribedWorkteamRequest,
   output: DescribeSubscribedWorkteamResponse,
@@ -42758,7 +42757,7 @@ export const describeTrainingJob: API.OperationMethod<
   DescribeTrainingJobRequest,
   DescribeTrainingJobResponse,
   DescribeTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrainingJobRequest,
   output: DescribeTrainingJobResponse,
@@ -42776,7 +42775,7 @@ export const describeTrainingPlan: API.OperationMethod<
   DescribeTrainingPlanRequest,
   DescribeTrainingPlanResponse,
   DescribeTrainingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrainingPlanRequest,
   output: DescribeTrainingPlanResponse,
@@ -42796,7 +42795,7 @@ export const describeTrainingPlanExtensionHistory: API.PaginatedOperationMethod<
   DescribeTrainingPlanExtensionHistoryRequest,
   DescribeTrainingPlanExtensionHistoryResponse,
   DescribeTrainingPlanExtensionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainingPlanExtension
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTrainingPlanExtensionHistoryRequest,
@@ -42821,7 +42820,7 @@ export const describeTransformJob: API.OperationMethod<
   DescribeTransformJobRequest,
   DescribeTransformJobResponse,
   DescribeTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTransformJobRequest,
   output: DescribeTransformJobResponse,
@@ -42839,7 +42838,7 @@ export const describeTrial: API.OperationMethod<
   DescribeTrialRequest,
   DescribeTrialResponse,
   DescribeTrialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrialRequest,
   output: DescribeTrialResponse,
@@ -42857,7 +42856,7 @@ export const describeTrialComponent: API.OperationMethod<
   DescribeTrialComponentRequest,
   DescribeTrialComponentResponse,
   DescribeTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrialComponentRequest,
   output: DescribeTrialComponentResponse,
@@ -42878,7 +42877,7 @@ export const describeUserProfile: API.OperationMethod<
   DescribeUserProfileRequest,
   DescribeUserProfileResponse,
   DescribeUserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserProfileRequest,
   output: DescribeUserProfileResponse,
@@ -42898,7 +42897,7 @@ export const describeWorkforce: API.OperationMethod<
   DescribeWorkforceRequest,
   DescribeWorkforceResponse,
   DescribeWorkforceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkforceRequest,
   output: DescribeWorkforceResponse,
@@ -42916,7 +42915,7 @@ export const describeWorkteam: API.OperationMethod<
   DescribeWorkteamRequest,
   DescribeWorkteamResponse,
   DescribeWorkteamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkteamRequest,
   output: DescribeWorkteamResponse,
@@ -42936,7 +42935,7 @@ export const detachClusterNodeVolume: API.OperationMethod<
   DetachClusterNodeVolumeRequest,
   DetachClusterNodeVolumeResponse,
   DetachClusterNodeVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachClusterNodeVolumeRequest,
   output: DetachClusterNodeVolumeResponse,
@@ -42954,7 +42953,7 @@ export const disableSagemakerServicecatalogPortfolio: API.OperationMethod<
   DisableSagemakerServicecatalogPortfolioInput,
   DisableSagemakerServicecatalogPortfolioOutput,
   DisableSagemakerServicecatalogPortfolioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSagemakerServicecatalogPortfolioInput,
   output: DisableSagemakerServicecatalogPortfolioOutput,
@@ -42974,7 +42973,7 @@ export const disassociateTrialComponent: API.OperationMethod<
   DisassociateTrialComponentRequest,
   DisassociateTrialComponentResponse,
   DisassociateTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTrialComponentRequest,
   output: DisassociateTrialComponentResponse,
@@ -42992,7 +42991,7 @@ export const enableSagemakerServicecatalogPortfolio: API.OperationMethod<
   EnableSagemakerServicecatalogPortfolioInput,
   EnableSagemakerServicecatalogPortfolioOutput,
   EnableSagemakerServicecatalogPortfolioError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSagemakerServicecatalogPortfolioInput,
   output: EnableSagemakerServicecatalogPortfolioOutput,
@@ -43014,7 +43013,7 @@ export const extendTrainingPlan: API.OperationMethod<
   ExtendTrainingPlanRequest,
   ExtendTrainingPlanResponse,
   ExtendTrainingPlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExtendTrainingPlanRequest,
   output: ExtendTrainingPlanResponse,
@@ -43032,7 +43031,7 @@ export const getDeviceFleetReport: API.OperationMethod<
   GetDeviceFleetReportRequest,
   GetDeviceFleetReportResponse,
   GetDeviceFleetReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceFleetReportRequest,
   output: GetDeviceFleetReportResponse,
@@ -43050,7 +43049,7 @@ export const getLineageGroupPolicy: API.OperationMethod<
   GetLineageGroupPolicyRequest,
   GetLineageGroupPolicyResponse,
   GetLineageGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLineageGroupPolicyRequest,
   output: GetLineageGroupPolicyResponse,
@@ -43068,7 +43067,7 @@ export const getModelPackageGroupPolicy: API.OperationMethod<
   GetModelPackageGroupPolicyInput,
   GetModelPackageGroupPolicyOutput,
   GetModelPackageGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetModelPackageGroupPolicyInput,
   output: GetModelPackageGroupPolicyOutput,
@@ -43086,7 +43085,7 @@ export const getSagemakerServicecatalogPortfolioStatus: API.OperationMethod<
   GetSagemakerServicecatalogPortfolioStatusInput,
   GetSagemakerServicecatalogPortfolioStatusOutput,
   GetSagemakerServicecatalogPortfolioStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSagemakerServicecatalogPortfolioStatusInput,
   output: GetSagemakerServicecatalogPortfolioStatusOutput,
@@ -43106,7 +43105,7 @@ export const getScalingConfigurationRecommendation: API.OperationMethod<
   GetScalingConfigurationRecommendationRequest,
   GetScalingConfigurationRecommendationResponse,
   GetScalingConfigurationRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScalingConfigurationRecommendationRequest,
   output: GetScalingConfigurationRecommendationResponse,
@@ -43124,7 +43123,7 @@ export const getSearchSuggestions: API.OperationMethod<
   GetSearchSuggestionsRequest,
   GetSearchSuggestionsResponse,
   GetSearchSuggestionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSearchSuggestionsRequest,
   output: GetSearchSuggestionsResponse,
@@ -43146,7 +43145,7 @@ export const importHubContent: API.OperationMethod<
   ImportHubContentRequest,
   ImportHubContentResponse,
   ImportHubContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportHubContentRequest,
   output: ImportHubContentResponse,
@@ -43164,7 +43163,7 @@ export const listActions: API.PaginatedOperationMethod<
   ListActionsRequest,
   ListActionsResponse,
   ListActionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActionsRequest,
@@ -43189,7 +43188,7 @@ export const listAIBenchmarkJobs: API.PaginatedOperationMethod<
   ListAIBenchmarkJobsRequest,
   ListAIBenchmarkJobsResponse,
   ListAIBenchmarkJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIBenchmarkJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIBenchmarkJobsRequest,
@@ -43214,7 +43213,7 @@ export const listAIRecommendationJobs: API.PaginatedOperationMethod<
   ListAIRecommendationJobsRequest,
   ListAIRecommendationJobsResponse,
   ListAIRecommendationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIRecommendationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIRecommendationJobsRequest,
@@ -43239,7 +43238,7 @@ export const listAIWorkloadConfigs: API.PaginatedOperationMethod<
   ListAIWorkloadConfigsRequest,
   ListAIWorkloadConfigsResponse,
   ListAIWorkloadConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AIWorkloadConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAIWorkloadConfigsRequest,
@@ -43264,7 +43263,7 @@ export const listAlgorithms: API.PaginatedOperationMethod<
   ListAlgorithmsInput,
   ListAlgorithmsOutput,
   ListAlgorithmsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AlgorithmSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAlgorithmsInput,
@@ -43289,7 +43288,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesRequest,
   ListAliasesResponse,
   ListAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SageMakerImageVersionAlias
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesRequest,
@@ -43314,7 +43313,7 @@ export const listAppImageConfigs: API.PaginatedOperationMethod<
   ListAppImageConfigsRequest,
   ListAppImageConfigsResponse,
   ListAppImageConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppImageConfigDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppImageConfigsRequest,
@@ -43339,7 +43338,7 @@ export const listApps: API.PaginatedOperationMethod<
   ListAppsRequest,
   ListAppsResponse,
   ListAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AppDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppsRequest,
@@ -43364,7 +43363,7 @@ export const listArtifacts: API.PaginatedOperationMethod<
   ListArtifactsRequest,
   ListArtifactsResponse,
   ListArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ArtifactSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArtifactsRequest,
@@ -43389,7 +43388,7 @@ export const listAssociations: API.PaginatedOperationMethod<
   ListAssociationsRequest,
   ListAssociationsResponse,
   ListAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociationsRequest,
@@ -43414,7 +43413,7 @@ export const listAutoMLJobs: API.PaginatedOperationMethod<
   ListAutoMLJobsRequest,
   ListAutoMLJobsResponse,
   ListAutoMLJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutoMLJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAutoMLJobsRequest,
@@ -43439,7 +43438,7 @@ export const listCandidatesForAutoMLJob: API.PaginatedOperationMethod<
   ListCandidatesForAutoMLJobRequest,
   ListCandidatesForAutoMLJobResponse,
   ListCandidatesForAutoMLJobError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AutoMLCandidate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCandidatesForAutoMLJobRequest,
@@ -43464,7 +43463,7 @@ export const listClusterEvents: API.PaginatedOperationMethod<
   ListClusterEventsRequest,
   ListClusterEventsResponse,
   ListClusterEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterEventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterEventsRequest,
@@ -43489,7 +43488,7 @@ export const listClusterNodes: API.PaginatedOperationMethod<
   ListClusterNodesRequest,
   ListClusterNodesResponse,
   ListClusterNodesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterNodeSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterNodesRequest,
@@ -43514,7 +43513,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResponse,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -43539,7 +43538,7 @@ export const listClusterSchedulerConfigs: API.PaginatedOperationMethod<
   ListClusterSchedulerConfigsRequest,
   ListClusterSchedulerConfigsResponse,
   ListClusterSchedulerConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterSchedulerConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterSchedulerConfigsRequest,
@@ -43564,7 +43563,7 @@ export const listCodeRepositories: API.PaginatedOperationMethod<
   ListCodeRepositoriesInput,
   ListCodeRepositoriesOutput,
   ListCodeRepositoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeRepositorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeRepositoriesInput,
@@ -43591,7 +43590,7 @@ export const listCompilationJobs: API.PaginatedOperationMethod<
   ListCompilationJobsRequest,
   ListCompilationJobsResponse,
   ListCompilationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CompilationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCompilationJobsRequest,
@@ -43616,7 +43615,7 @@ export const listComputeQuotas: API.PaginatedOperationMethod<
   ListComputeQuotasRequest,
   ListComputeQuotasResponse,
   ListComputeQuotasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComputeQuotaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComputeQuotasRequest,
@@ -43641,7 +43640,7 @@ export const listContexts: API.PaginatedOperationMethod<
   ListContextsRequest,
   ListContextsResponse,
   ListContextsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContextSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContextsRequest,
@@ -43666,7 +43665,7 @@ export const listDataQualityJobDefinitions: API.PaginatedOperationMethod<
   ListDataQualityJobDefinitionsRequest,
   ListDataQualityJobDefinitionsResponse,
   ListDataQualityJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringJobDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataQualityJobDefinitionsRequest,
@@ -43691,7 +43690,7 @@ export const listDeviceFleets: API.PaginatedOperationMethod<
   ListDeviceFleetsRequest,
   ListDeviceFleetsResponse,
   ListDeviceFleetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceFleetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeviceFleetsRequest,
@@ -43716,7 +43715,7 @@ export const listDevices: API.PaginatedOperationMethod<
   ListDevicesRequest,
   ListDevicesResponse,
   ListDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesRequest,
@@ -43741,7 +43740,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -43766,7 +43765,7 @@ export const listEdgeDeploymentPlans: API.PaginatedOperationMethod<
   ListEdgeDeploymentPlansRequest,
   ListEdgeDeploymentPlansResponse,
   ListEdgeDeploymentPlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EdgeDeploymentPlanSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEdgeDeploymentPlansRequest,
@@ -43791,7 +43790,7 @@ export const listEdgePackagingJobs: API.PaginatedOperationMethod<
   ListEdgePackagingJobsRequest,
   ListEdgePackagingJobsResponse,
   ListEdgePackagingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EdgePackagingJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEdgePackagingJobsRequest,
@@ -43816,7 +43815,7 @@ export const listEndpointConfigs: API.PaginatedOperationMethod<
   ListEndpointConfigsInput,
   ListEndpointConfigsOutput,
   ListEndpointConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointConfigsInput,
@@ -43841,7 +43840,7 @@ export const listEndpoints: API.PaginatedOperationMethod<
   ListEndpointsInput,
   ListEndpointsOutput,
   ListEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EndpointSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointsInput,
@@ -43866,7 +43865,7 @@ export const listExperiments: API.PaginatedOperationMethod<
   ListExperimentsRequest,
   ListExperimentsResponse,
   ListExperimentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExperimentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExperimentsRequest,
@@ -43891,7 +43890,7 @@ export const listFeatureGroups: API.PaginatedOperationMethod<
   ListFeatureGroupsRequest,
   ListFeatureGroupsResponse,
   ListFeatureGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FeatureGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFeatureGroupsRequest,
@@ -43916,7 +43915,7 @@ export const listFlowDefinitions: API.PaginatedOperationMethod<
   ListFlowDefinitionsRequest,
   ListFlowDefinitionsResponse,
   ListFlowDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FlowDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFlowDefinitionsRequest,
@@ -43941,7 +43940,7 @@ export const listHubContents: API.OperationMethod<
   ListHubContentsRequest,
   ListHubContentsResponse,
   ListHubContentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHubContentsRequest,
   output: ListHubContentsResponse,
@@ -43959,7 +43958,7 @@ export const listHubContentVersions: API.OperationMethod<
   ListHubContentVersionsRequest,
   ListHubContentVersionsResponse,
   ListHubContentVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHubContentVersionsRequest,
   output: ListHubContentVersionsResponse,
@@ -43977,7 +43976,7 @@ export const listHubs: API.OperationMethod<
   ListHubsRequest,
   ListHubsResponse,
   ListHubsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHubsRequest,
   output: ListHubsResponse,
@@ -43995,7 +43994,7 @@ export const listHumanTaskUis: API.PaginatedOperationMethod<
   ListHumanTaskUisRequest,
   ListHumanTaskUisResponse,
   ListHumanTaskUisError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HumanTaskUiSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHumanTaskUisRequest,
@@ -44020,7 +44019,7 @@ export const listHyperParameterTuningJobs: API.PaginatedOperationMethod<
   ListHyperParameterTuningJobsRequest,
   ListHyperParameterTuningJobsResponse,
   ListHyperParameterTuningJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HyperParameterTuningJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListHyperParameterTuningJobsRequest,
@@ -44045,7 +44044,7 @@ export const listImages: API.PaginatedOperationMethod<
   ListImagesRequest,
   ListImagesResponse,
   ListImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Image
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImagesRequest,
@@ -44070,7 +44069,7 @@ export const listImageVersions: API.PaginatedOperationMethod<
   ListImageVersionsRequest,
   ListImageVersionsResponse,
   ListImageVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImageVersion
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImageVersionsRequest,
@@ -44095,7 +44094,7 @@ export const listInferenceComponents: API.PaginatedOperationMethod<
   ListInferenceComponentsInput,
   ListInferenceComponentsOutput,
   ListInferenceComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InferenceComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceComponentsInput,
@@ -44120,7 +44119,7 @@ export const listInferenceExperiments: API.PaginatedOperationMethod<
   ListInferenceExperimentsRequest,
   ListInferenceExperimentsResponse,
   ListInferenceExperimentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InferenceExperimentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceExperimentsRequest,
@@ -44145,7 +44144,7 @@ export const listInferenceRecommendationsJobs: API.PaginatedOperationMethod<
   ListInferenceRecommendationsJobsRequest,
   ListInferenceRecommendationsJobsResponse,
   ListInferenceRecommendationsJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InferenceRecommendationsJob
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceRecommendationsJobsRequest,
@@ -44174,7 +44173,7 @@ export const listInferenceRecommendationsJobSteps: API.PaginatedOperationMethod<
   ListInferenceRecommendationsJobStepsRequest,
   ListInferenceRecommendationsJobStepsResponse,
   ListInferenceRecommendationsJobStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InferenceRecommendationsJobStep
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInferenceRecommendationsJobStepsRequest,
@@ -44205,7 +44204,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResponse,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -44236,7 +44235,7 @@ export const listJobSchemaVersions: API.PaginatedOperationMethod<
   ListJobSchemaVersionsRequest,
   ListJobSchemaVersionsResponse,
   ListJobSchemaVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobConfigSchemaVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobSchemaVersionsRequest,
@@ -44261,7 +44260,7 @@ export const listLabelingJobs: API.PaginatedOperationMethod<
   ListLabelingJobsRequest,
   ListLabelingJobsResponse,
   ListLabelingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LabelingJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLabelingJobsRequest,
@@ -44286,7 +44285,7 @@ export const listLabelingJobsForWorkteam: API.PaginatedOperationMethod<
   ListLabelingJobsForWorkteamRequest,
   ListLabelingJobsForWorkteamResponse,
   ListLabelingJobsForWorkteamError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LabelingJobForWorkteamSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLabelingJobsForWorkteamRequest,
@@ -44311,7 +44310,7 @@ export const listLineageGroups: API.PaginatedOperationMethod<
   ListLineageGroupsRequest,
   ListLineageGroupsResponse,
   ListLineageGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LineageGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLineageGroupsRequest,
@@ -44336,7 +44335,7 @@ export const listMlflowApps: API.PaginatedOperationMethod<
   ListMlflowAppsRequest,
   ListMlflowAppsResponse,
   ListMlflowAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MlflowAppSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMlflowAppsRequest,
@@ -44361,7 +44360,7 @@ export const listMlflowTrackingServers: API.PaginatedOperationMethod<
   ListMlflowTrackingServersRequest,
   ListMlflowTrackingServersResponse,
   ListMlflowTrackingServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrackingServerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMlflowTrackingServersRequest,
@@ -44386,7 +44385,7 @@ export const listModelBiasJobDefinitions: API.PaginatedOperationMethod<
   ListModelBiasJobDefinitionsRequest,
   ListModelBiasJobDefinitionsResponse,
   ListModelBiasJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringJobDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelBiasJobDefinitionsRequest,
@@ -44411,7 +44410,7 @@ export const listModelCardExportJobs: API.PaginatedOperationMethod<
   ListModelCardExportJobsRequest,
   ListModelCardExportJobsResponse,
   ListModelCardExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelCardExportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelCardExportJobsRequest,
@@ -44436,7 +44435,7 @@ export const listModelCards: API.PaginatedOperationMethod<
   ListModelCardsRequest,
   ListModelCardsResponse,
   ListModelCardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelCardSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelCardsRequest,
@@ -44461,7 +44460,7 @@ export const listModelCardVersions: API.PaginatedOperationMethod<
   ListModelCardVersionsRequest,
   ListModelCardVersionsResponse,
   ListModelCardVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelCardVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelCardVersionsRequest,
@@ -44486,7 +44485,7 @@ export const listModelExplainabilityJobDefinitions: API.PaginatedOperationMethod
   ListModelExplainabilityJobDefinitionsRequest,
   ListModelExplainabilityJobDefinitionsResponse,
   ListModelExplainabilityJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringJobDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelExplainabilityJobDefinitionsRequest,
@@ -44511,7 +44510,7 @@ export const listModelMetadata: API.PaginatedOperationMethod<
   ListModelMetadataRequest,
   ListModelMetadataResponse,
   ListModelMetadataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelMetadataSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelMetadataRequest,
@@ -44536,7 +44535,7 @@ export const listModelPackageGroups: API.PaginatedOperationMethod<
   ListModelPackageGroupsInput,
   ListModelPackageGroupsOutput,
   ListModelPackageGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelPackageGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelPackageGroupsInput,
@@ -44561,7 +44560,7 @@ export const listModelPackages: API.PaginatedOperationMethod<
   ListModelPackagesInput,
   ListModelPackagesOutput,
   ListModelPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelPackageSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelPackagesInput,
@@ -44586,7 +44585,7 @@ export const listModelQualityJobDefinitions: API.PaginatedOperationMethod<
   ListModelQualityJobDefinitionsRequest,
   ListModelQualityJobDefinitionsResponse,
   ListModelQualityJobDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringJobDefinitionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelQualityJobDefinitionsRequest,
@@ -44611,7 +44610,7 @@ export const listModels: API.PaginatedOperationMethod<
   ListModelsInput,
   ListModelsOutput,
   ListModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListModelsInput,
@@ -44636,7 +44635,7 @@ export const listMonitoringAlertHistory: API.PaginatedOperationMethod<
   ListMonitoringAlertHistoryRequest,
   ListMonitoringAlertHistoryResponse,
   ListMonitoringAlertHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringAlertHistorySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitoringAlertHistoryRequest,
@@ -44661,7 +44660,7 @@ export const listMonitoringAlerts: API.PaginatedOperationMethod<
   ListMonitoringAlertsRequest,
   ListMonitoringAlertsResponse,
   ListMonitoringAlertsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringAlertSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitoringAlertsRequest,
@@ -44686,7 +44685,7 @@ export const listMonitoringExecutions: API.PaginatedOperationMethod<
   ListMonitoringExecutionsRequest,
   ListMonitoringExecutionsResponse,
   ListMonitoringExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitoringExecutionsRequest,
@@ -44711,7 +44710,7 @@ export const listMonitoringSchedules: API.PaginatedOperationMethod<
   ListMonitoringSchedulesRequest,
   ListMonitoringSchedulesResponse,
   ListMonitoringSchedulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MonitoringScheduleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMonitoringSchedulesRequest,
@@ -44736,7 +44735,7 @@ export const listNotebookInstanceLifecycleConfigs: API.PaginatedOperationMethod<
   ListNotebookInstanceLifecycleConfigsInput,
   ListNotebookInstanceLifecycleConfigsOutput,
   ListNotebookInstanceLifecycleConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotebookInstanceLifecycleConfigSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotebookInstanceLifecycleConfigsInput,
@@ -44761,7 +44760,7 @@ export const listNotebookInstances: API.PaginatedOperationMethod<
   ListNotebookInstancesInput,
   ListNotebookInstancesOutput,
   ListNotebookInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NotebookInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotebookInstancesInput,
@@ -44786,7 +44785,7 @@ export const listOptimizationJobs: API.PaginatedOperationMethod<
   ListOptimizationJobsRequest,
   ListOptimizationJobsResponse,
   ListOptimizationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OptimizationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOptimizationJobsRequest,
@@ -44811,7 +44810,7 @@ export const listPartnerApps: API.PaginatedOperationMethod<
   ListPartnerAppsRequest,
   ListPartnerAppsResponse,
   ListPartnerAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PartnerAppSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPartnerAppsRequest,
@@ -44836,7 +44835,7 @@ export const listPipelineExecutions: API.PaginatedOperationMethod<
   ListPipelineExecutionsRequest,
   ListPipelineExecutionsResponse,
   ListPipelineExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineExecutionsRequest,
@@ -44861,7 +44860,7 @@ export const listPipelineExecutionSteps: API.PaginatedOperationMethod<
   ListPipelineExecutionStepsRequest,
   ListPipelineExecutionStepsResponse,
   ListPipelineExecutionStepsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineExecutionStep
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineExecutionStepsRequest,
@@ -44888,7 +44887,7 @@ export const listPipelineParametersForExecution: API.PaginatedOperationMethod<
   ListPipelineParametersForExecutionRequest,
   ListPipelineParametersForExecutionResponse,
   ListPipelineParametersForExecutionError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Parameter
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineParametersForExecutionRequest,
@@ -44913,7 +44912,7 @@ export const listPipelines: API.PaginatedOperationMethod<
   ListPipelinesRequest,
   ListPipelinesResponse,
   ListPipelinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelinesRequest,
@@ -44938,7 +44937,7 @@ export const listPipelineVersions: API.PaginatedOperationMethod<
   ListPipelineVersionsRequest,
   ListPipelineVersionsResponse,
   ListPipelineVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PipelineVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPipelineVersionsRequest,
@@ -44963,7 +44962,7 @@ export const listProcessingJobs: API.PaginatedOperationMethod<
   ListProcessingJobsRequest,
   ListProcessingJobsResponse,
   ListProcessingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProcessingJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProcessingJobsRequest,
@@ -44988,7 +44987,7 @@ export const listProjects: API.PaginatedOperationMethod<
   ListProjectsInput,
   ListProjectsOutput,
   ListProjectsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProjectsInput,
@@ -45012,7 +45011,7 @@ export const listResourceCatalogs: API.PaginatedOperationMethod<
   ListResourceCatalogsRequest,
   ListResourceCatalogsResponse,
   ListResourceCatalogsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceCatalog
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceCatalogsRequest,
@@ -45037,7 +45036,7 @@ export const listSpaces: API.PaginatedOperationMethod<
   ListSpacesRequest,
   ListSpacesResponse,
   ListSpacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpaceDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpacesRequest,
@@ -45062,7 +45061,7 @@ export const listStageDevices: API.PaginatedOperationMethod<
   ListStageDevicesRequest,
   ListStageDevicesResponse,
   ListStageDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceDeploymentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStageDevicesRequest,
@@ -45087,7 +45086,7 @@ export const listStudioLifecycleConfigs: API.PaginatedOperationMethod<
   ListStudioLifecycleConfigsRequest,
   ListStudioLifecycleConfigsResponse,
   ListStudioLifecycleConfigsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StudioLifecycleConfigDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStudioLifecycleConfigsRequest,
@@ -45112,7 +45111,7 @@ export const listSubscribedWorkteams: API.PaginatedOperationMethod<
   ListSubscribedWorkteamsRequest,
   ListSubscribedWorkteamsResponse,
   ListSubscribedWorkteamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscribedWorkteam
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscribedWorkteamsRequest,
@@ -45137,7 +45136,7 @@ export const listTags: API.PaginatedOperationMethod<
   ListTagsInput,
   ListTagsOutput,
   ListTagsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsInput,
@@ -45174,7 +45173,7 @@ export const listTrainingJobs: API.PaginatedOperationMethod<
   ListTrainingJobsRequest,
   ListTrainingJobsResponse,
   ListTrainingJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainingJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainingJobsRequest,
@@ -45201,7 +45200,7 @@ export const listTrainingJobsForHyperParameterTuningJob: API.PaginatedOperationM
   ListTrainingJobsForHyperParameterTuningJobRequest,
   ListTrainingJobsForHyperParameterTuningJobResponse,
   ListTrainingJobsForHyperParameterTuningJobError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HyperParameterTrainingJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainingJobsForHyperParameterTuningJobRequest,
@@ -45226,7 +45225,7 @@ export const listTrainingPlans: API.PaginatedOperationMethod<
   ListTrainingPlansRequest,
   ListTrainingPlansResponse,
   ListTrainingPlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrainingPlanSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrainingPlansRequest,
@@ -45251,7 +45250,7 @@ export const listTransformJobs: API.PaginatedOperationMethod<
   ListTransformJobsRequest,
   ListTransformJobsResponse,
   ListTransformJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TransformJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTransformJobsRequest,
@@ -45282,7 +45281,7 @@ export const listTrialComponents: API.PaginatedOperationMethod<
   ListTrialComponentsRequest,
   ListTrialComponentsResponse,
   ListTrialComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrialComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrialComponentsRequest,
@@ -45307,7 +45306,7 @@ export const listTrials: API.PaginatedOperationMethod<
   ListTrialsRequest,
   ListTrialsResponse,
   ListTrialsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrialSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrialsRequest,
@@ -45334,7 +45333,7 @@ export const listUltraServersByReservedCapacity: API.PaginatedOperationMethod<
   ListUltraServersByReservedCapacityRequest,
   ListUltraServersByReservedCapacityResponse,
   ListUltraServersByReservedCapacityError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UltraServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUltraServersByReservedCapacityRequest,
@@ -45359,7 +45358,7 @@ export const listUserProfiles: API.PaginatedOperationMethod<
   ListUserProfilesRequest,
   ListUserProfilesResponse,
   ListUserProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   UserProfileDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserProfilesRequest,
@@ -45384,7 +45383,7 @@ export const listWorkforces: API.PaginatedOperationMethod<
   ListWorkforcesRequest,
   ListWorkforcesResponse,
   ListWorkforcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Workforce
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkforcesRequest,
@@ -45409,7 +45408,7 @@ export const listWorkteams: API.PaginatedOperationMethod<
   ListWorkteamsRequest,
   ListWorkteamsResponse,
   ListWorkteamsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Workteam
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkteamsRequest,
@@ -45434,7 +45433,7 @@ export const putModelPackageGroupPolicy: API.OperationMethod<
   PutModelPackageGroupPolicyInput,
   PutModelPackageGroupPolicyOutput,
   PutModelPackageGroupPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutModelPackageGroupPolicyInput,
   output: PutModelPackageGroupPolicyOutput,
@@ -45452,7 +45451,7 @@ export const queryLineage: API.PaginatedOperationMethod<
   QueryLineageRequest,
   QueryLineageResponse,
   QueryLineageError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryLineageRequest,
@@ -45476,7 +45475,7 @@ export const registerDevices: API.OperationMethod<
   RegisterDevicesRequest,
   RegisterDevicesResponse,
   RegisterDevicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDevicesRequest,
   output: RegisterDevicesResponse,
@@ -45494,7 +45493,7 @@ export const renderUiTemplate: API.OperationMethod<
   RenderUiTemplateRequest,
   RenderUiTemplateResponse,
   RenderUiTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RenderUiTemplateRequest,
   output: RenderUiTemplateResponse,
@@ -45516,7 +45515,7 @@ export const retryPipelineExecution: API.OperationMethod<
   RetryPipelineExecutionRequest,
   RetryPipelineExecutionResponse,
   RetryPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetryPipelineExecutionRequest,
   output: RetryPipelineExecutionResponse,
@@ -45538,7 +45537,7 @@ export const search: API.PaginatedOperationMethod<
   SearchRequest,
   SearchResponse,
   SearchError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchRequest,
@@ -45571,7 +45570,7 @@ export const searchTrainingPlanOfferings: API.OperationMethod<
   SearchTrainingPlanOfferingsRequest,
   SearchTrainingPlanOfferingsResponse,
   SearchTrainingPlanOfferingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SearchTrainingPlanOfferingsRequest,
   output: SearchTrainingPlanOfferingsResponse,
@@ -45593,7 +45592,7 @@ export const sendPipelineExecutionStepFailure: API.OperationMethod<
   SendPipelineExecutionStepFailureRequest,
   SendPipelineExecutionStepFailureResponse,
   SendPipelineExecutionStepFailureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendPipelineExecutionStepFailureRequest,
   output: SendPipelineExecutionStepFailureResponse,
@@ -45615,7 +45614,7 @@ export const sendPipelineExecutionStepSuccess: API.OperationMethod<
   SendPipelineExecutionStepSuccessRequest,
   SendPipelineExecutionStepSuccessResponse,
   SendPipelineExecutionStepSuccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendPipelineExecutionStepSuccessRequest,
   output: SendPipelineExecutionStepSuccessResponse,
@@ -45633,7 +45632,7 @@ export const startClusterHealthCheck: API.OperationMethod<
   StartClusterHealthCheckRequest,
   StartClusterHealthCheckResponse,
   StartClusterHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartClusterHealthCheckRequest,
   output: StartClusterHealthCheckResponse,
@@ -45651,7 +45650,7 @@ export const startEdgeDeploymentStage: API.OperationMethod<
   StartEdgeDeploymentStageRequest,
   StartEdgeDeploymentStageResponse,
   StartEdgeDeploymentStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEdgeDeploymentStageRequest,
   output: StartEdgeDeploymentStageResponse,
@@ -45672,7 +45671,7 @@ export const startInferenceExperiment: API.OperationMethod<
   StartInferenceExperimentRequest,
   StartInferenceExperimentResponse,
   StartInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartInferenceExperimentRequest,
   output: StartInferenceExperimentResponse,
@@ -45693,7 +45692,7 @@ export const startMlflowTrackingServer: API.OperationMethod<
   StartMlflowTrackingServerRequest,
   StartMlflowTrackingServerResponse,
   StartMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMlflowTrackingServerRequest,
   output: StartMlflowTrackingServerResponse,
@@ -45713,7 +45712,7 @@ export const startMonitoringSchedule: API.OperationMethod<
   StartMonitoringScheduleRequest,
   StartMonitoringScheduleResponse,
   StartMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMonitoringScheduleRequest,
   output: StartMonitoringScheduleResponse,
@@ -45731,7 +45730,7 @@ export const startNotebookInstance: API.OperationMethod<
   StartNotebookInstanceInput,
   StartNotebookInstanceResponse,
   StartNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartNotebookInstanceInput,
   output: StartNotebookInstanceResponse,
@@ -45753,7 +45752,7 @@ export const startPipelineExecution: API.OperationMethod<
   StartPipelineExecutionRequest,
   StartPipelineExecutionResponse,
   StartPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPipelineExecutionRequest,
   output: StartPipelineExecutionResponse,
@@ -45774,7 +45773,7 @@ export const startSession: API.OperationMethod<
   StartSessionRequest,
   StartSessionResponse,
   StartSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionRequest,
   output: StartSessionResponse,
@@ -45792,7 +45791,7 @@ export const stopAIBenchmarkJob: API.OperationMethod<
   StopAIBenchmarkJobRequest,
   StopAIBenchmarkJobResponse,
   StopAIBenchmarkJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAIBenchmarkJobRequest,
   output: StopAIBenchmarkJobResponse,
@@ -45810,7 +45809,7 @@ export const stopAIRecommendationJob: API.OperationMethod<
   StopAIRecommendationJobRequest,
   StopAIRecommendationJobResponse,
   StopAIRecommendationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAIRecommendationJobRequest,
   output: StopAIRecommendationJobResponse,
@@ -45828,7 +45827,7 @@ export const stopAutoMLJob: API.OperationMethod<
   StopAutoMLJobRequest,
   StopAutoMLJobResponse,
   StopAutoMLJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAutoMLJobRequest,
   output: StopAutoMLJobResponse,
@@ -45850,7 +45849,7 @@ export const stopCompilationJob: API.OperationMethod<
   StopCompilationJobRequest,
   StopCompilationJobResponse,
   StopCompilationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCompilationJobRequest,
   output: StopCompilationJobResponse,
@@ -45868,7 +45867,7 @@ export const stopEdgeDeploymentStage: API.OperationMethod<
   StopEdgeDeploymentStageRequest,
   StopEdgeDeploymentStageResponse,
   StopEdgeDeploymentStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEdgeDeploymentStageRequest,
   output: StopEdgeDeploymentStageResponse,
@@ -45886,7 +45885,7 @@ export const stopEdgePackagingJob: API.OperationMethod<
   StopEdgePackagingJobRequest,
   StopEdgePackagingJobResponse,
   StopEdgePackagingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEdgePackagingJobRequest,
   output: StopEdgePackagingJobResponse,
@@ -45906,7 +45905,7 @@ export const stopHyperParameterTuningJob: API.OperationMethod<
   StopHyperParameterTuningJobRequest,
   StopHyperParameterTuningJobResponse,
   StopHyperParameterTuningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopHyperParameterTuningJobRequest,
   output: StopHyperParameterTuningJobResponse,
@@ -45927,7 +45926,7 @@ export const stopInferenceExperiment: API.OperationMethod<
   StopInferenceExperimentRequest,
   StopInferenceExperimentResponse,
   StopInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInferenceExperimentRequest,
   output: StopInferenceExperimentResponse,
@@ -45947,7 +45946,7 @@ export const stopInferenceRecommendationsJob: API.OperationMethod<
   StopInferenceRecommendationsJobRequest,
   StopInferenceRecommendationsJobResponse,
   StopInferenceRecommendationsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopInferenceRecommendationsJobRequest,
   output: StopInferenceRecommendationsJobResponse,
@@ -45973,7 +45972,7 @@ export const stopJob: API.OperationMethod<
   StopJobRequest,
   StopJobResponse,
   StopJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopJobRequest,
   output: StopJobResponse,
@@ -45991,7 +45990,7 @@ export const stopLabelingJob: API.OperationMethod<
   StopLabelingJobRequest,
   StopLabelingJobResponse,
   StopLabelingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopLabelingJobRequest,
   output: StopLabelingJobResponse,
@@ -46012,7 +46011,7 @@ export const stopMlflowTrackingServer: API.OperationMethod<
   StopMlflowTrackingServerRequest,
   StopMlflowTrackingServerResponse,
   StopMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMlflowTrackingServerRequest,
   output: StopMlflowTrackingServerResponse,
@@ -46030,7 +46029,7 @@ export const stopMonitoringSchedule: API.OperationMethod<
   StopMonitoringScheduleRequest,
   StopMonitoringScheduleResponse,
   StopMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopMonitoringScheduleRequest,
   output: StopMonitoringScheduleResponse,
@@ -46050,7 +46049,7 @@ export const stopNotebookInstance: API.OperationMethod<
   StopNotebookInstanceInput,
   StopNotebookInstanceResponse,
   StopNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopNotebookInstanceInput,
   output: StopNotebookInstanceResponse,
@@ -46068,7 +46067,7 @@ export const stopOptimizationJob: API.OperationMethod<
   StopOptimizationJobRequest,
   StopOptimizationJobResponse,
   StopOptimizationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopOptimizationJobRequest,
   output: StopOptimizationJobResponse,
@@ -46101,7 +46100,7 @@ export const stopPipelineExecution: API.OperationMethod<
   StopPipelineExecutionRequest,
   StopPipelineExecutionResponse,
   StopPipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPipelineExecutionRequest,
   output: StopPipelineExecutionResponse,
@@ -46119,7 +46118,7 @@ export const stopProcessingJob: API.OperationMethod<
   StopProcessingJobRequest,
   StopProcessingJobResponse,
   StopProcessingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopProcessingJobRequest,
   output: StopProcessingJobResponse,
@@ -46139,7 +46138,7 @@ export const stopTrainingJob: API.OperationMethod<
   StopTrainingJobRequest,
   StopTrainingJobResponse,
   StopTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTrainingJobRequest,
   output: StopTrainingJobResponse,
@@ -46159,7 +46158,7 @@ export const stopTransformJob: API.OperationMethod<
   StopTransformJobRequest,
   StopTransformJobResponse,
   StopTransformJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTransformJobRequest,
   output: StopTransformJobResponse,
@@ -46180,7 +46179,7 @@ export const updateAction: API.OperationMethod<
   UpdateActionRequest,
   UpdateActionResponse,
   UpdateActionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActionRequest,
   output: UpdateActionResponse,
@@ -46198,7 +46197,7 @@ export const updateAppImageConfig: API.OperationMethod<
   UpdateAppImageConfigRequest,
   UpdateAppImageConfigResponse,
   UpdateAppImageConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAppImageConfigRequest,
   output: UpdateAppImageConfigResponse,
@@ -46219,7 +46218,7 @@ export const updateArtifact: API.OperationMethod<
   UpdateArtifactRequest,
   UpdateArtifactResponse,
   UpdateArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateArtifactRequest,
   output: UpdateArtifactResponse,
@@ -46241,7 +46240,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResponse,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResponse,
@@ -46263,7 +46262,7 @@ export const updateClusterSchedulerConfig: API.OperationMethod<
   UpdateClusterSchedulerConfigRequest,
   UpdateClusterSchedulerConfigResponse,
   UpdateClusterSchedulerConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterSchedulerConfigRequest,
   output: UpdateClusterSchedulerConfigResponse,
@@ -46286,7 +46285,7 @@ export const updateClusterSoftware: API.OperationMethod<
   UpdateClusterSoftwareRequest,
   UpdateClusterSoftwareResponse,
   UpdateClusterSoftwareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterSoftwareRequest,
   output: UpdateClusterSoftwareResponse,
@@ -46304,7 +46303,7 @@ export const updateCodeRepository: API.OperationMethod<
   UpdateCodeRepositoryInput,
   UpdateCodeRepositoryOutput,
   UpdateCodeRepositoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCodeRepositoryInput,
   output: UpdateCodeRepositoryOutput,
@@ -46326,7 +46325,7 @@ export const updateComputeQuota: API.OperationMethod<
   UpdateComputeQuotaRequest,
   UpdateComputeQuotaResponse,
   UpdateComputeQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateComputeQuotaRequest,
   output: UpdateComputeQuotaResponse,
@@ -46347,7 +46346,7 @@ export const updateContext: API.OperationMethod<
   UpdateContextRequest,
   UpdateContextResponse,
   UpdateContextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContextRequest,
   output: UpdateContextResponse,
@@ -46365,7 +46364,7 @@ export const updateDeviceFleet: API.OperationMethod<
   UpdateDeviceFleetRequest,
   UpdateDeviceFleetResponse,
   UpdateDeviceFleetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceFleetRequest,
   output: UpdateDeviceFleetResponse,
@@ -46383,7 +46382,7 @@ export const updateDevices: API.OperationMethod<
   UpdateDevicesRequest,
   UpdateDevicesResponse,
   UpdateDevicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDevicesRequest,
   output: UpdateDevicesResponse,
@@ -46405,7 +46404,7 @@ export const updateDomain: API.OperationMethod<
   UpdateDomainRequest,
   UpdateDomainResponse,
   UpdateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainRequest,
   output: UpdateDomainResponse,
@@ -46433,7 +46432,7 @@ export const updateEndpoint: API.OperationMethod<
   UpdateEndpointInput,
   UpdateEndpointOutput,
   UpdateEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointInput,
   output: UpdateEndpointOutput,
@@ -46453,7 +46452,7 @@ export const updateEndpointWeightsAndCapacities: API.OperationMethod<
   UpdateEndpointWeightsAndCapacitiesInput,
   UpdateEndpointWeightsAndCapacitiesOutput,
   UpdateEndpointWeightsAndCapacitiesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEndpointWeightsAndCapacitiesInput,
   output: UpdateEndpointWeightsAndCapacitiesOutput,
@@ -46474,7 +46473,7 @@ export const updateExperiment: API.OperationMethod<
   UpdateExperimentRequest,
   UpdateExperimentResponse,
   UpdateExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateExperimentRequest,
   output: UpdateExperimentResponse,
@@ -46499,7 +46498,7 @@ export const updateFeatureGroup: API.OperationMethod<
   UpdateFeatureGroupRequest,
   UpdateFeatureGroupResponse,
   UpdateFeatureGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFeatureGroupRequest,
   output: UpdateFeatureGroupResponse,
@@ -46517,7 +46516,7 @@ export const updateFeatureMetadata: API.OperationMethod<
   UpdateFeatureMetadataRequest,
   UpdateFeatureMetadataResponse,
   UpdateFeatureMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFeatureMetadataRequest,
   output: UpdateFeatureMetadataResponse,
@@ -46535,7 +46534,7 @@ export const updateHub: API.OperationMethod<
   UpdateHubRequest,
   UpdateHubResponse,
   UpdateHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHubRequest,
   output: UpdateHubResponse,
@@ -46572,7 +46571,7 @@ export const updateHubContent: API.OperationMethod<
   UpdateHubContentRequest,
   UpdateHubContentResponse,
   UpdateHubContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHubContentRequest,
   output: UpdateHubContentResponse,
@@ -46599,7 +46598,7 @@ export const updateHubContentReference: API.OperationMethod<
   UpdateHubContentReferenceRequest,
   UpdateHubContentReferenceResponse,
   UpdateHubContentReferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHubContentReferenceRequest,
   output: UpdateHubContentReferenceResponse,
@@ -46617,7 +46616,7 @@ export const updateImage: API.OperationMethod<
   UpdateImageRequest,
   UpdateImageResponse,
   UpdateImageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImageRequest,
   output: UpdateImageResponse,
@@ -46638,7 +46637,7 @@ export const updateImageVersion: API.OperationMethod<
   UpdateImageVersionRequest,
   UpdateImageVersionResponse,
   UpdateImageVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImageVersionRequest,
   output: UpdateImageVersionResponse,
@@ -46658,7 +46657,7 @@ export const updateInferenceComponent: API.OperationMethod<
   UpdateInferenceComponentInput,
   UpdateInferenceComponentOutput,
   UpdateInferenceComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInferenceComponentInput,
   output: UpdateInferenceComponentOutput,
@@ -46678,7 +46677,7 @@ export const updateInferenceComponentRuntimeConfig: API.OperationMethod<
   UpdateInferenceComponentRuntimeConfigInput,
   UpdateInferenceComponentRuntimeConfigOutput,
   UpdateInferenceComponentRuntimeConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInferenceComponentRuntimeConfigInput,
   output: UpdateInferenceComponentRuntimeConfigOutput,
@@ -46699,7 +46698,7 @@ export const updateInferenceExperiment: API.OperationMethod<
   UpdateInferenceExperimentRequest,
   UpdateInferenceExperimentResponse,
   UpdateInferenceExperimentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInferenceExperimentRequest,
   output: UpdateInferenceExperimentResponse,
@@ -46720,7 +46719,7 @@ export const updateMlflowApp: API.OperationMethod<
   UpdateMlflowAppRequest,
   UpdateMlflowAppResponse,
   UpdateMlflowAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMlflowAppRequest,
   output: UpdateMlflowAppResponse,
@@ -46742,7 +46741,7 @@ export const updateMlflowTrackingServer: API.OperationMethod<
   UpdateMlflowTrackingServerRequest,
   UpdateMlflowTrackingServerResponse,
   UpdateMlflowTrackingServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMlflowTrackingServerRequest,
   output: UpdateMlflowTrackingServerResponse,
@@ -46766,7 +46765,7 @@ export const updateModelCard: API.OperationMethod<
   UpdateModelCardRequest,
   UpdateModelCardResponse,
   UpdateModelCardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelCardRequest,
   output: UpdateModelCardResponse,
@@ -46784,7 +46783,7 @@ export const updateModelPackage: API.OperationMethod<
   UpdateModelPackageInput,
   UpdateModelPackageOutput,
   UpdateModelPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateModelPackageInput,
   output: UpdateModelPackageOutput,
@@ -46805,7 +46804,7 @@ export const updateMonitoringAlert: API.OperationMethod<
   UpdateMonitoringAlertRequest,
   UpdateMonitoringAlertResponse,
   UpdateMonitoringAlertError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitoringAlertRequest,
   output: UpdateMonitoringAlertResponse,
@@ -46826,7 +46825,7 @@ export const updateMonitoringSchedule: API.OperationMethod<
   UpdateMonitoringScheduleRequest,
   UpdateMonitoringScheduleResponse,
   UpdateMonitoringScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMonitoringScheduleRequest,
   output: UpdateMonitoringScheduleResponse,
@@ -46846,7 +46845,7 @@ export const updateNotebookInstance: API.OperationMethod<
   UpdateNotebookInstanceInput,
   UpdateNotebookInstanceOutput,
   UpdateNotebookInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotebookInstanceInput,
   output: UpdateNotebookInstanceOutput,
@@ -46868,7 +46867,7 @@ export const updateNotebookInstanceLifecycleConfig: API.OperationMethod<
   UpdateNotebookInstanceLifecycleConfigInput,
   UpdateNotebookInstanceLifecycleConfigOutput,
   UpdateNotebookInstanceLifecycleConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNotebookInstanceLifecycleConfigInput,
   output: UpdateNotebookInstanceLifecycleConfigOutput,
@@ -46889,7 +46888,7 @@ export const updatePartnerApp: API.OperationMethod<
   UpdatePartnerAppRequest,
   UpdatePartnerAppResponse,
   UpdatePartnerAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePartnerAppRequest,
   output: UpdatePartnerAppResponse,
@@ -46910,7 +46909,7 @@ export const updatePipeline: API.OperationMethod<
   UpdatePipelineRequest,
   UpdatePipelineResponse,
   UpdatePipelineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipelineRequest,
   output: UpdatePipelineResponse,
@@ -46931,7 +46930,7 @@ export const updatePipelineExecution: API.OperationMethod<
   UpdatePipelineExecutionRequest,
   UpdatePipelineExecutionResponse,
   UpdatePipelineExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipelineExecutionRequest,
   output: UpdatePipelineExecutionResponse,
@@ -46952,7 +46951,7 @@ export const updatePipelineVersion: API.OperationMethod<
   UpdatePipelineVersionRequest,
   UpdatePipelineVersionResponse,
   UpdatePipelineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePipelineVersionRequest,
   output: UpdatePipelineVersionResponse,
@@ -46972,7 +46971,7 @@ export const updateProject: API.OperationMethod<
   UpdateProjectInput,
   UpdateProjectOutput,
   UpdateProjectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProjectInput,
   output: UpdateProjectOutput,
@@ -46996,7 +46995,7 @@ export const updateSpace: API.OperationMethod<
   UpdateSpaceRequest,
   UpdateSpaceResponse,
   UpdateSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSpaceRequest,
   output: UpdateSpaceResponse,
@@ -47017,7 +47016,7 @@ export const updateTrainingJob: API.OperationMethod<
   UpdateTrainingJobRequest,
   UpdateTrainingJobResponse,
   UpdateTrainingJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrainingJobRequest,
   output: UpdateTrainingJobResponse,
@@ -47038,7 +47037,7 @@ export const updateTrial: API.OperationMethod<
   UpdateTrialRequest,
   UpdateTrialResponse,
   UpdateTrialError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrialRequest,
   output: UpdateTrialResponse,
@@ -47059,7 +47058,7 @@ export const updateTrialComponent: API.OperationMethod<
   UpdateTrialComponentRequest,
   UpdateTrialComponentResponse,
   UpdateTrialComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrialComponentRequest,
   output: UpdateTrialComponentResponse,
@@ -47081,7 +47080,7 @@ export const updateUserProfile: API.OperationMethod<
   UpdateUserProfileRequest,
   UpdateUserProfileResponse,
   UpdateUserProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserProfileRequest,
   output: UpdateUserProfileResponse,
@@ -47115,7 +47114,7 @@ export const updateWorkforce: API.OperationMethod<
   UpdateWorkforceRequest,
   UpdateWorkforceResponse,
   UpdateWorkforceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkforceRequest,
   output: UpdateWorkforceResponse,
@@ -47133,7 +47132,7 @@ export const updateWorkteam: API.OperationMethod<
   UpdateWorkteamRequest,
   UpdateWorkteamResponse,
   UpdateWorkteamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkteamRequest,
   output: UpdateWorkteamResponse,

--- a/packages/aws/src/services/sagemakerjobruntime.ts
+++ b/packages/aws/src/services/sagemakerjobruntime.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SagemakerJobRuntime",
   serviceShapeName: "AgenticRFTRuntimeService",
@@ -268,7 +267,7 @@ export const completeRollout: API.OperationMethod<
   CompleteRolloutRequest,
   CompleteRolloutResponse,
   CompleteRolloutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CompleteRolloutRequest,
   output: CompleteRolloutResponse,
@@ -303,7 +302,7 @@ export const sample: API.OperationMethod<
   SampleRequest,
   SampleResponse,
   SampleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SampleRequest,
   output: SampleResponse,
@@ -337,7 +336,7 @@ export const sampleWithResponseStream: API.OperationMethod<
   SampleWithResponseStreamRequest,
   SampleWithResponseStreamResponse,
   SampleWithResponseStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SampleWithResponseStreamRequest,
   output: SampleWithResponseStreamResponse,
@@ -372,7 +371,7 @@ export const updateReward: API.OperationMethod<
   UpdateRewardRequest,
   UpdateRewardResponse,
   UpdateRewardError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRewardRequest,
   output: UpdateRewardResponse,

--- a/packages/aws/src/services/savingsplans.ts
+++ b/packages/aws/src/services/savingsplans.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "savingsplans",
   serviceShapeName: "AWSSavingsPlan",
@@ -1013,7 +1012,7 @@ export const createSavingsPlan: API.OperationMethod<
   CreateSavingsPlanRequest,
   CreateSavingsPlanResponse,
   CreateSavingsPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSavingsPlanRequest,
   output: CreateSavingsPlanResponse,
@@ -1041,7 +1040,7 @@ export const deleteQueuedSavingsPlan: API.OperationMethod<
   DeleteQueuedSavingsPlanRequest,
   DeleteQueuedSavingsPlanResponse,
   DeleteQueuedSavingsPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueuedSavingsPlanRequest,
   output: DeleteQueuedSavingsPlanResponse,
@@ -1068,7 +1067,7 @@ export const describeSavingsPlanRates: API.OperationMethod<
   DescribeSavingsPlanRatesRequest,
   DescribeSavingsPlanRatesResponse,
   DescribeSavingsPlanRatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSavingsPlanRatesRequest,
   output: DescribeSavingsPlanRatesResponse,
@@ -1093,7 +1092,7 @@ export const describeSavingsPlans: API.OperationMethod<
   DescribeSavingsPlansRequest,
   DescribeSavingsPlansResponse,
   DescribeSavingsPlansError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSavingsPlansRequest,
   output: DescribeSavingsPlansResponse,
@@ -1114,7 +1113,7 @@ export const describeSavingsPlansOfferingRates: API.OperationMethod<
   DescribeSavingsPlansOfferingRatesRequest,
   DescribeSavingsPlansOfferingRatesResponse,
   DescribeSavingsPlansOfferingRatesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSavingsPlansOfferingRatesRequest,
   output: DescribeSavingsPlansOfferingRatesResponse,
@@ -1135,7 +1134,7 @@ export const describeSavingsPlansOfferings: API.OperationMethod<
   DescribeSavingsPlansOfferingsRequest,
   DescribeSavingsPlansOfferingsResponse,
   DescribeSavingsPlansOfferingsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSavingsPlansOfferingsRequest,
   output: DescribeSavingsPlansOfferingsResponse,
@@ -1157,7 +1156,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1184,7 +1183,7 @@ export const returnSavingsPlan: API.OperationMethod<
   ReturnSavingsPlanRequest,
   ReturnSavingsPlanResponse,
   ReturnSavingsPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReturnSavingsPlanRequest,
   output: ReturnSavingsPlanResponse,
@@ -1212,7 +1211,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1239,7 +1238,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/scheduler.ts
+++ b/packages/aws/src/services/scheduler.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Scheduler",
   serviceShapeName: "AWSChronosService",
@@ -905,7 +904,7 @@ export const createSchedule: API.OperationMethod<
   CreateScheduleInput,
   CreateScheduleOutput,
   CreateScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduleInput,
   output: CreateScheduleOutput,
@@ -936,7 +935,7 @@ export const createScheduleGroup: API.OperationMethod<
   CreateScheduleGroupInput,
   CreateScheduleGroupOutput,
   CreateScheduleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduleGroupInput,
   output: CreateScheduleGroupOutput,
@@ -966,7 +965,7 @@ export const deleteSchedule: API.OperationMethod<
   DeleteScheduleInput,
   DeleteScheduleOutput,
   DeleteScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduleInput,
   output: DeleteScheduleOutput,
@@ -1001,7 +1000,7 @@ export const deleteScheduleGroup: API.OperationMethod<
   DeleteScheduleGroupInput,
   DeleteScheduleGroupOutput,
   DeleteScheduleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduleGroupInput,
   output: DeleteScheduleGroupOutput,
@@ -1030,7 +1029,7 @@ export const getSchedule: API.OperationMethod<
   GetScheduleInput,
   GetScheduleOutput,
   GetScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScheduleInput,
   output: GetScheduleOutput,
@@ -1058,7 +1057,7 @@ export const getScheduleGroup: API.OperationMethod<
   GetScheduleGroupInput,
   GetScheduleGroupOutput,
   GetScheduleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetScheduleGroupInput,
   output: GetScheduleGroupOutput,
@@ -1085,7 +1084,7 @@ export const listScheduleGroups: API.PaginatedOperationMethod<
   ListScheduleGroupsInput,
   ListScheduleGroupsOutput,
   ListScheduleGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduleGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduleGroupsInput,
@@ -1115,7 +1114,7 @@ export const listSchedules: API.PaginatedOperationMethod<
   ListSchedulesInput,
   ListSchedulesOutput,
   ListSchedulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchedulesInput,
@@ -1150,7 +1149,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1179,7 +1178,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1209,7 +1208,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1244,7 +1243,7 @@ export const updateSchedule: API.OperationMethod<
   UpdateScheduleInput,
   UpdateScheduleOutput,
   UpdateScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduleInput,
   output: UpdateScheduleOutput,

--- a/packages/aws/src/services/schemas.ts
+++ b/packages/aws/src/services/schemas.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "schemas", serviceShapeName: "schemas" });
 const auth = T.AwsAuthSigv4({ name: "schemas" });
 const ver = T.ServiceVersion("2019-12-02");
@@ -1494,7 +1493,7 @@ export const createDiscoverer: API.OperationMethod<
   CreateDiscovererRequest,
   CreateDiscovererResponse,
   CreateDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDiscovererRequest,
   output: CreateDiscovererResponse,
@@ -1526,7 +1525,7 @@ export const createRegistry: API.OperationMethod<
   CreateRegistryRequest,
   CreateRegistryResponse,
   CreateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegistryRequest,
   output: CreateRegistryResponse,
@@ -1558,7 +1557,7 @@ export const createSchema: API.OperationMethod<
   CreateSchemaRequest,
   CreateSchemaResponse,
   CreateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSchemaRequest,
   output: CreateSchemaResponse,
@@ -1588,7 +1587,7 @@ export const deleteDiscoverer: API.OperationMethod<
   DeleteDiscovererRequest,
   DeleteDiscovererResponse,
   DeleteDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDiscovererRequest,
   output: DeleteDiscovererResponse,
@@ -1620,7 +1619,7 @@ export const deleteRegistry: API.OperationMethod<
   DeleteRegistryRequest,
   DeleteRegistryResponse,
   DeleteRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegistryRequest,
   output: DeleteRegistryResponse,
@@ -1652,7 +1651,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -1684,7 +1683,7 @@ export const deleteSchema: API.OperationMethod<
   DeleteSchemaRequest,
   DeleteSchemaResponse,
   DeleteSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaRequest,
   output: DeleteSchemaResponse,
@@ -1716,7 +1715,7 @@ export const deleteSchemaVersion: API.OperationMethod<
   DeleteSchemaVersionRequest,
   DeleteSchemaVersionResponse,
   DeleteSchemaVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSchemaVersionRequest,
   output: DeleteSchemaVersionResponse,
@@ -1748,7 +1747,7 @@ export const describeCodeBinding: API.OperationMethod<
   DescribeCodeBindingRequest,
   DescribeCodeBindingResponse,
   DescribeCodeBindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCodeBindingRequest,
   output: DescribeCodeBindingResponse,
@@ -1780,7 +1779,7 @@ export const describeDiscoverer: API.OperationMethod<
   DescribeDiscovererRequest,
   DescribeDiscovererResponse,
   DescribeDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDiscovererRequest,
   output: DescribeDiscovererResponse,
@@ -1812,7 +1811,7 @@ export const describeRegistry: API.OperationMethod<
   DescribeRegistryRequest,
   DescribeRegistryResponse,
   DescribeRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRegistryRequest,
   output: DescribeRegistryResponse,
@@ -1844,7 +1843,7 @@ export const describeSchema: API.OperationMethod<
   DescribeSchemaRequest,
   DescribeSchemaResponse,
   DescribeSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSchemaRequest,
   output: DescribeSchemaResponse,
@@ -1877,7 +1876,7 @@ export const exportSchema: API.OperationMethod<
   ExportSchemaRequest,
   ExportSchemaResponse,
   ExportSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportSchemaRequest,
   output: ExportSchemaResponse,
@@ -1910,7 +1909,7 @@ export const getCodeBindingSource: API.OperationMethod<
   GetCodeBindingSourceRequest,
   GetCodeBindingSourceResponse,
   GetCodeBindingSourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCodeBindingSourceRequest,
   output: GetCodeBindingSourceResponse,
@@ -1941,7 +1940,7 @@ export const getDiscoveredSchema: API.OperationMethod<
   GetDiscoveredSchemaRequest,
   GetDiscoveredSchemaResponse,
   GetDiscoveredSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDiscoveredSchemaRequest,
   output: GetDiscoveredSchemaResponse,
@@ -1972,7 +1971,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -2003,7 +2002,7 @@ export const listDiscoverers: API.PaginatedOperationMethod<
   ListDiscoverersRequest,
   ListDiscoverersResponse,
   ListDiscoverersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DiscovererSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDiscoverersRequest,
@@ -2040,7 +2039,7 @@ export const listRegistries: API.PaginatedOperationMethod<
   ListRegistriesRequest,
   ListRegistriesResponse,
   ListRegistriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegistrySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegistriesRequest,
@@ -2077,7 +2076,7 @@ export const listSchemas: API.PaginatedOperationMethod<
   ListSchemasRequest,
   ListSchemasResponse,
   ListSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemasRequest,
@@ -2115,7 +2114,7 @@ export const listSchemaVersions: API.PaginatedOperationMethod<
   ListSchemaVersionsRequest,
   ListSchemaVersionsResponse,
   ListSchemaVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SchemaVersionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSchemaVersionsRequest,
@@ -2152,7 +2151,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2184,7 +2183,7 @@ export const putCodeBinding: API.OperationMethod<
   PutCodeBindingRequest,
   PutCodeBindingResponse,
   PutCodeBindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutCodeBindingRequest,
   output: PutCodeBindingResponse,
@@ -2219,7 +2218,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -2251,7 +2250,7 @@ export const searchSchemas: API.PaginatedOperationMethod<
   SearchSchemasRequest,
   SearchSchemasResponse,
   SearchSchemasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SearchSchemaSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSchemasRequest,
@@ -2289,7 +2288,7 @@ export const startDiscoverer: API.OperationMethod<
   StartDiscovererRequest,
   StartDiscovererResponse,
   StartDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDiscovererRequest,
   output: StartDiscovererResponse,
@@ -2321,7 +2320,7 @@ export const stopDiscoverer: API.OperationMethod<
   StopDiscovererRequest,
   StopDiscovererResponse,
   StopDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopDiscovererRequest,
   output: StopDiscovererResponse,
@@ -2351,7 +2350,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2379,7 +2378,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2409,7 +2408,7 @@ export const updateDiscoverer: API.OperationMethod<
   UpdateDiscovererRequest,
   UpdateDiscovererResponse,
   UpdateDiscovererError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDiscovererRequest,
   output: UpdateDiscovererResponse,
@@ -2441,7 +2440,7 @@ export const updateRegistry: API.OperationMethod<
   UpdateRegistryRequest,
   UpdateRegistryResponse,
   UpdateRegistryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegistryRequest,
   output: UpdateRegistryResponse,
@@ -2474,7 +2473,7 @@ export const updateSchema: API.OperationMethod<
   UpdateSchemaRequest,
   UpdateSchemaResponse,
   UpdateSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSchemaRequest,
   output: UpdateSchemaResponse,

--- a/packages/aws/src/services/secrets-manager.ts
+++ b/packages/aws/src/services/secrets-manager.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Secrets Manager",
@@ -1217,7 +1216,7 @@ export const batchGetSecretValue: API.PaginatedOperationMethod<
   BatchGetSecretValueRequest,
   BatchGetSecretValueResponse,
   BatchGetSecretValueError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetSecretValueRequest,
@@ -1272,7 +1271,7 @@ export const cancelRotateSecret: API.OperationMethod<
   CancelRotateSecretRequest,
   CancelRotateSecretResponse,
   CancelRotateSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelRotateSecretRequest,
   output: CancelRotateSecretResponse,
@@ -1360,7 +1359,7 @@ export const createSecret: API.OperationMethod<
   CreateSecretRequest,
   CreateSecretResponse,
   CreateSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecretRequest,
   output: CreateSecretResponse,
@@ -1403,7 +1402,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -1468,7 +1467,7 @@ export const deleteSecret: API.OperationMethod<
   DeleteSecretRequest,
   DeleteSecretResponse,
   DeleteSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecretRequest,
   output: DeleteSecretResponse,
@@ -1504,7 +1503,7 @@ export const describeSecret: API.OperationMethod<
   DescribeSecretRequest,
   DescribeSecretResponse,
   DescribeSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecretRequest,
   output: DescribeSecretResponse,
@@ -1543,7 +1542,7 @@ export const getRandomPassword: API.OperationMethod<
   GetRandomPasswordRequest,
   GetRandomPasswordResponse,
   GetRandomPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRandomPasswordRequest,
   output: GetRandomPasswordResponse,
@@ -1579,7 +1578,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -1629,7 +1628,7 @@ export const getSecretValue: API.OperationMethod<
   GetSecretValueRequest,
   GetSecretValueResponse,
   GetSecretValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecretValueRequest,
   output: GetSecretValueResponse,
@@ -1680,7 +1679,7 @@ export const listSecrets: API.PaginatedOperationMethod<
   ListSecretsRequest,
   ListSecretsResponse,
   ListSecretsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecretsRequest,
@@ -1726,7 +1725,7 @@ export const listSecretVersionIds: API.PaginatedOperationMethod<
   ListSecretVersionIdsRequest,
   ListSecretVersionIdsResponse,
   ListSecretVersionIdsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecretVersionIdsRequest,
@@ -1773,7 +1772,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -1844,7 +1843,7 @@ export const putSecretValue: API.OperationMethod<
   PutSecretValueRequest,
   PutSecretValueResponse,
   PutSecretValueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSecretValueRequest,
   output: PutSecretValueResponse,
@@ -1886,7 +1885,7 @@ export const removeRegionsFromReplication: API.OperationMethod<
   RemoveRegionsFromReplicationRequest,
   RemoveRegionsFromReplicationResponse,
   RemoveRegionsFromReplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRegionsFromReplicationRequest,
   output: RemoveRegionsFromReplicationResponse,
@@ -1927,7 +1926,7 @@ export const replicateSecretToRegions: API.OperationMethod<
   ReplicateSecretToRegionsRequest,
   ReplicateSecretToRegionsResponse,
   ReplicateSecretToRegionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReplicateSecretToRegionsRequest,
   output: ReplicateSecretToRegionsResponse,
@@ -1964,7 +1963,7 @@ export const restoreSecret: API.OperationMethod<
   RestoreSecretRequest,
   RestoreSecretResponse,
   RestoreSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreSecretRequest,
   output: RestoreSecretResponse,
@@ -2017,7 +2016,7 @@ export const rotateSecret: API.OperationMethod<
   RotateSecretRequest,
   RotateSecretResponse,
   RotateSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RotateSecretRequest,
   output: RotateSecretResponse,
@@ -2057,7 +2056,7 @@ export const stopReplicationToReplica: API.OperationMethod<
   StopReplicationToReplicaRequest,
   StopReplicationToReplicaResponse,
   StopReplicationToReplicaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopReplicationToReplicaRequest,
   output: StopReplicationToReplicaResponse,
@@ -2103,7 +2102,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2147,7 +2146,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2225,7 +2224,7 @@ export const updateSecret: API.OperationMethod<
   UpdateSecretRequest,
   UpdateSecretResponse,
   UpdateSecretError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecretRequest,
   output: UpdateSecretResponse,
@@ -2287,7 +2286,7 @@ export const updateSecretVersionStage: API.OperationMethod<
   UpdateSecretVersionStageRequest,
   UpdateSecretVersionStageResponse,
   UpdateSecretVersionStageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecretVersionStageRequest,
   output: UpdateSecretVersionStageResponse,
@@ -2337,7 +2336,7 @@ export const validateResourcePolicy: API.OperationMethod<
   ValidateResourcePolicyRequest,
   ValidateResourcePolicyResponse,
   ValidateResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateResourcePolicyRequest,
   output: ValidateResourcePolicyResponse,

--- a/packages/aws/src/services/security-ir.ts
+++ b/packages/aws/src/services/security-ir.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Security IR",
@@ -1489,7 +1488,7 @@ export const batchGetMemberAccountDetails: API.OperationMethod<
   BatchGetMemberAccountDetailsRequest,
   BatchGetMemberAccountDetailsResponse,
   BatchGetMemberAccountDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetMemberAccountDetailsRequest,
   output: BatchGetMemberAccountDetailsResponse,
@@ -1507,7 +1506,7 @@ export const cancelMembership: API.OperationMethod<
   CancelMembershipRequest,
   CancelMembershipResponse,
   CancelMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMembershipRequest,
   output: CancelMembershipResponse,
@@ -1525,7 +1524,7 @@ export const closeCase: API.OperationMethod<
   CloseCaseRequest,
   CloseCaseResponse,
   CloseCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloseCaseRequest,
   output: CloseCaseResponse,
@@ -1543,7 +1542,7 @@ export const createCase: API.OperationMethod<
   CreateCaseRequest,
   CreateCaseResponse,
   CreateCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCaseRequest,
   output: CreateCaseResponse,
@@ -1561,7 +1560,7 @@ export const createCaseComment: API.OperationMethod<
   CreateCaseCommentRequest,
   CreateCaseCommentResponse,
   CreateCaseCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCaseCommentRequest,
   output: CreateCaseCommentResponse,
@@ -1579,7 +1578,7 @@ export const createMembership: API.OperationMethod<
   CreateMembershipRequest,
   CreateMembershipResponse,
   CreateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembershipRequest,
   output: CreateMembershipResponse,
@@ -1597,7 +1596,7 @@ export const getCase: API.OperationMethod<
   GetCaseRequest,
   GetCaseResponse,
   GetCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCaseRequest,
   output: GetCaseResponse,
@@ -1615,7 +1614,7 @@ export const getCaseAttachmentDownloadUrl: API.OperationMethod<
   GetCaseAttachmentDownloadUrlRequest,
   GetCaseAttachmentDownloadUrlResponse,
   GetCaseAttachmentDownloadUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCaseAttachmentDownloadUrlRequest,
   output: GetCaseAttachmentDownloadUrlResponse,
@@ -1633,7 +1632,7 @@ export const getCaseAttachmentUploadUrl: API.OperationMethod<
   GetCaseAttachmentUploadUrlRequest,
   GetCaseAttachmentUploadUrlResponse,
   GetCaseAttachmentUploadUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCaseAttachmentUploadUrlRequest,
   output: GetCaseAttachmentUploadUrlResponse,
@@ -1651,7 +1650,7 @@ export const getMembership: API.OperationMethod<
   GetMembershipRequest,
   GetMembershipResponse,
   GetMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMembershipRequest,
   output: GetMembershipResponse,
@@ -1669,7 +1668,7 @@ export const listCaseEdits: API.PaginatedOperationMethod<
   ListCaseEditsRequest,
   ListCaseEditsResponse,
   ListCaseEditsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CaseEditItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCaseEditsRequest,
@@ -1694,7 +1693,7 @@ export const listCases: API.PaginatedOperationMethod<
   ListCasesRequest,
   ListCasesResponse,
   ListCasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListCasesItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCasesRequest,
@@ -1719,7 +1718,7 @@ export const listComments: API.PaginatedOperationMethod<
   ListCommentsRequest,
   ListCommentsResponse,
   ListCommentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListCommentsItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommentsRequest,
@@ -1744,7 +1743,7 @@ export const listInvestigations: API.PaginatedOperationMethod<
   ListInvestigationsRequest,
   ListInvestigationsResponse,
   ListInvestigationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InvestigationAction
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvestigationsRequest,
@@ -1769,7 +1768,7 @@ export const listMemberships: API.PaginatedOperationMethod<
   ListMembershipsRequest,
   ListMembershipsResponse,
   ListMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListMembershipItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembershipsRequest,
@@ -1798,7 +1797,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1820,7 +1819,7 @@ export const sendFeedback: API.OperationMethod<
   SendFeedbackRequest,
   SendFeedbackResponse,
   SendFeedbackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendFeedbackRequest,
   output: SendFeedbackResponse,
@@ -1842,7 +1841,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1868,7 +1867,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -1890,7 +1889,7 @@ export const updateCase: API.OperationMethod<
   UpdateCaseRequest,
   UpdateCaseResponse,
   UpdateCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCaseRequest,
   output: UpdateCaseResponse,
@@ -1908,7 +1907,7 @@ export const updateCaseComment: API.OperationMethod<
   UpdateCaseCommentRequest,
   UpdateCaseCommentResponse,
   UpdateCaseCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCaseCommentRequest,
   output: UpdateCaseCommentResponse,
@@ -1946,7 +1945,7 @@ export const updateCaseStatus: API.OperationMethod<
   UpdateCaseStatusRequest,
   UpdateCaseStatusResponse,
   UpdateCaseStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCaseStatusRequest,
   output: UpdateCaseStatusResponse,
@@ -1964,7 +1963,7 @@ export const updateMembership: API.OperationMethod<
   UpdateMembershipRequest,
   UpdateMembershipResponse,
   UpdateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMembershipRequest,
   output: UpdateMembershipResponse,
@@ -1984,7 +1983,7 @@ export const updateResolverType: API.OperationMethod<
   UpdateResolverTypeRequest,
   UpdateResolverTypeResponse,
   UpdateResolverTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResolverTypeRequest,
   output: UpdateResolverTypeResponse,

--- a/packages/aws/src/services/securityagent.ts
+++ b/packages/aws/src/services/securityagent.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SecurityAgent",
@@ -6305,7 +6304,7 @@ export const addArtifact: API.OperationMethod<
   AddArtifactInput,
   AddArtifactOutput,
   AddArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddArtifactInput,
   output: AddArtifactOutput,
@@ -6337,7 +6336,7 @@ export const batchCreateSecurityRequirements: API.OperationMethod<
   BatchCreateSecurityRequirementsInput,
   BatchCreateSecurityRequirementsOutput,
   BatchCreateSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateSecurityRequirementsInput,
   output: BatchCreateSecurityRequirementsOutput,
@@ -6363,7 +6362,7 @@ export const batchDeleteCodeReviews: API.OperationMethod<
   BatchDeleteCodeReviewsInput,
   BatchDeleteCodeReviewsOutput,
   BatchDeleteCodeReviewsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteCodeReviewsInput,
   output: BatchDeleteCodeReviewsOutput,
@@ -6381,7 +6380,7 @@ export const batchDeletePentests: API.OperationMethod<
   BatchDeletePentestsInput,
   BatchDeletePentestsOutput,
   BatchDeletePentestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeletePentestsInput,
   output: BatchDeletePentestsOutput,
@@ -6406,7 +6405,7 @@ export const batchDeleteSecurityRequirements: API.OperationMethod<
   BatchDeleteSecurityRequirementsInput,
   BatchDeleteSecurityRequirementsOutput,
   BatchDeleteSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteSecurityRequirementsInput,
   output: BatchDeleteSecurityRequirementsOutput,
@@ -6431,7 +6430,7 @@ export const batchDeleteThreatModels: API.OperationMethod<
   BatchDeleteThreatModelsInput,
   BatchDeleteThreatModelsOutput,
   BatchDeleteThreatModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteThreatModelsInput,
   output: BatchDeleteThreatModelsOutput,
@@ -6449,7 +6448,7 @@ export const batchGetAgentSpaces: API.OperationMethod<
   BatchGetAgentSpacesInput,
   BatchGetAgentSpacesOutput,
   BatchGetAgentSpacesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAgentSpacesInput,
   output: BatchGetAgentSpacesOutput,
@@ -6473,7 +6472,7 @@ export const batchGetArtifactMetadata: API.OperationMethod<
   BatchGetArtifactMetadataInput,
   BatchGetArtifactMetadataOutput,
   BatchGetArtifactMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetArtifactMetadataInput,
   output: BatchGetArtifactMetadataOutput,
@@ -6497,7 +6496,7 @@ export const batchGetCodeReviewJobs: API.OperationMethod<
   BatchGetCodeReviewJobsInput,
   BatchGetCodeReviewJobsOutput,
   BatchGetCodeReviewJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCodeReviewJobsInput,
   output: BatchGetCodeReviewJobsOutput,
@@ -6515,7 +6514,7 @@ export const batchGetCodeReviewJobTasks: API.OperationMethod<
   BatchGetCodeReviewJobTasksInput,
   BatchGetCodeReviewJobTasksOutput,
   BatchGetCodeReviewJobTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCodeReviewJobTasksInput,
   output: BatchGetCodeReviewJobTasksOutput,
@@ -6533,7 +6532,7 @@ export const batchGetCodeReviews: API.OperationMethod<
   BatchGetCodeReviewsInput,
   BatchGetCodeReviewsOutput,
   BatchGetCodeReviewsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetCodeReviewsInput,
   output: BatchGetCodeReviewsOutput,
@@ -6551,7 +6550,7 @@ export const batchGetFindings: API.OperationMethod<
   BatchGetFindingsInput,
   BatchGetFindingsOutput,
   BatchGetFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetFindingsInput,
   output: BatchGetFindingsOutput,
@@ -6569,7 +6568,7 @@ export const batchGetPentestJobs: API.OperationMethod<
   BatchGetPentestJobsInput,
   BatchGetPentestJobsOutput,
   BatchGetPentestJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPentestJobsInput,
   output: BatchGetPentestJobsOutput,
@@ -6587,7 +6586,7 @@ export const batchGetPentestJobTasks: API.OperationMethod<
   BatchGetPentestJobTasksInput,
   BatchGetPentestJobTasksOutput,
   BatchGetPentestJobTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPentestJobTasksInput,
   output: BatchGetPentestJobTasksOutput,
@@ -6605,7 +6604,7 @@ export const batchGetPentests: API.OperationMethod<
   BatchGetPentestsInput,
   BatchGetPentestsOutput,
   BatchGetPentestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPentestsInput,
   output: BatchGetPentestsOutput,
@@ -6629,7 +6628,7 @@ export const batchGetSecurityRequirements: API.OperationMethod<
   BatchGetSecurityRequirementsInput,
   BatchGetSecurityRequirementsOutput,
   BatchGetSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSecurityRequirementsInput,
   output: BatchGetSecurityRequirementsOutput,
@@ -6653,7 +6652,7 @@ export const batchGetTargetDomains: API.OperationMethod<
   BatchGetTargetDomainsInput,
   BatchGetTargetDomainsOutput,
   BatchGetTargetDomainsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTargetDomainsInput,
   output: BatchGetTargetDomainsOutput,
@@ -6671,7 +6670,7 @@ export const batchGetThreatModelJobs: API.OperationMethod<
   BatchGetThreatModelJobsInput,
   BatchGetThreatModelJobsOutput,
   BatchGetThreatModelJobsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetThreatModelJobsInput,
   output: BatchGetThreatModelJobsOutput,
@@ -6689,7 +6688,7 @@ export const batchGetThreatModelJobTasks: API.OperationMethod<
   BatchGetThreatModelJobTasksInput,
   BatchGetThreatModelJobTasksOutput,
   BatchGetThreatModelJobTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetThreatModelJobTasksInput,
   output: BatchGetThreatModelJobTasksOutput,
@@ -6707,7 +6706,7 @@ export const batchGetThreatModels: API.OperationMethod<
   BatchGetThreatModelsInput,
   BatchGetThreatModelsOutput,
   BatchGetThreatModelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetThreatModelsInput,
   output: BatchGetThreatModelsOutput,
@@ -6725,7 +6724,7 @@ export const batchGetThreats: API.OperationMethod<
   BatchGetThreatsInput,
   BatchGetThreatsOutput,
   BatchGetThreatsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetThreatsInput,
   output: BatchGetThreatsOutput,
@@ -6750,7 +6749,7 @@ export const batchUpdateSecurityRequirements: API.OperationMethod<
   BatchUpdateSecurityRequirementsInput,
   BatchUpdateSecurityRequirementsOutput,
   BatchUpdateSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateSecurityRequirementsInput,
   output: BatchUpdateSecurityRequirementsOutput,
@@ -6775,7 +6774,7 @@ export const createAgentSpace: API.OperationMethod<
   CreateAgentSpaceInput,
   CreateAgentSpaceOutput,
   CreateAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgentSpaceInput,
   output: CreateAgentSpaceOutput,
@@ -6793,7 +6792,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -6811,7 +6810,7 @@ export const createCodeReview: API.OperationMethod<
   CreateCodeReviewInput,
   CreateCodeReviewOutput,
   CreateCodeReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCodeReviewInput,
   output: CreateCodeReviewOutput,
@@ -6836,7 +6835,7 @@ export const createIntegration: API.OperationMethod<
   CreateIntegrationInput,
   CreateIntegrationOutput,
   CreateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIntegrationInput,
   output: CreateIntegrationOutput,
@@ -6861,7 +6860,7 @@ export const createMembership: API.OperationMethod<
   CreateMembershipRequest,
   CreateMembershipResponse,
   CreateMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembershipRequest,
   output: CreateMembershipResponse,
@@ -6879,7 +6878,7 @@ export const createPentest: API.OperationMethod<
   CreatePentestInput,
   CreatePentestOutput,
   CreatePentestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePentestInput,
   output: CreatePentestOutput,
@@ -6904,7 +6903,7 @@ export const createPrivateConnection: API.OperationMethod<
   CreatePrivateConnectionInput,
   CreatePrivateConnectionOutput,
   CreatePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivateConnectionInput,
   output: CreatePrivateConnectionOutput,
@@ -6936,7 +6935,7 @@ export const createSecurityRequirementPack: API.OperationMethod<
   CreateSecurityRequirementPackInput,
   CreateSecurityRequirementPackOutput,
   CreateSecurityRequirementPackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityRequirementPackInput,
   output: CreateSecurityRequirementPackOutput,
@@ -6961,7 +6960,7 @@ export const createTargetDomain: API.OperationMethod<
   CreateTargetDomainInput,
   CreateTargetDomainOutput,
   CreateTargetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTargetDomainInput,
   output: CreateTargetDomainOutput,
@@ -6979,7 +6978,7 @@ export const createThreat: API.OperationMethod<
   CreateThreatInput,
   CreateThreatOutput,
   CreateThreatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThreatInput,
   output: CreateThreatOutput,
@@ -6997,7 +6996,7 @@ export const createThreatModel: API.OperationMethod<
   CreateThreatModelInput,
   CreateThreatModelOutput,
   CreateThreatModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateThreatModelInput,
   output: CreateThreatModelOutput,
@@ -7015,7 +7014,7 @@ export const deleteAgentSpace: API.OperationMethod<
   DeleteAgentSpaceInput,
   DeleteAgentSpaceOutput,
   DeleteAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgentSpaceInput,
   output: DeleteAgentSpaceOutput,
@@ -7033,7 +7032,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -7057,7 +7056,7 @@ export const deleteArtifact: API.OperationMethod<
   DeleteArtifactInput,
   DeleteArtifactOutput,
   DeleteArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteArtifactInput,
   output: DeleteArtifactOutput,
@@ -7088,7 +7087,7 @@ export const deleteIntegration: API.OperationMethod<
   DeleteIntegrationInput,
   DeleteIntegrationOutput,
   DeleteIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIntegrationInput,
   output: DeleteIntegrationOutput,
@@ -7113,7 +7112,7 @@ export const deleteMembership: API.OperationMethod<
   DeleteMembershipRequest,
   DeleteMembershipResponse,
   DeleteMembershipError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMembershipRequest,
   output: DeleteMembershipResponse,
@@ -7138,7 +7137,7 @@ export const deletePrivateConnection: API.OperationMethod<
   DeletePrivateConnectionInput,
   DeletePrivateConnectionOutput,
   DeletePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePrivateConnectionInput,
   output: DeletePrivateConnectionOutput,
@@ -7170,7 +7169,7 @@ export const deleteSecurityRequirementPack: API.OperationMethod<
   DeleteSecurityRequirementPackInput,
   DeleteSecurityRequirementPackOutput,
   DeleteSecurityRequirementPackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityRequirementPackInput,
   output: DeleteSecurityRequirementPackOutput,
@@ -7195,7 +7194,7 @@ export const deleteTargetDomain: API.OperationMethod<
   DeleteTargetDomainInput,
   DeleteTargetDomainOutput,
   DeleteTargetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTargetDomainInput,
   output: DeleteTargetDomainOutput,
@@ -7219,7 +7218,7 @@ export const describePrivateConnection: API.OperationMethod<
   DescribePrivateConnectionInput,
   DescribePrivateConnectionOutput,
   DescribePrivateConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePrivateConnectionInput,
   output: DescribePrivateConnectionOutput,
@@ -7243,7 +7242,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -7267,7 +7266,7 @@ export const getArtifact: API.OperationMethod<
   GetArtifactInput,
   GetArtifactOutput,
   GetArtifactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetArtifactInput,
   output: GetArtifactOutput,
@@ -7297,7 +7296,7 @@ export const getIntegration: API.OperationMethod<
   GetIntegrationInput,
   GetIntegrationOutput,
   GetIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIntegrationInput,
   output: GetIntegrationOutput,
@@ -7327,7 +7326,7 @@ export const getSecurityRequirementPack: API.OperationMethod<
   GetSecurityRequirementPackInput,
   GetSecurityRequirementPackOutput,
   GetSecurityRequirementPackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityRequirementPackInput,
   output: GetSecurityRequirementPackOutput,
@@ -7359,7 +7358,7 @@ export const importSecurityRequirements: API.OperationMethod<
   ImportSecurityRequirementsInput,
   ImportSecurityRequirementsOutput,
   ImportSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportSecurityRequirementsInput,
   output: ImportSecurityRequirementsOutput,
@@ -7392,7 +7391,7 @@ export const initiateProviderRegistration: API.OperationMethod<
   InitiateProviderRegistrationInput,
   InitiateProviderRegistrationOutput,
   InitiateProviderRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateProviderRegistrationInput,
   output: InitiateProviderRegistrationOutput,
@@ -7417,7 +7416,7 @@ export const listAgentSpaces: API.PaginatedOperationMethod<
   ListAgentSpacesInput,
   ListAgentSpacesOutput,
   ListAgentSpacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AgentSpaceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgentSpacesInput,
@@ -7442,7 +7441,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -7473,7 +7472,7 @@ export const listArtifacts: API.PaginatedOperationMethod<
   ListArtifactsInput,
   ListArtifactsOutput,
   ListArtifactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ArtifactSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListArtifactsInput,
@@ -7504,7 +7503,7 @@ export const listCodeReviewJobsForCodeReview: API.PaginatedOperationMethod<
   ListCodeReviewJobsForCodeReviewInput,
   ListCodeReviewJobsForCodeReviewOutput,
   ListCodeReviewJobsForCodeReviewError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeReviewJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeReviewJobsForCodeReviewInput,
@@ -7529,7 +7528,7 @@ export const listCodeReviewJobTasks: API.PaginatedOperationMethod<
   ListCodeReviewJobTasksInput,
   ListCodeReviewJobTasksOutput,
   ListCodeReviewJobTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeReviewJobTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeReviewJobTasksInput,
@@ -7554,7 +7553,7 @@ export const listCodeReviews: API.PaginatedOperationMethod<
   ListCodeReviewsInput,
   ListCodeReviewsOutput,
   ListCodeReviewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CodeReviewSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCodeReviewsInput,
@@ -7579,7 +7578,7 @@ export const listDiscoveredEndpoints: API.PaginatedOperationMethod<
   ListDiscoveredEndpointsInput,
   ListDiscoveredEndpointsOutput,
   ListDiscoveredEndpointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DiscoveredEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDiscoveredEndpointsInput,
@@ -7604,7 +7603,7 @@ export const listFindings: API.PaginatedOperationMethod<
   ListFindingsInput,
   ListFindingsOutput,
   ListFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingsInput,
@@ -7635,7 +7634,7 @@ export const listIntegratedResources: API.PaginatedOperationMethod<
   ListIntegratedResourcesInput,
   ListIntegratedResourcesOutput,
   ListIntegratedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IntegratedResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntegratedResourcesInput,
@@ -7672,7 +7671,7 @@ export const listIntegrations: API.PaginatedOperationMethod<
   ListIntegrationsInput,
   ListIntegrationsOutput,
   ListIntegrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IntegrationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIntegrationsInput,
@@ -7703,7 +7702,7 @@ export const listMemberships: API.PaginatedOperationMethod<
   ListMembershipsRequest,
   ListMembershipsResponse,
   ListMembershipsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MembershipSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembershipsRequest,
@@ -7728,7 +7727,7 @@ export const listPentestJobsForPentest: API.PaginatedOperationMethod<
   ListPentestJobsForPentestInput,
   ListPentestJobsForPentestOutput,
   ListPentestJobsForPentestError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PentestJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPentestJobsForPentestInput,
@@ -7753,7 +7752,7 @@ export const listPentestJobTasks: API.PaginatedOperationMethod<
   ListPentestJobTasksInput,
   ListPentestJobTasksOutput,
   ListPentestJobTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPentestJobTasksInput,
@@ -7778,7 +7777,7 @@ export const listPentests: API.PaginatedOperationMethod<
   ListPentestsInput,
   ListPentestsOutput,
   ListPentestsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PentestSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPentestsInput,
@@ -7808,7 +7807,7 @@ export const listPrivateConnections: API.PaginatedOperationMethod<
   ListPrivateConnectionsInput,
   ListPrivateConnectionsOutput,
   ListPrivateConnectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PrivateConnectionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrivateConnectionsInput,
@@ -7843,7 +7842,7 @@ export const listSecurityRequirementPacks: API.PaginatedOperationMethod<
   ListSecurityRequirementPacksInput,
   ListSecurityRequirementPacksOutput,
   ListSecurityRequirementPacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityRequirementPackSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityRequirementPacksInput,
@@ -7879,7 +7878,7 @@ export const listSecurityRequirements: API.PaginatedOperationMethod<
   ListSecurityRequirementsInput,
   ListSecurityRequirementsOutput,
   ListSecurityRequirementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityRequirementSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityRequirementsInput,
@@ -7910,7 +7909,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -7928,7 +7927,7 @@ export const listTargetDomains: API.PaginatedOperationMethod<
   ListTargetDomainsInput,
   ListTargetDomainsOutput,
   ListTargetDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetDomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetDomainsInput,
@@ -7953,7 +7952,7 @@ export const listThreatModelJobs: API.PaginatedOperationMethod<
   ListThreatModelJobsInput,
   ListThreatModelJobsOutput,
   ListThreatModelJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThreatModelJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatModelJobsInput,
@@ -7978,7 +7977,7 @@ export const listThreatModelJobTasks: API.PaginatedOperationMethod<
   ListThreatModelJobTasksInput,
   ListThreatModelJobTasksOutput,
   ListThreatModelJobTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThreatModelJobTaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatModelJobTasksInput,
@@ -8003,7 +8002,7 @@ export const listThreatModels: API.PaginatedOperationMethod<
   ListThreatModelsInput,
   ListThreatModelsOutput,
   ListThreatModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThreatModelSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatModelsInput,
@@ -8028,7 +8027,7 @@ export const listThreats: API.PaginatedOperationMethod<
   ListThreatsInput,
   ListThreatsOutput,
   ListThreatsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ThreatSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListThreatsInput,
@@ -8053,7 +8052,7 @@ export const startCodeRemediation: API.OperationMethod<
   StartCodeRemediationInput,
   StartCodeRemediationOutput,
   StartCodeRemediationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCodeRemediationInput,
   output: StartCodeRemediationOutput,
@@ -8071,7 +8070,7 @@ export const startCodeReviewJob: API.OperationMethod<
   StartCodeReviewJobInput,
   StartCodeReviewJobOutput,
   StartCodeReviewJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCodeReviewJobInput,
   output: StartCodeReviewJobOutput,
@@ -8089,7 +8088,7 @@ export const startPentestJob: API.OperationMethod<
   StartPentestJobInput,
   StartPentestJobOutput,
   StartPentestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartPentestJobInput,
   output: StartPentestJobOutput,
@@ -8107,7 +8106,7 @@ export const startThreatModelJob: API.OperationMethod<
   StartThreatModelJobInput,
   StartThreatModelJobOutput,
   StartThreatModelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartThreatModelJobInput,
   output: StartThreatModelJobOutput,
@@ -8125,7 +8124,7 @@ export const stopCodeReviewJob: API.OperationMethod<
   StopCodeReviewJobInput,
   StopCodeReviewJobOutput,
   StopCodeReviewJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCodeReviewJobInput,
   output: StopCodeReviewJobOutput,
@@ -8143,7 +8142,7 @@ export const stopPentestJob: API.OperationMethod<
   StopPentestJobInput,
   StopPentestJobOutput,
   StopPentestJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopPentestJobInput,
   output: StopPentestJobOutput,
@@ -8161,7 +8160,7 @@ export const stopThreatModelJob: API.OperationMethod<
   StopThreatModelJobInput,
   StopThreatModelJobOutput,
   StopThreatModelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopThreatModelJobInput,
   output: StopThreatModelJobOutput,
@@ -8179,7 +8178,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -8197,7 +8196,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -8215,7 +8214,7 @@ export const updateAgentSpace: API.OperationMethod<
   UpdateAgentSpaceInput,
   UpdateAgentSpaceOutput,
   UpdateAgentSpaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgentSpaceInput,
   output: UpdateAgentSpaceOutput,
@@ -8233,7 +8232,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -8251,7 +8250,7 @@ export const updateCodeReview: API.OperationMethod<
   UpdateCodeReviewInput,
   UpdateCodeReviewOutput,
   UpdateCodeReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCodeReviewInput,
   output: UpdateCodeReviewOutput,
@@ -8269,7 +8268,7 @@ export const updateFinding: API.OperationMethod<
   UpdateFindingInput,
   UpdateFindingOutput,
   UpdateFindingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingInput,
   output: UpdateFindingOutput,
@@ -8294,7 +8293,7 @@ export const updateIntegratedResources: API.OperationMethod<
   UpdateIntegratedResourcesInput,
   UpdateIntegratedResourcesOutput,
   UpdateIntegratedResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegratedResourcesInput,
   output: UpdateIntegratedResourcesOutput,
@@ -8319,7 +8318,7 @@ export const updatePentest: API.OperationMethod<
   UpdatePentestInput,
   UpdatePentestOutput,
   UpdatePentestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePentestInput,
   output: UpdatePentestOutput,
@@ -8344,7 +8343,7 @@ export const updatePrivateConnectionCertificate: API.OperationMethod<
   UpdatePrivateConnectionCertificateInput,
   UpdatePrivateConnectionCertificateOutput,
   UpdatePrivateConnectionCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrivateConnectionCertificateInput,
   output: UpdatePrivateConnectionCertificateOutput,
@@ -8376,7 +8375,7 @@ export const updateSecurityRequirementPack: API.OperationMethod<
   UpdateSecurityRequirementPackInput,
   UpdateSecurityRequirementPackOutput,
   UpdateSecurityRequirementPackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityRequirementPackInput,
   output: UpdateSecurityRequirementPackOutput,
@@ -8401,7 +8400,7 @@ export const updateTargetDomain: API.OperationMethod<
   UpdateTargetDomainInput,
   UpdateTargetDomainOutput,
   UpdateTargetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTargetDomainInput,
   output: UpdateTargetDomainOutput,
@@ -8419,7 +8418,7 @@ export const updateThreat: API.OperationMethod<
   UpdateThreatInput,
   UpdateThreatOutput,
   UpdateThreatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThreatInput,
   output: UpdateThreatOutput,
@@ -8437,7 +8436,7 @@ export const updateThreatModel: API.OperationMethod<
   UpdateThreatModelInput,
   UpdateThreatModelOutput,
   UpdateThreatModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateThreatModelInput,
   output: UpdateThreatModelOutput,
@@ -8455,7 +8454,7 @@ export const verifyTargetDomain: API.OperationMethod<
   VerifyTargetDomainInput,
   VerifyTargetDomainOutput,
   VerifyTargetDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyTargetDomainInput,
   output: VerifyTargetDomainOutput,

--- a/packages/aws/src/services/securityhub.ts
+++ b/packages/aws/src/services/securityhub.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SecurityHub",
   serviceShapeName: "SecurityHubAPIService",
@@ -18944,7 +18943,7 @@ export const acceptAdministratorInvitation: API.OperationMethod<
   AcceptAdministratorInvitationRequest,
   AcceptAdministratorInvitationResponse,
   AcceptAdministratorInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAdministratorInvitationRequest,
   output: AcceptAdministratorInvitationResponse,
@@ -18985,7 +18984,7 @@ export const acceptInvitation: API.OperationMethod<
   AcceptInvitationRequest,
   AcceptInvitationResponse,
   AcceptInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptInvitationRequest,
   output: AcceptInvitationResponse,
@@ -19015,7 +19014,7 @@ export const batchDeleteAutomationRules: API.OperationMethod<
   BatchDeleteAutomationRulesRequest,
   BatchDeleteAutomationRulesResponse,
   BatchDeleteAutomationRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteAutomationRulesRequest,
   output: BatchDeleteAutomationRulesResponse,
@@ -19049,7 +19048,7 @@ export const batchDisableStandards: API.OperationMethod<
   BatchDisableStandardsRequest,
   BatchDisableStandardsResponse,
   BatchDisableStandardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisableStandardsRequest,
   output: BatchDisableStandardsResponse,
@@ -19084,7 +19083,7 @@ export const batchEnableStandards: API.OperationMethod<
   BatchEnableStandardsRequest,
   BatchEnableStandardsResponse,
   BatchEnableStandardsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchEnableStandardsRequest,
   output: BatchEnableStandardsResponse,
@@ -19116,7 +19115,7 @@ export const batchGetAutomationRules: API.OperationMethod<
   BatchGetAutomationRulesRequest,
   BatchGetAutomationRulesResponse,
   BatchGetAutomationRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetAutomationRulesRequest,
   output: BatchGetAutomationRulesResponse,
@@ -19150,7 +19149,7 @@ export const batchGetConfigurationPolicyAssociations: API.OperationMethod<
   BatchGetConfigurationPolicyAssociationsRequest,
   BatchGetConfigurationPolicyAssociationsResponse,
   BatchGetConfigurationPolicyAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetConfigurationPolicyAssociationsRequest,
   output: BatchGetConfigurationPolicyAssociationsResponse,
@@ -19180,7 +19179,7 @@ export const batchGetSecurityControls: API.OperationMethod<
   BatchGetSecurityControlsRequest,
   BatchGetSecurityControlsResponse,
   BatchGetSecurityControlsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetSecurityControlsRequest,
   output: BatchGetSecurityControlsResponse,
@@ -19210,7 +19209,7 @@ export const batchGetStandardsControlAssociations: API.OperationMethod<
   BatchGetStandardsControlAssociationsRequest,
   BatchGetStandardsControlAssociationsResponse,
   BatchGetStandardsControlAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetStandardsControlAssociationsRequest,
   output: BatchGetStandardsControlAssociationsResponse,
@@ -19281,7 +19280,7 @@ export const batchImportFindings: API.OperationMethod<
   BatchImportFindingsRequest,
   BatchImportFindingsResponse,
   BatchImportFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchImportFindingsRequest,
   output: BatchImportFindingsResponse,
@@ -19311,7 +19310,7 @@ export const batchUpdateAutomationRules: API.OperationMethod<
   BatchUpdateAutomationRulesRequest,
   BatchUpdateAutomationRulesResponse,
   BatchUpdateAutomationRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateAutomationRulesRequest,
   output: BatchUpdateAutomationRulesResponse,
@@ -19369,7 +19368,7 @@ export const batchUpdateFindings: API.OperationMethod<
   BatchUpdateFindingsRequest,
   BatchUpdateFindingsResponse,
   BatchUpdateFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateFindingsRequest,
   output: BatchUpdateFindingsResponse,
@@ -19407,7 +19406,7 @@ export const batchUpdateFindingsV2: API.OperationMethod<
   BatchUpdateFindingsV2Request,
   BatchUpdateFindingsV2Response,
   BatchUpdateFindingsV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateFindingsV2Request,
   output: BatchUpdateFindingsV2Response,
@@ -19437,7 +19436,7 @@ export const batchUpdateStandardsControlAssociations: API.OperationMethod<
   BatchUpdateStandardsControlAssociationsRequest,
   BatchUpdateStandardsControlAssociationsResponse,
   BatchUpdateStandardsControlAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateStandardsControlAssociationsRequest,
   output: BatchUpdateStandardsControlAssociationsResponse,
@@ -19470,7 +19469,7 @@ export const createActionTarget: API.OperationMethod<
   CreateActionTargetRequest,
   CreateActionTargetResponse,
   CreateActionTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActionTargetRequest,
   output: CreateActionTargetResponse,
@@ -19502,7 +19501,7 @@ export const createAggregatorV2: API.OperationMethod<
   CreateAggregatorV2Request,
   CreateAggregatorV2Response,
   CreateAggregatorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAggregatorV2Request,
   output: CreateAggregatorV2Response,
@@ -19534,7 +19533,7 @@ export const createAutomationRule: API.OperationMethod<
   CreateAutomationRuleRequest,
   CreateAutomationRuleResponse,
   CreateAutomationRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomationRuleRequest,
   output: CreateAutomationRuleResponse,
@@ -19565,7 +19564,7 @@ export const createAutomationRuleV2: API.OperationMethod<
   CreateAutomationRuleV2Request,
   CreateAutomationRuleV2Response,
   CreateAutomationRuleV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAutomationRuleV2Request,
   output: CreateAutomationRuleV2Response,
@@ -19598,7 +19597,7 @@ export const createConfigurationPolicy: API.OperationMethod<
   CreateConfigurationPolicyRequest,
   CreateConfigurationPolicyResponse,
   CreateConfigurationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationPolicyRequest,
   output: CreateConfigurationPolicyResponse,
@@ -19631,7 +19630,7 @@ export const createConnectorV2: API.OperationMethod<
   CreateConnectorV2Request,
   CreateConnectorV2Response,
   CreateConnectorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorV2Request,
   output: CreateConnectorV2Response,
@@ -19667,7 +19666,7 @@ export const createFindingAggregator: API.OperationMethod<
   CreateFindingAggregatorRequest,
   CreateFindingAggregatorResponse,
   CreateFindingAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFindingAggregatorRequest,
   output: CreateFindingAggregatorResponse,
@@ -19701,7 +19700,7 @@ export const createInsight: API.OperationMethod<
   CreateInsightRequest,
   CreateInsightResponse,
   CreateInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInsightRequest,
   output: CreateInsightResponse,
@@ -19764,7 +19763,7 @@ export const createMembers: API.OperationMethod<
   CreateMembersRequest,
   CreateMembersResponse,
   CreateMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMembersRequest,
   output: CreateMembersResponse,
@@ -19796,7 +19795,7 @@ export const createTicketV2: API.OperationMethod<
   CreateTicketV2Request,
   CreateTicketV2Response,
   CreateTicketV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTicketV2Request,
   output: CreateTicketV2Response,
@@ -19835,7 +19834,7 @@ export const declineInvitations: API.OperationMethod<
   DeclineInvitationsRequest,
   DeclineInvitationsResponse,
   DeclineInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeclineInvitationsRequest,
   output: DeclineInvitationsResponse,
@@ -19866,7 +19865,7 @@ export const deleteActionTarget: API.OperationMethod<
   DeleteActionTargetRequest,
   DeleteActionTargetResponse,
   DeleteActionTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActionTargetRequest,
   output: DeleteActionTargetResponse,
@@ -19896,7 +19895,7 @@ export const deleteAggregatorV2: API.OperationMethod<
   DeleteAggregatorV2Request,
   DeleteAggregatorV2Response,
   DeleteAggregatorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAggregatorV2Request,
   output: DeleteAggregatorV2Response,
@@ -19928,7 +19927,7 @@ export const deleteAutomationRuleV2: API.OperationMethod<
   DeleteAutomationRuleV2Request,
   DeleteAutomationRuleV2Response,
   DeleteAutomationRuleV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomationRuleV2Request,
   output: DeleteAutomationRuleV2Response,
@@ -19963,7 +19962,7 @@ export const deleteConfigurationPolicy: API.OperationMethod<
   DeleteConfigurationPolicyRequest,
   DeleteConfigurationPolicyResponse,
   DeleteConfigurationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationPolicyRequest,
   output: DeleteConfigurationPolicyResponse,
@@ -19996,7 +19995,7 @@ export const deleteConnectorV2: API.OperationMethod<
   DeleteConnectorV2Request,
   DeleteConnectorV2Response,
   DeleteConnectorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorV2Request,
   output: DeleteConnectorV2Response,
@@ -20034,7 +20033,7 @@ export const deleteFindingAggregator: API.OperationMethod<
   DeleteFindingAggregatorRequest,
   DeleteFindingAggregatorResponse,
   DeleteFindingAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFindingAggregatorRequest,
   output: DeleteFindingAggregatorResponse,
@@ -20065,7 +20064,7 @@ export const deleteInsight: API.OperationMethod<
   DeleteInsightRequest,
   DeleteInsightResponse,
   DeleteInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInsightRequest,
   output: DeleteInsightResponse,
@@ -20104,7 +20103,7 @@ export const deleteInvitations: API.OperationMethod<
   DeleteInvitationsRequest,
   DeleteInvitationsResponse,
   DeleteInvitationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInvitationsRequest,
   output: DeleteInvitationsResponse,
@@ -20137,7 +20136,7 @@ export const deleteMembers: API.OperationMethod<
   DeleteMembersRequest,
   DeleteMembersResponse,
   DeleteMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMembersRequest,
   output: DeleteMembersResponse,
@@ -20166,7 +20165,7 @@ export const describeActionTargets: API.PaginatedOperationMethod<
   DescribeActionTargetsRequest,
   DescribeActionTargetsResponse,
   DescribeActionTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActionTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeActionTargetsRequest,
@@ -20203,7 +20202,7 @@ export const describeHub: API.OperationMethod<
   DescribeHubRequest,
   DescribeHubResponse,
   DescribeHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHubRequest,
   output: DescribeHubResponse,
@@ -20233,7 +20232,7 @@ export const describeOrganizationConfiguration: API.OperationMethod<
   DescribeOrganizationConfigurationRequest,
   DescribeOrganizationConfigurationResponse,
   DescribeOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationConfigurationRequest,
   output: DescribeOrganizationConfigurationResponse,
@@ -20267,7 +20266,7 @@ export const describeProducts: API.PaginatedOperationMethod<
   DescribeProductsRequest,
   DescribeProductsResponse,
   DescribeProductsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Product
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeProductsRequest,
@@ -20303,7 +20302,7 @@ export const describeProductsV2: API.PaginatedOperationMethod<
   DescribeProductsV2Request,
   DescribeProductsV2Response,
   DescribeProductsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ProductV2
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeProductsV2Request,
@@ -20339,7 +20338,7 @@ export const describeSecurityHubV2: API.OperationMethod<
   DescribeSecurityHubV2Request,
   DescribeSecurityHubV2Response,
   DescribeSecurityHubV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityHubV2Request,
   output: DescribeSecurityHubV2Response,
@@ -20368,7 +20367,7 @@ export const describeStandards: API.PaginatedOperationMethod<
   DescribeStandardsRequest,
   DescribeStandardsResponse,
   DescribeStandardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Standard
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStandardsRequest,
@@ -20403,7 +20402,7 @@ export const describeStandardsControls: API.PaginatedOperationMethod<
   DescribeStandardsControlsRequest,
   DescribeStandardsControlsResponse,
   DescribeStandardsControlsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StandardsControl
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeStandardsControlsRequest,
@@ -20440,7 +20439,7 @@ export const disableImportFindingsForProduct: API.OperationMethod<
   DisableImportFindingsForProductRequest,
   DisableImportFindingsForProductResponse,
   DisableImportFindingsForProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableImportFindingsForProductRequest,
   output: DisableImportFindingsForProductResponse,
@@ -20471,7 +20470,7 @@ export const disableOrganizationAdminAccount: API.OperationMethod<
   DisableOrganizationAdminAccountRequest,
   DisableOrganizationAdminAccountResponse,
   DisableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableOrganizationAdminAccountRequest,
   output: DisableOrganizationAdminAccountResponse,
@@ -20511,7 +20510,7 @@ export const disableSecurityHub: API.OperationMethod<
   DisableSecurityHubRequest,
   DisableSecurityHubResponse,
   DisableSecurityHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSecurityHubRequest,
   output: DisableSecurityHubResponse,
@@ -20540,7 +20539,7 @@ export const disableSecurityHubV2: API.OperationMethod<
   DisableSecurityHubV2Request,
   DisableSecurityHubV2Response,
   DisableSecurityHubV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableSecurityHubV2Request,
   output: DisableSecurityHubV2Response,
@@ -20574,7 +20573,7 @@ export const disassociateFromAdministratorAccount: API.OperationMethod<
   DisassociateFromAdministratorAccountRequest,
   DisassociateFromAdministratorAccountResponse,
   DisassociateFromAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromAdministratorAccountRequest,
   output: DisassociateFromAdministratorAccountResponse,
@@ -20613,7 +20612,7 @@ export const disassociateFromMasterAccount: API.OperationMethod<
   DisassociateFromMasterAccountRequest,
   DisassociateFromMasterAccountResponse,
   DisassociateFromMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFromMasterAccountRequest,
   output: DisassociateFromMasterAccountResponse,
@@ -20647,7 +20646,7 @@ export const disassociateMembers: API.OperationMethod<
   DisassociateMembersRequest,
   DisassociateMembersResponse,
   DisassociateMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMembersRequest,
   output: DisassociateMembersResponse,
@@ -20682,7 +20681,7 @@ export const enableImportFindingsForProduct: API.OperationMethod<
   EnableImportFindingsForProductRequest,
   EnableImportFindingsForProductResponse,
   EnableImportFindingsForProductError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableImportFindingsForProductRequest,
   output: EnableImportFindingsForProductResponse,
@@ -20713,7 +20712,7 @@ export const enableOrganizationAdminAccount: API.OperationMethod<
   EnableOrganizationAdminAccountRequest,
   EnableOrganizationAdminAccountResponse,
   EnableOrganizationAdminAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableOrganizationAdminAccountRequest,
   output: EnableOrganizationAdminAccountResponse,
@@ -20764,7 +20763,7 @@ export const enableSecurityHub: API.OperationMethod<
   EnableSecurityHubRequest,
   EnableSecurityHubResponse,
   EnableSecurityHubError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSecurityHubRequest,
   output: EnableSecurityHubResponse,
@@ -20793,7 +20792,7 @@ export const enableSecurityHubV2: API.OperationMethod<
   EnableSecurityHubV2Request,
   EnableSecurityHubV2Response,
   EnableSecurityHubV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableSecurityHubV2Request,
   output: EnableSecurityHubV2Response,
@@ -20824,7 +20823,7 @@ export const generateRecommendedPolicyV2: API.OperationMethod<
   GenerateRecommendedPolicyV2Request,
   GenerateRecommendedPolicyV2Response,
   GenerateRecommendedPolicyV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateRecommendedPolicyV2Request,
   output: GenerateRecommendedPolicyV2Response,
@@ -20858,7 +20857,7 @@ export const getAdministratorAccount: API.OperationMethod<
   GetAdministratorAccountRequest,
   GetAdministratorAccountResponse,
   GetAdministratorAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdministratorAccountRequest,
   output: GetAdministratorAccountResponse,
@@ -20889,7 +20888,7 @@ export const getAggregatorV2: API.OperationMethod<
   GetAggregatorV2Request,
   GetAggregatorV2Response,
   GetAggregatorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAggregatorV2Request,
   output: GetAggregatorV2Response,
@@ -20921,7 +20920,7 @@ export const getAutomationRuleV2: API.OperationMethod<
   GetAutomationRuleV2Request,
   GetAutomationRuleV2Response,
   GetAutomationRuleV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomationRuleV2Request,
   output: GetAutomationRuleV2Response,
@@ -20954,7 +20953,7 @@ export const getConfigurationPolicy: API.OperationMethod<
   GetConfigurationPolicyRequest,
   GetConfigurationPolicyResponse,
   GetConfigurationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationPolicyRequest,
   output: GetConfigurationPolicyResponse,
@@ -20988,7 +20987,7 @@ export const getConfigurationPolicyAssociation: API.OperationMethod<
   GetConfigurationPolicyAssociationRequest,
   GetConfigurationPolicyAssociationResponse,
   GetConfigurationPolicyAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationPolicyAssociationRequest,
   output: GetConfigurationPolicyAssociationResponse,
@@ -21020,7 +21019,7 @@ export const getConnectorV2: API.OperationMethod<
   GetConnectorV2Request,
   GetConnectorV2Response,
   GetConnectorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectorV2Request,
   output: GetConnectorV2Response,
@@ -21050,7 +21049,7 @@ export const getEnabledStandards: API.PaginatedOperationMethod<
   GetEnabledStandardsRequest,
   GetEnabledStandardsResponse,
   GetEnabledStandardsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StandardsSubscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEnabledStandardsRequest,
@@ -21090,7 +21089,7 @@ export const getFindingAggregator: API.OperationMethod<
   GetFindingAggregatorRequest,
   GetFindingAggregatorResponse,
   GetFindingAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingAggregatorRequest,
   output: GetFindingAggregatorResponse,
@@ -21128,7 +21127,7 @@ export const getFindingHistory: API.PaginatedOperationMethod<
   GetFindingHistoryRequest,
   GetFindingHistoryResponse,
   GetFindingHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingHistoryRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingHistoryRequest,
@@ -21165,7 +21164,7 @@ export const getFindings: API.PaginatedOperationMethod<
   GetFindingsRequest,
   GetFindingsResponse,
   GetFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AwsSecurityFinding
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingsRequest,
@@ -21208,7 +21207,7 @@ export const getFindingStatisticsV2: API.OperationMethod<
   GetFindingStatisticsV2Request,
   GetFindingStatisticsV2Response,
   GetFindingStatisticsV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFindingStatisticsV2Request,
   output: GetFindingStatisticsV2Response,
@@ -21239,7 +21238,7 @@ export const getFindingsTrendsV2: API.PaginatedOperationMethod<
   GetFindingsTrendsV2Request,
   GetFindingsTrendsV2Response,
   GetFindingsTrendsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrendsMetricsResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingsTrendsV2Request,
@@ -21284,7 +21283,7 @@ export const getFindingsV2: API.PaginatedOperationMethod<
   GetFindingsV2Request,
   GetFindingsV2Response,
   GetFindingsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetFindingsV2Request,
@@ -21323,7 +21322,7 @@ export const getInsightResults: API.OperationMethod<
   GetInsightResultsRequest,
   GetInsightResultsResponse,
   GetInsightResultsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightResultsRequest,
   output: GetInsightResultsResponse,
@@ -21353,7 +21352,7 @@ export const getInsights: API.PaginatedOperationMethod<
   GetInsightsRequest,
   GetInsightsResponse,
   GetInsightsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Insight
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInsightsRequest,
@@ -21394,7 +21393,7 @@ export const getInvitationsCount: API.OperationMethod<
   GetInvitationsCountRequest,
   GetInvitationsCountResponse,
   GetInvitationsCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInvitationsCountRequest,
   output: GetInvitationsCountResponse,
@@ -21430,7 +21429,7 @@ export const getMasterAccount: API.OperationMethod<
   GetMasterAccountRequest,
   GetMasterAccountResponse,
   GetMasterAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMasterAccountRequest,
   output: GetMasterAccountResponse,
@@ -21466,7 +21465,7 @@ export const getMembers: API.OperationMethod<
   GetMembersRequest,
   GetMembersResponse,
   GetMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMembersRequest,
   output: GetMembersResponse,
@@ -21498,7 +21497,7 @@ export const getRecommendedPolicyV2: API.PaginatedOperationMethod<
   GetRecommendedPolicyV2Request,
   GetRecommendedPolicyV2Response,
   GetRecommendedPolicyV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationStep
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetRecommendedPolicyV2Request,
@@ -21541,7 +21540,7 @@ export const getResourcesStatisticsV2: API.OperationMethod<
   GetResourcesStatisticsV2Request,
   GetResourcesStatisticsV2Response,
   GetResourcesStatisticsV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcesStatisticsV2Request,
   output: GetResourcesStatisticsV2Response,
@@ -21573,7 +21572,7 @@ export const getResourcesTrendsV2: API.PaginatedOperationMethod<
   GetResourcesTrendsV2Request,
   GetResourcesTrendsV2Response,
   GetResourcesTrendsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcesTrendsMetricsResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcesTrendsV2Request,
@@ -21616,7 +21615,7 @@ export const getResourcesV2: API.PaginatedOperationMethod<
   GetResourcesV2Request,
   GetResourcesV2Response,
   GetResourcesV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcesV2Request,
@@ -21656,7 +21655,7 @@ export const getSecurityControlDefinition: API.OperationMethod<
   GetSecurityControlDefinitionRequest,
   GetSecurityControlDefinitionResponse,
   GetSecurityControlDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityControlDefinitionRequest,
   output: GetSecurityControlDefinitionResponse,
@@ -21699,7 +21698,7 @@ export const inviteMembers: API.OperationMethod<
   InviteMembersRequest,
   InviteMembersResponse,
   InviteMembersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InviteMembersRequest,
   output: InviteMembersResponse,
@@ -21730,7 +21729,7 @@ export const listAggregatorsV2: API.PaginatedOperationMethod<
   ListAggregatorsV2Request,
   ListAggregatorsV2Response,
   ListAggregatorsV2Error,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AggregatorV2
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAggregatorsV2Request,
@@ -21768,7 +21767,7 @@ export const listAutomationRules: API.OperationMethod<
   ListAutomationRulesRequest,
   ListAutomationRulesResponse,
   ListAutomationRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAutomationRulesRequest,
   output: ListAutomationRulesResponse,
@@ -21798,7 +21797,7 @@ export const listAutomationRulesV2: API.OperationMethod<
   ListAutomationRulesV2Request,
   ListAutomationRulesV2Response,
   ListAutomationRulesV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAutomationRulesV2Request,
   output: ListAutomationRulesV2Response,
@@ -21829,7 +21828,7 @@ export const listConfigurationPolicies: API.PaginatedOperationMethod<
   ListConfigurationPoliciesRequest,
   ListConfigurationPoliciesResponse,
   ListConfigurationPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationPolicySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationPoliciesRequest,
@@ -21867,7 +21866,7 @@ export const listConfigurationPolicyAssociations: API.PaginatedOperationMethod<
   ListConfigurationPolicyAssociationsRequest,
   ListConfigurationPolicyAssociationsResponse,
   ListConfigurationPolicyAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationPolicyAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationPolicyAssociationsRequest,
@@ -21905,7 +21904,7 @@ export const listConnectorsV2: API.OperationMethod<
   ListConnectorsV2Request,
   ListConnectorsV2Response,
   ListConnectorsV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConnectorsV2Request,
   output: ListConnectorsV2Response,
@@ -21935,7 +21934,7 @@ export const listEnabledProductsForImport: API.PaginatedOperationMethod<
   ListEnabledProductsForImportRequest,
   ListEnabledProductsForImportResponse,
   ListEnabledProductsForImportError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   NonEmptyString
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnabledProductsForImportRequest,
@@ -21967,7 +21966,7 @@ export const listFindingAggregators: API.PaginatedOperationMethod<
   ListFindingAggregatorsRequest,
   ListFindingAggregatorsResponse,
   ListFindingAggregatorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingAggregator
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFindingAggregatorsRequest,
@@ -22010,7 +22009,7 @@ export const listInvitations: API.PaginatedOperationMethod<
   ListInvitationsRequest,
   ListInvitationsResponse,
   ListInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Invitation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInvitationsRequest,
@@ -22049,7 +22048,7 @@ export const listMembers: API.PaginatedOperationMethod<
   ListMembersRequest,
   ListMembersResponse,
   ListMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Member
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMembersRequest,
@@ -22085,7 +22084,7 @@ export const listOrganizationAdminAccounts: API.PaginatedOperationMethod<
   ListOrganizationAdminAccountsRequest,
   ListOrganizationAdminAccountsResponse,
   ListOrganizationAdminAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdminAccount
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationAdminAccountsRequest,
@@ -22120,7 +22119,7 @@ export const listSecurityControlDefinitions: API.PaginatedOperationMethod<
   ListSecurityControlDefinitionsRequest,
   ListSecurityControlDefinitionsResponse,
   ListSecurityControlDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityControlDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityControlDefinitionsRequest,
@@ -22157,7 +22156,7 @@ export const listStandardsControlAssociations: API.PaginatedOperationMethod<
   ListStandardsControlAssociationsRequest,
   ListStandardsControlAssociationsResponse,
   ListStandardsControlAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StandardsControlAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStandardsControlAssociationsRequest,
@@ -22191,7 +22190,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -22216,7 +22215,7 @@ export const registerConnectorV2: API.OperationMethod<
   RegisterConnectorV2Request,
   RegisterConnectorV2Response,
   RegisterConnectorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterConnectorV2Request,
   output: RegisterConnectorV2Response,
@@ -22250,7 +22249,7 @@ export const startConfigurationPolicyAssociation: API.OperationMethod<
   StartConfigurationPolicyAssociationRequest,
   StartConfigurationPolicyAssociationResponse,
   StartConfigurationPolicyAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigurationPolicyAssociationRequest,
   output: StartConfigurationPolicyAssociationResponse,
@@ -22286,7 +22285,7 @@ export const startConfigurationPolicyDisassociation: API.OperationMethod<
   StartConfigurationPolicyDisassociationRequest,
   StartConfigurationPolicyDisassociationResponse,
   StartConfigurationPolicyDisassociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigurationPolicyDisassociationRequest,
   output: StartConfigurationPolicyDisassociationResponse,
@@ -22315,7 +22314,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -22337,7 +22336,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -22360,7 +22359,7 @@ export const updateActionTarget: API.OperationMethod<
   UpdateActionTargetRequest,
   UpdateActionTargetResponse,
   UpdateActionTargetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateActionTargetRequest,
   output: UpdateActionTargetResponse,
@@ -22390,7 +22389,7 @@ export const updateAggregatorV2: API.OperationMethod<
   UpdateAggregatorV2Request,
   UpdateAggregatorV2Response,
   UpdateAggregatorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAggregatorV2Request,
   output: UpdateAggregatorV2Response,
@@ -22422,7 +22421,7 @@ export const updateAutomationRuleV2: API.OperationMethod<
   UpdateAutomationRuleV2Request,
   UpdateAutomationRuleV2Response,
   UpdateAutomationRuleV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomationRuleV2Request,
   output: UpdateAutomationRuleV2Response,
@@ -22456,7 +22455,7 @@ export const updateConfigurationPolicy: API.OperationMethod<
   UpdateConfigurationPolicyRequest,
   UpdateConfigurationPolicyResponse,
   UpdateConfigurationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationPolicyRequest,
   output: UpdateConfigurationPolicyResponse,
@@ -22489,7 +22488,7 @@ export const updateConnectorV2: API.OperationMethod<
   UpdateConnectorV2Request,
   UpdateConnectorV2Response,
   UpdateConnectorV2Error,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorV2Request,
   output: UpdateConnectorV2Response,
@@ -22526,7 +22525,7 @@ export const updateFindingAggregator: API.OperationMethod<
   UpdateFindingAggregatorRequest,
   UpdateFindingAggregatorResponse,
   UpdateFindingAggregatorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingAggregatorRequest,
   output: UpdateFindingAggregatorResponse,
@@ -22566,7 +22565,7 @@ export const updateFindings: API.OperationMethod<
   UpdateFindingsRequest,
   UpdateFindingsResponse,
   UpdateFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFindingsRequest,
   output: UpdateFindingsResponse,
@@ -22596,7 +22595,7 @@ export const updateInsight: API.OperationMethod<
   UpdateInsightRequest,
   UpdateInsightResponse,
   UpdateInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInsightRequest,
   output: UpdateInsightResponse,
@@ -22629,7 +22628,7 @@ export const updateOrganizationConfiguration: API.OperationMethod<
   UpdateOrganizationConfigurationRequest,
   UpdateOrganizationConfigurationResponse,
   UpdateOrganizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationConfigurationRequest,
   output: UpdateOrganizationConfigurationResponse,
@@ -22663,7 +22662,7 @@ export const updateSecurityControl: API.OperationMethod<
   UpdateSecurityControlRequest,
   UpdateSecurityControlResponse,
   UpdateSecurityControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityControlRequest,
   output: UpdateSecurityControlResponse,
@@ -22696,7 +22695,7 @@ export const updateSecurityHubConfiguration: API.OperationMethod<
   UpdateSecurityHubConfigurationRequest,
   UpdateSecurityHubConfigurationResponse,
   UpdateSecurityHubConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityHubConfigurationRequest,
   output: UpdateSecurityHubConfigurationResponse,
@@ -22730,7 +22729,7 @@ export const updateStandardsControl: API.OperationMethod<
   UpdateStandardsControlRequest,
   UpdateStandardsControlResponse,
   UpdateStandardsControlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStandardsControlRequest,
   output: UpdateStandardsControlResponse,

--- a/packages/aws/src/services/securitylake.ts
+++ b/packages/aws/src/services/securitylake.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SecurityLake",
@@ -1543,7 +1542,7 @@ export const createAwsLogSource: API.OperationMethod<
   CreateAwsLogSourceRequest,
   CreateAwsLogSourceResponse,
   CreateAwsLogSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAwsLogSourceRequest,
   output: CreateAwsLogSourceResponse,
@@ -1583,7 +1582,7 @@ export const createCustomLogSource: API.OperationMethod<
   CreateCustomLogSourceRequest,
   CreateCustomLogSourceResponse,
   CreateCustomLogSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomLogSourceRequest,
   output: CreateCustomLogSourceResponse,
@@ -1631,7 +1630,7 @@ export const createDataLake: API.OperationMethod<
   CreateDataLakeRequest,
   CreateDataLakeResponse,
   CreateDataLakeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataLakeRequest,
   output: CreateDataLakeResponse,
@@ -1666,7 +1665,7 @@ export const createDataLakeExceptionSubscription: API.OperationMethod<
   CreateDataLakeExceptionSubscriptionRequest,
   CreateDataLakeExceptionSubscriptionResponse,
   CreateDataLakeExceptionSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataLakeExceptionSubscriptionRequest,
   output: CreateDataLakeExceptionSubscriptionResponse,
@@ -1703,7 +1702,7 @@ export const createDataLakeOrganizationConfiguration: API.OperationMethod<
   CreateDataLakeOrganizationConfigurationRequest,
   CreateDataLakeOrganizationConfigurationResponse,
   CreateDataLakeOrganizationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataLakeOrganizationConfigurationRequest,
   output: CreateDataLakeOrganizationConfigurationResponse,
@@ -1737,7 +1736,7 @@ export const createSubscriber: API.OperationMethod<
   CreateSubscriberRequest,
   CreateSubscriberResponse,
   CreateSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriberRequest,
   output: CreateSubscriberResponse,
@@ -1773,7 +1772,7 @@ export const createSubscriberNotification: API.OperationMethod<
   CreateSubscriberNotificationRequest,
   CreateSubscriberNotificationResponse,
   CreateSubscriberNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriberNotificationRequest,
   output: CreateSubscriberNotificationResponse,
@@ -1814,7 +1813,7 @@ export const deleteAwsLogSource: API.OperationMethod<
   DeleteAwsLogSourceRequest,
   DeleteAwsLogSourceResponse,
   DeleteAwsLogSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAwsLogSourceRequest,
   output: DeleteAwsLogSourceResponse,
@@ -1849,7 +1848,7 @@ export const deleteCustomLogSource: API.OperationMethod<
   DeleteCustomLogSourceRequest,
   DeleteCustomLogSourceResponse,
   DeleteCustomLogSourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomLogSourceRequest,
   output: DeleteCustomLogSourceResponse,
@@ -1891,7 +1890,7 @@ export const deleteDataLake: API.OperationMethod<
   DeleteDataLakeRequest,
   DeleteDataLakeResponse,
   DeleteDataLakeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataLakeRequest,
   output: DeleteDataLakeResponse,
@@ -1926,7 +1925,7 @@ export const deleteDataLakeExceptionSubscription: API.OperationMethod<
   DeleteDataLakeExceptionSubscriptionRequest,
   DeleteDataLakeExceptionSubscriptionResponse,
   DeleteDataLakeExceptionSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataLakeExceptionSubscriptionRequest,
   output: DeleteDataLakeExceptionSubscriptionResponse,
@@ -1961,7 +1960,7 @@ export const deleteDataLakeOrganizationConfiguration: API.OperationMethod<
   DeleteDataLakeOrganizationConfigurationRequest,
   DeleteDataLakeOrganizationConfigurationResponse,
   DeleteDataLakeOrganizationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataLakeOrganizationConfigurationRequest,
   output: DeleteDataLakeOrganizationConfigurationResponse,
@@ -1997,7 +1996,7 @@ export const deleteSubscriber: API.OperationMethod<
   DeleteSubscriberRequest,
   DeleteSubscriberResponse,
   DeleteSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriberRequest,
   output: DeleteSubscriberResponse,
@@ -2032,7 +2031,7 @@ export const deleteSubscriberNotification: API.OperationMethod<
   DeleteSubscriberNotificationRequest,
   DeleteSubscriberNotificationResponse,
   DeleteSubscriberNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriberNotificationRequest,
   output: DeleteSubscriberNotificationResponse,
@@ -2067,7 +2066,7 @@ export const deregisterDataLakeDelegatedAdministrator: API.OperationMethod<
   DeregisterDataLakeDelegatedAdministratorRequest,
   DeregisterDataLakeDelegatedAdministratorResponse,
   DeregisterDataLakeDelegatedAdministratorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterDataLakeDelegatedAdministratorRequest,
   output: DeregisterDataLakeDelegatedAdministratorResponse,
@@ -2100,7 +2099,7 @@ export const getDataLakeExceptionSubscription: API.OperationMethod<
   GetDataLakeExceptionSubscriptionRequest,
   GetDataLakeExceptionSubscriptionResponse,
   GetDataLakeExceptionSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakeExceptionSubscriptionRequest,
   output: GetDataLakeExceptionSubscriptionResponse,
@@ -2135,7 +2134,7 @@ export const getDataLakeOrganizationConfiguration: API.OperationMethod<
   GetDataLakeOrganizationConfigurationRequest,
   GetDataLakeOrganizationConfigurationResponse,
   GetDataLakeOrganizationConfigurationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakeOrganizationConfigurationRequest,
   output: GetDataLakeOrganizationConfigurationResponse,
@@ -2169,7 +2168,7 @@ export const getDataLakeSources: API.PaginatedOperationMethod<
   GetDataLakeSourcesRequest,
   GetDataLakeSourcesResponse,
   GetDataLakeSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataLakeSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDataLakeSourcesRequest,
@@ -2211,7 +2210,7 @@ export const getSubscriber: API.OperationMethod<
   GetSubscriberRequest,
   GetSubscriberResponse,
   GetSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriberRequest,
   output: GetSubscriberResponse,
@@ -2246,7 +2245,7 @@ export const listDataLakeExceptions: API.PaginatedOperationMethod<
   ListDataLakeExceptionsRequest,
   ListDataLakeExceptionsResponse,
   ListDataLakeExceptionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataLakeException
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataLakeExceptionsRequest,
@@ -2288,7 +2287,7 @@ export const listDataLakes: API.OperationMethod<
   ListDataLakesRequest,
   ListDataLakesResponse,
   ListDataLakesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDataLakesRequest,
   output: ListDataLakesResponse,
@@ -2322,7 +2321,7 @@ export const listLogSources: API.PaginatedOperationMethod<
   ListLogSourcesRequest,
   ListLogSourcesResponse,
   ListLogSourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LogSource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLogSourcesRequest,
@@ -2364,7 +2363,7 @@ export const listSubscribers: API.PaginatedOperationMethod<
   ListSubscribersRequest,
   ListSubscribersResponse,
   ListSubscribersError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubscriberResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscribersRequest,
@@ -2406,7 +2405,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2441,7 +2440,7 @@ export const registerDataLakeDelegatedAdministrator: API.OperationMethod<
   RegisterDataLakeDelegatedAdministratorRequest,
   RegisterDataLakeDelegatedAdministratorResponse,
   RegisterDataLakeDelegatedAdministratorError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDataLakeDelegatedAdministratorRequest,
   output: RegisterDataLakeDelegatedAdministratorResponse,
@@ -2481,7 +2480,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2516,7 +2515,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2562,7 +2561,7 @@ export const updateDataLake: API.OperationMethod<
   UpdateDataLakeRequest,
   UpdateDataLakeResponse,
   UpdateDataLakeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataLakeRequest,
   output: UpdateDataLakeResponse,
@@ -2597,7 +2596,7 @@ export const updateDataLakeExceptionSubscription: API.OperationMethod<
   UpdateDataLakeExceptionSubscriptionRequest,
   UpdateDataLakeExceptionSubscriptionResponse,
   UpdateDataLakeExceptionSubscriptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataLakeExceptionSubscriptionRequest,
   output: UpdateDataLakeExceptionSubscriptionResponse,
@@ -2632,7 +2631,7 @@ export const updateSubscriber: API.OperationMethod<
   UpdateSubscriberRequest,
   UpdateSubscriberResponse,
   UpdateSubscriberError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriberRequest,
   output: UpdateSubscriberResponse,
@@ -2667,7 +2666,7 @@ export const updateSubscriberNotification: API.OperationMethod<
   UpdateSubscriberNotificationRequest,
   UpdateSubscriberNotificationResponse,
   UpdateSubscriberNotificationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriberNotificationRequest,
   output: UpdateSubscriberNotificationResponse,

--- a/packages/aws/src/services/serverlessapplicationrepository.ts
+++ b/packages/aws/src/services/serverlessapplicationrepository.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ServerlessApplicationRepository",
   serviceShapeName: "ServerlessApplicationRepository",
@@ -1265,7 +1264,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1295,7 +1294,7 @@ export const createApplicationVersion: API.OperationMethod<
   CreateApplicationVersionRequest,
   CreateApplicationVersionResponse,
   CreateApplicationVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationVersionRequest,
   output: CreateApplicationVersionResponse,
@@ -1324,7 +1323,7 @@ export const createCloudFormationChangeSet: API.OperationMethod<
   CreateCloudFormationChangeSetRequest,
   CreateCloudFormationChangeSetResponse,
   CreateCloudFormationChangeSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudFormationChangeSetRequest,
   output: CreateCloudFormationChangeSetResponse,
@@ -1353,7 +1352,7 @@ export const createCloudFormationTemplate: API.OperationMethod<
   CreateCloudFormationTemplateRequest,
   CreateCloudFormationTemplateResponse,
   CreateCloudFormationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCloudFormationTemplateRequest,
   output: CreateCloudFormationTemplateResponse,
@@ -1384,7 +1383,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1415,7 +1414,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -1445,7 +1444,7 @@ export const getApplicationPolicy: API.OperationMethod<
   GetApplicationPolicyRequest,
   GetApplicationPolicyResponse,
   GetApplicationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationPolicyRequest,
   output: GetApplicationPolicyResponse,
@@ -1475,7 +1474,7 @@ export const getCloudFormationTemplate: API.OperationMethod<
   GetCloudFormationTemplateRequest,
   GetCloudFormationTemplateResponse,
   GetCloudFormationTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCloudFormationTemplateRequest,
   output: GetCloudFormationTemplateResponse,
@@ -1505,7 +1504,7 @@ export const listApplicationDependencies: API.PaginatedOperationMethod<
   ListApplicationDependenciesRequest,
   ListApplicationDependenciesResponse,
   ListApplicationDependenciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationDependenciesRequest,
@@ -1540,7 +1539,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -1575,7 +1574,7 @@ export const listApplicationVersions: API.PaginatedOperationMethod<
   ListApplicationVersionsRequest,
   ListApplicationVersionsResponse,
   ListApplicationVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationVersionsRequest,
@@ -1614,7 +1613,7 @@ export const putApplicationPolicy: API.OperationMethod<
   PutApplicationPolicyRequest,
   PutApplicationPolicyResponse,
   PutApplicationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationPolicyRequest,
   output: PutApplicationPolicyResponse,
@@ -1646,7 +1645,7 @@ export const unshareApplication: API.OperationMethod<
   UnshareApplicationRequest,
   UnshareApplicationResponse,
   UnshareApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnshareApplicationRequest,
   output: UnshareApplicationResponse,
@@ -1677,7 +1676,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,

--- a/packages/aws/src/services/service-catalog-appregistry.ts
+++ b/packages/aws/src/services/service-catalog-appregistry.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Service Catalog AppRegistry",
   serviceShapeName: "AWS242AppRegistry",
@@ -1290,7 +1289,7 @@ export const associateAttributeGroup: API.OperationMethod<
   AssociateAttributeGroupRequest,
   AssociateAttributeGroupResponse,
   AssociateAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateAttributeGroupRequest,
   output: AssociateAttributeGroupResponse,
@@ -1344,7 +1343,7 @@ export const associateResource: API.OperationMethod<
   AssociateResourceRequest,
   AssociateResourceResponse,
   AssociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceRequest,
   output: AssociateResourceResponse,
@@ -1375,7 +1374,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -1407,7 +1406,7 @@ export const createAttributeGroup: API.OperationMethod<
   CreateAttributeGroupRequest,
   CreateAttributeGroupResponse,
   CreateAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAttributeGroupRequest,
   output: CreateAttributeGroupResponse,
@@ -1434,7 +1433,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -1460,7 +1459,7 @@ export const deleteAttributeGroup: API.OperationMethod<
   DeleteAttributeGroupRequest,
   DeleteAttributeGroupResponse,
   DeleteAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttributeGroupRequest,
   output: DeleteAttributeGroupResponse,
@@ -1486,7 +1485,7 @@ export const disassociateAttributeGroup: API.OperationMethod<
   DisassociateAttributeGroupRequest,
   DisassociateAttributeGroupResponse,
   DisassociateAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateAttributeGroupRequest,
   output: DisassociateAttributeGroupResponse,
@@ -1534,7 +1533,7 @@ export const disassociateResource: API.OperationMethod<
   DisassociateResourceRequest,
   DisassociateResourceResponse,
   DisassociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceRequest,
   output: DisassociateResourceResponse,
@@ -1578,7 +1577,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationRequest,
   GetApplicationResponse,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationRequest,
   output: GetApplicationResponse,
@@ -1605,7 +1604,7 @@ export const getAssociatedResource: API.OperationMethod<
   GetAssociatedResourceRequest,
   GetAssociatedResourceResponse,
   GetAssociatedResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociatedResourceRequest,
   output: GetAssociatedResourceResponse,
@@ -1635,7 +1634,7 @@ export const getAttributeGroup: API.OperationMethod<
   GetAttributeGroupRequest,
   GetAttributeGroupResponse,
   GetAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAttributeGroupRequest,
   output: GetAttributeGroupResponse,
@@ -1659,7 +1658,7 @@ export const getConfiguration: API.OperationMethod<
   GetConfigurationRequest,
   GetConfigurationResponse,
   GetConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationRequest,
   output: GetConfigurationResponse,
@@ -1680,7 +1679,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -1709,7 +1708,7 @@ export const listAssociatedAttributeGroups: API.PaginatedOperationMethod<
   ListAssociatedAttributeGroupsRequest,
   ListAssociatedAttributeGroupsResponse,
   ListAssociatedAttributeGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttributeGroupId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedAttributeGroupsRequest,
@@ -1757,7 +1756,7 @@ export const listAssociatedResources: API.PaginatedOperationMethod<
   ListAssociatedResourcesRequest,
   ListAssociatedResourcesResponse,
   ListAssociatedResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedResourcesRequest,
@@ -1789,7 +1788,7 @@ export const listAttributeGroups: API.PaginatedOperationMethod<
   ListAttributeGroupsRequest,
   ListAttributeGroupsResponse,
   ListAttributeGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttributeGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttributeGroupsRequest,
@@ -1818,7 +1817,7 @@ export const listAttributeGroupsForApplication: API.PaginatedOperationMethod<
   ListAttributeGroupsForApplicationRequest,
   ListAttributeGroupsForApplicationResponse,
   ListAttributeGroupsForApplicationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttributeGroupDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttributeGroupsForApplicationRequest,
@@ -1851,7 +1850,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1878,7 +1877,7 @@ export const putConfiguration: API.OperationMethod<
   PutConfigurationRequest,
   PutConfigurationResponse,
   PutConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationRequest,
   output: PutConfigurationResponse,
@@ -1904,7 +1903,7 @@ export const syncResource: API.OperationMethod<
   SyncResourceRequest,
   SyncResourceResponse,
   SyncResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SyncResourceRequest,
   output: SyncResourceResponse,
@@ -1936,7 +1935,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1964,7 +1963,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1992,7 +1991,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -2021,7 +2020,7 @@ export const updateAttributeGroup: API.OperationMethod<
   UpdateAttributeGroupRequest,
   UpdateAttributeGroupResponse,
   UpdateAttributeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAttributeGroupRequest,
   output: UpdateAttributeGroupResponse,

--- a/packages/aws/src/services/service-catalog.ts
+++ b/packages/aws/src/services/service-catalog.ts
@@ -6,7 +6,6 @@ import { Retry } from "../retry.ts";
 import * as T from "../traits.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Service Catalog",
   serviceShapeName: "AWS242ServiceCatalogService",
@@ -4232,7 +4231,7 @@ export const acceptPortfolioShare: API.OperationMethod<
   AcceptPortfolioShareInput,
   AcceptPortfolioShareOutput,
   AcceptPortfolioShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptPortfolioShareInput,
   output: AcceptPortfolioShareOutput,
@@ -4259,7 +4258,7 @@ export const associateBudgetWithResource: API.OperationMethod<
   AssociateBudgetWithResourceInput,
   AssociateBudgetWithResourceOutput,
   AssociateBudgetWithResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateBudgetWithResourceInput,
   output: AssociateBudgetWithResourceOutput,
@@ -4302,7 +4301,7 @@ export const associatePrincipalWithPortfolio: API.OperationMethod<
   AssociatePrincipalWithPortfolioInput,
   AssociatePrincipalWithPortfolioOutput,
   AssociatePrincipalWithPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociatePrincipalWithPortfolioInput,
   output: AssociatePrincipalWithPortfolioOutput,
@@ -4330,7 +4329,7 @@ export const associateProductWithPortfolio: API.OperationMethod<
   AssociateProductWithPortfolioInput,
   AssociateProductWithPortfolioOutput,
   AssociateProductWithPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateProductWithPortfolioInput,
   output: AssociateProductWithPortfolioOutput,
@@ -4357,7 +4356,7 @@ export const associateServiceActionWithProvisioningArtifact: API.OperationMethod
   AssociateServiceActionWithProvisioningArtifactInput,
   AssociateServiceActionWithProvisioningArtifactOutput,
   AssociateServiceActionWithProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateServiceActionWithProvisioningArtifactInput,
   output: AssociateServiceActionWithProvisioningArtifactOutput,
@@ -4387,7 +4386,7 @@ export const associateTagOptionWithResource: API.OperationMethod<
   AssociateTagOptionWithResourceInput,
   AssociateTagOptionWithResourceOutput,
   AssociateTagOptionWithResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTagOptionWithResourceInput,
   output: AssociateTagOptionWithResourceOutput,
@@ -4414,7 +4413,7 @@ export const batchAssociateServiceActionWithProvisioningArtifact: API.OperationM
   BatchAssociateServiceActionWithProvisioningArtifactInput,
   BatchAssociateServiceActionWithProvisioningArtifactOutput,
   BatchAssociateServiceActionWithProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchAssociateServiceActionWithProvisioningArtifactInput,
   output: BatchAssociateServiceActionWithProvisioningArtifactOutput,
@@ -4434,7 +4433,7 @@ export const batchDisassociateServiceActionFromProvisioningArtifact: API.Operati
   BatchDisassociateServiceActionFromProvisioningArtifactInput,
   BatchDisassociateServiceActionFromProvisioningArtifactOutput,
   BatchDisassociateServiceActionFromProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDisassociateServiceActionFromProvisioningArtifactInput,
   output: BatchDisassociateServiceActionFromProvisioningArtifactOutput,
@@ -4463,7 +4462,7 @@ export const copyProduct: API.OperationMethod<
   CopyProductInput,
   CopyProductOutput,
   CopyProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyProductInput,
   output: CopyProductOutput,
@@ -4488,7 +4487,7 @@ export const createConstraint: API.OperationMethod<
   CreateConstraintInput,
   CreateConstraintOutput,
   CreateConstraintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConstraintInput,
   output: CreateConstraintOutput,
@@ -4517,7 +4516,7 @@ export const createPortfolio: API.OperationMethod<
   CreatePortfolioInput,
   CreatePortfolioOutput,
   CreatePortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortfolioInput,
   output: CreatePortfolioOutput,
@@ -4565,7 +4564,7 @@ export const createPortfolioShare: API.OperationMethod<
   CreatePortfolioShareInput,
   CreatePortfolioShareOutput,
   CreatePortfolioShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortfolioShareInput,
   output: CreatePortfolioShareOutput,
@@ -4600,7 +4599,7 @@ export const createProduct: API.OperationMethod<
   CreateProductInput,
   CreateProductOutput,
   CreateProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProductInput,
   output: CreateProductOutput,
@@ -4636,7 +4635,7 @@ export const createProvisionedProductPlan: API.OperationMethod<
   CreateProvisionedProductPlanInput,
   CreateProvisionedProductPlanOutput,
   CreateProvisionedProductPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisionedProductPlanInput,
   output: CreateProvisionedProductPlanOutput,
@@ -4668,7 +4667,7 @@ export const createProvisioningArtifact: API.OperationMethod<
   CreateProvisioningArtifactInput,
   CreateProvisioningArtifactOutput,
   CreateProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProvisioningArtifactInput,
   output: CreateProvisioningArtifactOutput,
@@ -4693,7 +4692,7 @@ export const createServiceAction: API.OperationMethod<
   CreateServiceActionInput,
   CreateServiceActionOutput,
   CreateServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceActionInput,
   output: CreateServiceActionOutput,
@@ -4715,7 +4714,7 @@ export const createTagOption: API.OperationMethod<
   CreateTagOptionInput,
   CreateTagOptionOutput,
   CreateTagOptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagOptionInput,
   output: CreateTagOptionOutput,
@@ -4742,7 +4741,7 @@ export const deleteConstraint: API.OperationMethod<
   DeleteConstraintInput,
   DeleteConstraintOutput,
   DeleteConstraintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConstraintInput,
   output: DeleteConstraintOutput,
@@ -4770,7 +4769,7 @@ export const deletePortfolio: API.OperationMethod<
   DeletePortfolioInput,
   DeletePortfolioOutput,
   DeletePortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortfolioInput,
   output: DeletePortfolioOutput,
@@ -4802,7 +4801,7 @@ export const deletePortfolioShare: API.OperationMethod<
   DeletePortfolioShareInput,
   DeletePortfolioShareOutput,
   DeletePortfolioShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortfolioShareInput,
   output: DeletePortfolioShareOutput,
@@ -4834,7 +4833,7 @@ export const deleteProduct: API.OperationMethod<
   DeleteProductInput,
   DeleteProductOutput,
   DeleteProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProductInput,
   output: DeleteProductOutput,
@@ -4860,7 +4859,7 @@ export const deleteProvisionedProductPlan: API.OperationMethod<
   DeleteProvisionedProductPlanInput,
   DeleteProvisionedProductPlanOutput,
   DeleteProvisionedProductPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisionedProductPlanInput,
   output: DeleteProvisionedProductPlanOutput,
@@ -4886,7 +4885,7 @@ export const deleteProvisioningArtifact: API.OperationMethod<
   DeleteProvisioningArtifactInput,
   DeleteProvisioningArtifactOutput,
   DeleteProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProvisioningArtifactInput,
   output: DeleteProvisioningArtifactOutput,
@@ -4912,7 +4911,7 @@ export const deleteServiceAction: API.OperationMethod<
   DeleteServiceActionInput,
   DeleteServiceActionOutput,
   DeleteServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceActionInput,
   output: DeleteServiceActionOutput,
@@ -4940,7 +4939,7 @@ export const deleteTagOption: API.OperationMethod<
   DeleteTagOptionInput,
   DeleteTagOptionOutput,
   DeleteTagOptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagOptionInput,
   output: DeleteTagOptionOutput,
@@ -4962,7 +4961,7 @@ export const describeConstraint: API.OperationMethod<
   DescribeConstraintInput,
   DescribeConstraintOutput,
   DescribeConstraintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConstraintInput,
   output: DescribeConstraintOutput,
@@ -4982,7 +4981,7 @@ export const describeCopyProductStatus: API.OperationMethod<
   DescribeCopyProductStatusInput,
   DescribeCopyProductStatusOutput,
   DescribeCopyProductStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCopyProductStatusInput,
   output: DescribeCopyProductStatusOutput,
@@ -5002,7 +5001,7 @@ export const describePortfolio: API.OperationMethod<
   DescribePortfolioInput,
   DescribePortfolioOutput,
   DescribePortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePortfolioInput,
   output: DescribePortfolioOutput,
@@ -5029,7 +5028,7 @@ export const describePortfolioShares: API.PaginatedOperationMethod<
   DescribePortfolioSharesInput,
   DescribePortfolioSharesOutput,
   DescribePortfolioSharesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePortfolioSharesInput,
@@ -5058,7 +5057,7 @@ export const describePortfolioShareStatus: API.OperationMethod<
   DescribePortfolioShareStatusInput,
   DescribePortfolioShareStatusOutput,
   DescribePortfolioShareStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePortfolioShareStatusInput,
   output: DescribePortfolioShareStatusOutput,
@@ -5089,7 +5088,7 @@ export const describeProduct: API.OperationMethod<
   DescribeProductInput,
   DescribeProductOutput,
   DescribeProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProductInput,
   output: DescribeProductOutput,
@@ -5110,7 +5109,7 @@ export const describeProductAsAdmin: API.OperationMethod<
   DescribeProductAsAdminInput,
   DescribeProductAsAdminOutput,
   DescribeProductAsAdminError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProductAsAdminInput,
   output: DescribeProductAsAdminOutput,
@@ -5131,7 +5130,7 @@ export const describeProductView: API.OperationMethod<
   DescribeProductViewInput,
   DescribeProductViewOutput,
   DescribeProductViewError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProductViewInput,
   output: DescribeProductViewOutput,
@@ -5152,7 +5151,7 @@ export const describeProvisionedProduct: API.OperationMethod<
   DescribeProvisionedProductInput,
   DescribeProvisionedProductOutput,
   DescribeProvisionedProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisionedProductInput,
   output: DescribeProvisionedProductOutput,
@@ -5173,7 +5172,7 @@ export const describeProvisionedProductPlan: API.OperationMethod<
   DescribeProvisionedProductPlanInput,
   DescribeProvisionedProductPlanOutput,
   DescribeProvisionedProductPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisionedProductPlanInput,
   output: DescribeProvisionedProductPlanOutput,
@@ -5194,7 +5193,7 @@ export const describeProvisioningArtifact: API.OperationMethod<
   DescribeProvisioningArtifactInput,
   DescribeProvisioningArtifactOutput,
   DescribeProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisioningArtifactInput,
   output: DescribeProvisioningArtifactOutput,
@@ -5223,7 +5222,7 @@ export const describeProvisioningParameters: API.OperationMethod<
   DescribeProvisioningParametersInput,
   DescribeProvisioningParametersOutput,
   DescribeProvisioningParametersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProvisioningParametersInput,
   output: DescribeProvisioningParametersOutput,
@@ -5248,7 +5247,7 @@ export const describeRecord: API.OperationMethod<
   DescribeRecordInput,
   DescribeRecordOutput,
   DescribeRecordError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRecordInput,
   output: DescribeRecordOutput,
@@ -5268,7 +5267,7 @@ export const describeServiceAction: API.OperationMethod<
   DescribeServiceActionInput,
   DescribeServiceActionOutput,
   DescribeServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceActionInput,
   output: DescribeServiceActionOutput,
@@ -5289,7 +5288,7 @@ export const describeServiceActionExecutionParameters: API.OperationMethod<
   DescribeServiceActionExecutionParametersInput,
   DescribeServiceActionExecutionParametersOutput,
   DescribeServiceActionExecutionParametersError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServiceActionExecutionParametersInput,
   output: DescribeServiceActionExecutionParametersOutput,
@@ -5310,7 +5309,7 @@ export const describeTagOption: API.OperationMethod<
   DescribeTagOptionInput,
   DescribeTagOptionOutput,
   DescribeTagOptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagOptionInput,
   output: DescribeTagOptionOutput,
@@ -5345,7 +5344,7 @@ export const disableAWSOrganizationsAccess: API.OperationMethod<
   DisableAWSOrganizationsAccessInput,
   DisableAWSOrganizationsAccessOutput,
   DisableAWSOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableAWSOrganizationsAccessInput,
   output: DisableAWSOrganizationsAccessOutput,
@@ -5369,7 +5368,7 @@ export const disassociateBudgetFromResource: API.OperationMethod<
   DisassociateBudgetFromResourceInput,
   DisassociateBudgetFromResourceOutput,
   DisassociateBudgetFromResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateBudgetFromResourceInput,
   output: DisassociateBudgetFromResourceOutput,
@@ -5409,7 +5408,7 @@ export const disassociatePrincipalFromPortfolio: API.OperationMethod<
   DisassociatePrincipalFromPortfolioInput,
   DisassociatePrincipalFromPortfolioOutput,
   DisassociatePrincipalFromPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociatePrincipalFromPortfolioInput,
   output: DisassociatePrincipalFromPortfolioOutput,
@@ -5433,7 +5432,7 @@ export const disassociateProductFromPortfolio: API.OperationMethod<
   DisassociateProductFromPortfolioInput,
   DisassociateProductFromPortfolioOutput,
   DisassociateProductFromPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateProductFromPortfolioInput,
   output: DisassociateProductFromPortfolioOutput,
@@ -5458,7 +5457,7 @@ export const disassociateServiceActionFromProvisioningArtifact: API.OperationMet
   DisassociateServiceActionFromProvisioningArtifactInput,
   DisassociateServiceActionFromProvisioningArtifactOutput,
   DisassociateServiceActionFromProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateServiceActionFromProvisioningArtifactInput,
   output: DisassociateServiceActionFromProvisioningArtifactOutput,
@@ -5479,7 +5478,7 @@ export const disassociateTagOptionFromResource: API.OperationMethod<
   DisassociateTagOptionFromResourceInput,
   DisassociateTagOptionFromResourceOutput,
   DisassociateTagOptionFromResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTagOptionFromResourceInput,
   output: DisassociateTagOptionFromResourceOutput,
@@ -5514,7 +5513,7 @@ export const enableAWSOrganizationsAccess: API.OperationMethod<
   EnableAWSOrganizationsAccessInput,
   EnableAWSOrganizationsAccessOutput,
   EnableAWSOrganizationsAccessError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableAWSOrganizationsAccessInput,
   output: EnableAWSOrganizationsAccessOutput,
@@ -5540,7 +5539,7 @@ export const executeProvisionedProductPlan: API.OperationMethod<
   ExecuteProvisionedProductPlanInput,
   ExecuteProvisionedProductPlanOutput,
   ExecuteProvisionedProductPlanError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteProvisionedProductPlanInput,
   output: ExecuteProvisionedProductPlanOutput,
@@ -5567,7 +5566,7 @@ export const executeProvisionedProductServiceAction: API.OperationMethod<
   ExecuteProvisionedProductServiceActionInput,
   ExecuteProvisionedProductServiceActionOutput,
   ExecuteProvisionedProductServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteProvisionedProductServiceActionInput,
   output: ExecuteProvisionedProductServiceActionOutput,
@@ -5594,7 +5593,7 @@ export const getAWSOrganizationsAccessStatus: API.OperationMethod<
   GetAWSOrganizationsAccessStatusInput,
   GetAWSOrganizationsAccessStatusOutput,
   GetAWSOrganizationsAccessStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAWSOrganizationsAccessStatusInput,
   output: GetAWSOrganizationsAccessStatusOutput,
@@ -5615,7 +5614,7 @@ export const getProvisionedProductOutputs: API.PaginatedOperationMethod<
   GetProvisionedProductOutputsInput,
   GetProvisionedProductOutputsOutput,
   GetProvisionedProductOutputsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetProvisionedProductOutputsInput,
@@ -5669,7 +5668,7 @@ export const importAsProvisionedProduct: API.OperationMethod<
   ImportAsProvisionedProductInput,
   ImportAsProvisionedProductOutput,
   ImportAsProvisionedProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportAsProvisionedProductInput,
   output: ImportAsProvisionedProductOutput,
@@ -5697,7 +5696,7 @@ export const listAcceptedPortfolioShares: API.PaginatedOperationMethod<
   ListAcceptedPortfolioSharesInput,
   ListAcceptedPortfolioSharesOutput,
   ListAcceptedPortfolioSharesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAcceptedPortfolioSharesInput,
@@ -5724,7 +5723,7 @@ export const listBudgetsForResource: API.PaginatedOperationMethod<
   ListBudgetsForResourceInput,
   ListBudgetsForResourceOutput,
   ListBudgetsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBudgetsForResourceInput,
@@ -5751,7 +5750,7 @@ export const listConstraintsForPortfolio: API.PaginatedOperationMethod<
   ListConstraintsForPortfolioInput,
   ListConstraintsForPortfolioOutput,
   ListConstraintsForPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConstraintsForPortfolioInput,
@@ -5798,7 +5797,7 @@ export const listLaunchPaths: API.PaginatedOperationMethod<
   ListLaunchPathsInput,
   ListLaunchPathsOutput,
   ListLaunchPathsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLaunchPathsInput,
@@ -5830,7 +5829,7 @@ export const listOrganizationPortfolioAccess: API.PaginatedOperationMethod<
   ListOrganizationPortfolioAccessInput,
   ListOrganizationPortfolioAccessOutput,
   ListOrganizationPortfolioAccessError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationPortfolioAccessInput,
@@ -5863,7 +5862,7 @@ export const listPortfolioAccess: API.PaginatedOperationMethod<
   ListPortfolioAccessInput,
   ListPortfolioAccessOutput,
   ListPortfolioAccessError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPortfolioAccessInput,
@@ -5887,7 +5886,7 @@ export const listPortfolios: API.PaginatedOperationMethod<
   ListPortfoliosInput,
   ListPortfoliosOutput,
   ListPortfoliosError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPortfoliosInput,
@@ -5914,7 +5913,7 @@ export const listPortfoliosForProduct: API.PaginatedOperationMethod<
   ListPortfoliosForProductInput,
   ListPortfoliosForProductOutput,
   ListPortfoliosForProductError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPortfoliosForProductInput,
@@ -5941,7 +5940,7 @@ export const listPrincipalsForPortfolio: API.PaginatedOperationMethod<
   ListPrincipalsForPortfolioInput,
   ListPrincipalsForPortfolioOutput,
   ListPrincipalsForPortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPrincipalsForPortfolioInput,
@@ -5968,7 +5967,7 @@ export const listProvisionedProductPlans: API.OperationMethod<
   ListProvisionedProductPlansInput,
   ListProvisionedProductPlansOutput,
   ListProvisionedProductPlansError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProvisionedProductPlansInput,
   output: ListProvisionedProductPlansOutput,
@@ -5989,7 +5988,7 @@ export const listProvisioningArtifacts: API.OperationMethod<
   ListProvisioningArtifactsInput,
   ListProvisioningArtifactsOutput,
   ListProvisioningArtifactsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProvisioningArtifactsInput,
   output: ListProvisioningArtifactsOutput,
@@ -6010,7 +6009,7 @@ export const listProvisioningArtifactsForServiceAction: API.PaginatedOperationMe
   ListProvisioningArtifactsForServiceActionInput,
   ListProvisioningArtifactsForServiceActionOutput,
   ListProvisioningArtifactsForServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProvisioningArtifactsForServiceActionInput,
@@ -6034,7 +6033,7 @@ export const listRecordHistory: API.OperationMethod<
   ListRecordHistoryInput,
   ListRecordHistoryOutput,
   ListRecordHistoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRecordHistoryInput,
   output: ListRecordHistoryOutput,
@@ -6056,7 +6055,7 @@ export const listResourcesForTagOption: API.PaginatedOperationMethod<
   ListResourcesForTagOptionInput,
   ListResourcesForTagOptionOutput,
   ListResourcesForTagOptionError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesForTagOptionInput,
@@ -6084,7 +6083,7 @@ export const listServiceActions: API.PaginatedOperationMethod<
   ListServiceActionsInput,
   ListServiceActionsOutput,
   ListServiceActionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceActionsInput,
@@ -6111,7 +6110,7 @@ export const listServiceActionsForProvisioningArtifact: API.PaginatedOperationMe
   ListServiceActionsForProvisioningArtifactInput,
   ListServiceActionsForProvisioningArtifactOutput,
   ListServiceActionsForProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceActionsForProvisioningArtifactInput,
@@ -6138,7 +6137,7 @@ export const listStackInstancesForProvisionedProduct: API.OperationMethod<
   ListStackInstancesForProvisionedProductInput,
   ListStackInstancesForProvisionedProductOutput,
   ListStackInstancesForProvisionedProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStackInstancesForProvisionedProductInput,
   output: ListStackInstancesForProvisionedProductOutput,
@@ -6159,7 +6158,7 @@ export const listTagOptions: API.PaginatedOperationMethod<
   ListTagOptionsInput,
   ListTagOptionsOutput,
   ListTagOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagOptionsInput,
@@ -6187,7 +6186,7 @@ export const notifyProvisionProductEngineWorkflowResult: API.OperationMethod<
   NotifyProvisionProductEngineWorkflowResultInput,
   NotifyProvisionProductEngineWorkflowResultOutput,
   NotifyProvisionProductEngineWorkflowResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyProvisionProductEngineWorkflowResultInput,
   output: NotifyProvisionProductEngineWorkflowResultOutput,
@@ -6209,7 +6208,7 @@ export const notifyTerminateProvisionedProductEngineWorkflowResult: API.Operatio
   NotifyTerminateProvisionedProductEngineWorkflowResultInput,
   NotifyTerminateProvisionedProductEngineWorkflowResultOutput,
   NotifyTerminateProvisionedProductEngineWorkflowResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyTerminateProvisionedProductEngineWorkflowResultInput,
   output: NotifyTerminateProvisionedProductEngineWorkflowResultOutput,
@@ -6231,7 +6230,7 @@ export const notifyUpdateProvisionedProductEngineWorkflowResult: API.OperationMe
   NotifyUpdateProvisionedProductEngineWorkflowResultInput,
   NotifyUpdateProvisionedProductEngineWorkflowResultOutput,
   NotifyUpdateProvisionedProductEngineWorkflowResultError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyUpdateProvisionedProductEngineWorkflowResultInput,
   output: NotifyUpdateProvisionedProductEngineWorkflowResultOutput,
@@ -6282,7 +6281,7 @@ export const provisionProduct: API.OperationMethod<
   ProvisionProductInput,
   ProvisionProductOutput,
   ProvisionProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionProductInput,
   output: ProvisionProductOutput,
@@ -6306,7 +6305,7 @@ export const rejectPortfolioShare: API.OperationMethod<
   RejectPortfolioShareInput,
   RejectPortfolioShareOutput,
   RejectPortfolioShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectPortfolioShareInput,
   output: RejectPortfolioShareOutput,
@@ -6328,7 +6327,7 @@ export const scanProvisionedProducts: API.OperationMethod<
   ScanProvisionedProductsInput,
   ScanProvisionedProductsOutput,
   ScanProvisionedProductsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ScanProvisionedProductsInput,
   output: ScanProvisionedProductsOutput,
@@ -6346,7 +6345,7 @@ export const searchProducts: API.PaginatedOperationMethod<
   SearchProductsInput,
   SearchProductsOutput,
   SearchProductsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchProductsInput,
@@ -6373,7 +6372,7 @@ export const searchProductsAsAdmin: API.PaginatedOperationMethod<
   SearchProductsAsAdminInput,
   SearchProductsAsAdminOutput,
   SearchProductsAsAdminError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchProductsAsAdminInput,
@@ -6399,7 +6398,7 @@ export const searchProvisionedProducts: API.PaginatedOperationMethod<
   SearchProvisionedProductsInput,
   SearchProvisionedProductsOutput,
   SearchProvisionedProductsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchProvisionedProductsInput,
@@ -6429,7 +6428,7 @@ export const terminateProvisionedProduct: API.OperationMethod<
   TerminateProvisionedProductInput,
   TerminateProvisionedProductOutput,
   TerminateProvisionedProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateProvisionedProductInput,
   output: TerminateProvisionedProductOutput,
@@ -6450,7 +6449,7 @@ export const updateConstraint: API.OperationMethod<
   UpdateConstraintInput,
   UpdateConstraintOutput,
   UpdateConstraintError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConstraintInput,
   output: UpdateConstraintOutput,
@@ -6475,7 +6474,7 @@ export const updatePortfolio: API.OperationMethod<
   UpdatePortfolioInput,
   UpdatePortfolioOutput,
   UpdatePortfolioError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortfolioInput,
   output: UpdatePortfolioOutput,
@@ -6521,7 +6520,7 @@ export const updatePortfolioShare: API.OperationMethod<
   UpdatePortfolioShareInput,
   UpdatePortfolioShareOutput,
   UpdatePortfolioShareError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortfolioShareInput,
   output: UpdatePortfolioShareOutput,
@@ -6548,7 +6547,7 @@ export const updateProduct: API.OperationMethod<
   UpdateProductInput,
   UpdateProductOutput,
   UpdateProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProductInput,
   output: UpdateProductOutput,
@@ -6579,7 +6578,7 @@ export const updateProvisionedProduct: API.OperationMethod<
   UpdateProvisionedProductInput,
   UpdateProvisionedProductOutput,
   UpdateProvisionedProductError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProvisionedProductInput,
   output: UpdateProvisionedProductOutput,
@@ -6601,7 +6600,7 @@ export const updateProvisionedProductProperties: API.OperationMethod<
   UpdateProvisionedProductPropertiesInput,
   UpdateProvisionedProductPropertiesOutput,
   UpdateProvisionedProductPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProvisionedProductPropertiesInput,
   output: UpdateProvisionedProductPropertiesOutput,
@@ -6628,7 +6627,7 @@ export const updateProvisioningArtifact: API.OperationMethod<
   UpdateProvisioningArtifactInput,
   UpdateProvisioningArtifactOutput,
   UpdateProvisioningArtifactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProvisioningArtifactInput,
   output: UpdateProvisioningArtifactOutput,
@@ -6649,7 +6648,7 @@ export const updateServiceAction: API.OperationMethod<
   UpdateServiceActionInput,
   UpdateServiceActionOutput,
   UpdateServiceActionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceActionInput,
   output: UpdateServiceActionOutput,
@@ -6672,7 +6671,7 @@ export const updateTagOption: API.OperationMethod<
   UpdateTagOptionInput,
   UpdateTagOptionOutput,
   UpdateTagOptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTagOptionInput,
   output: UpdateTagOptionOutput,

--- a/packages/aws/src/services/service-quotas.ts
+++ b/packages/aws/src/services/service-quotas.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Service Quotas",
   serviceShapeName: "ServiceQuotasV20190624",
@@ -1197,7 +1196,7 @@ export const associateServiceQuotaTemplate: API.OperationMethod<
   AssociateServiceQuotaTemplateRequest,
   AssociateServiceQuotaTemplateResponse,
   AssociateServiceQuotaTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateServiceQuotaTemplateRequest,
   output: AssociateServiceQuotaTemplateResponse,
@@ -1234,7 +1233,7 @@ export const createSupportCase: API.OperationMethod<
   CreateSupportCaseRequest,
   CreateSupportCaseResponse,
   CreateSupportCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSupportCaseRequest,
   output: CreateSupportCaseResponse,
@@ -1272,7 +1271,7 @@ export const deleteServiceQuotaIncreaseRequestFromTemplate: API.OperationMethod<
   DeleteServiceQuotaIncreaseRequestFromTemplateRequest,
   DeleteServiceQuotaIncreaseRequestFromTemplateResponse,
   DeleteServiceQuotaIncreaseRequestFromTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceQuotaIncreaseRequestFromTemplateRequest,
   output: DeleteServiceQuotaIncreaseRequestFromTemplateResponse,
@@ -1311,7 +1310,7 @@ export const disassociateServiceQuotaTemplate: API.OperationMethod<
   DisassociateServiceQuotaTemplateRequest,
   DisassociateServiceQuotaTemplateResponse,
   DisassociateServiceQuotaTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateServiceQuotaTemplateRequest,
   output: DisassociateServiceQuotaTemplateResponse,
@@ -1347,7 +1346,7 @@ export const getAssociationForServiceQuotaTemplate: API.OperationMethod<
   GetAssociationForServiceQuotaTemplateRequest,
   GetAssociationForServiceQuotaTemplateResponse,
   GetAssociationForServiceQuotaTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssociationForServiceQuotaTemplateRequest,
   output: GetAssociationForServiceQuotaTemplateResponse,
@@ -1381,7 +1380,7 @@ export const getAutoManagementConfiguration: API.OperationMethod<
   GetAutoManagementConfigurationRequest,
   GetAutoManagementConfigurationResponse,
   GetAutoManagementConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutoManagementConfigurationRequest,
   output: GetAutoManagementConfigurationResponse,
@@ -1412,7 +1411,7 @@ export const getAWSDefaultServiceQuota: API.OperationMethod<
   GetAWSDefaultServiceQuotaRequest,
   GetAWSDefaultServiceQuotaResponse,
   GetAWSDefaultServiceQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAWSDefaultServiceQuotaRequest,
   output: GetAWSDefaultServiceQuotaResponse,
@@ -1453,7 +1452,7 @@ export const getQuotaUtilizationReport: API.OperationMethod<
   GetQuotaUtilizationReportRequest,
   GetQuotaUtilizationReportResponse,
   GetQuotaUtilizationReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuotaUtilizationReportRequest,
   output: GetQuotaUtilizationReportResponse,
@@ -1483,7 +1482,7 @@ export const getRequestedServiceQuotaChange: API.OperationMethod<
   GetRequestedServiceQuotaChangeRequest,
   GetRequestedServiceQuotaChangeResponse,
   GetRequestedServiceQuotaChangeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRequestedServiceQuotaChangeRequest,
   output: GetRequestedServiceQuotaChangeResponse,
@@ -1515,7 +1514,7 @@ export const getServiceQuota: API.OperationMethod<
   GetServiceQuotaRequest,
   GetServiceQuotaResponse,
   GetServiceQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceQuotaRequest,
   output: GetServiceQuotaResponse,
@@ -1550,7 +1549,7 @@ export const getServiceQuotaIncreaseRequestFromTemplate: API.OperationMethod<
   GetServiceQuotaIncreaseRequestFromTemplateRequest,
   GetServiceQuotaIncreaseRequestFromTemplateResponse,
   GetServiceQuotaIncreaseRequestFromTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceQuotaIncreaseRequestFromTemplateRequest,
   output: GetServiceQuotaIncreaseRequestFromTemplateResponse,
@@ -1586,7 +1585,7 @@ export const listAWSDefaultServiceQuotas: API.PaginatedOperationMethod<
   ListAWSDefaultServiceQuotasRequest,
   ListAWSDefaultServiceQuotasResponse,
   ListAWSDefaultServiceQuotasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceQuota
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAWSDefaultServiceQuotasRequest,
@@ -1627,7 +1626,7 @@ export const listRequestedServiceQuotaChangeHistory: API.PaginatedOperationMetho
   ListRequestedServiceQuotaChangeHistoryRequest,
   ListRequestedServiceQuotaChangeHistoryResponse,
   ListRequestedServiceQuotaChangeHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RequestedServiceQuotaChange
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRequestedServiceQuotaChangeHistoryRequest,
@@ -1667,7 +1666,7 @@ export const listRequestedServiceQuotaChangeHistoryByQuota: API.PaginatedOperati
   ListRequestedServiceQuotaChangeHistoryByQuotaRequest,
   ListRequestedServiceQuotaChangeHistoryByQuotaResponse,
   ListRequestedServiceQuotaChangeHistoryByQuotaError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RequestedServiceQuotaChange
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRequestedServiceQuotaChangeHistoryByQuotaRequest,
@@ -1708,7 +1707,7 @@ export const listServiceQuotaIncreaseRequestsInTemplate: API.PaginatedOperationM
   ListServiceQuotaIncreaseRequestsInTemplateRequest,
   ListServiceQuotaIncreaseRequestsInTemplateResponse,
   ListServiceQuotaIncreaseRequestsInTemplateError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceQuotaIncreaseRequestInTemplate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceQuotaIncreaseRequestsInTemplateRequest,
@@ -1752,7 +1751,7 @@ export const listServiceQuotas: API.PaginatedOperationMethod<
   ListServiceQuotasRequest,
   ListServiceQuotasResponse,
   ListServiceQuotasError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceQuota
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceQuotasRequest,
@@ -1790,7 +1789,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -1827,7 +1826,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1862,7 +1861,7 @@ export const putServiceQuotaIncreaseRequestIntoTemplate: API.OperationMethod<
   PutServiceQuotaIncreaseRequestIntoTemplateRequest,
   PutServiceQuotaIncreaseRequestIntoTemplateResponse,
   PutServiceQuotaIncreaseRequestIntoTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutServiceQuotaIncreaseRequestIntoTemplateRequest,
   output: PutServiceQuotaIncreaseRequestIntoTemplateResponse,
@@ -1902,7 +1901,7 @@ export const requestServiceQuotaIncrease: API.OperationMethod<
   RequestServiceQuotaIncreaseRequest,
   RequestServiceQuotaIncreaseResponse,
   RequestServiceQuotaIncreaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestServiceQuotaIncreaseRequest,
   output: RequestServiceQuotaIncreaseResponse,
@@ -1938,7 +1937,7 @@ export const startAutoManagement: API.OperationMethod<
   StartAutoManagementRequest,
   StartAutoManagementResponse,
   StartAutoManagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutoManagementRequest,
   output: StartAutoManagementResponse,
@@ -1975,7 +1974,7 @@ export const startQuotaUtilizationReport: API.OperationMethod<
   StartQuotaUtilizationReportRequest,
   StartQuotaUtilizationReportResponse,
   StartQuotaUtilizationReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartQuotaUtilizationReportRequest,
   output: StartQuotaUtilizationReportResponse,
@@ -2008,7 +2007,7 @@ export const stopAutoManagement: API.OperationMethod<
   StopAutoManagementRequest,
   StopAutoManagementResponse,
   StopAutoManagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAutoManagementRequest,
   output: StopAutoManagementResponse,
@@ -2041,7 +2040,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2074,7 +2073,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2106,7 +2105,7 @@ export const updateAutoManagement: API.OperationMethod<
   UpdateAutoManagementRequest,
   UpdateAutoManagementResponse,
   UpdateAutoManagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutoManagementRequest,
   output: UpdateAutoManagementResponse,

--- a/packages/aws/src/services/servicediscovery.ts
+++ b/packages/aws/src/services/servicediscovery.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "ServiceDiscovery",
   serviceShapeName: "Route53AutoNaming_v20170314",
@@ -1563,7 +1562,7 @@ export const createHttpNamespace: API.OperationMethod<
   CreateHttpNamespaceRequest,
   CreateHttpNamespaceResponse,
   CreateHttpNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateHttpNamespaceRequest,
   output: CreateHttpNamespaceResponse,
@@ -1600,7 +1599,7 @@ export const createPrivateDnsNamespace: API.OperationMethod<
   CreatePrivateDnsNamespaceRequest,
   CreatePrivateDnsNamespaceResponse,
   CreatePrivateDnsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePrivateDnsNamespaceRequest,
   output: CreatePrivateDnsNamespaceResponse,
@@ -1638,7 +1637,7 @@ export const createPublicDnsNamespace: API.OperationMethod<
   CreatePublicDnsNamespaceRequest,
   CreatePublicDnsNamespaceResponse,
   CreatePublicDnsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePublicDnsNamespaceRequest,
   output: CreatePublicDnsNamespaceResponse,
@@ -1690,7 +1689,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -1720,7 +1719,7 @@ export const deleteNamespace: API.OperationMethod<
   DeleteNamespaceRequest,
   DeleteNamespaceResponse,
   DeleteNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNamespaceRequest,
   output: DeleteNamespaceResponse,
@@ -1743,7 +1742,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -1764,7 +1763,7 @@ export const deleteServiceAttributes: API.OperationMethod<
   DeleteServiceAttributesRequest,
   DeleteServiceAttributesResponse,
   DeleteServiceAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceAttributesRequest,
   output: DeleteServiceAttributesResponse,
@@ -1789,7 +1788,7 @@ export const deregisterInstance: API.OperationMethod<
   DeregisterInstanceRequest,
   DeregisterInstanceResponse,
   DeregisterInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterInstanceRequest,
   output: DeregisterInstanceResponse,
@@ -1822,7 +1821,7 @@ export const discoverInstances: API.OperationMethod<
   DiscoverInstancesRequest,
   DiscoverInstancesResponse,
   DiscoverInstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscoverInstancesRequest,
   output: DiscoverInstancesResponse,
@@ -1851,7 +1850,7 @@ export const discoverInstancesRevision: API.OperationMethod<
   DiscoverInstancesRevisionRequest,
   DiscoverInstancesRevisionResponse,
   DiscoverInstancesRevisionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DiscoverInstancesRevisionRequest,
   output: DiscoverInstancesRevisionResponse,
@@ -1879,7 +1878,7 @@ export const getInstance: API.OperationMethod<
   GetInstanceRequest,
   GetInstanceResponse,
   GetInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceRequest,
   output: GetInstanceResponse,
@@ -1906,7 +1905,7 @@ export const getInstancesHealthStatus: API.PaginatedOperationMethod<
   GetInstancesHealthStatusRequest,
   GetInstancesHealthStatusResponse,
   GetInstancesHealthStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInstancesHealthStatusRequest,
@@ -1930,7 +1929,7 @@ export const getNamespace: API.OperationMethod<
   GetNamespaceRequest,
   GetNamespaceResponse,
   GetNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNamespaceRequest,
   output: GetNamespaceResponse,
@@ -1951,7 +1950,7 @@ export const getOperation: API.OperationMethod<
   GetOperationRequest,
   GetOperationResponse,
   GetOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationRequest,
   output: GetOperationResponse,
@@ -1969,7 +1968,7 @@ export const getService: API.OperationMethod<
   GetServiceRequest,
   GetServiceResponse,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRequest,
   output: GetServiceResponse,
@@ -1990,7 +1989,7 @@ export const getServiceAttributes: API.OperationMethod<
   GetServiceAttributesRequest,
   GetServiceAttributesResponse,
   GetServiceAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceAttributesRequest,
   output: GetServiceAttributesResponse,
@@ -2009,7 +2008,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesRequest,
   ListInstancesResponse,
   ListInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesRequest,
@@ -2033,7 +2032,7 @@ export const listNamespaces: API.PaginatedOperationMethod<
   ListNamespacesRequest,
   ListNamespacesResponse,
   ListNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNamespacesRequest,
@@ -2057,7 +2056,7 @@ export const listOperations: API.PaginatedOperationMethod<
   ListOperationsRequest,
   ListOperationsResponse,
   ListOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOperationsRequest,
@@ -2082,7 +2081,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -2109,7 +2108,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2165,7 +2164,7 @@ export const registerInstance: API.OperationMethod<
   RegisterInstanceRequest,
   RegisterInstanceResponse,
   RegisterInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterInstanceRequest,
   output: RegisterInstanceResponse,
@@ -2193,7 +2192,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2214,7 +2213,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2238,7 +2237,7 @@ export const updateHttpNamespace: API.OperationMethod<
   UpdateHttpNamespaceRequest,
   UpdateHttpNamespaceResponse,
   UpdateHttpNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHttpNamespaceRequest,
   output: UpdateHttpNamespaceResponse,
@@ -2269,7 +2268,7 @@ export const updateInstanceCustomHealthStatus: API.OperationMethod<
   UpdateInstanceCustomHealthStatusRequest,
   UpdateInstanceCustomHealthStatusResponse,
   UpdateInstanceCustomHealthStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceCustomHealthStatusRequest,
   output: UpdateInstanceCustomHealthStatusResponse,
@@ -2298,7 +2297,7 @@ export const updatePrivateDnsNamespace: API.OperationMethod<
   UpdatePrivateDnsNamespaceRequest,
   UpdatePrivateDnsNamespaceResponse,
   UpdatePrivateDnsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrivateDnsNamespaceRequest,
   output: UpdatePrivateDnsNamespaceResponse,
@@ -2321,7 +2320,7 @@ export const updatePublicDnsNamespace: API.OperationMethod<
   UpdatePublicDnsNamespaceRequest,
   UpdatePublicDnsNamespaceResponse,
   UpdatePublicDnsNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePublicDnsNamespaceRequest,
   output: UpdatePublicDnsNamespaceResponse,
@@ -2371,7 +2370,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceRequest,
   UpdateServiceResponse,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceRequest,
   output: UpdateServiceResponse,
@@ -2393,7 +2392,7 @@ export const updateServiceAttributes: API.OperationMethod<
   UpdateServiceAttributesRequest,
   UpdateServiceAttributesResponse,
   UpdateServiceAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceAttributesRequest,
   output: UpdateServiceAttributesResponse,

--- a/packages/aws/src/services/ses.ts
+++ b/packages/aws/src/services/ses.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://ses.amazonaws.com/doc/2010-12-01/");
 const svc = T.AwsApiService({
   sdkId: "SES",
@@ -3383,7 +3382,7 @@ export const cloneReceiptRuleSet: API.OperationMethod<
   CloneReceiptRuleSetRequest,
   CloneReceiptRuleSetResponse,
   CloneReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CloneReceiptRuleSetRequest,
   output: CloneReceiptRuleSetResponse,
@@ -3415,7 +3414,7 @@ export const createConfigurationSet: API.OperationMethod<
   CreateConfigurationSetRequest,
   CreateConfigurationSetResponse,
   CreateConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetRequest,
   output: CreateConfigurationSetResponse,
@@ -3454,7 +3453,7 @@ export const createConfigurationSetEventDestination: API.OperationMethod<
   CreateConfigurationSetEventDestinationRequest,
   CreateConfigurationSetEventDestinationResponse,
   CreateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetEventDestinationRequest,
   output: CreateConfigurationSetEventDestinationResponse,
@@ -3488,7 +3487,7 @@ export const createConfigurationSetTrackingOptions: API.OperationMethod<
   CreateConfigurationSetTrackingOptionsRequest,
   CreateConfigurationSetTrackingOptionsResponse,
   CreateConfigurationSetTrackingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetTrackingOptionsRequest,
   output: CreateConfigurationSetTrackingOptionsResponse,
@@ -3521,7 +3520,7 @@ export const createCustomVerificationEmailTemplate: API.OperationMethod<
   CreateCustomVerificationEmailTemplateRequest,
   CreateCustomVerificationEmailTemplateResponse,
   CreateCustomVerificationEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomVerificationEmailTemplateRequest,
   output: CreateCustomVerificationEmailTemplateResponse,
@@ -3552,7 +3551,7 @@ export const createReceiptFilter: API.OperationMethod<
   CreateReceiptFilterRequest,
   CreateReceiptFilterResponse,
   CreateReceiptFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReceiptFilterRequest,
   output: CreateReceiptFilterResponse,
@@ -3585,7 +3584,7 @@ export const createReceiptRule: API.OperationMethod<
   CreateReceiptRuleRequest,
   CreateReceiptRuleResponse,
   CreateReceiptRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReceiptRuleRequest,
   output: CreateReceiptRuleResponse,
@@ -3620,7 +3619,7 @@ export const createReceiptRuleSet: API.OperationMethod<
   CreateReceiptRuleSetRequest,
   CreateReceiptRuleSetResponse,
   CreateReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReceiptRuleSetRequest,
   output: CreateReceiptRuleSetResponse,
@@ -3646,7 +3645,7 @@ export const createTemplate: API.OperationMethod<
   CreateTemplateRequest,
   CreateTemplateResponse,
   CreateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateRequest,
   output: CreateTemplateResponse,
@@ -3674,7 +3673,7 @@ export const deleteConfigurationSet: API.OperationMethod<
   DeleteConfigurationSetRequest,
   DeleteConfigurationSetResponse,
   DeleteConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetRequest,
   output: DeleteConfigurationSetResponse,
@@ -3700,7 +3699,7 @@ export const deleteConfigurationSetEventDestination: API.OperationMethod<
   DeleteConfigurationSetEventDestinationRequest,
   DeleteConfigurationSetEventDestinationResponse,
   DeleteConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetEventDestinationRequest,
   output: DeleteConfigurationSetEventDestinationResponse,
@@ -3733,7 +3732,7 @@ export const deleteConfigurationSetTrackingOptions: API.OperationMethod<
   DeleteConfigurationSetTrackingOptionsRequest,
   DeleteConfigurationSetTrackingOptionsResponse,
   DeleteConfigurationSetTrackingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetTrackingOptionsRequest,
   output: DeleteConfigurationSetTrackingOptionsResponse,
@@ -3760,7 +3759,7 @@ export const deleteCustomVerificationEmailTemplate: API.OperationMethod<
   DeleteCustomVerificationEmailTemplateRequest,
   DeleteCustomVerificationEmailTemplateResponse,
   DeleteCustomVerificationEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomVerificationEmailTemplateRequest,
   output: DeleteCustomVerificationEmailTemplateResponse,
@@ -3781,7 +3780,7 @@ export const deleteIdentity: API.OperationMethod<
   DeleteIdentityRequest,
   DeleteIdentityResponse,
   DeleteIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityRequest,
   output: DeleteIdentityResponse,
@@ -3811,7 +3810,7 @@ export const deleteIdentityPolicy: API.OperationMethod<
   DeleteIdentityPolicyRequest,
   DeleteIdentityPolicyResponse,
   DeleteIdentityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityPolicyRequest,
   output: DeleteIdentityPolicyResponse,
@@ -3834,7 +3833,7 @@ export const deleteReceiptFilter: API.OperationMethod<
   DeleteReceiptFilterRequest,
   DeleteReceiptFilterResponse,
   DeleteReceiptFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReceiptFilterRequest,
   output: DeleteReceiptFilterResponse,
@@ -3859,7 +3858,7 @@ export const deleteReceiptRule: API.OperationMethod<
   DeleteReceiptRuleRequest,
   DeleteReceiptRuleResponse,
   DeleteReceiptRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReceiptRuleRequest,
   output: DeleteReceiptRuleResponse,
@@ -3885,7 +3884,7 @@ export const deleteReceiptRuleSet: API.OperationMethod<
   DeleteReceiptRuleSetRequest,
   DeleteReceiptRuleSetResponse,
   DeleteReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReceiptRuleSetRequest,
   output: DeleteReceiptRuleSetResponse,
@@ -3905,7 +3904,7 @@ export const deleteTemplate: API.OperationMethod<
   DeleteTemplateRequest,
   DeleteTemplateResponse,
   DeleteTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateRequest,
   output: DeleteTemplateResponse,
@@ -3924,7 +3923,7 @@ export const deleteVerifiedEmailAddress: API.OperationMethod<
   DeleteVerifiedEmailAddressRequest,
   DeleteVerifiedEmailAddressResponse,
   DeleteVerifiedEmailAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVerifiedEmailAddressRequest,
   output: DeleteVerifiedEmailAddressResponse,
@@ -3947,7 +3946,7 @@ export const describeActiveReceiptRuleSet: API.OperationMethod<
   DescribeActiveReceiptRuleSetRequest,
   DescribeActiveReceiptRuleSetResponse,
   DescribeActiveReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActiveReceiptRuleSetRequest,
   output: DescribeActiveReceiptRuleSetResponse,
@@ -3971,7 +3970,7 @@ export const describeConfigurationSet: API.OperationMethod<
   DescribeConfigurationSetRequest,
   DescribeConfigurationSetResponse,
   DescribeConfigurationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConfigurationSetRequest,
   output: DescribeConfigurationSetResponse,
@@ -3997,7 +3996,7 @@ export const describeReceiptRule: API.OperationMethod<
   DescribeReceiptRuleRequest,
   DescribeReceiptRuleResponse,
   DescribeReceiptRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReceiptRuleRequest,
   output: DescribeReceiptRuleResponse,
@@ -4022,7 +4021,7 @@ export const describeReceiptRuleSet: API.OperationMethod<
   DescribeReceiptRuleSetRequest,
   DescribeReceiptRuleSetResponse,
   DescribeReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReceiptRuleSetRequest,
   output: DescribeReceiptRuleSetResponse,
@@ -4042,7 +4041,7 @@ export const getAccountSendingEnabled: API.OperationMethod<
   GetAccountSendingEnabledRequest,
   GetAccountSendingEnabledResponse,
   GetAccountSendingEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountSendingEnabledRequest,
   output: GetAccountSendingEnabledResponse,
@@ -4069,7 +4068,7 @@ export const getCustomVerificationEmailTemplate: API.OperationMethod<
   GetCustomVerificationEmailTemplateRequest,
   GetCustomVerificationEmailTemplateResponse,
   GetCustomVerificationEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomVerificationEmailTemplateRequest,
   output: GetCustomVerificationEmailTemplateResponse,
@@ -4108,7 +4107,7 @@ export const getIdentityDkimAttributes: API.OperationMethod<
   GetIdentityDkimAttributesRequest,
   GetIdentityDkimAttributesResponse,
   GetIdentityDkimAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityDkimAttributesRequest,
   output: GetIdentityDkimAttributesResponse,
@@ -4130,7 +4129,7 @@ export const getIdentityMailFromDomainAttributes: API.OperationMethod<
   GetIdentityMailFromDomainAttributesRequest,
   GetIdentityMailFromDomainAttributesResponse,
   GetIdentityMailFromDomainAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityMailFromDomainAttributesRequest,
   output: GetIdentityMailFromDomainAttributesResponse,
@@ -4155,7 +4154,7 @@ export const getIdentityNotificationAttributes: API.OperationMethod<
   GetIdentityNotificationAttributesRequest,
   GetIdentityNotificationAttributesResponse,
   GetIdentityNotificationAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityNotificationAttributesRequest,
   output: GetIdentityNotificationAttributesResponse,
@@ -4185,7 +4184,7 @@ export const getIdentityPolicies: API.OperationMethod<
   GetIdentityPoliciesRequest,
   GetIdentityPoliciesResponse,
   GetIdentityPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityPoliciesRequest,
   output: GetIdentityPoliciesResponse,
@@ -4221,7 +4220,7 @@ export const getIdentityVerificationAttributes: API.OperationMethod<
   GetIdentityVerificationAttributesRequest,
   GetIdentityVerificationAttributesResponse,
   GetIdentityVerificationAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityVerificationAttributesRequest,
   output: GetIdentityVerificationAttributesResponse,
@@ -4241,7 +4240,7 @@ export const getSendQuota: API.OperationMethod<
   GetSendQuotaRequest,
   GetSendQuotaResponse,
   GetSendQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSendQuotaRequest,
   output: GetSendQuotaResponse,
@@ -4263,7 +4262,7 @@ export const getSendStatistics: API.OperationMethod<
   GetSendStatisticsRequest,
   GetSendStatisticsResponse,
   GetSendStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSendStatisticsRequest,
   output: GetSendStatisticsResponse,
@@ -4284,7 +4283,7 @@ export const getTemplate: API.OperationMethod<
   GetTemplateRequest,
   GetTemplateResponse,
   GetTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTemplateRequest,
   output: GetTemplateResponse,
@@ -4312,7 +4311,7 @@ export const listConfigurationSets: API.OperationMethod<
   ListConfigurationSetsRequest,
   ListConfigurationSetsResponse,
   ListConfigurationSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListConfigurationSetsRequest,
   output: ListConfigurationSetsResponse,
@@ -4337,7 +4336,7 @@ export const listCustomVerificationEmailTemplates: API.PaginatedOperationMethod<
   ListCustomVerificationEmailTemplatesRequest,
   ListCustomVerificationEmailTemplatesResponse,
   ListCustomVerificationEmailTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomVerificationEmailTemplatesRequest,
@@ -4373,7 +4372,7 @@ export const listIdentities: API.PaginatedOperationMethod<
   ListIdentitiesRequest,
   ListIdentitiesResponse,
   ListIdentitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Identity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentitiesRequest,
@@ -4410,7 +4409,7 @@ export const listIdentityPolicies: API.OperationMethod<
   ListIdentityPoliciesRequest,
   ListIdentityPoliciesResponse,
   ListIdentityPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIdentityPoliciesRequest,
   output: ListIdentityPoliciesResponse,
@@ -4434,7 +4433,7 @@ export const listReceiptFilters: API.OperationMethod<
   ListReceiptFiltersRequest,
   ListReceiptFiltersResponse,
   ListReceiptFiltersError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceiptFiltersRequest,
   output: ListReceiptFiltersResponse,
@@ -4460,7 +4459,7 @@ export const listReceiptRuleSets: API.OperationMethod<
   ListReceiptRuleSetsRequest,
   ListReceiptRuleSetsResponse,
   ListReceiptRuleSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListReceiptRuleSetsRequest,
   output: ListReceiptRuleSetsResponse,
@@ -4481,7 +4480,7 @@ export const listTemplates: API.OperationMethod<
   ListTemplatesRequest,
   ListTemplatesResponse,
   ListTemplatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTemplatesRequest,
   output: ListTemplatesResponse,
@@ -4500,7 +4499,7 @@ export const listVerifiedEmailAddresses: API.OperationMethod<
   ListVerifiedEmailAddressesRequest,
   ListVerifiedEmailAddressesResponse,
   ListVerifiedEmailAddressesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVerifiedEmailAddressesRequest,
   output: ListVerifiedEmailAddressesResponse,
@@ -4521,7 +4520,7 @@ export const putConfigurationSetDeliveryOptions: API.OperationMethod<
   PutConfigurationSetDeliveryOptionsRequest,
   PutConfigurationSetDeliveryOptionsResponse,
   PutConfigurationSetDeliveryOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetDeliveryOptionsRequest,
   output: PutConfigurationSetDeliveryOptionsResponse,
@@ -4553,7 +4552,7 @@ export const putIdentityPolicy: API.OperationMethod<
   PutIdentityPolicyRequest,
   PutIdentityPolicyResponse,
   PutIdentityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIdentityPolicyRequest,
   output: PutIdentityPolicyResponse,
@@ -4582,7 +4581,7 @@ export const reorderReceiptRuleSet: API.OperationMethod<
   ReorderReceiptRuleSetRequest,
   ReorderReceiptRuleSetResponse,
   ReorderReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReorderReceiptRuleSetRequest,
   output: ReorderReceiptRuleSetResponse,
@@ -4610,7 +4609,7 @@ export const sendBounce: API.OperationMethod<
   SendBounceRequest,
   SendBounceResponse,
   SendBounceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendBounceRequest,
   output: SendBounceResponse,
@@ -4668,7 +4667,7 @@ export const sendBulkTemplatedEmail: API.OperationMethod<
   SendBulkTemplatedEmailRequest,
   SendBulkTemplatedEmailResponse,
   SendBulkTemplatedEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendBulkTemplatedEmailRequest,
   output: SendBulkTemplatedEmailResponse,
@@ -4709,7 +4708,7 @@ export const sendCustomVerificationEmail: API.OperationMethod<
   SendCustomVerificationEmailRequest,
   SendCustomVerificationEmailResponse,
   SendCustomVerificationEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendCustomVerificationEmailRequest,
   output: SendCustomVerificationEmailResponse,
@@ -4771,7 +4770,7 @@ export const sendEmail: API.OperationMethod<
   SendEmailRequest,
   SendEmailResponse,
   SendEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEmailRequest,
   output: SendEmailResponse,
@@ -4878,7 +4877,7 @@ export const sendRawEmail: API.OperationMethod<
   SendRawEmailRequest,
   SendRawEmailResponse,
   SendRawEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendRawEmailRequest,
   output: SendRawEmailResponse,
@@ -4949,7 +4948,7 @@ export const sendTemplatedEmail: API.OperationMethod<
   SendTemplatedEmailRequest,
   SendTemplatedEmailResponse,
   SendTemplatedEmailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTemplatedEmailRequest,
   output: SendTemplatedEmailResponse,
@@ -4984,7 +4983,7 @@ export const setActiveReceiptRuleSet: API.OperationMethod<
   SetActiveReceiptRuleSetRequest,
   SetActiveReceiptRuleSetResponse,
   SetActiveReceiptRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetActiveReceiptRuleSetRequest,
   output: SetActiveReceiptRuleSetResponse,
@@ -5017,7 +5016,7 @@ export const setIdentityDkimEnabled: API.OperationMethod<
   SetIdentityDkimEnabledRequest,
   SetIdentityDkimEnabledResponse,
   SetIdentityDkimEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityDkimEnabledRequest,
   output: SetIdentityDkimEnabledResponse,
@@ -5046,7 +5045,7 @@ export const setIdentityFeedbackForwardingEnabled: API.OperationMethod<
   SetIdentityFeedbackForwardingEnabledRequest,
   SetIdentityFeedbackForwardingEnabledResponse,
   SetIdentityFeedbackForwardingEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityFeedbackForwardingEnabledRequest,
   output: SetIdentityFeedbackForwardingEnabledResponse,
@@ -5071,7 +5070,7 @@ export const setIdentityHeadersInNotificationsEnabled: API.OperationMethod<
   SetIdentityHeadersInNotificationsEnabledRequest,
   SetIdentityHeadersInNotificationsEnabledResponse,
   SetIdentityHeadersInNotificationsEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityHeadersInNotificationsEnabledRequest,
   output: SetIdentityHeadersInNotificationsEnabledResponse,
@@ -5097,7 +5096,7 @@ export const setIdentityMailFromDomain: API.OperationMethod<
   SetIdentityMailFromDomainRequest,
   SetIdentityMailFromDomainResponse,
   SetIdentityMailFromDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityMailFromDomainRequest,
   output: SetIdentityMailFromDomainResponse,
@@ -5125,7 +5124,7 @@ export const setIdentityNotificationTopic: API.OperationMethod<
   SetIdentityNotificationTopicRequest,
   SetIdentityNotificationTopicResponse,
   SetIdentityNotificationTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetIdentityNotificationTopicRequest,
   output: SetIdentityNotificationTopicResponse,
@@ -5151,7 +5150,7 @@ export const setReceiptRulePosition: API.OperationMethod<
   SetReceiptRulePositionRequest,
   SetReceiptRulePositionResponse,
   SetReceiptRulePositionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetReceiptRulePositionRequest,
   output: SetReceiptRulePositionResponse,
@@ -5176,7 +5175,7 @@ export const testRenderTemplate: API.OperationMethod<
   TestRenderTemplateRequest,
   TestRenderTemplateResponse,
   TestRenderTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestRenderTemplateRequest,
   output: TestRenderTemplateResponse,
@@ -5204,7 +5203,7 @@ export const updateAccountSendingEnabled: API.OperationMethod<
   UpdateAccountSendingEnabledRequest,
   UpdateAccountSendingEnabledResponse,
   UpdateAccountSendingEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSendingEnabledRequest,
   output: UpdateAccountSendingEnabledResponse,
@@ -5238,7 +5237,7 @@ export const updateConfigurationSetEventDestination: API.OperationMethod<
   UpdateConfigurationSetEventDestinationRequest,
   UpdateConfigurationSetEventDestinationResponse,
   UpdateConfigurationSetEventDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetEventDestinationRequest,
   output: UpdateConfigurationSetEventDestinationResponse,
@@ -5269,7 +5268,7 @@ export const updateConfigurationSetReputationMetricsEnabled: API.OperationMethod
   UpdateConfigurationSetReputationMetricsEnabledRequest,
   UpdateConfigurationSetReputationMetricsEnabledResponse,
   UpdateConfigurationSetReputationMetricsEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetReputationMetricsEnabledRequest,
   output: UpdateConfigurationSetReputationMetricsEnabledResponse,
@@ -5295,7 +5294,7 @@ export const updateConfigurationSetSendingEnabled: API.OperationMethod<
   UpdateConfigurationSetSendingEnabledRequest,
   UpdateConfigurationSetSendingEnabledResponse,
   UpdateConfigurationSetSendingEnabledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetSendingEnabledRequest,
   output: UpdateConfigurationSetSendingEnabledResponse,
@@ -5322,7 +5321,7 @@ export const updateConfigurationSetTrackingOptions: API.OperationMethod<
   UpdateConfigurationSetTrackingOptionsRequest,
   UpdateConfigurationSetTrackingOptionsResponse,
   UpdateConfigurationSetTrackingOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetTrackingOptionsRequest,
   output: UpdateConfigurationSetTrackingOptionsResponse,
@@ -5354,7 +5353,7 @@ export const updateCustomVerificationEmailTemplate: API.OperationMethod<
   UpdateCustomVerificationEmailTemplateRequest,
   UpdateCustomVerificationEmailTemplateResponse,
   UpdateCustomVerificationEmailTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomVerificationEmailTemplateRequest,
   output: UpdateCustomVerificationEmailTemplateResponse,
@@ -5390,7 +5389,7 @@ export const updateReceiptRule: API.OperationMethod<
   UpdateReceiptRuleRequest,
   UpdateReceiptRuleResponse,
   UpdateReceiptRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReceiptRuleRequest,
   output: UpdateReceiptRuleResponse,
@@ -5424,7 +5423,7 @@ export const updateTemplate: API.OperationMethod<
   UpdateTemplateRequest,
   UpdateTemplateResponse,
   UpdateTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTemplateRequest,
   output: UpdateTemplateResponse,
@@ -5474,7 +5473,7 @@ export const verifyDomainDkim: API.OperationMethod<
   VerifyDomainDkimRequest,
   VerifyDomainDkimResponse,
   VerifyDomainDkimError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyDomainDkimRequest,
   output: VerifyDomainDkimResponse,
@@ -5497,7 +5496,7 @@ export const verifyDomainIdentity: API.OperationMethod<
   VerifyDomainIdentityRequest,
   VerifyDomainIdentityResponse,
   VerifyDomainIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyDomainIdentityRequest,
   output: VerifyDomainIdentityResponse,
@@ -5516,7 +5515,7 @@ export const verifyEmailAddress: API.OperationMethod<
   VerifyEmailAddressRequest,
   VerifyEmailAddressResponse,
   VerifyEmailAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyEmailAddressRequest,
   output: VerifyEmailAddressResponse,
@@ -5538,7 +5537,7 @@ export const verifyEmailIdentity: API.OperationMethod<
   VerifyEmailIdentityRequest,
   VerifyEmailIdentityResponse,
   VerifyEmailIdentityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifyEmailIdentityRequest,
   output: VerifyEmailIdentityResponse,

--- a/packages/aws/src/services/sesv2.ts
+++ b/packages/aws/src/services/sesv2.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SESv2",
@@ -6072,7 +6071,7 @@ export const batchGetMetricData: API.OperationMethod<
   BatchGetMetricDataRequest,
   BatchGetMetricDataResponse,
   BatchGetMetricDataError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetMetricDataRequest,
   output: BatchGetMetricDataResponse,
@@ -6099,7 +6098,7 @@ export const cancelExportJob: API.OperationMethod<
   CancelExportJobRequest,
   CancelExportJobResponse,
   CancelExportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelExportJobRequest,
   output: CancelExportJobResponse,
@@ -6128,7 +6127,7 @@ export const createConfigurationSet: API.OperationMethod<
   CreateConfigurationSetRequest,
   CreateConfigurationSetResponse,
   CreateConfigurationSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetRequest,
   output: CreateConfigurationSetResponse,
@@ -6165,7 +6164,7 @@ export const createConfigurationSetEventDestination: API.OperationMethod<
   CreateConfigurationSetEventDestinationRequest,
   CreateConfigurationSetEventDestinationResponse,
   CreateConfigurationSetEventDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationSetEventDestinationRequest,
   output: CreateConfigurationSetEventDestinationResponse,
@@ -6195,7 +6194,7 @@ export const createContact: API.OperationMethod<
   CreateContactRequest,
   CreateContactResponse,
   CreateContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactRequest,
   output: CreateContactResponse,
@@ -6223,7 +6222,7 @@ export const createContactList: API.OperationMethod<
   CreateContactListRequest,
   CreateContactListResponse,
   CreateContactListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactListRequest,
   output: CreateContactListResponse,
@@ -6258,7 +6257,7 @@ export const createCustomVerificationEmailTemplate: API.OperationMethod<
   CreateCustomVerificationEmailTemplateRequest,
   CreateCustomVerificationEmailTemplateResponse,
   CreateCustomVerificationEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomVerificationEmailTemplateRequest,
   output: CreateCustomVerificationEmailTemplateResponse,
@@ -6291,7 +6290,7 @@ export const createDedicatedIpPool: API.OperationMethod<
   CreateDedicatedIpPoolRequest,
   CreateDedicatedIpPoolResponse,
   CreateDedicatedIpPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDedicatedIpPoolRequest,
   output: CreateDedicatedIpPoolResponse,
@@ -6331,7 +6330,7 @@ export const createDeliverabilityTestReport: API.OperationMethod<
   CreateDeliverabilityTestReportRequest,
   CreateDeliverabilityTestReportResponse,
   CreateDeliverabilityTestReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDeliverabilityTestReportRequest,
   output: CreateDeliverabilityTestReportResponse,
@@ -6394,7 +6393,7 @@ export const createEmailIdentity: API.OperationMethod<
   CreateEmailIdentityRequest,
   CreateEmailIdentityResponse,
   CreateEmailIdentityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailIdentityRequest,
   output: CreateEmailIdentityResponse,
@@ -6436,7 +6435,7 @@ export const createEmailIdentityPolicy: API.OperationMethod<
   CreateEmailIdentityPolicyRequest,
   CreateEmailIdentityPolicyResponse,
   CreateEmailIdentityPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailIdentityPolicyRequest,
   output: CreateEmailIdentityPolicyResponse,
@@ -6469,7 +6468,7 @@ export const createEmailTemplate: API.OperationMethod<
   CreateEmailTemplateRequest,
   CreateEmailTemplateResponse,
   CreateEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEmailTemplateRequest,
   output: CreateEmailTemplateResponse,
@@ -6499,7 +6498,7 @@ export const createExportJob: API.OperationMethod<
   CreateExportJobRequest,
   CreateExportJobResponse,
   CreateExportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateExportJobRequest,
   output: CreateExportJobResponse,
@@ -6526,7 +6525,7 @@ export const createImportJob: API.OperationMethod<
   CreateImportJobRequest,
   CreateImportJobResponse,
   CreateImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImportJobRequest,
   output: CreateImportJobResponse,
@@ -6559,7 +6558,7 @@ export const createMultiRegionEndpoint: API.OperationMethod<
   CreateMultiRegionEndpointRequest,
   CreateMultiRegionEndpointResponse,
   CreateMultiRegionEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMultiRegionEndpointRequest,
   output: CreateMultiRegionEndpointResponse,
@@ -6596,7 +6595,7 @@ export const createTenant: API.OperationMethod<
   CreateTenantRequest,
   CreateTenantResponse,
   CreateTenantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTenantRequest,
   output: CreateTenantResponse,
@@ -6631,7 +6630,7 @@ export const createTenantResourceAssociation: API.OperationMethod<
   CreateTenantResourceAssociationRequest,
   CreateTenantResourceAssociationResponse,
   CreateTenantResourceAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTenantResourceAssociationRequest,
   output: CreateTenantResourceAssociationResponse,
@@ -6664,7 +6663,7 @@ export const deleteConfigurationSet: API.OperationMethod<
   DeleteConfigurationSetRequest,
   DeleteConfigurationSetResponse,
   DeleteConfigurationSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetRequest,
   output: DeleteConfigurationSetResponse,
@@ -6696,7 +6695,7 @@ export const deleteConfigurationSetEventDestination: API.OperationMethod<
   DeleteConfigurationSetEventDestinationRequest,
   DeleteConfigurationSetEventDestinationResponse,
   DeleteConfigurationSetEventDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationSetEventDestinationRequest,
   output: DeleteConfigurationSetEventDestinationResponse,
@@ -6718,7 +6717,7 @@ export const deleteContact: API.OperationMethod<
   DeleteContactRequest,
   DeleteContactResponse,
   DeleteContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactRequest,
   output: DeleteContactResponse,
@@ -6741,7 +6740,7 @@ export const deleteContactList: API.OperationMethod<
   DeleteContactListRequest,
   DeleteContactListResponse,
   DeleteContactListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactListRequest,
   output: DeleteContactListResponse,
@@ -6774,7 +6773,7 @@ export const deleteCustomVerificationEmailTemplate: API.OperationMethod<
   DeleteCustomVerificationEmailTemplateRequest,
   DeleteCustomVerificationEmailTemplateResponse,
   DeleteCustomVerificationEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomVerificationEmailTemplateRequest,
   output: DeleteCustomVerificationEmailTemplateResponse,
@@ -6797,7 +6796,7 @@ export const deleteDedicatedIpPool: API.OperationMethod<
   DeleteDedicatedIpPoolRequest,
   DeleteDedicatedIpPoolResponse,
   DeleteDedicatedIpPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDedicatedIpPoolRequest,
   output: DeleteDedicatedIpPoolResponse,
@@ -6826,7 +6825,7 @@ export const deleteEmailIdentity: API.OperationMethod<
   DeleteEmailIdentityRequest,
   DeleteEmailIdentityResponse,
   DeleteEmailIdentityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailIdentityRequest,
   output: DeleteEmailIdentityResponse,
@@ -6865,7 +6864,7 @@ export const deleteEmailIdentityPolicy: API.OperationMethod<
   DeleteEmailIdentityPolicyRequest,
   DeleteEmailIdentityPolicyResponse,
   DeleteEmailIdentityPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailIdentityPolicyRequest,
   output: DeleteEmailIdentityPolicyResponse,
@@ -6889,7 +6888,7 @@ export const deleteEmailTemplate: API.OperationMethod<
   DeleteEmailTemplateRequest,
   DeleteEmailTemplateResponse,
   DeleteEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailTemplateRequest,
   output: DeleteEmailTemplateResponse,
@@ -6915,7 +6914,7 @@ export const deleteMultiRegionEndpoint: API.OperationMethod<
   DeleteMultiRegionEndpointRequest,
   DeleteMultiRegionEndpointResponse,
   DeleteMultiRegionEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMultiRegionEndpointRequest,
   output: DeleteMultiRegionEndpointResponse,
@@ -6945,7 +6944,7 @@ export const deleteSuppressedDestination: API.OperationMethod<
   DeleteSuppressedDestinationRequest,
   DeleteSuppressedDestinationResponse,
   DeleteSuppressedDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSuppressedDestinationRequest,
   output: DeleteSuppressedDestinationResponse,
@@ -6970,7 +6969,7 @@ export const deleteTenant: API.OperationMethod<
   DeleteTenantRequest,
   DeleteTenantResponse,
   DeleteTenantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTenantRequest,
   output: DeleteTenantResponse,
@@ -6996,7 +6995,7 @@ export const deleteTenantResourceAssociation: API.OperationMethod<
   DeleteTenantResourceAssociationRequest,
   DeleteTenantResourceAssociationResponse,
   DeleteTenantResourceAssociationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTenantResourceAssociationRequest,
   output: DeleteTenantResourceAssociationResponse,
@@ -7018,7 +7017,7 @@ export const getAccount: API.OperationMethod<
   GetAccountRequest,
   GetAccountResponse,
   GetAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountRequest,
   output: GetAccountResponse,
@@ -7040,7 +7039,7 @@ export const getBlacklistReports: API.OperationMethod<
   GetBlacklistReportsRequest,
   GetBlacklistReportsResponse,
   GetBlacklistReportsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBlacklistReportsRequest,
   output: GetBlacklistReportsResponse,
@@ -7069,7 +7068,7 @@ export const getConfigurationSet: API.OperationMethod<
   GetConfigurationSetRequest,
   GetConfigurationSetResponse,
   GetConfigurationSetError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationSetRequest,
   output: GetConfigurationSetResponse,
@@ -7097,7 +7096,7 @@ export const getConfigurationSetEventDestinations: API.OperationMethod<
   GetConfigurationSetEventDestinationsRequest,
   GetConfigurationSetEventDestinationsResponse,
   GetConfigurationSetEventDestinationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationSetEventDestinationsRequest,
   output: GetConfigurationSetEventDestinationsResponse,
@@ -7119,7 +7118,7 @@ export const getContact: API.OperationMethod<
   GetContactRequest,
   GetContactResponse,
   GetContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactRequest,
   output: GetContactResponse,
@@ -7142,7 +7141,7 @@ export const getContactList: API.OperationMethod<
   GetContactListRequest,
   GetContactListResponse,
   GetContactListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactListRequest,
   output: GetContactListResponse,
@@ -7171,7 +7170,7 @@ export const getCustomVerificationEmailTemplate: API.OperationMethod<
   GetCustomVerificationEmailTemplateRequest,
   GetCustomVerificationEmailTemplateResponse,
   GetCustomVerificationEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCustomVerificationEmailTemplateRequest,
   output: GetCustomVerificationEmailTemplateResponse,
@@ -7195,7 +7194,7 @@ export const getDedicatedIp: API.OperationMethod<
   GetDedicatedIpRequest,
   GetDedicatedIpResponse,
   GetDedicatedIpError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDedicatedIpRequest,
   output: GetDedicatedIpResponse,
@@ -7217,7 +7216,7 @@ export const getDedicatedIpPool: API.OperationMethod<
   GetDedicatedIpPoolRequest,
   GetDedicatedIpPoolResponse,
   GetDedicatedIpPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDedicatedIpPoolRequest,
   output: GetDedicatedIpPoolResponse,
@@ -7240,7 +7239,7 @@ export const getDedicatedIps: API.PaginatedOperationMethod<
   GetDedicatedIpsRequest,
   GetDedicatedIpsResponse,
   GetDedicatedIpsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetDedicatedIpsRequest,
@@ -7275,7 +7274,7 @@ export const getDeliverabilityDashboardOptions: API.OperationMethod<
   GetDeliverabilityDashboardOptionsRequest,
   GetDeliverabilityDashboardOptionsResponse,
   GetDeliverabilityDashboardOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliverabilityDashboardOptionsRequest,
   output: GetDeliverabilityDashboardOptionsResponse,
@@ -7301,7 +7300,7 @@ export const getDeliverabilityTestReport: API.OperationMethod<
   GetDeliverabilityTestReportRequest,
   GetDeliverabilityTestReportResponse,
   GetDeliverabilityTestReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeliverabilityTestReportRequest,
   output: GetDeliverabilityTestReportResponse,
@@ -7325,7 +7324,7 @@ export const getDomainDeliverabilityCampaign: API.OperationMethod<
   GetDomainDeliverabilityCampaignRequest,
   GetDomainDeliverabilityCampaignResponse,
   GetDomainDeliverabilityCampaignError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainDeliverabilityCampaignRequest,
   output: GetDomainDeliverabilityCampaignResponse,
@@ -7348,7 +7347,7 @@ export const getDomainStatisticsReport: API.OperationMethod<
   GetDomainStatisticsReportRequest,
   GetDomainStatisticsReportResponse,
   GetDomainStatisticsReportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainStatisticsReportRequest,
   output: GetDomainStatisticsReportResponse,
@@ -7369,7 +7368,7 @@ export const getEmailAddressInsights: API.OperationMethod<
   GetEmailAddressInsightsRequest,
   GetEmailAddressInsightsResponse,
   GetEmailAddressInsightsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailAddressInsightsRequest,
   output: GetEmailAddressInsightsResponse,
@@ -7393,7 +7392,7 @@ export const getEmailIdentity: API.OperationMethod<
   GetEmailIdentityRequest,
   GetEmailIdentityResponse,
   GetEmailIdentityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailIdentityRequest,
   output: GetEmailIdentityResponse,
@@ -7427,7 +7426,7 @@ export const getEmailIdentityPolicies: API.OperationMethod<
   GetEmailIdentityPoliciesRequest,
   GetEmailIdentityPoliciesResponse,
   GetEmailIdentityPoliciesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailIdentityPoliciesRequest,
   output: GetEmailIdentityPoliciesResponse,
@@ -7452,7 +7451,7 @@ export const getEmailTemplate: API.OperationMethod<
   GetEmailTemplateRequest,
   GetEmailTemplateResponse,
   GetEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEmailTemplateRequest,
   output: GetEmailTemplateResponse,
@@ -7474,7 +7473,7 @@ export const getExportJob: API.OperationMethod<
   GetExportJobRequest,
   GetExportJobResponse,
   GetExportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportJobRequest,
   output: GetExportJobResponse,
@@ -7496,7 +7495,7 @@ export const getImportJob: API.OperationMethod<
   GetImportJobRequest,
   GetImportJobResponse,
   GetImportJobError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportJobRequest,
   output: GetImportJobResponse,
@@ -7521,7 +7520,7 @@ export const getMessageInsights: API.OperationMethod<
   GetMessageInsightsRequest,
   GetMessageInsightsResponse,
   GetMessageInsightsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMessageInsightsRequest,
   output: GetMessageInsightsResponse,
@@ -7546,7 +7545,7 @@ export const getMultiRegionEndpoint: API.OperationMethod<
   GetMultiRegionEndpointRequest,
   GetMultiRegionEndpointResponse,
   GetMultiRegionEndpointError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMultiRegionEndpointRequest,
   output: GetMultiRegionEndpointResponse,
@@ -7575,7 +7574,7 @@ export const getReputationEntity: API.OperationMethod<
   GetReputationEntityRequest,
   GetReputationEntityResponse,
   GetReputationEntityError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReputationEntityRequest,
   output: GetReputationEntityResponse,
@@ -7600,7 +7599,7 @@ export const getSuppressedDestination: API.OperationMethod<
   GetSuppressedDestinationRequest,
   GetSuppressedDestinationResponse,
   GetSuppressedDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSuppressedDestinationRequest,
   output: GetSuppressedDestinationResponse,
@@ -7623,7 +7622,7 @@ export const getTenant: API.OperationMethod<
   GetTenantRequest,
   GetTenantResponse,
   GetTenantError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTenantRequest,
   output: GetTenantResponse,
@@ -7650,7 +7649,7 @@ export const listConfigurationSets: API.PaginatedOperationMethod<
   ListConfigurationSetsRequest,
   ListConfigurationSetsResponse,
   ListConfigurationSetsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationSetsRequest,
@@ -7680,7 +7679,7 @@ export const listContactLists: API.PaginatedOperationMethod<
   ListContactListsRequest,
   ListContactListsResponse,
   ListContactListsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactListsRequest,
@@ -7708,7 +7707,7 @@ export const listContacts: API.PaginatedOperationMethod<
   ListContactsRequest,
   ListContactsResponse,
   ListContactsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactsRequest,
@@ -7742,7 +7741,7 @@ export const listCustomVerificationEmailTemplates: API.PaginatedOperationMethod<
   ListCustomVerificationEmailTemplatesRequest,
   ListCustomVerificationEmailTemplatesResponse,
   ListCustomVerificationEmailTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomVerificationEmailTemplatesRequest,
@@ -7770,7 +7769,7 @@ export const listDedicatedIpPools: API.PaginatedOperationMethod<
   ListDedicatedIpPoolsRequest,
   ListDedicatedIpPoolsResponse,
   ListDedicatedIpPoolsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDedicatedIpPoolsRequest,
@@ -7800,7 +7799,7 @@ export const listDeliverabilityTestReports: API.PaginatedOperationMethod<
   ListDeliverabilityTestReportsRequest,
   ListDeliverabilityTestReportsResponse,
   ListDeliverabilityTestReportsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeliverabilityTestReportsRequest,
@@ -7830,7 +7829,7 @@ export const listDomainDeliverabilityCampaigns: API.PaginatedOperationMethod<
   ListDomainDeliverabilityCampaignsRequest,
   ListDomainDeliverabilityCampaignsResponse,
   ListDomainDeliverabilityCampaignsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainDeliverabilityCampaignsRequest,
@@ -7860,7 +7859,7 @@ export const listEmailIdentities: API.PaginatedOperationMethod<
   ListEmailIdentitiesRequest,
   ListEmailIdentitiesResponse,
   ListEmailIdentitiesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEmailIdentitiesRequest,
@@ -7890,7 +7889,7 @@ export const listEmailTemplates: API.PaginatedOperationMethod<
   ListEmailTemplatesRequest,
   ListEmailTemplatesResponse,
   ListEmailTemplatesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEmailTemplatesRequest,
@@ -7917,7 +7916,7 @@ export const listExportJobs: API.PaginatedOperationMethod<
   ListExportJobsRequest,
   ListExportJobsResponse,
   ListExportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportJobsRequest,
@@ -7944,7 +7943,7 @@ export const listImportJobs: API.PaginatedOperationMethod<
   ListImportJobsRequest,
   ListImportJobsResponse,
   ListImportJobsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportJobsRequest,
@@ -7974,7 +7973,7 @@ export const listMultiRegionEndpoints: API.PaginatedOperationMethod<
   ListMultiRegionEndpointsRequest,
   ListMultiRegionEndpointsResponse,
   ListMultiRegionEndpointsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MultiRegionEndpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMultiRegionEndpointsRequest,
@@ -8005,7 +8004,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -8038,7 +8037,7 @@ export const listReputationEntities: API.PaginatedOperationMethod<
   ListReputationEntitiesRequest,
   ListReputationEntitiesResponse,
   ListReputationEntitiesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ReputationEntity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReputationEntitiesRequest,
@@ -8071,7 +8070,7 @@ export const listResourceTenants: API.PaginatedOperationMethod<
   ListResourceTenantsRequest,
   ListResourceTenantsResponse,
   ListResourceTenantsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceTenantMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceTenantsRequest,
@@ -8104,7 +8103,7 @@ export const listSuppressedDestinations: API.PaginatedOperationMethod<
   ListSuppressedDestinationsRequest,
   ListSuppressedDestinationsResponse,
   ListSuppressedDestinationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSuppressedDestinationsRequest,
@@ -8142,7 +8141,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -8168,7 +8167,7 @@ export const listTenantResources: API.PaginatedOperationMethod<
   ListTenantResourcesRequest,
   ListTenantResourcesResponse,
   ListTenantResourcesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TenantResource
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTenantResourcesRequest,
@@ -8199,7 +8198,7 @@ export const listTenants: API.PaginatedOperationMethod<
   ListTenantsRequest,
   ListTenantsResponse,
   ListTenantsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TenantInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTenantsRequest,
@@ -8227,7 +8226,7 @@ export const putAccountDedicatedIpWarmupAttributes: API.OperationMethod<
   PutAccountDedicatedIpWarmupAttributesRequest,
   PutAccountDedicatedIpWarmupAttributesResponse,
   PutAccountDedicatedIpWarmupAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountDedicatedIpWarmupAttributesRequest,
   output: PutAccountDedicatedIpWarmupAttributesResponse,
@@ -8249,7 +8248,7 @@ export const putAccountDetails: API.OperationMethod<
   PutAccountDetailsRequest,
   PutAccountDetailsResponse,
   PutAccountDetailsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountDetailsRequest,
   output: PutAccountDetailsResponse,
@@ -8270,7 +8269,7 @@ export const putAccountSendingAttributes: API.OperationMethod<
   PutAccountSendingAttributesRequest,
   PutAccountSendingAttributesResponse,
   PutAccountSendingAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSendingAttributesRequest,
   output: PutAccountSendingAttributesResponse,
@@ -8291,7 +8290,7 @@ export const putAccountSuppressionAttributes: API.OperationMethod<
   PutAccountSuppressionAttributesRequest,
   PutAccountSuppressionAttributesResponse,
   PutAccountSuppressionAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountSuppressionAttributesRequest,
   output: PutAccountSuppressionAttributesResponse,
@@ -8314,7 +8313,7 @@ export const putAccountVdmAttributes: API.OperationMethod<
   PutAccountVdmAttributesRequest,
   PutAccountVdmAttributesResponse,
   PutAccountVdmAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountVdmAttributesRequest,
   output: PutAccountVdmAttributesResponse,
@@ -8338,7 +8337,7 @@ export const putConfigurationSetArchivingOptions: API.OperationMethod<
   PutConfigurationSetArchivingOptionsRequest,
   PutConfigurationSetArchivingOptionsResponse,
   PutConfigurationSetArchivingOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetArchivingOptionsRequest,
   output: PutConfigurationSetArchivingOptionsResponse,
@@ -8361,7 +8360,7 @@ export const putConfigurationSetDeliveryOptions: API.OperationMethod<
   PutConfigurationSetDeliveryOptionsRequest,
   PutConfigurationSetDeliveryOptionsResponse,
   PutConfigurationSetDeliveryOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetDeliveryOptionsRequest,
   output: PutConfigurationSetDeliveryOptionsResponse,
@@ -8384,7 +8383,7 @@ export const putConfigurationSetReputationOptions: API.OperationMethod<
   PutConfigurationSetReputationOptionsRequest,
   PutConfigurationSetReputationOptionsResponse,
   PutConfigurationSetReputationOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetReputationOptionsRequest,
   output: PutConfigurationSetReputationOptionsResponse,
@@ -8407,7 +8406,7 @@ export const putConfigurationSetSendingOptions: API.OperationMethod<
   PutConfigurationSetSendingOptionsRequest,
   PutConfigurationSetSendingOptionsResponse,
   PutConfigurationSetSendingOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetSendingOptionsRequest,
   output: PutConfigurationSetSendingOptionsResponse,
@@ -8432,7 +8431,7 @@ export const putConfigurationSetSuppressionOptions: API.OperationMethod<
   PutConfigurationSetSuppressionOptionsRequest,
   PutConfigurationSetSuppressionOptionsResponse,
   PutConfigurationSetSuppressionOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetSuppressionOptionsRequest,
   output: PutConfigurationSetSuppressionOptionsResponse,
@@ -8455,7 +8454,7 @@ export const putConfigurationSetTrackingOptions: API.OperationMethod<
   PutConfigurationSetTrackingOptionsRequest,
   PutConfigurationSetTrackingOptionsResponse,
   PutConfigurationSetTrackingOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetTrackingOptionsRequest,
   output: PutConfigurationSetTrackingOptionsResponse,
@@ -8479,7 +8478,7 @@ export const putConfigurationSetVdmOptions: API.OperationMethod<
   PutConfigurationSetVdmOptionsRequest,
   PutConfigurationSetVdmOptionsResponse,
   PutConfigurationSetVdmOptionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConfigurationSetVdmOptionsRequest,
   output: PutConfigurationSetVdmOptionsResponse,
@@ -8507,7 +8506,7 @@ export const putDedicatedIpInPool: API.OperationMethod<
   PutDedicatedIpInPoolRequest,
   PutDedicatedIpInPoolResponse,
   PutDedicatedIpInPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDedicatedIpInPoolRequest,
   output: PutDedicatedIpInPoolResponse,
@@ -8532,7 +8531,7 @@ export const putDedicatedIpPoolScalingAttributes: API.OperationMethod<
   PutDedicatedIpPoolScalingAttributesRequest,
   PutDedicatedIpPoolScalingAttributesResponse,
   PutDedicatedIpPoolScalingAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDedicatedIpPoolScalingAttributesRequest,
   output: PutDedicatedIpPoolScalingAttributesResponse,
@@ -8559,7 +8558,7 @@ export const putDedicatedIpWarmupAttributes: API.OperationMethod<
   PutDedicatedIpWarmupAttributesRequest,
   PutDedicatedIpWarmupAttributesResponse,
   PutDedicatedIpWarmupAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDedicatedIpWarmupAttributesRequest,
   output: PutDedicatedIpWarmupAttributesResponse,
@@ -8589,7 +8588,7 @@ export const putDeliverabilityDashboardOption: API.OperationMethod<
   PutDeliverabilityDashboardOptionRequest,
   PutDeliverabilityDashboardOptionResponse,
   PutDeliverabilityDashboardOptionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDeliverabilityDashboardOptionRequest,
   output: PutDeliverabilityDashboardOptionResponse,
@@ -8617,7 +8616,7 @@ export const putEmailIdentityConfigurationSetAttributes: API.OperationMethod<
   PutEmailIdentityConfigurationSetAttributesRequest,
   PutEmailIdentityConfigurationSetAttributesResponse,
   PutEmailIdentityConfigurationSetAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityConfigurationSetAttributesRequest,
   output: PutEmailIdentityConfigurationSetAttributesResponse,
@@ -8639,7 +8638,7 @@ export const putEmailIdentityDkimAttributes: API.OperationMethod<
   PutEmailIdentityDkimAttributesRequest,
   PutEmailIdentityDkimAttributesResponse,
   PutEmailIdentityDkimAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityDkimAttributesRequest,
   output: PutEmailIdentityDkimAttributesResponse,
@@ -8675,7 +8674,7 @@ export const putEmailIdentityDkimSigningAttributes: API.OperationMethod<
   PutEmailIdentityDkimSigningAttributesRequest,
   PutEmailIdentityDkimSigningAttributesResponse,
   PutEmailIdentityDkimSigningAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityDkimSigningAttributesRequest,
   output: PutEmailIdentityDkimSigningAttributesResponse,
@@ -8708,7 +8707,7 @@ export const putEmailIdentityFeedbackAttributes: API.OperationMethod<
   PutEmailIdentityFeedbackAttributesRequest,
   PutEmailIdentityFeedbackAttributesResponse,
   PutEmailIdentityFeedbackAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityFeedbackAttributesRequest,
   output: PutEmailIdentityFeedbackAttributesResponse,
@@ -8731,7 +8730,7 @@ export const putEmailIdentityMailFromAttributes: API.OperationMethod<
   PutEmailIdentityMailFromAttributesRequest,
   PutEmailIdentityMailFromAttributesResponse,
   PutEmailIdentityMailFromAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailIdentityMailFromAttributesRequest,
   output: PutEmailIdentityMailFromAttributesResponse,
@@ -8756,7 +8755,7 @@ export const putSuppressedDestination: API.OperationMethod<
   PutSuppressedDestinationRequest,
   PutSuppressedDestinationResponse,
   PutSuppressedDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSuppressedDestinationRequest,
   output: PutSuppressedDestinationResponse,
@@ -8783,7 +8782,7 @@ export const putTenantSuppressionAttributes: API.OperationMethod<
   PutTenantSuppressionAttributesRequest,
   PutTenantSuppressionAttributesResponse,
   PutTenantSuppressionAttributesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTenantSuppressionAttributesRequest,
   output: PutTenantSuppressionAttributesResponse,
@@ -8810,7 +8809,7 @@ export const sendBulkEmail: API.OperationMethod<
   SendBulkEmailRequest,
   SendBulkEmailResponse,
   SendBulkEmailError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendBulkEmailRequest,
   output: SendBulkEmailResponse,
@@ -8855,7 +8854,7 @@ export const sendCustomVerificationEmail: API.OperationMethod<
   SendCustomVerificationEmailRequest,
   SendCustomVerificationEmailResponse,
   SendCustomVerificationEmailError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendCustomVerificationEmailRequest,
   output: SendCustomVerificationEmailResponse,
@@ -8905,7 +8904,7 @@ export const sendEmail: API.OperationMethod<
   SendEmailRequest,
   SendEmailResponse,
   SendEmailError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendEmailRequest,
   output: SendEmailResponse,
@@ -8946,7 +8945,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -8976,7 +8975,7 @@ export const testRenderEmailTemplate: API.OperationMethod<
   TestRenderEmailTemplateRequest,
   TestRenderEmailTemplateResponse,
   TestRenderEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestRenderEmailTemplateRequest,
   output: TestRenderEmailTemplateResponse,
@@ -8999,7 +8998,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -9031,7 +9030,7 @@ export const updateConfigurationSetEventDestination: API.OperationMethod<
   UpdateConfigurationSetEventDestinationRequest,
   UpdateConfigurationSetEventDestinationResponse,
   UpdateConfigurationSetEventDestinationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationSetEventDestinationRequest,
   output: UpdateConfigurationSetEventDestinationResponse,
@@ -9058,7 +9057,7 @@ export const updateContact: API.OperationMethod<
   UpdateContactRequest,
   UpdateContactResponse,
   UpdateContactError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactRequest,
   output: UpdateContactResponse,
@@ -9086,7 +9085,7 @@ export const updateContactList: API.OperationMethod<
   UpdateContactListRequest,
   UpdateContactListResponse,
   UpdateContactListError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactListRequest,
   output: UpdateContactListResponse,
@@ -9119,7 +9118,7 @@ export const updateCustomVerificationEmailTemplate: API.OperationMethod<
   UpdateCustomVerificationEmailTemplateRequest,
   UpdateCustomVerificationEmailTemplateResponse,
   UpdateCustomVerificationEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCustomVerificationEmailTemplateRequest,
   output: UpdateCustomVerificationEmailTemplateResponse,
@@ -9153,7 +9152,7 @@ export const updateEmailIdentityPolicy: API.OperationMethod<
   UpdateEmailIdentityPolicyRequest,
   UpdateEmailIdentityPolicyResponse,
   UpdateEmailIdentityPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmailIdentityPolicyRequest,
   output: UpdateEmailIdentityPolicyResponse,
@@ -9179,7 +9178,7 @@ export const updateEmailTemplate: API.OperationMethod<
   UpdateEmailTemplateRequest,
   UpdateEmailTemplateResponse,
   UpdateEmailTemplateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmailTemplateRequest,
   output: UpdateEmailTemplateResponse,
@@ -9210,7 +9209,7 @@ export const updateReputationEntityCustomerManagedStatus: API.OperationMethod<
   UpdateReputationEntityCustomerManagedStatusRequest,
   UpdateReputationEntityCustomerManagedStatusResponse,
   UpdateReputationEntityCustomerManagedStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReputationEntityCustomerManagedStatusRequest,
   output: UpdateReputationEntityCustomerManagedStatusResponse,
@@ -9237,7 +9236,7 @@ export const updateReputationEntityPolicy: API.OperationMethod<
   UpdateReputationEntityPolicyRequest,
   UpdateReputationEntityPolicyResponse,
   UpdateReputationEntityPolicyError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReputationEntityPolicyRequest,
   output: UpdateReputationEntityPolicyResponse,

--- a/packages/aws/src/services/sfn.ts
+++ b/packages/aws/src/services/sfn.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://swf.amazonaws.com/doc/2015-07-20/");
 const svc = T.AwsApiService({
@@ -2964,7 +2963,7 @@ export const createActivity: API.OperationMethod<
   CreateActivityInput,
   CreateActivityOutput,
   CreateActivityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActivityInput,
   output: CreateActivityOutput,
@@ -3027,7 +3026,7 @@ export const createStateMachine: API.OperationMethod<
   CreateStateMachineInput,
   CreateStateMachineOutput,
   CreateStateMachineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStateMachineInput,
   output: CreateStateMachineOutput,
@@ -3097,7 +3096,7 @@ export const createStateMachineAlias: API.OperationMethod<
   CreateStateMachineAliasInput,
   CreateStateMachineAliasOutput,
   CreateStateMachineAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStateMachineAliasInput,
   output: CreateStateMachineAliasOutput,
@@ -3123,7 +3122,7 @@ export const deleteActivity: API.OperationMethod<
   DeleteActivityInput,
   DeleteActivityOutput,
   DeleteActivityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActivityInput,
   output: DeleteActivityOutput,
@@ -3165,7 +3164,7 @@ export const deleteStateMachine: API.OperationMethod<
   DeleteStateMachineInput,
   DeleteStateMachineOutput,
   DeleteStateMachineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStateMachineInput,
   output: DeleteStateMachineOutput,
@@ -3202,7 +3201,7 @@ export const deleteStateMachineAlias: API.OperationMethod<
   DeleteStateMachineAliasInput,
   DeleteStateMachineAliasOutput,
   DeleteStateMachineAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStateMachineAliasInput,
   output: DeleteStateMachineAliasOutput,
@@ -3241,7 +3240,7 @@ export const deleteStateMachineVersion: API.OperationMethod<
   DeleteStateMachineVersionInput,
   DeleteStateMachineVersionOutput,
   DeleteStateMachineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteStateMachineVersionInput,
   output: DeleteStateMachineVersionOutput,
@@ -3264,7 +3263,7 @@ export const describeActivity: API.OperationMethod<
   DescribeActivityInput,
   DescribeActivityOutput,
   DescribeActivityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActivityInput,
   output: DescribeActivityOutput,
@@ -3295,7 +3294,7 @@ export const describeExecution: API.OperationMethod<
   DescribeExecutionInput,
   DescribeExecutionOutput,
   DescribeExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExecutionInput,
   output: DescribeExecutionOutput,
@@ -3319,7 +3318,7 @@ export const describeMapRun: API.OperationMethod<
   DescribeMapRunInput,
   DescribeMapRunOutput,
   DescribeMapRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMapRunInput,
   output: DescribeMapRunOutput,
@@ -3368,7 +3367,7 @@ export const describeStateMachine: API.OperationMethod<
   DescribeStateMachineInput,
   DescribeStateMachineOutput,
   DescribeStateMachineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStateMachineInput,
   output: DescribeStateMachineOutput,
@@ -3406,7 +3405,7 @@ export const describeStateMachineAlias: API.OperationMethod<
   DescribeStateMachineAliasInput,
   DescribeStateMachineAliasOutput,
   DescribeStateMachineAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStateMachineAliasInput,
   output: DescribeStateMachineAliasOutput,
@@ -3437,7 +3436,7 @@ export const describeStateMachineForExecution: API.OperationMethod<
   DescribeStateMachineForExecutionInput,
   DescribeStateMachineForExecutionOutput,
   DescribeStateMachineForExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStateMachineForExecutionInput,
   output: DescribeStateMachineForExecutionOutput,
@@ -3482,7 +3481,7 @@ export const getActivityTask: API.OperationMethod<
   GetActivityTaskInput,
   GetActivityTaskOutput,
   GetActivityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetActivityTaskInput,
   output: GetActivityTaskOutput,
@@ -3521,7 +3520,7 @@ export const getExecutionHistory: API.PaginatedOperationMethod<
   GetExecutionHistoryInput,
   GetExecutionHistoryOutput,
   GetExecutionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HistoryEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetExecutionHistoryInput,
@@ -3558,7 +3557,7 @@ export const listActivities: API.PaginatedOperationMethod<
   ListActivitiesInput,
   ListActivitiesOutput,
   ListActivitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActivityListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActivitiesInput,
@@ -3602,7 +3601,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsInput,
   ListExecutionsOutput,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExecutionListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsInput,
@@ -3638,7 +3637,7 @@ export const listMapRuns: API.PaginatedOperationMethod<
   ListMapRunsInput,
   ListMapRunsOutput,
   ListMapRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MapRunListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMapRunsInput,
@@ -3684,7 +3683,7 @@ export const listStateMachineAliases: API.OperationMethod<
   ListStateMachineAliasesInput,
   ListStateMachineAliasesOutput,
   ListStateMachineAliasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStateMachineAliasesInput,
   output: ListStateMachineAliasesOutput,
@@ -3713,7 +3712,7 @@ export const listStateMachines: API.PaginatedOperationMethod<
   ListStateMachinesInput,
   ListStateMachinesOutput,
   ListStateMachinesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   StateMachineListItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListStateMachinesInput,
@@ -3753,7 +3752,7 @@ export const listStateMachineVersions: API.OperationMethod<
   ListStateMachineVersionsInput,
   ListStateMachineVersionsOutput,
   ListStateMachineVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListStateMachineVersionsInput,
   output: ListStateMachineVersionsOutput,
@@ -3776,7 +3775,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -3819,7 +3818,7 @@ export const publishStateMachineVersion: API.OperationMethod<
   PublishStateMachineVersionInput,
   PublishStateMachineVersionOutput,
   PublishStateMachineVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishStateMachineVersionInput,
   output: PublishStateMachineVersionOutput,
@@ -3868,7 +3867,7 @@ export const redriveExecution: API.OperationMethod<
   RedriveExecutionInput,
   RedriveExecutionOutput,
   RedriveExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RedriveExecutionInput,
   output: RedriveExecutionOutput,
@@ -3904,7 +3903,7 @@ export const sendTaskFailure: API.OperationMethod<
   SendTaskFailureInput,
   SendTaskFailureOutput,
   SendTaskFailureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTaskFailureInput,
   output: SendTaskFailureOutput,
@@ -3946,7 +3945,7 @@ export const sendTaskHeartbeat: API.OperationMethod<
   SendTaskHeartbeatInput,
   SendTaskHeartbeatOutput,
   SendTaskHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTaskHeartbeatInput,
   output: SendTaskHeartbeatOutput,
@@ -3974,7 +3973,7 @@ export const sendTaskSuccess: API.OperationMethod<
   SendTaskSuccessInput,
   SendTaskSuccessOutput,
   SendTaskSuccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendTaskSuccessInput,
   output: SendTaskSuccessOutput,
@@ -4045,7 +4044,7 @@ export const startExecution: API.OperationMethod<
   StartExecutionInput,
   StartExecutionOutput,
   StartExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExecutionInput,
   output: StartExecutionOutput,
@@ -4094,7 +4093,7 @@ export const startSyncExecution: API.OperationMethod<
   StartSyncExecutionInput,
   StartSyncExecutionOutput,
   StartSyncExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSyncExecutionInput,
   output: StartSyncExecutionOutput,
@@ -4136,7 +4135,7 @@ export const stopExecution: API.OperationMethod<
   StopExecutionInput,
   StopExecutionOutput,
   StopExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopExecutionInput,
   output: StopExecutionOutput,
@@ -4172,7 +4171,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -4222,7 +4221,7 @@ export const testState: API.OperationMethod<
   TestStateInput,
   TestStateOutput,
   TestStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestStateInput,
   output: TestStateOutput,
@@ -4246,7 +4245,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -4268,7 +4267,7 @@ export const updateMapRun: API.OperationMethod<
   UpdateMapRunInput,
   UpdateMapRunOutput,
   UpdateMapRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMapRunInput,
   output: UpdateMapRunOutput,
@@ -4337,7 +4336,7 @@ export const updateStateMachine: API.OperationMethod<
   UpdateStateMachineInput,
   UpdateStateMachineOutput,
   UpdateStateMachineError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStateMachineInput,
   output: UpdateStateMachineOutput,
@@ -4397,7 +4396,7 @@ export const updateStateMachineAlias: API.OperationMethod<
   UpdateStateMachineAliasInput,
   UpdateStateMachineAliasOutput,
   UpdateStateMachineAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateStateMachineAliasInput,
   output: UpdateStateMachineAliasOutput,
@@ -4454,7 +4453,7 @@ export const validateStateMachineDefinition: API.OperationMethod<
   ValidateStateMachineDefinitionInput,
   ValidateStateMachineDefinitionOutput,
   ValidateStateMachineDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateStateMachineDefinitionInput,
   output: ValidateStateMachineDefinitionOutput,

--- a/packages/aws/src/services/shield.ts
+++ b/packages/aws/src/services/shield.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://ddp.amazonaws.com/doc/2016-06-02/");
 const svc = T.AwsApiService({
   sdkId: "Shield",
@@ -1712,7 +1711,7 @@ export const associateDRTLogBucket: API.OperationMethod<
   AssociateDRTLogBucketRequest,
   AssociateDRTLogBucketResponse,
   AssociateDRTLogBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDRTLogBucketRequest,
   output: AssociateDRTLogBucketResponse,
@@ -1757,7 +1756,7 @@ export const associateDRTRole: API.OperationMethod<
   AssociateDRTRoleRequest,
   AssociateDRTRoleResponse,
   AssociateDRTRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDRTRoleRequest,
   output: AssociateDRTRoleResponse,
@@ -1791,7 +1790,7 @@ export const associateHealthCheck: API.OperationMethod<
   AssociateHealthCheckRequest,
   AssociateHealthCheckResponse,
   AssociateHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateHealthCheckRequest,
   output: AssociateHealthCheckResponse,
@@ -1828,7 +1827,7 @@ export const associateProactiveEngagementDetails: API.OperationMethod<
   AssociateProactiveEngagementDetailsRequest,
   AssociateProactiveEngagementDetailsResponse,
   AssociateProactiveEngagementDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateProactiveEngagementDetailsRequest,
   output: AssociateProactiveEngagementDetailsResponse,
@@ -1868,7 +1867,7 @@ export const createProtection: API.OperationMethod<
   CreateProtectionRequest,
   CreateProtectionResponse,
   CreateProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProtectionRequest,
   output: CreateProtectionResponse,
@@ -1904,7 +1903,7 @@ export const createProtectionGroup: API.OperationMethod<
   CreateProtectionGroupRequest,
   CreateProtectionGroupResponse,
   CreateProtectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProtectionGroupRequest,
   output: CreateProtectionGroupResponse,
@@ -1938,7 +1937,7 @@ export const createSubscription: API.OperationMethod<
   CreateSubscriptionRequest,
   CreateSubscriptionResponse,
   CreateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSubscriptionRequest,
   output: CreateSubscriptionResponse,
@@ -1961,7 +1960,7 @@ export const deleteProtection: API.OperationMethod<
   DeleteProtectionRequest,
   DeleteProtectionResponse,
   DeleteProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProtectionRequest,
   output: DeleteProtectionResponse,
@@ -1989,7 +1988,7 @@ export const deleteProtectionGroup: API.OperationMethod<
   DeleteProtectionGroupRequest,
   DeleteProtectionGroupResponse,
   DeleteProtectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProtectionGroupRequest,
   output: DeleteProtectionGroupResponse,
@@ -2017,7 +2016,7 @@ export const deleteSubscription: API.OperationMethod<
   DeleteSubscriptionRequest,
   DeleteSubscriptionResponse,
   DeleteSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSubscriptionRequest,
   output: DeleteSubscriptionResponse,
@@ -2043,7 +2042,7 @@ export const describeAttack: API.OperationMethod<
   DescribeAttackRequest,
   DescribeAttackResponse,
   DescribeAttackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAttackRequest,
   output: DescribeAttackResponse,
@@ -2067,7 +2066,7 @@ export const describeAttackStatistics: API.OperationMethod<
   DescribeAttackStatisticsRequest,
   DescribeAttackStatisticsResponse,
   DescribeAttackStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAttackStatisticsRequest,
   output: DescribeAttackStatisticsResponse,
@@ -2088,7 +2087,7 @@ export const describeDRTAccess: API.OperationMethod<
   DescribeDRTAccessRequest,
   DescribeDRTAccessResponse,
   DescribeDRTAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDRTAccessRequest,
   output: DescribeDRTAccessResponse,
@@ -2109,7 +2108,7 @@ export const describeEmergencyContactSettings: API.OperationMethod<
   DescribeEmergencyContactSettingsRequest,
   DescribeEmergencyContactSettingsResponse,
   DescribeEmergencyContactSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEmergencyContactSettingsRequest,
   output: DescribeEmergencyContactSettingsResponse,
@@ -2132,7 +2131,7 @@ export const describeProtection: API.OperationMethod<
   DescribeProtectionRequest,
   DescribeProtectionResponse,
   DescribeProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProtectionRequest,
   output: DescribeProtectionResponse,
@@ -2159,7 +2158,7 @@ export const describeProtectionGroup: API.OperationMethod<
   DescribeProtectionGroupRequest,
   DescribeProtectionGroupResponse,
   DescribeProtectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProtectionGroupRequest,
   output: DescribeProtectionGroupResponse,
@@ -2185,7 +2184,7 @@ export const describeSubscription: API.OperationMethod<
   DescribeSubscriptionRequest,
   DescribeSubscriptionResponse,
   DescribeSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSubscriptionRequest,
   output: DescribeSubscriptionResponse,
@@ -2214,7 +2213,7 @@ export const disableApplicationLayerAutomaticResponse: API.OperationMethod<
   DisableApplicationLayerAutomaticResponseRequest,
   DisableApplicationLayerAutomaticResponseResponse,
   DisableApplicationLayerAutomaticResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableApplicationLayerAutomaticResponseRequest,
   output: DisableApplicationLayerAutomaticResponseResponse,
@@ -2244,7 +2243,7 @@ export const disableProactiveEngagement: API.OperationMethod<
   DisableProactiveEngagementRequest,
   DisableProactiveEngagementResponse,
   DisableProactiveEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableProactiveEngagementRequest,
   output: DisableProactiveEngagementResponse,
@@ -2275,7 +2274,7 @@ export const disassociateDRTLogBucket: API.OperationMethod<
   DisassociateDRTLogBucketRequest,
   DisassociateDRTLogBucketResponse,
   DisassociateDRTLogBucketError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDRTLogBucketRequest,
   output: DisassociateDRTLogBucketResponse,
@@ -2305,7 +2304,7 @@ export const disassociateDRTRole: API.OperationMethod<
   DisassociateDRTRoleRequest,
   DisassociateDRTRoleResponse,
   DisassociateDRTRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDRTRoleRequest,
   output: DisassociateDRTRoleResponse,
@@ -2336,7 +2335,7 @@ export const disassociateHealthCheck: API.OperationMethod<
   DisassociateHealthCheckRequest,
   DisassociateHealthCheckResponse,
   DisassociateHealthCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateHealthCheckRequest,
   output: DisassociateHealthCheckResponse,
@@ -2381,7 +2380,7 @@ export const enableApplicationLayerAutomaticResponse: API.OperationMethod<
   EnableApplicationLayerAutomaticResponseRequest,
   EnableApplicationLayerAutomaticResponseResponse,
   EnableApplicationLayerAutomaticResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableApplicationLayerAutomaticResponseRequest,
   output: EnableApplicationLayerAutomaticResponseResponse,
@@ -2412,7 +2411,7 @@ export const enableProactiveEngagement: API.OperationMethod<
   EnableProactiveEngagementRequest,
   EnableProactiveEngagementResponse,
   EnableProactiveEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EnableProactiveEngagementRequest,
   output: EnableProactiveEngagementResponse,
@@ -2436,7 +2435,7 @@ export const getSubscriptionState: API.OperationMethod<
   GetSubscriptionStateRequest,
   GetSubscriptionStateResponse,
   GetSubscriptionStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionStateRequest,
   output: GetSubscriptionStateResponse,
@@ -2459,7 +2458,7 @@ export const listAttacks: API.PaginatedOperationMethod<
   ListAttacksRequest,
   ListAttacksResponse,
   ListAttacksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttackSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAttacksRequest,
@@ -2494,7 +2493,7 @@ export const listProtectionGroups: API.PaginatedOperationMethod<
   ListProtectionGroupsRequest,
   ListProtectionGroupsResponse,
   ListProtectionGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectionGroupsRequest,
@@ -2529,7 +2528,7 @@ export const listProtections: API.PaginatedOperationMethod<
   ListProtectionsRequest,
   ListProtectionsResponse,
   ListProtectionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Protection
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProtectionsRequest,
@@ -2563,7 +2562,7 @@ export const listResourcesInProtectionGroup: API.PaginatedOperationMethod<
   ListResourcesInProtectionGroupRequest,
   ListResourcesInProtectionGroupResponse,
   ListResourcesInProtectionGroupError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesInProtectionGroupRequest,
@@ -2596,7 +2595,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2625,7 +2624,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2655,7 +2654,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2685,7 +2684,7 @@ export const updateApplicationLayerAutomaticResponse: API.OperationMethod<
   UpdateApplicationLayerAutomaticResponseRequest,
   UpdateApplicationLayerAutomaticResponseResponse,
   UpdateApplicationLayerAutomaticResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationLayerAutomaticResponseRequest,
   output: UpdateApplicationLayerAutomaticResponseResponse,
@@ -2714,7 +2713,7 @@ export const updateEmergencyContactSettings: API.OperationMethod<
   UpdateEmergencyContactSettingsRequest,
   UpdateEmergencyContactSettingsResponse,
   UpdateEmergencyContactSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEmergencyContactSettingsRequest,
   output: UpdateEmergencyContactSettingsResponse,
@@ -2743,7 +2742,7 @@ export const updateProtectionGroup: API.OperationMethod<
   UpdateProtectionGroupRequest,
   UpdateProtectionGroupResponse,
   UpdateProtectionGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProtectionGroupRequest,
   output: UpdateProtectionGroupResponse,
@@ -2777,7 +2776,7 @@ export const updateSubscription: API.OperationMethod<
   UpdateSubscriptionRequest,
   UpdateSubscriptionResponse,
   UpdateSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSubscriptionRequest,
   output: UpdateSubscriptionResponse,

--- a/packages/aws/src/services/signer-data.ts
+++ b/packages/aws/src/services/signer-data.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Signer Data",
   serviceShapeName: "SignerDataPlane",
@@ -148,7 +147,7 @@ export const getRevocationStatus: API.OperationMethod<
   GetRevocationStatusRequest,
   GetRevocationStatusResponse,
   GetRevocationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevocationStatusRequest,
   output: GetRevocationStatusResponse,

--- a/packages/aws/src/services/signer.ts
+++ b/packages/aws/src/services/signer.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "signer",
   serviceShapeName: "WallabyService",
@@ -1282,7 +1281,7 @@ export const addProfilePermission: API.OperationMethod<
   AddProfilePermissionRequest,
   AddProfilePermissionResponse,
   AddProfilePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddProfilePermissionRequest,
   output: AddProfilePermissionResponse,
@@ -1315,7 +1314,7 @@ export const cancelSigningProfile: API.OperationMethod<
   CancelSigningProfileRequest,
   CancelSigningProfileResponse,
   CancelSigningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSigningProfileRequest,
   output: CancelSigningProfileResponse,
@@ -1345,7 +1344,7 @@ export const describeSigningJob: API.OperationMethod<
   DescribeSigningJobRequest,
   DescribeSigningJobResponse,
   DescribeSigningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSigningJobRequest,
   output: DescribeSigningJobResponse,
@@ -1374,7 +1373,7 @@ export const getRevocationStatus: API.OperationMethod<
   GetRevocationStatusRequest,
   GetRevocationStatusResponse,
   GetRevocationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevocationStatusRequest,
   output: GetRevocationStatusResponse,
@@ -1403,7 +1402,7 @@ export const getSigningPlatform: API.OperationMethod<
   GetSigningPlatformRequest,
   GetSigningPlatformResponse,
   GetSigningPlatformError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSigningPlatformRequest,
   output: GetSigningPlatformResponse,
@@ -1431,7 +1430,7 @@ export const getSigningProfile: API.OperationMethod<
   GetSigningProfileRequest,
   GetSigningProfileResponse,
   GetSigningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSigningProfileRequest,
   output: GetSigningProfileResponse,
@@ -1460,7 +1459,7 @@ export const listProfilePermissions: API.OperationMethod<
   ListProfilePermissionsRequest,
   ListProfilePermissionsResponse,
   ListProfilePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListProfilePermissionsRequest,
   output: ListProfilePermissionsResponse,
@@ -1495,7 +1494,7 @@ export const listSigningJobs: API.PaginatedOperationMethod<
   ListSigningJobsRequest,
   ListSigningJobsResponse,
   ListSigningJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSigningJobsRequest,
@@ -1535,7 +1534,7 @@ export const listSigningPlatforms: API.PaginatedOperationMethod<
   ListSigningPlatformsRequest,
   ListSigningPlatformsResponse,
   ListSigningPlatformsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSigningPlatformsRequest,
@@ -1575,7 +1574,7 @@ export const listSigningProfiles: API.PaginatedOperationMethod<
   ListSigningProfilesRequest,
   ListSigningProfilesResponse,
   ListSigningProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSigningProfilesRequest,
@@ -1608,7 +1607,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1639,7 +1638,7 @@ export const putSigningProfile: API.OperationMethod<
   PutSigningProfileRequest,
   PutSigningProfileResponse,
   PutSigningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSigningProfileRequest,
   output: PutSigningProfileResponse,
@@ -1671,7 +1670,7 @@ export const removeProfilePermission: API.OperationMethod<
   RemoveProfilePermissionRequest,
   RemoveProfilePermissionResponse,
   RemoveProfilePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveProfilePermissionRequest,
   output: RemoveProfilePermissionResponse,
@@ -1703,7 +1702,7 @@ export const revokeSignature: API.OperationMethod<
   RevokeSignatureRequest,
   RevokeSignatureResponse,
   RevokeSignatureError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSignatureRequest,
   output: RevokeSignatureResponse,
@@ -1737,7 +1736,7 @@ export const revokeSigningProfile: API.OperationMethod<
   RevokeSigningProfileRequest,
   RevokeSigningProfileResponse,
   RevokeSigningProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeSigningProfileRequest,
   output: RevokeSigningProfileResponse,
@@ -1767,7 +1766,7 @@ export const signPayload: API.OperationMethod<
   SignPayloadRequest,
   SignPayloadResponse,
   SignPayloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignPayloadRequest,
   output: SignPayloadResponse,
@@ -1819,7 +1818,7 @@ export const startSigningJob: API.OperationMethod<
   StartSigningJobRequest,
   StartSigningJobResponse,
   StartSigningJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSigningJobRequest,
   output: StartSigningJobResponse,
@@ -1852,7 +1851,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1881,7 +1880,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/signin.ts
+++ b/packages/aws/src/services/signin.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Signin", serviceShapeName: "Signin" });
 const auth = T.AwsAuthSigv4({ name: "signin" });
@@ -848,7 +847,7 @@ export const createOAuth2Token: API.OperationMethod<
   CreateOAuth2TokenRequest,
   CreateOAuth2TokenResponse,
   CreateOAuth2TokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOAuth2TokenRequest,
   output: CreateOAuth2TokenResponse,
@@ -877,7 +876,7 @@ export const deleteConsoleAuthorizationConfiguration: API.OperationMethod<
   DeleteConsoleAuthorizationConfigurationInput,
   DeleteConsoleAuthorizationConfigurationOutput,
   DeleteConsoleAuthorizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConsoleAuthorizationConfigurationInput,
   output: DeleteConsoleAuthorizationConfigurationOutput,
@@ -907,7 +906,7 @@ export const deleteResourcePermissionStatement: API.OperationMethod<
   DeleteResourcePermissionStatementInput,
   DeleteResourcePermissionStatementOutput,
   DeleteResourcePermissionStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePermissionStatementInput,
   output: DeleteResourcePermissionStatementOutput,
@@ -937,7 +936,7 @@ export const getConsoleAuthorizationConfiguration: API.OperationMethod<
   GetConsoleAuthorizationConfigurationInput,
   GetConsoleAuthorizationConfigurationOutput,
   GetConsoleAuthorizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConsoleAuthorizationConfigurationInput,
   output: GetConsoleAuthorizationConfigurationOutput,
@@ -966,7 +965,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyInput,
   GetResourcePolicyOutput,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyInput,
   output: GetResourcePolicyOutput,
@@ -995,7 +994,7 @@ export const listResourcePermissionStatements: API.PaginatedOperationMethod<
   ListResourcePermissionStatementsInput,
   ListResourcePermissionStatementsOutput,
   ListResourcePermissionStatementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PermissionStatementSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcePermissionStatementsInput,
@@ -1033,7 +1032,7 @@ export const putConsoleAuthorizationConfiguration: API.OperationMethod<
   PutConsoleAuthorizationConfigurationInput,
   PutConsoleAuthorizationConfigurationOutput,
   PutConsoleAuthorizationConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutConsoleAuthorizationConfigurationInput,
   output: PutConsoleAuthorizationConfigurationOutput,
@@ -1065,7 +1064,7 @@ export const putResourcePermissionStatement: API.OperationMethod<
   PutResourcePermissionStatementInput,
   PutResourcePermissionStatementOutput,
   PutResourcePermissionStatementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePermissionStatementInput,
   output: PutResourcePermissionStatementOutput,

--- a/packages/aws/src/services/simpledb.ts
+++ b/packages/aws/src/services/simpledb.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://sdb.amazonaws.com/doc/2009-04-15/");
 const svc = T.AwsApiService({
   sdkId: "SimpleDB",
@@ -635,7 +634,7 @@ export const batchDeleteAttributes: API.OperationMethod<
   BatchDeleteAttributesRequest,
   BatchDeleteAttributesResponse,
   BatchDeleteAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteAttributesRequest,
   output: BatchDeleteAttributesResponse,
@@ -663,7 +662,7 @@ export const batchPutAttributes: API.OperationMethod<
   BatchPutAttributesRequest,
   BatchPutAttributesResponse,
   BatchPutAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutAttributesRequest,
   output: BatchPutAttributesResponse,
@@ -695,7 +694,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -718,7 +717,7 @@ export const deleteAttributes: API.OperationMethod<
   DeleteAttributesRequest,
   DeleteAttributesResponse,
   DeleteAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAttributesRequest,
   output: DeleteAttributesResponse,
@@ -741,7 +740,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -762,7 +761,7 @@ export const domainMetadata: API.OperationMethod<
   DomainMetadataRequest,
   DomainMetadataResponse,
   DomainMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DomainMetadataRequest,
   output: DomainMetadataResponse,
@@ -784,7 +783,7 @@ export const getAttributes: API.OperationMethod<
   GetAttributesRequest,
   GetAttributesResponse,
   GetAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAttributesRequest,
   output: GetAttributesResponse,
@@ -805,7 +804,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -838,7 +837,7 @@ export const putAttributes: API.OperationMethod<
   PutAttributesRequest,
   PutAttributesResponse,
   PutAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAttributesRequest,
   output: PutAttributesResponse,
@@ -874,7 +873,7 @@ export const select: API.PaginatedOperationMethod<
   SelectRequest,
   SelectResponse,
   SelectError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Item
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SelectRequest,

--- a/packages/aws/src/services/simpledbv2.ts
+++ b/packages/aws/src/services/simpledbv2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SimpleDBv2",
   serviceShapeName: "SimpleDBv2",
@@ -323,7 +322,7 @@ export const getExport: API.OperationMethod<
   GetExportRequest,
   GetExportResponse,
   GetExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExportRequest,
   output: GetExportResponse,
@@ -345,7 +344,7 @@ export const listExports: API.PaginatedOperationMethod<
   ListExportsRequest,
   ListExportsResponse,
   ListExportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExportSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExportsRequest,
@@ -380,7 +379,7 @@ export const startDomainExport: API.OperationMethod<
   StartDomainExportRequest,
   StartDomainExportResponse,
   StartDomainExportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDomainExportRequest,
   output: StartDomainExportResponse,

--- a/packages/aws/src/services/simspaceweaver.ts
+++ b/packages/aws/src/services/simspaceweaver.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SimSpaceWeaver",
@@ -856,7 +855,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotInput,
   CreateSnapshotOutput,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotInput,
   output: CreateSnapshotOutput,
@@ -886,7 +885,7 @@ export const deleteApp: API.OperationMethod<
   DeleteAppInput,
   DeleteAppOutput,
   DeleteAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAppInput,
   output: DeleteAppOutput,
@@ -919,7 +918,7 @@ export const deleteSimulation: API.OperationMethod<
   DeleteSimulationInput,
   DeleteSimulationOutput,
   DeleteSimulationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSimulationInput,
   output: DeleteSimulationOutput,
@@ -948,7 +947,7 @@ export const describeApp: API.OperationMethod<
   DescribeAppInput,
   DescribeAppOutput,
   DescribeAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAppInput,
   output: DescribeAppOutput,
@@ -976,7 +975,7 @@ export const describeSimulation: API.OperationMethod<
   DescribeSimulationInput,
   DescribeSimulationOutput,
   DescribeSimulationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSimulationInput,
   output: DescribeSimulationOutput,
@@ -1004,7 +1003,7 @@ export const listApps: API.PaginatedOperationMethod<
   ListAppsInput,
   ListAppsOutput,
   ListAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAppsInput,
@@ -1037,7 +1036,7 @@ export const listSimulations: API.PaginatedOperationMethod<
   ListSimulationsInput,
   ListSimulationsOutput,
   ListSimulationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSimulationsInput,
@@ -1064,7 +1063,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1088,7 +1087,7 @@ export const startApp: API.OperationMethod<
   StartAppInput,
   StartAppOutput,
   StartAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAppInput,
   output: StartAppOutput,
@@ -1118,7 +1117,7 @@ export const startClock: API.OperationMethod<
   StartClockInput,
   StartClockOutput,
   StartClockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartClockInput,
   output: StartClockOutput,
@@ -1153,7 +1152,7 @@ export const startSimulation: API.OperationMethod<
   StartSimulationInput,
   StartSimulationOutput,
   StartSimulationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSimulationInput,
   output: StartSimulationOutput,
@@ -1183,7 +1182,7 @@ export const stopApp: API.OperationMethod<
   StopAppInput,
   StopAppOutput,
   StopAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAppInput,
   output: StopAppOutput,
@@ -1213,7 +1212,7 @@ export const stopClock: API.OperationMethod<
   StopClockInput,
   StopClockOutput,
   StopClockError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopClockInput,
   output: StopClockOutput,
@@ -1246,7 +1245,7 @@ export const stopSimulation: API.OperationMethod<
   StopSimulationInput,
   StopSimulationOutput,
   StopSimulationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopSimulationInput,
   output: StopSimulationOutput,
@@ -1275,7 +1274,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -1301,7 +1300,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,

--- a/packages/aws/src/services/snow-device-management.ts
+++ b/packages/aws/src/services/snow-device-management.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Snow Device Management",
   serviceShapeName: "SnowDeviceManagement",
@@ -869,7 +868,7 @@ export const cancelTask: API.OperationMethod<
   CancelTaskInput,
   CancelTaskOutput,
   CancelTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTaskInput,
   output: CancelTaskOutput,
@@ -900,7 +899,7 @@ export const createTask: API.OperationMethod<
   CreateTaskInput,
   CreateTaskOutput,
   CreateTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTaskInput,
   output: CreateTaskOutput,
@@ -932,7 +931,7 @@ export const describeDevice: API.OperationMethod<
   DescribeDeviceInput,
   DescribeDeviceOutput,
   DescribeDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceInput,
   output: DescribeDeviceOutput,
@@ -964,7 +963,7 @@ export const describeDeviceEc2Instances: API.OperationMethod<
   DescribeDeviceEc2Input,
   DescribeDeviceEc2Output,
   DescribeDeviceEc2InstancesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDeviceEc2Input,
   output: DescribeDeviceEc2Output,
@@ -994,7 +993,7 @@ export const describeExecution: API.OperationMethod<
   DescribeExecutionInput,
   DescribeExecutionOutput,
   DescribeExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExecutionInput,
   output: DescribeExecutionOutput,
@@ -1024,7 +1023,7 @@ export const describeTask: API.OperationMethod<
   DescribeTaskInput,
   DescribeTaskOutput,
   DescribeTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTaskInput,
   output: DescribeTaskOutput,
@@ -1054,7 +1053,7 @@ export const listDeviceResources: API.PaginatedOperationMethod<
   ListDeviceResourcesInput,
   ListDeviceResourcesOutput,
   ListDeviceResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeviceResourcesInput,
@@ -1091,7 +1090,7 @@ export const listDevices: API.PaginatedOperationMethod<
   ListDevicesInput,
   ListDevicesOutput,
   ListDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesInput,
@@ -1127,7 +1126,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsInput,
   ListExecutionsOutput,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ExecutionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsInput,
@@ -1162,7 +1161,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -1189,7 +1188,7 @@ export const listTasks: API.PaginatedOperationMethod<
   ListTasksInput,
   ListTasksOutput,
   ListTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TaskSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTasksInput,
@@ -1223,7 +1222,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -1249,7 +1248,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/snowball.ts
+++ b/packages/aws/src/services/snowball.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Snowball",
@@ -1520,7 +1519,7 @@ export const cancelCluster: API.OperationMethod<
   CancelClusterRequest,
   CancelClusterResult,
   CancelClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelClusterRequest,
   output: CancelClusterResult,
@@ -1549,7 +1548,7 @@ export const cancelJob: API.OperationMethod<
   CancelJobRequest,
   CancelJobResult,
   CancelJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelJobRequest,
   output: CancelJobResult,
@@ -1577,7 +1576,7 @@ export const createAddress: API.OperationMethod<
   CreateAddressRequest,
   CreateAddressResult,
   CreateAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAddressRequest,
   output: CreateAddressResult,
@@ -1601,7 +1600,7 @@ export const createCluster: API.OperationMethod<
   CreateClusterRequest,
   CreateClusterResult,
   CreateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateClusterRequest,
   output: CreateClusterResult,
@@ -1709,7 +1708,7 @@ export const createJob: API.OperationMethod<
   CreateJobRequest,
   CreateJobResult,
   CreateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateJobRequest,
   output: CreateJobResult,
@@ -1736,7 +1735,7 @@ export const createLongTermPricing: API.OperationMethod<
   CreateLongTermPricingRequest,
   CreateLongTermPricingResult,
   CreateLongTermPricingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLongTermPricingRequest,
   output: CreateLongTermPricingResult,
@@ -1760,7 +1759,7 @@ export const createReturnShippingLabel: API.OperationMethod<
   CreateReturnShippingLabelRequest,
   CreateReturnShippingLabelResult,
   CreateReturnShippingLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReturnShippingLabelRequest,
   output: CreateReturnShippingLabelResult,
@@ -1785,7 +1784,7 @@ export const describeAddress: API.OperationMethod<
   DescribeAddressRequest,
   DescribeAddressResult,
   DescribeAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAddressRequest,
   output: DescribeAddressResult,
@@ -1808,7 +1807,7 @@ export const describeAddresses: API.PaginatedOperationMethod<
   DescribeAddressesRequest,
   DescribeAddressesResult,
   DescribeAddressesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Address
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAddressesRequest,
@@ -1834,7 +1833,7 @@ export const describeCluster: API.OperationMethod<
   DescribeClusterRequest,
   DescribeClusterResult,
   DescribeClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClusterRequest,
   output: DescribeClusterResult,
@@ -1853,7 +1852,7 @@ export const describeJob: API.OperationMethod<
   DescribeJobRequest,
   DescribeJobResult,
   DescribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeJobRequest,
   output: DescribeJobResult,
@@ -1875,7 +1874,7 @@ export const describeReturnShippingLabel: API.OperationMethod<
   DescribeReturnShippingLabelRequest,
   DescribeReturnShippingLabelResult,
   DescribeReturnShippingLabelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeReturnShippingLabelRequest,
   output: DescribeReturnShippingLabelResult,
@@ -1918,7 +1917,7 @@ export const getJobManifest: API.OperationMethod<
   GetJobManifestRequest,
   GetJobManifestResult,
   GetJobManifestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobManifestRequest,
   output: GetJobManifestResult,
@@ -1953,7 +1952,7 @@ export const getJobUnlockCode: API.OperationMethod<
   GetJobUnlockCodeRequest,
   GetJobUnlockCodeResult,
   GetJobUnlockCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetJobUnlockCodeRequest,
   output: GetJobUnlockCodeResult,
@@ -1975,7 +1974,7 @@ export const getSnowballUsage: API.OperationMethod<
   GetSnowballUsageRequest,
   GetSnowballUsageResult,
   GetSnowballUsageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSnowballUsageRequest,
   output: GetSnowballUsageResult,
@@ -1997,7 +1996,7 @@ export const getSoftwareUpdates: API.OperationMethod<
   GetSoftwareUpdatesRequest,
   GetSoftwareUpdatesResult,
   GetSoftwareUpdatesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSoftwareUpdatesRequest,
   output: GetSoftwareUpdatesResult,
@@ -2020,7 +2019,7 @@ export const listClusterJobs: API.PaginatedOperationMethod<
   ListClusterJobsRequest,
   ListClusterJobsResult,
   ListClusterJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClusterJobsRequest,
@@ -2047,7 +2046,7 @@ export const listClusters: API.PaginatedOperationMethod<
   ListClustersRequest,
   ListClustersResult,
   ListClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ClusterListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClustersRequest,
@@ -2078,7 +2077,7 @@ export const listCompatibleImages: API.PaginatedOperationMethod<
   ListCompatibleImagesRequest,
   ListCompatibleImagesResult,
   ListCompatibleImagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CompatibleImage
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCompatibleImagesRequest,
@@ -2107,7 +2106,7 @@ export const listJobs: API.PaginatedOperationMethod<
   ListJobsRequest,
   ListJobsResult,
   ListJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   JobListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListJobsRequest,
@@ -2135,7 +2134,7 @@ export const listLongTermPricing: API.PaginatedOperationMethod<
   ListLongTermPricingRequest,
   ListLongTermPricingResult,
   ListLongTermPricingError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LongTermPricingListEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLongTermPricingRequest,
@@ -2160,7 +2159,7 @@ export const listPickupLocations: API.PaginatedOperationMethod<
   ListPickupLocationsRequest,
   ListPickupLocationsResult,
   ListPickupLocationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPickupLocationsRequest,
@@ -2188,7 +2187,7 @@ export const listServiceVersions: API.OperationMethod<
   ListServiceVersionsRequest,
   ListServiceVersionsResult,
   ListServiceVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListServiceVersionsRequest,
   output: ListServiceVersionsResult,
@@ -2215,7 +2214,7 @@ export const updateCluster: API.OperationMethod<
   UpdateClusterRequest,
   UpdateClusterResult,
   UpdateClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateClusterRequest,
   output: UpdateClusterResult,
@@ -2248,7 +2247,7 @@ export const updateJob: API.OperationMethod<
   UpdateJobRequest,
   UpdateJobResult,
   UpdateJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobRequest,
   output: UpdateJobResult,
@@ -2276,7 +2275,7 @@ export const updateJobShipmentState: API.OperationMethod<
   UpdateJobShipmentStateRequest,
   UpdateJobShipmentStateResult,
   UpdateJobShipmentStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateJobShipmentStateRequest,
   output: UpdateJobShipmentStateResult,
@@ -2296,7 +2295,7 @@ export const updateLongTermPricing: API.OperationMethod<
   UpdateLongTermPricingRequest,
   UpdateLongTermPricingResult,
   UpdateLongTermPricingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLongTermPricingRequest,
   output: UpdateLongTermPricingResult,

--- a/packages/aws/src/services/sns.ts
+++ b/packages/aws/src/services/sns.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://sns.amazonaws.com/doc/2010-03-31/");
 const svc = T.AwsApiService({
@@ -1920,7 +1919,7 @@ export const addPermission: API.OperationMethod<
   AddPermissionInput,
   AddPermissionResponse,
   AddPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddPermissionInput,
   output: AddPermissionResponse,
@@ -1955,7 +1954,7 @@ export const checkIfPhoneNumberIsOptedOut: API.OperationMethod<
   CheckIfPhoneNumberIsOptedOutInput,
   CheckIfPhoneNumberIsOptedOutResponse,
   CheckIfPhoneNumberIsOptedOutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckIfPhoneNumberIsOptedOutInput,
   output: CheckIfPhoneNumberIsOptedOutResponse,
@@ -1990,7 +1989,7 @@ export const confirmSubscription: API.OperationMethod<
   ConfirmSubscriptionInput,
   ConfirmSubscriptionResponse,
   ConfirmSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ConfirmSubscriptionInput,
   output: ConfirmSubscriptionResponse,
@@ -2057,7 +2056,7 @@ export const createPlatformApplication: API.OperationMethod<
   CreatePlatformApplicationInput,
   CreatePlatformApplicationResponse,
   CreatePlatformApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlatformApplicationInput,
   output: CreatePlatformApplicationResponse,
@@ -2100,7 +2099,7 @@ export const createPlatformEndpoint: API.OperationMethod<
   CreatePlatformEndpointInput,
   CreateEndpointResponse,
   CreatePlatformEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePlatformEndpointInput,
   output: CreateEndpointResponse,
@@ -2142,7 +2141,7 @@ export const createSMSSandboxPhoneNumber: API.OperationMethod<
   CreateSMSSandboxPhoneNumberInput,
   CreateSMSSandboxPhoneNumberResult,
   CreateSMSSandboxPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSMSSandboxPhoneNumberInput,
   output: CreateSMSSandboxPhoneNumberResult,
@@ -2181,7 +2180,7 @@ export const createTopic: API.OperationMethod<
   CreateTopicInput,
   CreateTopicResponse,
   CreateTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTopicInput,
   output: CreateTopicResponse,
@@ -2220,7 +2219,7 @@ export const deleteEndpoint: API.OperationMethod<
   DeleteEndpointInput,
   DeleteEndpointResponse,
   DeleteEndpointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEndpointInput,
   output: DeleteEndpointResponse,
@@ -2253,7 +2252,7 @@ export const deletePlatformApplication: API.OperationMethod<
   DeletePlatformApplicationInput,
   DeletePlatformApplicationResponse,
   DeletePlatformApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePlatformApplicationInput,
   output: DeletePlatformApplicationResponse,
@@ -2294,7 +2293,7 @@ export const deleteSMSSandboxPhoneNumber: API.OperationMethod<
   DeleteSMSSandboxPhoneNumberInput,
   DeleteSMSSandboxPhoneNumberResult,
   DeleteSMSSandboxPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSMSSandboxPhoneNumberInput,
   output: DeleteSMSSandboxPhoneNumberResult,
@@ -2333,7 +2332,7 @@ export const deleteTopic: API.OperationMethod<
   DeleteTopicInput,
   DeleteTopicResponse,
   DeleteTopicError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTopicInput,
   output: DeleteTopicResponse,
@@ -2371,7 +2370,7 @@ export const getDataProtectionPolicy: API.OperationMethod<
   GetDataProtectionPolicyInput,
   GetDataProtectionPolicyResponse,
   GetDataProtectionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataProtectionPolicyInput,
   output: GetDataProtectionPolicyResponse,
@@ -2406,7 +2405,7 @@ export const getEndpointAttributes: API.OperationMethod<
   GetEndpointAttributesInput,
   GetEndpointAttributesResponse,
   GetEndpointAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEndpointAttributesInput,
   output: GetEndpointAttributesResponse,
@@ -2440,7 +2439,7 @@ export const getPlatformApplicationAttributes: API.OperationMethod<
   GetPlatformApplicationAttributesInput,
   GetPlatformApplicationAttributesResponse,
   GetPlatformApplicationAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPlatformApplicationAttributesInput,
   output: GetPlatformApplicationAttributesResponse,
@@ -2472,7 +2471,7 @@ export const getSMSAttributes: API.OperationMethod<
   GetSMSAttributesInput,
   GetSMSAttributesResponse,
   GetSMSAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSMSAttributesInput,
   output: GetSMSAttributesResponse,
@@ -2509,7 +2508,7 @@ export const getSMSSandboxAccountStatus: API.OperationMethod<
   GetSMSSandboxAccountStatusInput,
   GetSMSSandboxAccountStatusResult,
   GetSMSSandboxAccountStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSMSSandboxAccountStatusInput,
   output: GetSMSSandboxAccountStatusResult,
@@ -2536,7 +2535,7 @@ export const getSubscriptionAttributes: API.OperationMethod<
   GetSubscriptionAttributesInput,
   GetSubscriptionAttributesResponse,
   GetSubscriptionAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSubscriptionAttributesInput,
   output: GetSubscriptionAttributesResponse,
@@ -2568,7 +2567,7 @@ export const getTopicAttributes: API.OperationMethod<
   GetTopicAttributesInput,
   GetTopicAttributesResponse,
   GetTopicAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTopicAttributesInput,
   output: GetTopicAttributesResponse,
@@ -2611,7 +2610,7 @@ export const listEndpointsByPlatformApplication: API.PaginatedOperationMethod<
   ListEndpointsByPlatformApplicationInput,
   ListEndpointsByPlatformApplicationResponse,
   ListEndpointsByPlatformApplicationError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Endpoint
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEndpointsByPlatformApplicationInput,
@@ -2650,7 +2649,7 @@ export const listOriginationNumbers: API.PaginatedOperationMethod<
   ListOriginationNumbersRequest,
   ListOriginationNumbersResult,
   ListOriginationNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PhoneNumberInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOriginationNumbersRequest,
@@ -2694,7 +2693,7 @@ export const listPhoneNumbersOptedOut: API.PaginatedOperationMethod<
   ListPhoneNumbersOptedOutInput,
   ListPhoneNumbersOptedOutResponse,
   ListPhoneNumbersOptedOutError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PhoneNumber
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPhoneNumbersOptedOutInput,
@@ -2737,7 +2736,7 @@ export const listPlatformApplications: API.PaginatedOperationMethod<
   ListPlatformApplicationsInput,
   ListPlatformApplicationsResponse,
   ListPlatformApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PlatformApplication
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPlatformApplicationsInput,
@@ -2781,7 +2780,7 @@ export const listSMSSandboxPhoneNumbers: API.PaginatedOperationMethod<
   ListSMSSandboxPhoneNumbersInput,
   ListSMSSandboxPhoneNumbersResult,
   ListSMSSandboxPhoneNumbersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SMSSandboxPhoneNumber
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSMSSandboxPhoneNumbersInput,
@@ -2821,7 +2820,7 @@ export const listSubscriptions: API.PaginatedOperationMethod<
   ListSubscriptionsInput,
   ListSubscriptionsResponse,
   ListSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsInput,
@@ -2861,7 +2860,7 @@ export const listSubscriptionsByTopic: API.PaginatedOperationMethod<
   ListSubscriptionsByTopicInput,
   ListSubscriptionsByTopicResponse,
   ListSubscriptionsByTopicError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubscriptionsByTopicInput,
@@ -2901,7 +2900,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2936,7 +2935,7 @@ export const listTopics: API.PaginatedOperationMethod<
   ListTopicsInput,
   ListTopicsResponse,
   ListTopicsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Topic
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTopicsInput,
@@ -2972,7 +2971,7 @@ export const optInPhoneNumber: API.OperationMethod<
   OptInPhoneNumberInput,
   OptInPhoneNumberResponse,
   OptInPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OptInPhoneNumberInput,
   output: OptInPhoneNumberResponse,
@@ -3033,7 +3032,7 @@ export const publish: API.OperationMethod<
   PublishInput,
   PublishResponse,
   PublishError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishInput,
   output: PublishResponse,
@@ -3127,7 +3126,7 @@ export const publishBatch: API.OperationMethod<
   PublishBatchInput,
   PublishBatchResponse,
   PublishBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishBatchInput,
   output: PublishBatchResponse,
@@ -3175,7 +3174,7 @@ export const putDataProtectionPolicy: API.OperationMethod<
   PutDataProtectionPolicyInput,
   PutDataProtectionPolicyResponse,
   PutDataProtectionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutDataProtectionPolicyInput,
   output: PutDataProtectionPolicyResponse,
@@ -3212,7 +3211,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionInput,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionInput,
   output: RemovePermissionResponse,
@@ -3246,7 +3245,7 @@ export const setEndpointAttributes: API.OperationMethod<
   SetEndpointAttributesInput,
   SetEndpointAttributesResponse,
   SetEndpointAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetEndpointAttributesInput,
   output: SetEndpointAttributesResponse,
@@ -3282,7 +3281,7 @@ export const setPlatformApplicationAttributes: API.OperationMethod<
   SetPlatformApplicationAttributesInput,
   SetPlatformApplicationAttributesResponse,
   SetPlatformApplicationAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetPlatformApplicationAttributesInput,
   output: SetPlatformApplicationAttributesResponse,
@@ -3322,7 +3321,7 @@ export const setSMSAttributes: API.OperationMethod<
   SetSMSAttributesInput,
   SetSMSAttributesResponse,
   SetSMSAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSMSAttributesInput,
   output: SetSMSAttributesResponse,
@@ -3353,7 +3352,7 @@ export const setSubscriptionAttributes: API.OperationMethod<
   SetSubscriptionAttributesInput,
   SetSubscriptionAttributesResponse,
   SetSubscriptionAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSubscriptionAttributesInput,
   output: SetSubscriptionAttributesResponse,
@@ -3390,7 +3389,7 @@ export const setTopicAttributes: API.OperationMethod<
   SetTopicAttributesInput,
   SetTopicAttributesResponse,
   SetTopicAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetTopicAttributesInput,
   output: SetTopicAttributesResponse,
@@ -3434,7 +3433,7 @@ export const subscribe: API.OperationMethod<
   SubscribeInput,
   SubscribeResponse,
   SubscribeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SubscribeInput,
   output: SubscribeResponse,
@@ -3489,7 +3488,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3530,7 +3529,7 @@ export const unsubscribe: API.OperationMethod<
   UnsubscribeInput,
   UnsubscribeResponse,
   UnsubscribeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnsubscribeInput,
   output: UnsubscribeResponse,
@@ -3565,7 +3564,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3610,7 +3609,7 @@ export const verifySMSSandboxPhoneNumber: API.OperationMethod<
   VerifySMSSandboxPhoneNumberInput,
   VerifySMSSandboxPhoneNumberResult,
   VerifySMSSandboxPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: VerifySMSSandboxPhoneNumberInput,
   output: VerifySMSSandboxPhoneNumberResult,

--- a/packages/aws/src/services/socialmessaging.ts
+++ b/packages/aws/src/services/socialmessaging.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SocialMessaging",
@@ -1732,7 +1731,7 @@ export const associateWhatsAppBusinessAccount: API.OperationMethod<
   AssociateWhatsAppBusinessAccountInput,
   AssociateWhatsAppBusinessAccountOutput,
   AssociateWhatsAppBusinessAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWhatsAppBusinessAccountInput,
   output: AssociateWhatsAppBusinessAccountOutput,
@@ -1764,7 +1763,7 @@ export const createWhatsAppFlow: API.OperationMethod<
   CreateWhatsAppFlowInput,
   CreateWhatsAppFlowOutput,
   CreateWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatsAppFlowInput,
   output: CreateWhatsAppFlowOutput,
@@ -1798,7 +1797,7 @@ export const createWhatsAppMessageTemplate: API.OperationMethod<
   CreateWhatsAppMessageTemplateInput,
   CreateWhatsAppMessageTemplateOutput,
   CreateWhatsAppMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatsAppMessageTemplateInput,
   output: CreateWhatsAppMessageTemplateOutput,
@@ -1830,7 +1829,7 @@ export const createWhatsAppMessageTemplateFromLibrary: API.OperationMethod<
   CreateWhatsAppMessageTemplateFromLibraryInput,
   CreateWhatsAppMessageTemplateFromLibraryOutput,
   CreateWhatsAppMessageTemplateFromLibraryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatsAppMessageTemplateFromLibraryInput,
   output: CreateWhatsAppMessageTemplateFromLibraryOutput,
@@ -1862,7 +1861,7 @@ export const createWhatsAppMessageTemplateMedia: API.OperationMethod<
   CreateWhatsAppMessageTemplateMediaInput,
   CreateWhatsAppMessageTemplateMediaOutput,
   CreateWhatsAppMessageTemplateMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWhatsAppMessageTemplateMediaInput,
   output: CreateWhatsAppMessageTemplateMediaOutput,
@@ -1894,7 +1893,7 @@ export const deleteWhatsAppFlow: API.OperationMethod<
   DeleteWhatsAppFlowInput,
   DeleteWhatsAppFlowOutput,
   DeleteWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatsAppFlowInput,
   output: DeleteWhatsAppFlowOutput,
@@ -1926,7 +1925,7 @@ export const deleteWhatsAppMessageMedia: API.OperationMethod<
   DeleteWhatsAppMessageMediaInput,
   DeleteWhatsAppMessageMediaOutput,
   DeleteWhatsAppMessageMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatsAppMessageMediaInput,
   output: DeleteWhatsAppMessageMediaOutput,
@@ -1958,7 +1957,7 @@ export const deleteWhatsAppMessageTemplate: API.OperationMethod<
   DeleteWhatsAppMessageTemplateInput,
   DeleteWhatsAppMessageTemplateOutput,
   DeleteWhatsAppMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWhatsAppMessageTemplateInput,
   output: DeleteWhatsAppMessageTemplateOutput,
@@ -1990,7 +1989,7 @@ export const deprecateWhatsAppFlow: API.OperationMethod<
   DeprecateWhatsAppFlowInput,
   DeprecateWhatsAppFlowOutput,
   DeprecateWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateWhatsAppFlowInput,
   output: DeprecateWhatsAppFlowOutput,
@@ -2020,7 +2019,7 @@ export const disassociateWhatsAppBusinessAccount: API.OperationMethod<
   DisassociateWhatsAppBusinessAccountInput,
   DisassociateWhatsAppBusinessAccountOutput,
   DisassociateWhatsAppBusinessAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWhatsAppBusinessAccountInput,
   output: DisassociateWhatsAppBusinessAccountOutput,
@@ -2049,7 +2048,7 @@ export const getLinkedWhatsAppBusinessAccount: API.OperationMethod<
   GetLinkedWhatsAppBusinessAccountInput,
   GetLinkedWhatsAppBusinessAccountOutput,
   GetLinkedWhatsAppBusinessAccountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkedWhatsAppBusinessAccountInput,
   output: GetLinkedWhatsAppBusinessAccountOutput,
@@ -2079,7 +2078,7 @@ export const getLinkedWhatsAppBusinessAccountPhoneNumber: API.OperationMethod<
   GetLinkedWhatsAppBusinessAccountPhoneNumberInput,
   GetLinkedWhatsAppBusinessAccountPhoneNumberOutput,
   GetLinkedWhatsAppBusinessAccountPhoneNumberError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLinkedWhatsAppBusinessAccountPhoneNumberInput,
   output: GetLinkedWhatsAppBusinessAccountPhoneNumberOutput,
@@ -2110,7 +2109,7 @@ export const getWhatsAppFlow: API.OperationMethod<
   GetWhatsAppFlowInput,
   GetWhatsAppFlowOutput,
   GetWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWhatsAppFlowInput,
   output: GetWhatsAppFlowOutput,
@@ -2142,7 +2141,7 @@ export const getWhatsAppFlowPreview: API.OperationMethod<
   GetWhatsAppFlowPreviewInput,
   GetWhatsAppFlowPreviewOutput,
   GetWhatsAppFlowPreviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWhatsAppFlowPreviewInput,
   output: GetWhatsAppFlowPreviewOutput,
@@ -2178,7 +2177,7 @@ export const getWhatsAppMessageMedia: API.OperationMethod<
   GetWhatsAppMessageMediaInput,
   GetWhatsAppMessageMediaOutput,
   GetWhatsAppMessageMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWhatsAppMessageMediaInput,
   output: GetWhatsAppMessageMediaOutput,
@@ -2210,7 +2209,7 @@ export const getWhatsAppMessageTemplate: API.OperationMethod<
   GetWhatsAppMessageTemplateInput,
   GetWhatsAppMessageTemplateOutput,
   GetWhatsAppMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWhatsAppMessageTemplateInput,
   output: GetWhatsAppMessageTemplateOutput,
@@ -2240,7 +2239,7 @@ export const listLinkedWhatsAppBusinessAccounts: API.PaginatedOperationMethod<
   ListLinkedWhatsAppBusinessAccountsInput,
   ListLinkedWhatsAppBusinessAccountsOutput,
   ListLinkedWhatsAppBusinessAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   LinkedWhatsAppBusinessAccountSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLinkedWhatsAppBusinessAccountsInput,
@@ -2274,7 +2273,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2303,7 +2302,7 @@ export const listWhatsAppFlowAssets: API.PaginatedOperationMethod<
   ListWhatsAppFlowAssetsInput,
   ListWhatsAppFlowAssetsOutput,
   ListWhatsAppFlowAssetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetaFlowAsset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatsAppFlowAssetsInput,
@@ -2342,7 +2341,7 @@ export const listWhatsAppFlows: API.PaginatedOperationMethod<
   ListWhatsAppFlowsInput,
   ListWhatsAppFlowsOutput,
   ListWhatsAppFlowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetaFlowSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatsAppFlowsInput,
@@ -2381,7 +2380,7 @@ export const listWhatsAppMessageTemplates: API.PaginatedOperationMethod<
   ListWhatsAppMessageTemplatesInput,
   ListWhatsAppMessageTemplatesOutput,
   ListWhatsAppMessageTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TemplateSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatsAppMessageTemplatesInput,
@@ -2420,7 +2419,7 @@ export const listWhatsAppTemplateLibrary: API.PaginatedOperationMethod<
   ListWhatsAppTemplateLibraryInput,
   ListWhatsAppTemplateLibraryOutput,
   ListWhatsAppTemplateLibraryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   MetaLibraryTemplateDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWhatsAppTemplateLibraryInput,
@@ -2463,7 +2462,7 @@ export const postWhatsAppMessageMedia: API.OperationMethod<
   PostWhatsAppMessageMediaInput,
   PostWhatsAppMessageMediaOutput,
   PostWhatsAppMessageMediaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PostWhatsAppMessageMediaInput,
   output: PostWhatsAppMessageMediaOutput,
@@ -2495,7 +2494,7 @@ export const publishWhatsAppFlow: API.OperationMethod<
   PublishWhatsAppFlowInput,
   PublishWhatsAppFlowOutput,
   PublishWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PublishWhatsAppFlowInput,
   output: PublishWhatsAppFlowOutput,
@@ -2524,7 +2523,7 @@ export const putWhatsAppBusinessAccountEventDestinations: API.OperationMethod<
   PutWhatsAppBusinessAccountEventDestinationsInput,
   PutWhatsAppBusinessAccountEventDestinationsOutput,
   PutWhatsAppBusinessAccountEventDestinationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutWhatsAppBusinessAccountEventDestinationsInput,
   output: PutWhatsAppBusinessAccountEventDestinationsOutput,
@@ -2557,7 +2556,7 @@ export const sendWhatsAppMessage: API.OperationMethod<
   SendWhatsAppMessageInput,
   SendWhatsAppMessageOutput,
   SendWhatsAppMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendWhatsAppMessageInput,
   output: SendWhatsAppMessageOutput,
@@ -2587,7 +2586,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2613,7 +2612,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2642,7 +2641,7 @@ export const updateWhatsAppFlow: API.OperationMethod<
   UpdateWhatsAppFlowInput,
   UpdateWhatsAppFlowOutput,
   UpdateWhatsAppFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWhatsAppFlowInput,
   output: UpdateWhatsAppFlowOutput,
@@ -2674,7 +2673,7 @@ export const updateWhatsAppFlowAssets: API.OperationMethod<
   UpdateWhatsAppFlowAssetsInput,
   UpdateWhatsAppFlowAssetsOutput,
   UpdateWhatsAppFlowAssetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWhatsAppFlowAssetsInput,
   output: UpdateWhatsAppFlowAssetsOutput,
@@ -2706,7 +2705,7 @@ export const updateWhatsAppMessageTemplate: API.OperationMethod<
   UpdateWhatsAppMessageTemplateInput,
   UpdateWhatsAppMessageTemplateOutput,
   UpdateWhatsAppMessageTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWhatsAppMessageTemplateInput,
   output: UpdateWhatsAppMessageTemplateOutput,

--- a/packages/aws/src/services/sqs.ts
+++ b/packages/aws/src/services/sqs.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "SQS", serviceShapeName: "AmazonSQS" });
 const auth = T.AwsAuthSigv4({ name: "sqs" });
 const ver = T.ServiceVersion("2012-11-05");
@@ -1389,7 +1388,7 @@ export const addPermission: API.OperationMethod<
   AddPermissionRequest,
   AddPermissionResponse,
   AddPermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddPermissionRequest,
   output: AddPermissionResponse,
@@ -1433,7 +1432,7 @@ export const cancelMessageMoveTask: API.OperationMethod<
   CancelMessageMoveTaskRequest,
   CancelMessageMoveTaskResult,
   CancelMessageMoveTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMessageMoveTaskRequest,
   output: CancelMessageMoveTaskResult,
@@ -1509,7 +1508,7 @@ export const changeMessageVisibility: API.OperationMethod<
   ChangeMessageVisibilityRequest,
   ChangeMessageVisibilityResponse,
   ChangeMessageVisibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeMessageVisibilityRequest,
   output: ChangeMessageVisibilityResponse,
@@ -1554,7 +1553,7 @@ export const changeMessageVisibilityBatch: API.OperationMethod<
   ChangeMessageVisibilityBatchRequest,
   ChangeMessageVisibilityBatchResult,
   ChangeMessageVisibilityBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ChangeMessageVisibilityBatchRequest,
   output: ChangeMessageVisibilityBatchResult,
@@ -1638,7 +1637,7 @@ export const createQueue: API.OperationMethod<
   CreateQueueRequest,
   CreateQueueResult,
   CreateQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQueueRequest,
   output: CreateQueueResult,
@@ -1695,7 +1694,7 @@ export const deleteMessage: API.OperationMethod<
   DeleteMessageRequest,
   DeleteMessageResponse,
   DeleteMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessageRequest,
   output: DeleteMessageResponse,
@@ -1736,7 +1735,7 @@ export const deleteMessageBatch: API.OperationMethod<
   DeleteMessageBatchRequest,
   DeleteMessageBatchResult,
   DeleteMessageBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMessageBatchRequest,
   output: DeleteMessageBatchResult,
@@ -1790,7 +1789,7 @@ export const deleteQueue: API.OperationMethod<
   DeleteQueueRequest,
   DeleteQueueResponse,
   DeleteQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQueueRequest,
   output: DeleteQueueResponse,
@@ -1823,7 +1822,7 @@ export const getQueueAttributes: API.OperationMethod<
   GetQueueAttributesRequest,
   GetQueueAttributesResult,
   GetQueueAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueAttributesRequest,
   output: GetQueueAttributesResult,
@@ -1865,7 +1864,7 @@ export const getQueueUrl: API.OperationMethod<
   GetQueueUrlRequest,
   GetQueueUrlResult,
   GetQueueUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQueueUrlRequest,
   output: GetQueueUrlResult,
@@ -1907,7 +1906,7 @@ export const listDeadLetterSourceQueues: API.PaginatedOperationMethod<
   ListDeadLetterSourceQueuesRequest,
   ListDeadLetterSourceQueuesResult,
   ListDeadLetterSourceQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDeadLetterSourceQueuesRequest,
@@ -1955,7 +1954,7 @@ export const listMessageMoveTasks: API.OperationMethod<
   ListMessageMoveTasksRequest,
   ListMessageMoveTasksResult,
   ListMessageMoveTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMessageMoveTasksRequest,
   output: ListMessageMoveTasksResult,
@@ -2001,7 +2000,7 @@ export const listQueues: API.PaginatedOperationMethod<
   ListQueuesRequest,
   ListQueuesResult,
   ListQueuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   string
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQueuesRequest,
@@ -2043,7 +2042,7 @@ export const listQueueTags: API.OperationMethod<
   ListQueueTagsRequest,
   ListQueueTagsResult,
   ListQueueTagsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListQueueTagsRequest,
   output: ListQueueTagsResult,
@@ -2088,7 +2087,7 @@ export const purgeQueue: API.OperationMethod<
   PurgeQueueRequest,
   PurgeQueueResponse,
   PurgeQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PurgeQueueRequest,
   output: PurgeQueueResponse,
@@ -2166,7 +2165,7 @@ export const receiveMessage: API.OperationMethod<
   ReceiveMessageRequest,
   ReceiveMessageResult,
   ReceiveMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ReceiveMessageRequest,
   output: ReceiveMessageResult,
@@ -2215,7 +2214,7 @@ export const removePermission: API.OperationMethod<
   RemovePermissionRequest,
   RemovePermissionResponse,
   RemovePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemovePermissionRequest,
   output: RemovePermissionResponse,
@@ -2262,7 +2261,7 @@ export const sendMessage: API.OperationMethod<
   SendMessageRequest,
   SendMessageResult,
   SendMessageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessageRequest,
   output: SendMessageResult,
@@ -2338,7 +2337,7 @@ export const sendMessageBatch: API.OperationMethod<
   SendMessageBatchRequest,
   SendMessageBatchResult,
   SendMessageBatchError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendMessageBatchRequest,
   output: SendMessageBatchResult,
@@ -2403,7 +2402,7 @@ export const setQueueAttributes: API.OperationMethod<
   SetQueueAttributesRequest,
   SetQueueAttributesResponse,
   SetQueueAttributesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetQueueAttributesRequest,
   output: SetQueueAttributesResponse,
@@ -2456,7 +2455,7 @@ export const startMessageMoveTask: API.OperationMethod<
   StartMessageMoveTaskRequest,
   StartMessageMoveTaskResult,
   StartMessageMoveTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMessageMoveTaskRequest,
   output: StartMessageMoveTaskResult,
@@ -2508,7 +2507,7 @@ export const tagQueue: API.OperationMethod<
   TagQueueRequest,
   TagQueueResponse,
   TagQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagQueueRequest,
   output: TagQueueResponse,
@@ -2543,7 +2542,7 @@ export const untagQueue: API.OperationMethod<
   UntagQueueRequest,
   UntagQueueResponse,
   UntagQueueError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagQueueRequest,
   output: UntagQueueResponse,

--- a/packages/aws/src/services/ssm-contacts.ts
+++ b/packages/aws/src/services/ssm-contacts.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SSM Contacts",
   serviceShapeName: "SSMContacts",
@@ -1675,7 +1674,7 @@ export const acceptPage: API.OperationMethod<
   AcceptPageRequest,
   AcceptPageResult,
   AcceptPageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptPageRequest,
   output: AcceptPageResult,
@@ -1708,7 +1707,7 @@ export const activateContactChannel: API.OperationMethod<
   ActivateContactChannelRequest,
   ActivateContactChannelResult,
   ActivateContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateContactChannelRequest,
   output: ActivateContactChannelResult,
@@ -1744,7 +1743,7 @@ export const createContact: API.OperationMethod<
   CreateContactRequest,
   CreateContactResult,
   CreateContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactRequest,
   output: CreateContactResult,
@@ -1779,7 +1778,7 @@ export const createContactChannel: API.OperationMethod<
   CreateContactChannelRequest,
   CreateContactChannelResult,
   CreateContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContactChannelRequest,
   output: CreateContactChannelResult,
@@ -1814,7 +1813,7 @@ export const createRotation: API.OperationMethod<
   CreateRotationRequest,
   CreateRotationResult,
   CreateRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRotationRequest,
   output: CreateRotationResult,
@@ -1850,7 +1849,7 @@ export const createRotationOverride: API.OperationMethod<
   CreateRotationOverrideRequest,
   CreateRotationOverrideResult,
   CreateRotationOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRotationOverrideRequest,
   output: CreateRotationOverrideResult,
@@ -1885,7 +1884,7 @@ export const deactivateContactChannel: API.OperationMethod<
   DeactivateContactChannelRequest,
   DeactivateContactChannelResult,
   DeactivateContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateContactChannelRequest,
   output: DeactivateContactChannelResult,
@@ -1922,7 +1921,7 @@ export const deleteContact: API.OperationMethod<
   DeleteContactRequest,
   DeleteContactResult,
   DeleteContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactRequest,
   output: DeleteContactResult,
@@ -1959,7 +1958,7 @@ export const deleteContactChannel: API.OperationMethod<
   DeleteContactChannelRequest,
   DeleteContactChannelResult,
   DeleteContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContactChannelRequest,
   output: DeleteContactChannelResult,
@@ -1994,7 +1993,7 @@ export const deleteRotation: API.OperationMethod<
   DeleteRotationRequest,
   DeleteRotationResult,
   DeleteRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRotationRequest,
   output: DeleteRotationResult,
@@ -2029,7 +2028,7 @@ export const deleteRotationOverride: API.OperationMethod<
   DeleteRotationOverrideRequest,
   DeleteRotationOverrideResult,
   DeleteRotationOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRotationOverrideRequest,
   output: DeleteRotationOverrideResult,
@@ -2064,7 +2063,7 @@ export const describeEngagement: API.OperationMethod<
   DescribeEngagementRequest,
   DescribeEngagementResult,
   DescribeEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEngagementRequest,
   output: DescribeEngagementResult,
@@ -2098,7 +2097,7 @@ export const describePage: API.OperationMethod<
   DescribePageRequest,
   DescribePageResult,
   DescribePageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePageRequest,
   output: DescribePageResult,
@@ -2132,7 +2131,7 @@ export const getContact: API.OperationMethod<
   GetContactRequest,
   GetContactResult,
   GetContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactRequest,
   output: GetContactResult,
@@ -2166,7 +2165,7 @@ export const getContactChannel: API.OperationMethod<
   GetContactChannelRequest,
   GetContactChannelResult,
   GetContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactChannelRequest,
   output: GetContactChannelResult,
@@ -2200,7 +2199,7 @@ export const getContactPolicy: API.OperationMethod<
   GetContactPolicyRequest,
   GetContactPolicyResult,
   GetContactPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContactPolicyRequest,
   output: GetContactPolicyResult,
@@ -2233,7 +2232,7 @@ export const getRotation: API.OperationMethod<
   GetRotationRequest,
   GetRotationResult,
   GetRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRotationRequest,
   output: GetRotationResult,
@@ -2267,7 +2266,7 @@ export const getRotationOverride: API.OperationMethod<
   GetRotationOverrideRequest,
   GetRotationOverrideResult,
   GetRotationOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRotationOverrideRequest,
   output: GetRotationOverrideResult,
@@ -2301,7 +2300,7 @@ export const listContactChannels: API.PaginatedOperationMethod<
   ListContactChannelsRequest,
   ListContactChannelsResult,
   ListContactChannelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContactChannel
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactChannelsRequest,
@@ -2340,7 +2339,7 @@ export const listContacts: API.PaginatedOperationMethod<
   ListContactsRequest,
   ListContactsResult,
   ListContactsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Contact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContactsRequest,
@@ -2377,7 +2376,7 @@ export const listEngagements: API.PaginatedOperationMethod<
   ListEngagementsRequest,
   ListEngagementsResult,
   ListEngagementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Engagement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEngagementsRequest,
@@ -2415,7 +2414,7 @@ export const listPageReceipts: API.PaginatedOperationMethod<
   ListPageReceiptsRequest,
   ListPageReceiptsResult,
   ListPageReceiptsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Receipt
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPageReceiptsRequest,
@@ -2458,7 +2457,7 @@ export const listPageResolutions: API.PaginatedOperationMethod<
   ListPageResolutionsRequest,
   ListPageResolutionsResult,
   ListPageResolutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResolutionContact
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPageResolutionsRequest,
@@ -2496,7 +2495,7 @@ export const listPagesByContact: API.PaginatedOperationMethod<
   ListPagesByContactRequest,
   ListPagesByContactResult,
   ListPagesByContactError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Page
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPagesByContactRequest,
@@ -2535,7 +2534,7 @@ export const listPagesByEngagement: API.PaginatedOperationMethod<
   ListPagesByEngagementRequest,
   ListPagesByEngagementResult,
   ListPagesByEngagementError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Page
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPagesByEngagementRequest,
@@ -2575,7 +2574,7 @@ export const listPreviewRotationShifts: API.PaginatedOperationMethod<
   ListPreviewRotationShiftsRequest,
   ListPreviewRotationShiftsResult,
   ListPreviewRotationShiftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RotationShift
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPreviewRotationShiftsRequest,
@@ -2614,7 +2613,7 @@ export const listRotationOverrides: API.PaginatedOperationMethod<
   ListRotationOverridesRequest,
   ListRotationOverridesResult,
   ListRotationOverridesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RotationOverride
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRotationOverridesRequest,
@@ -2654,7 +2653,7 @@ export const listRotations: API.PaginatedOperationMethod<
   ListRotationsRequest,
   ListRotationsResult,
   ListRotationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Rotation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRotationsRequest,
@@ -2695,7 +2694,7 @@ export const listRotationShifts: API.PaginatedOperationMethod<
   ListRotationShiftsRequest,
   ListRotationShiftsResult,
   ListRotationShiftsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RotationShift
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRotationShiftsRequest,
@@ -2736,7 +2735,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -2771,7 +2770,7 @@ export const putContactPolicy: API.OperationMethod<
   PutContactPolicyRequest,
   PutContactPolicyResult,
   PutContactPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutContactPolicyRequest,
   output: PutContactPolicyResult,
@@ -2808,7 +2807,7 @@ export const sendActivationCode: API.OperationMethod<
   SendActivationCodeRequest,
   SendActivationCodeResult,
   SendActivationCodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendActivationCodeRequest,
   output: SendActivationCodeResult,
@@ -2844,7 +2843,7 @@ export const startEngagement: API.OperationMethod<
   StartEngagementRequest,
   StartEngagementResult,
   StartEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartEngagementRequest,
   output: StartEngagementResult,
@@ -2878,7 +2877,7 @@ export const stopEngagement: API.OperationMethod<
   StopEngagementRequest,
   StopEngagementResult,
   StopEngagementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopEngagementRequest,
   output: StopEngagementResult,
@@ -2912,7 +2911,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResult,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResult,
@@ -2945,7 +2944,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResult,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResult,
@@ -2979,7 +2978,7 @@ export const updateContact: API.OperationMethod<
   UpdateContactRequest,
   UpdateContactResult,
   UpdateContactError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactRequest,
   output: UpdateContactResult,
@@ -3015,7 +3014,7 @@ export const updateContactChannel: API.OperationMethod<
   UpdateContactChannelRequest,
   UpdateContactChannelResult,
   UpdateContactChannelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContactChannelRequest,
   output: UpdateContactChannelResult,
@@ -3051,7 +3050,7 @@ export const updateRotation: API.OperationMethod<
   UpdateRotationRequest,
   UpdateRotationResult,
   UpdateRotationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRotationRequest,
   output: UpdateRotationResult,

--- a/packages/aws/src/services/ssm-guiconnect.ts
+++ b/packages/aws/src/services/ssm-guiconnect.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SSM GuiConnect",
   serviceShapeName: "SSMGuiConnect",
@@ -278,7 +277,7 @@ export const deleteConnectionRecordingPreferences: API.OperationMethod<
   DeleteConnectionRecordingPreferencesRequest,
   DeleteConnectionRecordingPreferencesResponse,
   DeleteConnectionRecordingPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionRecordingPreferencesRequest,
   output: DeleteConnectionRecordingPreferencesResponse,
@@ -312,7 +311,7 @@ export const getConnectionRecordingPreferences: API.OperationMethod<
   GetConnectionRecordingPreferencesRequest,
   GetConnectionRecordingPreferencesResponse,
   GetConnectionRecordingPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionRecordingPreferencesRequest,
   output: GetConnectionRecordingPreferencesResponse,
@@ -346,7 +345,7 @@ export const updateConnectionRecordingPreferences: API.OperationMethod<
   UpdateConnectionRecordingPreferencesRequest,
   UpdateConnectionRecordingPreferencesResponse,
   UpdateConnectionRecordingPreferencesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionRecordingPreferencesRequest,
   output: UpdateConnectionRecordingPreferencesResponse,

--- a/packages/aws/src/services/ssm-incidents.ts
+++ b/packages/aws/src/services/ssm-incidents.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SSM Incidents",
   serviceShapeName: "SSMIncidents",
@@ -1759,7 +1758,7 @@ export const batchGetIncidentFindings: API.OperationMethod<
   BatchGetIncidentFindingsInput,
   BatchGetIncidentFindingsOutput,
   BatchGetIncidentFindingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetIncidentFindingsInput,
   output: BatchGetIncidentFindingsOutput,
@@ -1792,7 +1791,7 @@ export const createReplicationSet: API.OperationMethod<
   CreateReplicationSetInput,
   CreateReplicationSetOutput,
   CreateReplicationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReplicationSetInput,
   output: CreateReplicationSetOutput,
@@ -1827,7 +1826,7 @@ export const createResponsePlan: API.OperationMethod<
   CreateResponsePlanInput,
   CreateResponsePlanOutput,
   CreateResponsePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResponsePlanInput,
   output: CreateResponsePlanOutput,
@@ -1862,7 +1861,7 @@ export const createTimelineEvent: API.OperationMethod<
   CreateTimelineEventInput,
   CreateTimelineEventOutput,
   CreateTimelineEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTimelineEventInput,
   output: CreateTimelineEventOutput,
@@ -1892,7 +1891,7 @@ export const deleteIncidentRecord: API.OperationMethod<
   DeleteIncidentRecordInput,
   DeleteIncidentRecordOutput,
   DeleteIncidentRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIncidentRecordInput,
   output: DeleteIncidentRecordOutput,
@@ -1922,7 +1921,7 @@ export const deleteReplicationSet: API.OperationMethod<
   DeleteReplicationSetInput,
   DeleteReplicationSetOutput,
   DeleteReplicationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReplicationSetInput,
   output: DeleteReplicationSetOutput,
@@ -1953,7 +1952,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyInput,
   DeleteResourcePolicyOutput,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyInput,
   output: DeleteResourcePolicyOutput,
@@ -1983,7 +1982,7 @@ export const deleteResponsePlan: API.OperationMethod<
   DeleteResponsePlanInput,
   DeleteResponsePlanOutput,
   DeleteResponsePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResponsePlanInput,
   output: DeleteResponsePlanOutput,
@@ -2011,7 +2010,7 @@ export const deleteTimelineEvent: API.OperationMethod<
   DeleteTimelineEventInput,
   DeleteTimelineEventOutput,
   DeleteTimelineEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTimelineEventInput,
   output: DeleteTimelineEventOutput,
@@ -2040,7 +2039,7 @@ export const getIncidentRecord: API.OperationMethod<
   GetIncidentRecordInput,
   GetIncidentRecordOutput,
   GetIncidentRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIncidentRecordInput,
   output: GetIncidentRecordOutput,
@@ -2070,7 +2069,7 @@ export const getReplicationSet: API.OperationMethod<
   GetReplicationSetInput,
   GetReplicationSetOutput,
   GetReplicationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReplicationSetInput,
   output: GetReplicationSetOutput,
@@ -2100,7 +2099,7 @@ export const getResourcePolicies: API.PaginatedOperationMethod<
   GetResourcePoliciesInput,
   GetResourcePoliciesOutput,
   GetResourcePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcePoliciesInput,
@@ -2137,7 +2136,7 @@ export const getResponsePlan: API.OperationMethod<
   GetResponsePlanInput,
   GetResponsePlanOutput,
   GetResponsePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResponsePlanInput,
   output: GetResponsePlanOutput,
@@ -2167,7 +2166,7 @@ export const getTimelineEvent: API.OperationMethod<
   GetTimelineEventInput,
   GetTimelineEventOutput,
   GetTimelineEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTimelineEventInput,
   output: GetTimelineEventOutput,
@@ -2200,7 +2199,7 @@ export const listIncidentFindings: API.PaginatedOperationMethod<
   ListIncidentFindingsInput,
   ListIncidentFindingsOutput,
   ListIncidentFindingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FindingSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIncidentFindingsInput,
@@ -2237,7 +2236,7 @@ export const listIncidentRecords: API.PaginatedOperationMethod<
   ListIncidentRecordsInput,
   ListIncidentRecordsOutput,
   ListIncidentRecordsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IncidentRecordSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIncidentRecordsInput,
@@ -2272,7 +2271,7 @@ export const listRelatedItems: API.PaginatedOperationMethod<
   ListRelatedItemsInput,
   ListRelatedItemsOutput,
   ListRelatedItemsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RelatedItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRelatedItemsInput,
@@ -2307,7 +2306,7 @@ export const listReplicationSets: API.PaginatedOperationMethod<
   ListReplicationSetsInput,
   ListReplicationSetsOutput,
   ListReplicationSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Arn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReplicationSetsInput,
@@ -2342,7 +2341,7 @@ export const listResponsePlans: API.PaginatedOperationMethod<
   ListResponsePlansInput,
   ListResponsePlansOutput,
   ListResponsePlansError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResponsePlanSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResponsePlansInput,
@@ -2378,7 +2377,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2407,7 +2406,7 @@ export const listTimelineEvents: API.PaginatedOperationMethod<
   ListTimelineEventsInput,
   ListTimelineEventsOutput,
   ListTimelineEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTimelineEventsInput,
@@ -2445,7 +2444,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyInput,
   PutResourcePolicyOutput,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyInput,
   output: PutResourcePolicyOutput,
@@ -2477,7 +2476,7 @@ export const startIncident: API.OperationMethod<
   StartIncidentInput,
   StartIncidentOutput,
   StartIncidentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartIncidentInput,
   output: StartIncidentOutput,
@@ -2510,7 +2509,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2543,7 +2542,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2575,7 +2574,7 @@ export const updateDeletionProtection: API.OperationMethod<
   UpdateDeletionProtectionInput,
   UpdateDeletionProtectionOutput,
   UpdateDeletionProtectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeletionProtectionInput,
   output: UpdateDeletionProtectionOutput,
@@ -2608,7 +2607,7 @@ export const updateIncidentRecord: API.OperationMethod<
   UpdateIncidentRecordInput,
   UpdateIncidentRecordOutput,
   UpdateIncidentRecordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIncidentRecordInput,
   output: UpdateIncidentRecordOutput,
@@ -2640,7 +2639,7 @@ export const updateRelatedItems: API.OperationMethod<
   UpdateRelatedItemsInput,
   UpdateRelatedItemsOutput,
   UpdateRelatedItemsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRelatedItemsInput,
   output: UpdateRelatedItemsOutput,
@@ -2672,7 +2671,7 @@ export const updateReplicationSet: API.OperationMethod<
   UpdateReplicationSetInput,
   UpdateReplicationSetOutput,
   UpdateReplicationSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReplicationSetInput,
   output: UpdateReplicationSetOutput,
@@ -2704,7 +2703,7 @@ export const updateResponsePlan: API.OperationMethod<
   UpdateResponsePlanInput,
   UpdateResponsePlanOutput,
   UpdateResponsePlanError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResponsePlanInput,
   output: UpdateResponsePlanOutput,
@@ -2736,7 +2735,7 @@ export const updateTimelineEvent: API.OperationMethod<
   UpdateTimelineEventInput,
   UpdateTimelineEventOutput,
   UpdateTimelineEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTimelineEventInput,
   output: UpdateTimelineEventOutput,

--- a/packages/aws/src/services/ssm-quicksetup.ts
+++ b/packages/aws/src/services/ssm-quicksetup.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SSM QuickSetup",
   serviceShapeName: "QuickSetup",
@@ -794,7 +793,7 @@ export const createConfigurationManager: API.OperationMethod<
   CreateConfigurationManagerInput,
   CreateConfigurationManagerOutput,
   CreateConfigurationManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConfigurationManagerInput,
   output: CreateConfigurationManagerOutput,
@@ -825,7 +824,7 @@ export const deleteConfigurationManager: API.OperationMethod<
   DeleteConfigurationManagerInput,
   DeleteConfigurationManagerResponse,
   DeleteConfigurationManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConfigurationManagerInput,
   output: DeleteConfigurationManagerResponse,
@@ -857,7 +856,7 @@ export const getConfiguration: API.OperationMethod<
   GetConfigurationInput,
   GetConfigurationOutput,
   GetConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationInput,
   output: GetConfigurationOutput,
@@ -889,7 +888,7 @@ export const getConfigurationManager: API.OperationMethod<
   GetConfigurationManagerInput,
   GetConfigurationManagerOutput,
   GetConfigurationManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationManagerInput,
   output: GetConfigurationManagerOutput,
@@ -919,7 +918,7 @@ export const getServiceSettings: API.OperationMethod<
   GetServiceSettingsRequest,
   GetServiceSettingsOutput,
   GetServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSettingsRequest,
   output: GetServiceSettingsOutput,
@@ -948,7 +947,7 @@ export const listConfigurationManagers: API.PaginatedOperationMethod<
   ListConfigurationManagersInput,
   ListConfigurationManagersOutput,
   ListConfigurationManagersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationManagerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationManagersInput,
@@ -985,7 +984,7 @@ export const listConfigurations: API.PaginatedOperationMethod<
   ListConfigurationsInput,
   ListConfigurationsOutput,
   ListConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationsInput,
@@ -1021,7 +1020,7 @@ export const listQuickSetupTypes: API.OperationMethod<
   ListQuickSetupTypesRequest,
   ListQuickSetupTypesOutput,
   ListQuickSetupTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListQuickSetupTypesRequest,
   output: ListQuickSetupTypesOutput,
@@ -1051,7 +1050,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1083,7 +1082,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -1115,7 +1114,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,
@@ -1147,7 +1146,7 @@ export const updateConfigurationDefinition: API.OperationMethod<
   UpdateConfigurationDefinitionInput,
   UpdateConfigurationDefinitionResponse,
   UpdateConfigurationDefinitionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationDefinitionInput,
   output: UpdateConfigurationDefinitionResponse,
@@ -1179,7 +1178,7 @@ export const updateConfigurationManager: API.OperationMethod<
   UpdateConfigurationManagerInput,
   UpdateConfigurationManagerResponse,
   UpdateConfigurationManagerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConfigurationManagerInput,
   output: UpdateConfigurationManagerResponse,
@@ -1210,7 +1209,7 @@ export const updateServiceSettings: API.OperationMethod<
   UpdateServiceSettingsInput,
   UpdateServiceSettingsResponse,
   UpdateServiceSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSettingsInput,
   output: UpdateServiceSettingsResponse,

--- a/packages/aws/src/services/ssm-sap.ts
+++ b/packages/aws/src/services/ssm-sap.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Ssm Sap", serviceShapeName: "SsmSap" });
 const auth = T.AwsAuthSigv4({ name: "ssm-sap" });
@@ -1674,7 +1673,7 @@ export const deleteResourcePermission: API.OperationMethod<
   DeleteResourcePermissionInput,
   DeleteResourcePermissionOutput,
   DeleteResourcePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePermissionInput,
   output: DeleteResourcePermissionOutput,
@@ -1700,7 +1699,7 @@ export const deregisterApplication: API.OperationMethod<
   DeregisterApplicationInput,
   DeregisterApplicationOutput,
   DeregisterApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterApplicationInput,
   output: DeregisterApplicationOutput,
@@ -1721,7 +1720,7 @@ export const getApplication: API.OperationMethod<
   GetApplicationInput,
   GetApplicationOutput,
   GetApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationInput,
   output: GetApplicationOutput,
@@ -1743,7 +1742,7 @@ export const getComponent: API.OperationMethod<
   GetComponentInput,
   GetComponentOutput,
   GetComponentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetComponentInput,
   output: GetComponentOutput,
@@ -1764,7 +1763,7 @@ export const getConfigurationCheckOperation: API.OperationMethod<
   GetConfigurationCheckOperationInput,
   GetConfigurationCheckOperationOutput,
   GetConfigurationCheckOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConfigurationCheckOperationInput,
   output: GetConfigurationCheckOperationOutput,
@@ -1785,7 +1784,7 @@ export const getDatabase: API.OperationMethod<
   GetDatabaseInput,
   GetDatabaseOutput,
   GetDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDatabaseInput,
   output: GetDatabaseOutput,
@@ -1806,7 +1805,7 @@ export const getOperation: API.OperationMethod<
   GetOperationInput,
   GetOperationOutput,
   GetOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOperationInput,
   output: GetOperationOutput,
@@ -1828,7 +1827,7 @@ export const getResourcePermission: API.OperationMethod<
   GetResourcePermissionInput,
   GetResourcePermissionOutput,
   GetResourcePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePermissionInput,
   output: GetResourcePermissionOutput,
@@ -1854,7 +1853,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsInput,
   ListApplicationsOutput,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsInput,
@@ -1888,7 +1887,7 @@ export const listComponents: API.PaginatedOperationMethod<
   ListComponentsInput,
   ListComponentsOutput,
   ListComponentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ComponentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComponentsInput,
@@ -1921,7 +1920,7 @@ export const listConfigurationCheckDefinitions: API.PaginatedOperationMethod<
   ListConfigurationCheckDefinitionsInput,
   ListConfigurationCheckDefinitionsOutput,
   ListConfigurationCheckDefinitionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationCheckDefinition
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationCheckDefinitionsInput,
@@ -1950,7 +1949,7 @@ export const listConfigurationCheckOperations: API.PaginatedOperationMethod<
   ListConfigurationCheckOperationsInput,
   ListConfigurationCheckOperationsOutput,
   ListConfigurationCheckOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConfigurationCheckOperation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConfigurationCheckOperationsInput,
@@ -1983,7 +1982,7 @@ export const listDatabases: API.PaginatedOperationMethod<
   ListDatabasesInput,
   ListDatabasesOutput,
   ListDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DatabaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatabasesInput,
@@ -2017,7 +2016,7 @@ export const listOperationEvents: API.PaginatedOperationMethod<
   ListOperationEventsInput,
   ListOperationEventsOutput,
   ListOperationEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OperationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOperationEventsInput,
@@ -2045,7 +2044,7 @@ export const listOperations: API.PaginatedOperationMethod<
   ListOperationsInput,
   ListOperationsOutput,
   ListOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Operation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOperationsInput,
@@ -2073,7 +2072,7 @@ export const listSubCheckResults: API.PaginatedOperationMethod<
   ListSubCheckResultsInput,
   ListSubCheckResultsOutput,
   ListSubCheckResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SubCheckResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubCheckResultsInput,
@@ -2101,7 +2100,7 @@ export const listSubCheckRuleResults: API.PaginatedOperationMethod<
   ListSubCheckRuleResultsInput,
   ListSubCheckRuleResultsOutput,
   ListSubCheckRuleResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSubCheckRuleResultsInput,
@@ -2130,7 +2129,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2152,7 +2151,7 @@ export const putResourcePermission: API.OperationMethod<
   PutResourcePermissionInput,
   PutResourcePermissionOutput,
   PutResourcePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePermissionInput,
   output: PutResourcePermissionOutput,
@@ -2185,7 +2184,7 @@ export const registerApplication: API.OperationMethod<
   RegisterApplicationInput,
   RegisterApplicationOutput,
   RegisterApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterApplicationInput,
   output: RegisterApplicationOutput,
@@ -2215,7 +2214,7 @@ export const startApplication: API.OperationMethod<
   StartApplicationInput,
   StartApplicationOutput,
   StartApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationInput,
   output: StartApplicationOutput,
@@ -2244,7 +2243,7 @@ export const startApplicationRefresh: API.OperationMethod<
   StartApplicationRefreshInput,
   StartApplicationRefreshOutput,
   StartApplicationRefreshError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartApplicationRefreshInput,
   output: StartApplicationRefreshOutput,
@@ -2273,7 +2272,7 @@ export const startConfigurationChecks: API.OperationMethod<
   StartConfigurationChecksInput,
   StartConfigurationChecksOutput,
   StartConfigurationChecksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartConfigurationChecksInput,
   output: StartConfigurationChecksOutput,
@@ -2303,7 +2302,7 @@ export const stopApplication: API.OperationMethod<
   StopApplicationInput,
   StopApplicationOutput,
   StopApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopApplicationInput,
   output: StopApplicationOutput,
@@ -2330,7 +2329,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2352,7 +2351,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2376,7 +2375,7 @@ export const updateApplicationSettings: API.OperationMethod<
   UpdateApplicationSettingsInput,
   UpdateApplicationSettingsOutput,
   UpdateApplicationSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationSettingsInput,
   output: UpdateApplicationSettingsOutput,

--- a/packages/aws/src/services/ssm.ts
+++ b/packages/aws/src/services/ssm.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://ssm.amazonaws.com/doc/2014-11-06/");
 const svc = T.AwsApiService({ sdkId: "SSM", serviceShapeName: "AmazonSSM" });
@@ -12118,7 +12117,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceRequest,
   AddTagsToResourceResult,
   AddTagsToResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceRequest,
   output: AddTagsToResourceResult,
@@ -12151,7 +12150,7 @@ export const associateOpsItemRelatedItem: API.OperationMethod<
   AssociateOpsItemRelatedItemRequest,
   AssociateOpsItemRelatedItemResponse,
   AssociateOpsItemRelatedItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateOpsItemRelatedItemRequest,
   output: AssociateOpsItemRelatedItemResponse,
@@ -12182,7 +12181,7 @@ export const cancelCommand: API.OperationMethod<
   CancelCommandRequest,
   CancelCommandResult,
   CancelCommandError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCommandRequest,
   output: CancelCommandResult,
@@ -12210,7 +12209,7 @@ export const cancelMaintenanceWindowExecution: API.OperationMethod<
   CancelMaintenanceWindowExecutionRequest,
   CancelMaintenanceWindowExecutionResult,
   CancelMaintenanceWindowExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMaintenanceWindowExecutionRequest,
   output: CancelMaintenanceWindowExecutionResult,
@@ -12239,7 +12238,7 @@ export const createActivation: API.OperationMethod<
   CreateActivationRequest,
   CreateActivationResult,
   CreateActivationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateActivationRequest,
   output: CreateActivationResult,
@@ -12280,7 +12279,7 @@ export const createAssociation: API.OperationMethod<
   CreateAssociationRequest,
   CreateAssociationResult,
   CreateAssociationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssociationRequest,
   output: CreateAssociationResult,
@@ -12333,7 +12332,7 @@ export const createAssociationBatch: API.OperationMethod<
   CreateAssociationBatchRequest,
   CreateAssociationBatchResult,
   CreateAssociationBatchError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssociationBatchRequest,
   output: CreateAssociationBatchResult,
@@ -12376,7 +12375,7 @@ export const createDocument: API.OperationMethod<
   CreateDocumentRequest,
   CreateDocumentResult,
   CreateDocumentError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDocumentRequest,
   output: CreateDocumentResult,
@@ -12414,7 +12413,7 @@ export const createMaintenanceWindow: API.OperationMethod<
   CreateMaintenanceWindowRequest,
   CreateMaintenanceWindowResult,
   CreateMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMaintenanceWindowRequest,
   output: CreateMaintenanceWindowResult,
@@ -12448,7 +12447,7 @@ export const createOpsItem: API.OperationMethod<
   CreateOpsItemRequest,
   CreateOpsItemResponse,
   CreateOpsItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOpsItemRequest,
   output: CreateOpsItemResponse,
@@ -12479,7 +12478,7 @@ export const createOpsMetadata: API.OperationMethod<
   CreateOpsMetadataRequest,
   CreateOpsMetadataResult,
   CreateOpsMetadataError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOpsMetadataRequest,
   output: CreateOpsMetadataResult,
@@ -12510,7 +12509,7 @@ export const createPatchBaseline: API.OperationMethod<
   CreatePatchBaselineRequest,
   CreatePatchBaselineResult,
   CreatePatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePatchBaselineRequest,
   output: CreatePatchBaselineResult,
@@ -12559,7 +12558,7 @@ export const createResourceDataSync: API.OperationMethod<
   CreateResourceDataSyncRequest,
   CreateResourceDataSyncResult,
   CreateResourceDataSyncError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceDataSyncRequest,
   output: CreateResourceDataSyncResult,
@@ -12589,7 +12588,7 @@ export const deleteActivation: API.OperationMethod<
   DeleteActivationRequest,
   DeleteActivationResult,
   DeleteActivationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActivationRequest,
   output: DeleteActivationResult,
@@ -12625,7 +12624,7 @@ export const deleteAssociation: API.OperationMethod<
   DeleteAssociationRequest,
   DeleteAssociationResult,
   DeleteAssociationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssociationRequest,
   output: DeleteAssociationResult,
@@ -12658,7 +12657,7 @@ export const deleteDocument: API.OperationMethod<
   DeleteDocumentRequest,
   DeleteDocumentResult,
   DeleteDocumentError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentRequest,
   output: DeleteDocumentResult,
@@ -12689,7 +12688,7 @@ export const deleteInventory: API.OperationMethod<
   DeleteInventoryRequest,
   DeleteInventoryResult,
   DeleteInventoryError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInventoryRequest,
   output: DeleteInventoryResult,
@@ -12713,7 +12712,7 @@ export const deleteMaintenanceWindow: API.OperationMethod<
   DeleteMaintenanceWindowRequest,
   DeleteMaintenanceWindowResult,
   DeleteMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMaintenanceWindowRequest,
   output: DeleteMaintenanceWindowResult,
@@ -12754,7 +12753,7 @@ export const deleteOpsItem: API.OperationMethod<
   DeleteOpsItemRequest,
   DeleteOpsItemResponse,
   DeleteOpsItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOpsItemRequest,
   output: DeleteOpsItemResponse,
@@ -12776,7 +12775,7 @@ export const deleteOpsMetadata: API.OperationMethod<
   DeleteOpsMetadataRequest,
   DeleteOpsMetadataResult,
   DeleteOpsMetadataError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOpsMetadataRequest,
   output: DeleteOpsMetadataResult,
@@ -12802,7 +12801,7 @@ export const deleteParameter: API.OperationMethod<
   DeleteParameterRequest,
   DeleteParameterResult,
   DeleteParameterError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteParameterRequest,
   output: DeleteParameterResult,
@@ -12821,7 +12820,7 @@ export const deleteParameters: API.OperationMethod<
   DeleteParametersRequest,
   DeleteParametersResult,
   DeleteParametersError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteParametersRequest,
   output: DeleteParametersResult,
@@ -12842,7 +12841,7 @@ export const deletePatchBaseline: API.OperationMethod<
   DeletePatchBaselineRequest,
   DeletePatchBaselineResult,
   DeletePatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePatchBaselineRequest,
   output: DeletePatchBaselineResult,
@@ -12866,7 +12865,7 @@ export const deleteResourceDataSync: API.OperationMethod<
   DeleteResourceDataSyncRequest,
   DeleteResourceDataSyncResult,
   DeleteResourceDataSyncError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceDataSyncRequest,
   output: DeleteResourceDataSyncResult,
@@ -12904,7 +12903,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -12939,7 +12938,7 @@ export const deregisterManagedInstance: API.OperationMethod<
   DeregisterManagedInstanceRequest,
   DeregisterManagedInstanceResult,
   DeregisterManagedInstanceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterManagedInstanceRequest,
   output: DeregisterManagedInstanceResult,
@@ -12960,7 +12959,7 @@ export const deregisterPatchBaselineForPatchGroup: API.OperationMethod<
   DeregisterPatchBaselineForPatchGroupRequest,
   DeregisterPatchBaselineForPatchGroupResult,
   DeregisterPatchBaselineForPatchGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterPatchBaselineForPatchGroupRequest,
   output: DeregisterPatchBaselineForPatchGroupResult,
@@ -12982,7 +12981,7 @@ export const deregisterTargetFromMaintenanceWindow: API.OperationMethod<
   DeregisterTargetFromMaintenanceWindowRequest,
   DeregisterTargetFromMaintenanceWindowResult,
   DeregisterTargetFromMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTargetFromMaintenanceWindowRequest,
   output: DeregisterTargetFromMaintenanceWindowResult,
@@ -13003,7 +13002,7 @@ export const deregisterTaskFromMaintenanceWindow: API.OperationMethod<
   DeregisterTaskFromMaintenanceWindowRequest,
   DeregisterTaskFromMaintenanceWindowResult,
   DeregisterTaskFromMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTaskFromMaintenanceWindowRequest,
   output: DeregisterTaskFromMaintenanceWindowResult,
@@ -13028,7 +13027,7 @@ export const describeActivations: API.PaginatedOperationMethod<
   DescribeActivationsRequest,
   DescribeActivationsResult,
   DescribeActivationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Activation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeActivationsRequest,
@@ -13061,7 +13060,7 @@ export const describeAssociation: API.OperationMethod<
   DescribeAssociationRequest,
   DescribeAssociationResult,
   DescribeAssociationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAssociationRequest,
   output: DescribeAssociationResult,
@@ -13089,7 +13088,7 @@ export const describeAssociationExecutions: API.PaginatedOperationMethod<
   DescribeAssociationExecutionsRequest,
   DescribeAssociationExecutionsResult,
   DescribeAssociationExecutionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AssociationExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAssociationExecutionsRequest,
@@ -13119,7 +13118,7 @@ export const describeAssociationExecutionTargets: API.PaginatedOperationMethod<
   DescribeAssociationExecutionTargetsRequest,
   DescribeAssociationExecutionTargetsResult,
   DescribeAssociationExecutionTargetsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AssociationExecutionTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAssociationExecutionTargetsRequest,
@@ -13154,7 +13153,7 @@ export const describeAutomationExecutions: API.PaginatedOperationMethod<
   DescribeAutomationExecutionsRequest,
   DescribeAutomationExecutionsResult,
   DescribeAutomationExecutionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AutomationExecutionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAutomationExecutionsRequest,
@@ -13191,7 +13190,7 @@ export const describeAutomationStepExecutions: API.PaginatedOperationMethod<
   DescribeAutomationStepExecutionsRequest,
   DescribeAutomationStepExecutionsResult,
   DescribeAutomationStepExecutionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   StepExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAutomationStepExecutionsRequest,
@@ -13225,7 +13224,7 @@ export const describeAvailablePatches: API.PaginatedOperationMethod<
   DescribeAvailablePatchesRequest,
   DescribeAvailablePatchesResult,
   DescribeAvailablePatchesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Patch
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeAvailablePatchesRequest,
@@ -13254,7 +13253,7 @@ export const describeDocument: API.OperationMethod<
   DescribeDocumentRequest,
   DescribeDocumentResult,
   DescribeDocumentError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDocumentRequest,
   output: DescribeDocumentResult,
@@ -13280,7 +13279,7 @@ export const describeDocumentPermission: API.OperationMethod<
   DescribeDocumentPermissionRequest,
   DescribeDocumentPermissionResponse,
   DescribeDocumentPermissionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDocumentPermissionRequest,
   output: DescribeDocumentPermissionResponse,
@@ -13308,7 +13307,7 @@ export const describeEffectiveInstanceAssociations: API.PaginatedOperationMethod
   DescribeEffectiveInstanceAssociationsRequest,
   DescribeEffectiveInstanceAssociationsResult,
   DescribeEffectiveInstanceAssociationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEffectiveInstanceAssociationsRequest,
@@ -13339,7 +13338,7 @@ export const describeEffectivePatchesForPatchBaseline: API.PaginatedOperationMet
   DescribeEffectivePatchesForPatchBaselineRequest,
   DescribeEffectivePatchesForPatchBaselineResult,
   DescribeEffectivePatchesForPatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   EffectivePatch
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeEffectivePatchesForPatchBaselineRequest,
@@ -13373,7 +13372,7 @@ export const describeInstanceAssociationsStatus: API.PaginatedOperationMethod<
   DescribeInstanceAssociationsStatusRequest,
   DescribeInstanceAssociationsStatusResult,
   DescribeInstanceAssociationsStatusError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceAssociationStatusInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceAssociationsStatusRequest,
@@ -13414,7 +13413,7 @@ export const describeInstanceInformation: API.PaginatedOperationMethod<
   DescribeInstanceInformationRequest,
   DescribeInstanceInformationResult,
   DescribeInstanceInformationError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceInformation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstanceInformationRequest,
@@ -13451,7 +13450,7 @@ export const describeInstancePatches: API.PaginatedOperationMethod<
   DescribeInstancePatchesRequest,
   DescribeInstancePatchesResult,
   DescribeInstancePatchesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PatchComplianceData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancePatchesRequest,
@@ -13484,7 +13483,7 @@ export const describeInstancePatchStates: API.PaginatedOperationMethod<
   DescribeInstancePatchStatesRequest,
   DescribeInstancePatchStatesResult,
   DescribeInstancePatchStatesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstancePatchState
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancePatchStatesRequest,
@@ -13514,7 +13513,7 @@ export const describeInstancePatchStatesForPatchGroup: API.PaginatedOperationMet
   DescribeInstancePatchStatesForPatchGroupRequest,
   DescribeInstancePatchStatesForPatchGroupResult,
   DescribeInstancePatchStatesForPatchGroupError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstancePatchState
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancePatchStatesForPatchGroupRequest,
@@ -13548,7 +13547,7 @@ export const describeInstanceProperties: API.PaginatedOperationMethod<
   DescribeInstancePropertiesRequest,
   DescribeInstancePropertiesResult,
   DescribeInstancePropertiesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InstanceProperty
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInstancePropertiesRequest,
@@ -13585,7 +13584,7 @@ export const describeInventoryDeletions: API.PaginatedOperationMethod<
   DescribeInventoryDeletionsRequest,
   DescribeInventoryDeletionsResult,
   DescribeInventoryDeletionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InventoryDeletionStatusItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInventoryDeletionsRequest,
@@ -13614,7 +13613,7 @@ export const describeMaintenanceWindowExecutions: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowExecutionsRequest,
   DescribeMaintenanceWindowExecutionsResult,
   DescribeMaintenanceWindowExecutionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowExecutionsRequest,
@@ -13643,7 +13642,7 @@ export const describeMaintenanceWindowExecutionTaskInvocations: API.PaginatedOpe
   DescribeMaintenanceWindowExecutionTaskInvocationsRequest,
   DescribeMaintenanceWindowExecutionTaskInvocationsResult,
   DescribeMaintenanceWindowExecutionTaskInvocationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowExecutionTaskInvocationIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowExecutionTaskInvocationsRequest,
@@ -13671,7 +13670,7 @@ export const describeMaintenanceWindowExecutionTasks: API.PaginatedOperationMeth
   DescribeMaintenanceWindowExecutionTasksRequest,
   DescribeMaintenanceWindowExecutionTasksResult,
   DescribeMaintenanceWindowExecutionTasksError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowExecutionTaskIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowExecutionTasksRequest,
@@ -13698,7 +13697,7 @@ export const describeMaintenanceWindows: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowsRequest,
   DescribeMaintenanceWindowsResult,
   DescribeMaintenanceWindowsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowsRequest,
@@ -13726,7 +13725,7 @@ export const describeMaintenanceWindowSchedule: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowScheduleRequest,
   DescribeMaintenanceWindowScheduleResult,
   DescribeMaintenanceWindowScheduleError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ScheduledWindowExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowScheduleRequest,
@@ -13754,7 +13753,7 @@ export const describeMaintenanceWindowsForTarget: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowsForTargetRequest,
   DescribeMaintenanceWindowsForTargetResult,
   DescribeMaintenanceWindowsForTargetError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowIdentityForTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowsForTargetRequest,
@@ -13782,7 +13781,7 @@ export const describeMaintenanceWindowTargets: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowTargetsRequest,
   DescribeMaintenanceWindowTargetsResult,
   DescribeMaintenanceWindowTargetsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowTarget
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowTargetsRequest,
@@ -13815,7 +13814,7 @@ export const describeMaintenanceWindowTasks: API.PaginatedOperationMethod<
   DescribeMaintenanceWindowTasksRequest,
   DescribeMaintenanceWindowTasksResult,
   DescribeMaintenanceWindowTasksError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   MaintenanceWindowTask
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeMaintenanceWindowTasksRequest,
@@ -13846,7 +13845,7 @@ export const describeOpsItems: API.PaginatedOperationMethod<
   DescribeOpsItemsRequest,
   DescribeOpsItemsResponse,
   DescribeOpsItemsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   OpsItemSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeOpsItemsRequest,
@@ -13894,7 +13893,7 @@ export const describeParameters: API.PaginatedOperationMethod<
   DescribeParametersRequest,
   DescribeParametersResult,
   DescribeParametersError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeParametersRequest,
@@ -13924,7 +13923,7 @@ export const describePatchBaselines: API.PaginatedOperationMethod<
   DescribePatchBaselinesRequest,
   DescribePatchBaselinesResult,
   DescribePatchBaselinesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PatchBaselineIdentity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePatchBaselinesRequest,
@@ -13949,7 +13948,7 @@ export const describePatchGroups: API.PaginatedOperationMethod<
   DescribePatchGroupsRequest,
   DescribePatchGroupsResult,
   DescribePatchGroupsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   PatchGroupPatchBaselineMapping
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePatchGroupsRequest,
@@ -13977,7 +13976,7 @@ export const describePatchGroupState: API.OperationMethod<
   DescribePatchGroupStateRequest,
   DescribePatchGroupStateResult,
   DescribePatchGroupStateError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePatchGroupStateRequest,
   output: DescribePatchGroupStateResult,
@@ -14052,7 +14051,7 @@ export const describePatchProperties: API.PaginatedOperationMethod<
   DescribePatchPropertiesRequest,
   DescribePatchPropertiesResult,
   DescribePatchPropertiesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   { [key: string]: string | undefined }
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribePatchPropertiesRequest,
@@ -14082,7 +14081,7 @@ export const describeSessions: API.PaginatedOperationMethod<
   DescribeSessionsRequest,
   DescribeSessionsResponse,
   DescribeSessionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Session
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeSessionsRequest,
@@ -14115,7 +14114,7 @@ export const disassociateOpsItemRelatedItem: API.OperationMethod<
   DisassociateOpsItemRelatedItemRequest,
   DisassociateOpsItemRelatedItemResponse,
   DisassociateOpsItemRelatedItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateOpsItemRelatedItemRequest,
   output: DisassociateOpsItemRelatedItemResponse,
@@ -14145,7 +14144,7 @@ export const getAccessToken: API.OperationMethod<
   GetAccessTokenRequest,
   GetAccessTokenResponse,
   GetAccessTokenError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessTokenRequest,
   output: GetAccessTokenResponse,
@@ -14172,7 +14171,7 @@ export const getAutomationExecution: API.OperationMethod<
   GetAutomationExecutionRequest,
   GetAutomationExecutionResult,
   GetAutomationExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAutomationExecutionRequest,
   output: GetAutomationExecutionResult,
@@ -14205,7 +14204,7 @@ export const getCalendarState: API.OperationMethod<
   GetCalendarStateRequest,
   GetCalendarStateResponse,
   GetCalendarStateError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCalendarStateRequest,
   output: GetCalendarStateResponse,
@@ -14243,7 +14242,7 @@ export const getCommandInvocation: API.OperationMethod<
   GetCommandInvocationRequest,
   GetCommandInvocationResult,
   GetCommandInvocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCommandInvocationRequest,
   output: GetCommandInvocationResult,
@@ -14268,7 +14267,7 @@ export const getConnectionStatus: API.OperationMethod<
   GetConnectionStatusRequest,
   GetConnectionStatusResponse,
   GetConnectionStatusError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetConnectionStatusRequest,
   output: GetConnectionStatusResponse,
@@ -14290,7 +14289,7 @@ export const getDefaultPatchBaseline: API.OperationMethod<
   GetDefaultPatchBaselineRequest,
   GetDefaultPatchBaselineResult,
   GetDefaultPatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultPatchBaselineRequest,
   output: GetDefaultPatchBaselineResult,
@@ -14319,7 +14318,7 @@ export const getDeployablePatchSnapshotForInstance: API.OperationMethod<
   GetDeployablePatchSnapshotForInstanceRequest,
   GetDeployablePatchSnapshotForInstanceResult,
   GetDeployablePatchSnapshotForInstanceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeployablePatchSnapshotForInstanceRequest,
   output: GetDeployablePatchSnapshotForInstanceResult,
@@ -14345,7 +14344,7 @@ export const getDocument: API.OperationMethod<
   GetDocumentRequest,
   GetDocumentResult,
   GetDocumentError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentRequest,
   output: GetDocumentResult,
@@ -14367,7 +14366,7 @@ export const getExecutionPreview: API.OperationMethod<
   GetExecutionPreviewRequest,
   GetExecutionPreviewResponse,
   GetExecutionPreviewError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExecutionPreviewRequest,
   output: GetExecutionPreviewResponse,
@@ -14394,7 +14393,7 @@ export const getInventory: API.PaginatedOperationMethod<
   GetInventoryRequest,
   GetInventoryResult,
   GetInventoryError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InventoryResultEntity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInventoryRequest,
@@ -14432,7 +14431,7 @@ export const getInventorySchema: API.PaginatedOperationMethod<
   GetInventorySchemaRequest,
   GetInventorySchemaResult,
   GetInventorySchemaError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   InventoryItemSchema
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInventorySchemaRequest,
@@ -14460,7 +14459,7 @@ export const getMaintenanceWindow: API.OperationMethod<
   GetMaintenanceWindowRequest,
   GetMaintenanceWindowResult,
   GetMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaintenanceWindowRequest,
   output: GetMaintenanceWindowResult,
@@ -14481,7 +14480,7 @@ export const getMaintenanceWindowExecution: API.OperationMethod<
   GetMaintenanceWindowExecutionRequest,
   GetMaintenanceWindowExecutionResult,
   GetMaintenanceWindowExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaintenanceWindowExecutionRequest,
   output: GetMaintenanceWindowExecutionResult,
@@ -14503,7 +14502,7 @@ export const getMaintenanceWindowExecutionTask: API.OperationMethod<
   GetMaintenanceWindowExecutionTaskRequest,
   GetMaintenanceWindowExecutionTaskResult,
   GetMaintenanceWindowExecutionTaskError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaintenanceWindowExecutionTaskRequest,
   output: GetMaintenanceWindowExecutionTaskResult,
@@ -14524,7 +14523,7 @@ export const getMaintenanceWindowExecutionTaskInvocation: API.OperationMethod<
   GetMaintenanceWindowExecutionTaskInvocationRequest,
   GetMaintenanceWindowExecutionTaskInvocationResult,
   GetMaintenanceWindowExecutionTaskInvocationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaintenanceWindowExecutionTaskInvocationRequest,
   output: GetMaintenanceWindowExecutionTaskInvocationResult,
@@ -14552,7 +14551,7 @@ export const getMaintenanceWindowTask: API.OperationMethod<
   GetMaintenanceWindowTaskRequest,
   GetMaintenanceWindowTaskResult,
   GetMaintenanceWindowTaskError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMaintenanceWindowTaskRequest,
   output: GetMaintenanceWindowTaskResult,
@@ -14581,7 +14580,7 @@ export const getOpsItem: API.OperationMethod<
   GetOpsItemRequest,
   GetOpsItemResponse,
   GetOpsItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpsItemRequest,
   output: GetOpsItemResponse,
@@ -14607,7 +14606,7 @@ export const getOpsMetadata: API.OperationMethod<
   GetOpsMetadataRequest,
   GetOpsMetadataResult,
   GetOpsMetadataError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpsMetadataRequest,
   output: GetOpsMetadataResult,
@@ -14639,7 +14638,7 @@ export const getOpsSummary: API.PaginatedOperationMethod<
   GetOpsSummaryRequest,
   GetOpsSummaryResult,
   GetOpsSummaryError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   OpsEntity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetOpsSummaryRequest,
@@ -14682,7 +14681,7 @@ export const getParameter: API.OperationMethod<
   GetParameterRequest,
   GetParameterResult,
   GetParameterError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParameterRequest,
   output: GetParameterResult,
@@ -14719,7 +14718,7 @@ export const getParameterHistory: API.PaginatedOperationMethod<
   GetParameterHistoryRequest,
   GetParameterHistoryResult,
   GetParameterHistoryError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetParameterHistoryRequest,
@@ -14758,7 +14757,7 @@ export const getParameters: API.OperationMethod<
   GetParametersRequest,
   GetParametersResult,
   GetParametersError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParametersRequest,
   output: GetParametersResult,
@@ -14794,7 +14793,7 @@ export const getParametersByPath: API.PaginatedOperationMethod<
   GetParametersByPathRequest,
   GetParametersByPathResult,
   GetParametersByPathError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetParametersByPathRequest,
@@ -14829,7 +14828,7 @@ export const getPatchBaseline: API.OperationMethod<
   GetPatchBaselineRequest,
   GetPatchBaselineResult,
   GetPatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPatchBaselineRequest,
   output: GetPatchBaselineResult,
@@ -14849,7 +14848,7 @@ export const getPatchBaselineForPatchGroup: API.OperationMethod<
   GetPatchBaselineForPatchGroupRequest,
   GetPatchBaselineForPatchGroupResult,
   GetPatchBaselineForPatchGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPatchBaselineForPatchGroupRequest,
   output: GetPatchBaselineForPatchGroupResult,
@@ -14871,7 +14870,7 @@ export const getResourcePolicies: API.PaginatedOperationMethod<
   GetResourcePoliciesRequest,
   GetResourcePoliciesResponse,
   GetResourcePoliciesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   GetResourcePoliciesResponseEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetResourcePoliciesRequest,
@@ -14917,7 +14916,7 @@ export const getServiceSetting: API.OperationMethod<
   GetServiceSettingRequest,
   GetServiceSettingResult,
   GetServiceSettingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceSettingRequest,
   output: GetServiceSettingResult,
@@ -14972,7 +14971,7 @@ export const labelParameterVersion: API.OperationMethod<
   LabelParameterVersionRequest,
   LabelParameterVersionResult,
   LabelParameterVersionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LabelParameterVersionRequest,
   output: LabelParameterVersionResult,
@@ -15001,7 +15000,7 @@ export const listAssociations: API.PaginatedOperationMethod<
   ListAssociationsRequest,
   ListAssociationsResult,
   ListAssociationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Association
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociationsRequest,
@@ -15030,7 +15029,7 @@ export const listAssociationVersions: API.PaginatedOperationMethod<
   ListAssociationVersionsRequest,
   ListAssociationVersionsResult,
   ListAssociationVersionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   AssociationVersionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociationVersionsRequest,
@@ -15065,7 +15064,7 @@ export const listCommandInvocations: API.PaginatedOperationMethod<
   ListCommandInvocationsRequest,
   ListCommandInvocationsResult,
   ListCommandInvocationsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   CommandInvocation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommandInvocationsRequest,
@@ -15102,7 +15101,7 @@ export const listCommands: API.PaginatedOperationMethod<
   ListCommandsRequest,
   ListCommandsResult,
   ListCommandsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Command
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCommandsRequest,
@@ -15141,7 +15140,7 @@ export const listComplianceItems: API.PaginatedOperationMethod<
   ListComplianceItemsRequest,
   ListComplianceItemsResult,
   ListComplianceItemsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ComplianceItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComplianceItemsRequest,
@@ -15178,7 +15177,7 @@ export const listComplianceSummaries: API.PaginatedOperationMethod<
   ListComplianceSummariesRequest,
   ListComplianceSummariesResult,
   ListComplianceSummariesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ComplianceSummaryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListComplianceSummariesRequest,
@@ -15212,7 +15211,7 @@ export const listDocumentMetadataHistory: API.OperationMethod<
   ListDocumentMetadataHistoryRequest,
   ListDocumentMetadataHistoryResponse,
   ListDocumentMetadataHistoryError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListDocumentMetadataHistoryRequest,
   output: ListDocumentMetadataHistoryResponse,
@@ -15240,7 +15239,7 @@ export const listDocuments: API.PaginatedOperationMethod<
   ListDocumentsRequest,
   ListDocumentsResult,
   ListDocumentsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DocumentIdentifier
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentsRequest,
@@ -15269,7 +15268,7 @@ export const listDocumentVersions: API.PaginatedOperationMethod<
   ListDocumentVersionsRequest,
   ListDocumentVersionsResult,
   ListDocumentVersionsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   DocumentVersionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDocumentVersionsRequest,
@@ -15300,7 +15299,7 @@ export const listInventoryEntries: API.OperationMethod<
   ListInventoryEntriesRequest,
   ListInventoryEntriesResult,
   ListInventoryEntriesError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListInventoryEntriesRequest,
   output: ListInventoryEntriesResult,
@@ -15330,7 +15329,7 @@ export const listNodes: API.PaginatedOperationMethod<
   ListNodesRequest,
   ListNodesResult,
   ListNodesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   Node
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesRequest,
@@ -15369,7 +15368,7 @@ export const listNodesSummary: API.PaginatedOperationMethod<
   ListNodesSummaryRequest,
   ListNodesSummaryResult,
   ListNodesSummaryError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   { [key: string]: string | undefined }
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNodesSummaryRequest,
@@ -15407,7 +15406,7 @@ export const listOpsItemEvents: API.PaginatedOperationMethod<
   ListOpsItemEventsRequest,
   ListOpsItemEventsResponse,
   ListOpsItemEventsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   OpsItemEventSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpsItemEventsRequest,
@@ -15441,7 +15440,7 @@ export const listOpsItemRelatedItems: API.PaginatedOperationMethod<
   ListOpsItemRelatedItemsRequest,
   ListOpsItemRelatedItemsResponse,
   ListOpsItemRelatedItemsError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   OpsItemRelatedItemSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpsItemRelatedItemsRequest,
@@ -15470,7 +15469,7 @@ export const listOpsMetadata: API.PaginatedOperationMethod<
   ListOpsMetadataRequest,
   ListOpsMetadataResult,
   ListOpsMetadataError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   OpsMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpsMetadataRequest,
@@ -15501,7 +15500,7 @@ export const listResourceComplianceSummaries: API.PaginatedOperationMethod<
   ListResourceComplianceSummariesRequest,
   ListResourceComplianceSummariesResult,
   ListResourceComplianceSummariesError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ResourceComplianceSummaryItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceComplianceSummariesRequest,
@@ -15539,7 +15538,7 @@ export const listResourceDataSync: API.PaginatedOperationMethod<
   ListResourceDataSyncRequest,
   ListResourceDataSyncResult,
   ListResourceDataSyncError,
-  Creds | Rgn | HttpClient.HttpClient,
+  Creds | HttpClient.HttpClient,
   ResourceDataSyncItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceDataSyncRequest,
@@ -15574,7 +15573,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResult,
   ListTagsForResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResult,
@@ -15601,7 +15600,7 @@ export const modifyDocumentPermission: API.OperationMethod<
   ModifyDocumentPermissionRequest,
   ModifyDocumentPermissionResponse,
   ModifyDocumentPermissionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyDocumentPermissionRequest,
   output: ModifyDocumentPermissionResponse,
@@ -15679,7 +15678,7 @@ export const putComplianceItems: API.OperationMethod<
   PutComplianceItemsRequest,
   PutComplianceItemsResult,
   PutComplianceItemsError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutComplianceItemsRequest,
   output: PutComplianceItemsResult,
@@ -15720,7 +15719,7 @@ export const putInventory: API.OperationMethod<
   PutInventoryRequest,
   PutInventoryResult,
   PutInventoryError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInventoryRequest,
   output: PutInventoryResult,
@@ -15767,7 +15766,7 @@ export const putParameter: API.OperationMethod<
   PutParameterRequest,
   PutParameterResult,
   PutParameterError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutParameterRequest,
   output: PutParameterResult,
@@ -15835,7 +15834,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -15870,7 +15869,7 @@ export const registerDefaultPatchBaseline: API.OperationMethod<
   RegisterDefaultPatchBaselineRequest,
   RegisterDefaultPatchBaselineResult,
   RegisterDefaultPatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDefaultPatchBaselineRequest,
   output: RegisterDefaultPatchBaselineResult,
@@ -15894,7 +15893,7 @@ export const registerPatchBaselineForPatchGroup: API.OperationMethod<
   RegisterPatchBaselineForPatchGroupRequest,
   RegisterPatchBaselineForPatchGroupResult,
   RegisterPatchBaselineForPatchGroupError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterPatchBaselineForPatchGroupRequest,
   output: RegisterPatchBaselineForPatchGroupResult,
@@ -15923,7 +15922,7 @@ export const registerTargetWithMaintenanceWindow: API.OperationMethod<
   RegisterTargetWithMaintenanceWindowRequest,
   RegisterTargetWithMaintenanceWindowResult,
   RegisterTargetWithMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTargetWithMaintenanceWindowRequest,
   output: RegisterTargetWithMaintenanceWindowResult,
@@ -15952,7 +15951,7 @@ export const registerTaskWithMaintenanceWindow: API.OperationMethod<
   RegisterTaskWithMaintenanceWindowRequest,
   RegisterTaskWithMaintenanceWindowResult,
   RegisterTaskWithMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTaskWithMaintenanceWindowRequest,
   output: RegisterTaskWithMaintenanceWindowResult,
@@ -15981,7 +15980,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceRequest,
   RemoveTagsFromResourceResult,
   RemoveTagsFromResourceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceRequest,
   output: RemoveTagsFromResourceResult,
@@ -16023,7 +16022,7 @@ export const resetServiceSetting: API.OperationMethod<
   ResetServiceSettingRequest,
   ResetServiceSettingResult,
   ResetServiceSettingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetServiceSettingRequest,
   output: ResetServiceSettingResult,
@@ -16048,7 +16047,7 @@ export const resumeSession: API.OperationMethod<
   ResumeSessionRequest,
   ResumeSessionResponse,
   ResumeSessionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeSessionRequest,
   output: ResumeSessionResponse,
@@ -16072,7 +16071,7 @@ export const sendAutomationSignal: API.OperationMethod<
   SendAutomationSignalRequest,
   SendAutomationSignalResult,
   SendAutomationSignalError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendAutomationSignalRequest,
   output: SendAutomationSignalResult,
@@ -16107,7 +16106,7 @@ export const sendCommand: API.OperationMethod<
   SendCommandRequest,
   SendCommandResult,
   SendCommandError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendCommandRequest,
   output: SendCommandResult,
@@ -16144,7 +16143,7 @@ export const startAccessRequest: API.OperationMethod<
   StartAccessRequestRequest,
   StartAccessRequestResponse,
   StartAccessRequestError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAccessRequestRequest,
   output: StartAccessRequestResponse,
@@ -16173,7 +16172,7 @@ export const startAssociationsOnce: API.OperationMethod<
   StartAssociationsOnceRequest,
   StartAssociationsOnceResult,
   StartAssociationsOnceError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAssociationsOnceRequest,
   output: StartAssociationsOnceResult,
@@ -16199,7 +16198,7 @@ export const startAutomationExecution: API.OperationMethod<
   StartAutomationExecutionRequest,
   StartAutomationExecutionResult,
   StartAutomationExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAutomationExecutionRequest,
   output: StartAutomationExecutionResult,
@@ -16240,7 +16239,7 @@ export const startChangeRequestExecution: API.OperationMethod<
   StartChangeRequestExecutionRequest,
   StartChangeRequestExecutionResult,
   StartChangeRequestExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartChangeRequestExecutionRequest,
   output: StartChangeRequestExecutionResult,
@@ -16271,7 +16270,7 @@ export const startExecutionPreview: API.OperationMethod<
   StartExecutionPreviewRequest,
   StartExecutionPreviewResponse,
   StartExecutionPreviewError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExecutionPreviewRequest,
   output: StartExecutionPreviewResponse,
@@ -16302,7 +16301,7 @@ export const startSession: API.OperationMethod<
   StartSessionRequest,
   StartSessionResponse,
   StartSessionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSessionRequest,
   output: StartSessionResponse,
@@ -16324,7 +16323,7 @@ export const stopAutomationExecution: API.OperationMethod<
   StopAutomationExecutionRequest,
   StopAutomationExecutionResult,
   StopAutomationExecutionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopAutomationExecutionRequest,
   output: StopAutomationExecutionResult,
@@ -16347,7 +16346,7 @@ export const terminateSession: API.OperationMethod<
   TerminateSessionRequest,
   TerminateSessionResponse,
   TerminateSessionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateSessionRequest,
   output: TerminateSessionResponse,
@@ -16374,7 +16373,7 @@ export const unlabelParameterVersion: API.OperationMethod<
   UnlabelParameterVersionRequest,
   UnlabelParameterVersionResult,
   UnlabelParameterVersionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UnlabelParameterVersionRequest,
   output: UnlabelParameterVersionResult,
@@ -16428,7 +16427,7 @@ export const updateAssociation: API.OperationMethod<
   UpdateAssociationRequest,
   UpdateAssociationResult,
   UpdateAssociationError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssociationRequest,
   output: UpdateAssociationResult,
@@ -16472,7 +16471,7 @@ export const updateAssociationStatus: API.OperationMethod<
   UpdateAssociationStatusRequest,
   UpdateAssociationStatusResult,
   UpdateAssociationStatusError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAssociationStatusRequest,
   output: UpdateAssociationStatusResult,
@@ -16508,7 +16507,7 @@ export const updateDocument: API.OperationMethod<
   UpdateDocumentRequest,
   UpdateDocumentResult,
   UpdateDocumentError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentRequest,
   output: UpdateDocumentResult,
@@ -16546,7 +16545,7 @@ export const updateDocumentDefaultVersion: API.OperationMethod<
   UpdateDocumentDefaultVersionRequest,
   UpdateDocumentDefaultVersionResult,
   UpdateDocumentDefaultVersionError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentDefaultVersionRequest,
   output: UpdateDocumentDefaultVersionResult,
@@ -16580,7 +16579,7 @@ export const updateDocumentMetadata: API.OperationMethod<
   UpdateDocumentMetadataRequest,
   UpdateDocumentMetadataResponse,
   UpdateDocumentMetadataError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentMetadataRequest,
   output: UpdateDocumentMetadataResponse,
@@ -16614,7 +16613,7 @@ export const updateMaintenanceWindow: API.OperationMethod<
   UpdateMaintenanceWindowRequest,
   UpdateMaintenanceWindowResult,
   UpdateMaintenanceWindowError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMaintenanceWindowRequest,
   output: UpdateMaintenanceWindowResult,
@@ -16651,7 +16650,7 @@ export const updateMaintenanceWindowTarget: API.OperationMethod<
   UpdateMaintenanceWindowTargetRequest,
   UpdateMaintenanceWindowTargetResult,
   UpdateMaintenanceWindowTargetError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMaintenanceWindowTargetRequest,
   output: UpdateMaintenanceWindowTargetResult,
@@ -16707,7 +16706,7 @@ export const updateMaintenanceWindowTask: API.OperationMethod<
   UpdateMaintenanceWindowTaskRequest,
   UpdateMaintenanceWindowTaskResult,
   UpdateMaintenanceWindowTaskError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMaintenanceWindowTaskRequest,
   output: UpdateMaintenanceWindowTaskResult,
@@ -16730,7 +16729,7 @@ export const updateManagedInstanceRole: API.OperationMethod<
   UpdateManagedInstanceRoleRequest,
   UpdateManagedInstanceRoleResult,
   UpdateManagedInstanceRoleError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateManagedInstanceRoleRequest,
   output: UpdateManagedInstanceRoleResult,
@@ -16762,7 +16761,7 @@ export const updateOpsItem: API.OperationMethod<
   UpdateOpsItemRequest,
   UpdateOpsItemResponse,
   UpdateOpsItemError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOpsItemRequest,
   output: UpdateOpsItemResponse,
@@ -16794,7 +16793,7 @@ export const updateOpsMetadata: API.OperationMethod<
   UpdateOpsMetadataRequest,
   UpdateOpsMetadataResult,
   UpdateOpsMetadataError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOpsMetadataRequest,
   output: UpdateOpsMetadataResult,
@@ -16825,7 +16824,7 @@ export const updatePatchBaseline: API.OperationMethod<
   UpdatePatchBaselineRequest,
   UpdatePatchBaselineResult,
   UpdatePatchBaselineError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePatchBaselineRequest,
   output: UpdatePatchBaselineResult,
@@ -16856,7 +16855,7 @@ export const updateResourceDataSync: API.OperationMethod<
   UpdateResourceDataSyncRequest,
   UpdateResourceDataSyncResult,
   UpdateResourceDataSyncError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceDataSyncRequest,
   output: UpdateResourceDataSyncResult,
@@ -16897,7 +16896,7 @@ export const updateServiceSetting: API.OperationMethod<
   UpdateServiceSettingRequest,
   UpdateServiceSettingResult,
   UpdateServiceSettingError,
-  Creds | Rgn | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceSettingRequest,
   output: UpdateServiceSettingResult,

--- a/packages/aws/src/services/sso-admin.ts
+++ b/packages/aws/src/services/sso-admin.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "SSO Admin",
   serviceShapeName: "SWBExternalService",
@@ -3011,7 +3010,7 @@ export const addRegion: API.OperationMethod<
   AddRegionRequest,
   AddRegionResponse,
   AddRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddRegionRequest,
   output: AddRegionResponse,
@@ -3044,7 +3043,7 @@ export const attachCustomerManagedPolicyReferenceToPermissionSet: API.OperationM
   AttachCustomerManagedPolicyReferenceToPermissionSetRequest,
   AttachCustomerManagedPolicyReferenceToPermissionSetResponse,
   AttachCustomerManagedPolicyReferenceToPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachCustomerManagedPolicyReferenceToPermissionSetRequest,
   output: AttachCustomerManagedPolicyReferenceToPermissionSetResponse,
@@ -3080,7 +3079,7 @@ export const attachManagedPolicyToPermissionSet: API.OperationMethod<
   AttachManagedPolicyToPermissionSetRequest,
   AttachManagedPolicyToPermissionSetResponse,
   AttachManagedPolicyToPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachManagedPolicyToPermissionSetRequest,
   output: AttachManagedPolicyToPermissionSetResponse,
@@ -3120,7 +3119,7 @@ export const createAccountAssignment: API.OperationMethod<
   CreateAccountAssignmentRequest,
   CreateAccountAssignmentResponse,
   CreateAccountAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountAssignmentRequest,
   output: CreateAccountAssignmentResponse,
@@ -3156,7 +3155,7 @@ export const createApplication: API.OperationMethod<
   CreateApplicationRequest,
   CreateApplicationResponse,
   CreateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationRequest,
   output: CreateApplicationResponse,
@@ -3190,7 +3189,7 @@ export const createApplicationAssignment: API.OperationMethod<
   CreateApplicationAssignmentRequest,
   CreateApplicationAssignmentResponse,
   CreateApplicationAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateApplicationAssignmentRequest,
   output: CreateApplicationAssignmentResponse,
@@ -3229,7 +3228,7 @@ export const createInstance: API.OperationMethod<
   CreateInstanceRequest,
   CreateInstanceResponse,
   CreateInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceRequest,
   output: CreateInstanceResponse,
@@ -3263,7 +3262,7 @@ export const createInstanceAccessControlAttributeConfiguration: API.OperationMet
   CreateInstanceAccessControlAttributeConfigurationRequest,
   CreateInstanceAccessControlAttributeConfigurationResponse,
   CreateInstanceAccessControlAttributeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceAccessControlAttributeConfigurationRequest,
   output: CreateInstanceAccessControlAttributeConfigurationResponse,
@@ -3298,7 +3297,7 @@ export const createPermissionSet: API.OperationMethod<
   CreatePermissionSetRequest,
   CreatePermissionSetResponse,
   CreatePermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePermissionSetRequest,
   output: CreatePermissionSetResponse,
@@ -3333,7 +3332,7 @@ export const createTrustedTokenIssuer: API.OperationMethod<
   CreateTrustedTokenIssuerRequest,
   CreateTrustedTokenIssuerResponse,
   CreateTrustedTokenIssuerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustedTokenIssuerRequest,
   output: CreateTrustedTokenIssuerResponse,
@@ -3367,7 +3366,7 @@ export const deleteAccountAssignment: API.OperationMethod<
   DeleteAccountAssignmentRequest,
   DeleteAccountAssignmentResponse,
   DeleteAccountAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountAssignmentRequest,
   output: DeleteAccountAssignmentResponse,
@@ -3399,7 +3398,7 @@ export const deleteApplication: API.OperationMethod<
   DeleteApplicationRequest,
   DeleteApplicationResponse,
   DeleteApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationRequest,
   output: DeleteApplicationResponse,
@@ -3431,7 +3430,7 @@ export const deleteApplicationAccessScope: API.OperationMethod<
   DeleteApplicationAccessScopeRequest,
   DeleteApplicationAccessScopeResponse,
   DeleteApplicationAccessScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationAccessScopeRequest,
   output: DeleteApplicationAccessScopeResponse,
@@ -3463,7 +3462,7 @@ export const deleteApplicationAssignment: API.OperationMethod<
   DeleteApplicationAssignmentRequest,
   DeleteApplicationAssignmentResponse,
   DeleteApplicationAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationAssignmentRequest,
   output: DeleteApplicationAssignmentResponse,
@@ -3495,7 +3494,7 @@ export const deleteApplicationAuthenticationMethod: API.OperationMethod<
   DeleteApplicationAuthenticationMethodRequest,
   DeleteApplicationAuthenticationMethodResponse,
   DeleteApplicationAuthenticationMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationAuthenticationMethodRequest,
   output: DeleteApplicationAuthenticationMethodResponse,
@@ -3527,7 +3526,7 @@ export const deleteApplicationGrant: API.OperationMethod<
   DeleteApplicationGrantRequest,
   DeleteApplicationGrantResponse,
   DeleteApplicationGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteApplicationGrantRequest,
   output: DeleteApplicationGrantResponse,
@@ -3559,7 +3558,7 @@ export const deleteInlinePolicyFromPermissionSet: API.OperationMethod<
   DeleteInlinePolicyFromPermissionSetRequest,
   DeleteInlinePolicyFromPermissionSetResponse,
   DeleteInlinePolicyFromPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInlinePolicyFromPermissionSetRequest,
   output: DeleteInlinePolicyFromPermissionSetResponse,
@@ -3590,7 +3589,7 @@ export const deleteInstance: API.OperationMethod<
   DeleteInstanceRequest,
   DeleteInstanceResponse,
   DeleteInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceRequest,
   output: DeleteInstanceResponse,
@@ -3621,7 +3620,7 @@ export const deleteInstanceAccessControlAttributeConfiguration: API.OperationMet
   DeleteInstanceAccessControlAttributeConfigurationRequest,
   DeleteInstanceAccessControlAttributeConfigurationResponse,
   DeleteInstanceAccessControlAttributeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceAccessControlAttributeConfigurationRequest,
   output: DeleteInstanceAccessControlAttributeConfigurationResponse,
@@ -3653,7 +3652,7 @@ export const deletePermissionsBoundaryFromPermissionSet: API.OperationMethod<
   DeletePermissionsBoundaryFromPermissionSetRequest,
   DeletePermissionsBoundaryFromPermissionSetResponse,
   DeletePermissionsBoundaryFromPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionsBoundaryFromPermissionSetRequest,
   output: DeletePermissionsBoundaryFromPermissionSetResponse,
@@ -3685,7 +3684,7 @@ export const deletePermissionSet: API.OperationMethod<
   DeletePermissionSetRequest,
   DeletePermissionSetResponse,
   DeletePermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionSetRequest,
   output: DeletePermissionSetResponse,
@@ -3719,7 +3718,7 @@ export const deleteTrustedTokenIssuer: API.OperationMethod<
   DeleteTrustedTokenIssuerRequest,
   DeleteTrustedTokenIssuerResponse,
   DeleteTrustedTokenIssuerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustedTokenIssuerRequest,
   output: DeleteTrustedTokenIssuerResponse,
@@ -3750,7 +3749,7 @@ export const describeAccountAssignmentCreationStatus: API.OperationMethod<
   DescribeAccountAssignmentCreationStatusRequest,
   DescribeAccountAssignmentCreationStatusResponse,
   DescribeAccountAssignmentCreationStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAssignmentCreationStatusRequest,
   output: DescribeAccountAssignmentCreationStatusResponse,
@@ -3780,7 +3779,7 @@ export const describeAccountAssignmentDeletionStatus: API.OperationMethod<
   DescribeAccountAssignmentDeletionStatusRequest,
   DescribeAccountAssignmentDeletionStatusResponse,
   DescribeAccountAssignmentDeletionStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountAssignmentDeletionStatusRequest,
   output: DescribeAccountAssignmentDeletionStatusResponse,
@@ -3810,7 +3809,7 @@ export const describeApplication: API.OperationMethod<
   DescribeApplicationRequest,
   DescribeApplicationResponse,
   DescribeApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationRequest,
   output: DescribeApplicationResponse,
@@ -3840,7 +3839,7 @@ export const describeApplicationAssignment: API.OperationMethod<
   DescribeApplicationAssignmentRequest,
   DescribeApplicationAssignmentResponse,
   DescribeApplicationAssignmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationAssignmentRequest,
   output: DescribeApplicationAssignmentResponse,
@@ -3870,7 +3869,7 @@ export const describeApplicationProvider: API.OperationMethod<
   DescribeApplicationProviderRequest,
   DescribeApplicationProviderResponse,
   DescribeApplicationProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeApplicationProviderRequest,
   output: DescribeApplicationProviderResponse,
@@ -3905,7 +3904,7 @@ export const describeInstance: API.OperationMethod<
   DescribeInstanceRequest,
   DescribeInstanceResponse,
   DescribeInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceRequest,
   output: DescribeInstanceResponse,
@@ -3934,7 +3933,7 @@ export const describeInstanceAccessControlAttributeConfiguration: API.OperationM
   DescribeInstanceAccessControlAttributeConfigurationRequest,
   DescribeInstanceAccessControlAttributeConfigurationResponse,
   DescribeInstanceAccessControlAttributeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInstanceAccessControlAttributeConfigurationRequest,
   output: DescribeInstanceAccessControlAttributeConfigurationResponse,
@@ -3964,7 +3963,7 @@ export const describePermissionSet: API.OperationMethod<
   DescribePermissionSetRequest,
   DescribePermissionSetResponse,
   DescribePermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePermissionSetRequest,
   output: DescribePermissionSetResponse,
@@ -3994,7 +3993,7 @@ export const describePermissionSetProvisioningStatus: API.OperationMethod<
   DescribePermissionSetProvisioningStatusRequest,
   DescribePermissionSetProvisioningStatusResponse,
   DescribePermissionSetProvisioningStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribePermissionSetProvisioningStatusRequest,
   output: DescribePermissionSetProvisioningStatusResponse,
@@ -4032,7 +4031,7 @@ export const describeRegion: API.OperationMethod<
   DescribeRegionRequest,
   DescribeRegionResponse,
   DescribeRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeRegionRequest,
   output: DescribeRegionResponse,
@@ -4062,7 +4061,7 @@ export const describeTrustedTokenIssuer: API.OperationMethod<
   DescribeTrustedTokenIssuerRequest,
   DescribeTrustedTokenIssuerResponse,
   DescribeTrustedTokenIssuerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrustedTokenIssuerRequest,
   output: DescribeTrustedTokenIssuerResponse,
@@ -4093,7 +4092,7 @@ export const detachCustomerManagedPolicyReferenceFromPermissionSet: API.Operatio
   DetachCustomerManagedPolicyReferenceFromPermissionSetRequest,
   DetachCustomerManagedPolicyReferenceFromPermissionSetResponse,
   DetachCustomerManagedPolicyReferenceFromPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachCustomerManagedPolicyReferenceFromPermissionSetRequest,
   output: DetachCustomerManagedPolicyReferenceFromPermissionSetResponse,
@@ -4125,7 +4124,7 @@ export const detachManagedPolicyFromPermissionSet: API.OperationMethod<
   DetachManagedPolicyFromPermissionSetRequest,
   DetachManagedPolicyFromPermissionSetResponse,
   DetachManagedPolicyFromPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachManagedPolicyFromPermissionSetRequest,
   output: DetachManagedPolicyFromPermissionSetResponse,
@@ -4156,7 +4155,7 @@ export const getApplicationAccessScope: API.OperationMethod<
   GetApplicationAccessScopeRequest,
   GetApplicationAccessScopeResponse,
   GetApplicationAccessScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationAccessScopeRequest,
   output: GetApplicationAccessScopeResponse,
@@ -4186,7 +4185,7 @@ export const getApplicationAssignmentConfiguration: API.OperationMethod<
   GetApplicationAssignmentConfigurationRequest,
   GetApplicationAssignmentConfigurationResponse,
   GetApplicationAssignmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationAssignmentConfigurationRequest,
   output: GetApplicationAssignmentConfigurationResponse,
@@ -4216,7 +4215,7 @@ export const getApplicationAuthenticationMethod: API.OperationMethod<
   GetApplicationAuthenticationMethodRequest,
   GetApplicationAuthenticationMethodResponse,
   GetApplicationAuthenticationMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationAuthenticationMethodRequest,
   output: GetApplicationAuthenticationMethodResponse,
@@ -4246,7 +4245,7 @@ export const getApplicationGrant: API.OperationMethod<
   GetApplicationGrantRequest,
   GetApplicationGrantResponse,
   GetApplicationGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationGrantRequest,
   output: GetApplicationGrantResponse,
@@ -4278,7 +4277,7 @@ export const getApplicationSessionConfiguration: API.OperationMethod<
   GetApplicationSessionConfigurationRequest,
   GetApplicationSessionConfigurationResponse,
   GetApplicationSessionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetApplicationSessionConfigurationRequest,
   output: GetApplicationSessionConfigurationResponse,
@@ -4308,7 +4307,7 @@ export const getInlinePolicyForPermissionSet: API.OperationMethod<
   GetInlinePolicyForPermissionSetRequest,
   GetInlinePolicyForPermissionSetResponse,
   GetInlinePolicyForPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInlinePolicyForPermissionSetRequest,
   output: GetInlinePolicyForPermissionSetResponse,
@@ -4338,7 +4337,7 @@ export const getPermissionsBoundaryForPermissionSet: API.OperationMethod<
   GetPermissionsBoundaryForPermissionSetRequest,
   GetPermissionsBoundaryForPermissionSetResponse,
   GetPermissionsBoundaryForPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionsBoundaryForPermissionSetRequest,
   output: GetPermissionsBoundaryForPermissionSetResponse,
@@ -4368,7 +4367,7 @@ export const listAccountAssignmentCreationStatus: API.PaginatedOperationMethod<
   ListAccountAssignmentCreationStatusRequest,
   ListAccountAssignmentCreationStatusResponse,
   ListAccountAssignmentCreationStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssignmentOperationStatusMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssignmentCreationStatusRequest,
@@ -4405,7 +4404,7 @@ export const listAccountAssignmentDeletionStatus: API.PaginatedOperationMethod<
   ListAccountAssignmentDeletionStatusRequest,
   ListAccountAssignmentDeletionStatusResponse,
   ListAccountAssignmentDeletionStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssignmentOperationStatusMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssignmentDeletionStatusRequest,
@@ -4442,7 +4441,7 @@ export const listAccountAssignments: API.PaginatedOperationMethod<
   ListAccountAssignmentsRequest,
   ListAccountAssignmentsResponse,
   ListAccountAssignmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssignment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssignmentsRequest,
@@ -4479,7 +4478,7 @@ export const listAccountAssignmentsForPrincipal: API.PaginatedOperationMethod<
   ListAccountAssignmentsForPrincipalRequest,
   ListAccountAssignmentsForPrincipalResponse,
   ListAccountAssignmentsForPrincipalError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountAssignmentForPrincipal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountAssignmentsForPrincipalRequest,
@@ -4516,7 +4515,7 @@ export const listAccountsForProvisionedPermissionSet: API.PaginatedOperationMeth
   ListAccountsForProvisionedPermissionSetRequest,
   ListAccountsForProvisionedPermissionSetResponse,
   ListAccountsForProvisionedPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountId
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsForProvisionedPermissionSetRequest,
@@ -4553,7 +4552,7 @@ export const listApplicationAccessScopes: API.PaginatedOperationMethod<
   ListApplicationAccessScopesRequest,
   ListApplicationAccessScopesResponse,
   ListApplicationAccessScopesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScopeDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationAccessScopesRequest,
@@ -4590,7 +4589,7 @@ export const listApplicationAssignments: API.PaginatedOperationMethod<
   ListApplicationAssignmentsRequest,
   ListApplicationAssignmentsResponse,
   ListApplicationAssignmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationAssignment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationAssignmentsRequest,
@@ -4627,7 +4626,7 @@ export const listApplicationAssignmentsForPrincipal: API.PaginatedOperationMetho
   ListApplicationAssignmentsForPrincipalRequest,
   ListApplicationAssignmentsForPrincipalResponse,
   ListApplicationAssignmentsForPrincipalError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationAssignmentForPrincipal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationAssignmentsForPrincipalRequest,
@@ -4664,7 +4663,7 @@ export const listApplicationAuthenticationMethods: API.PaginatedOperationMethod<
   ListApplicationAuthenticationMethodsRequest,
   ListApplicationAuthenticationMethodsResponse,
   ListApplicationAuthenticationMethodsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AuthenticationMethodItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationAuthenticationMethodsRequest,
@@ -4700,7 +4699,7 @@ export const listApplicationGrants: API.PaginatedOperationMethod<
   ListApplicationGrantsRequest,
   ListApplicationGrantsResponse,
   ListApplicationGrantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GrantItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationGrantsRequest,
@@ -4735,7 +4734,7 @@ export const listApplicationProviders: API.PaginatedOperationMethod<
   ListApplicationProvidersRequest,
   ListApplicationProvidersResponse,
   ListApplicationProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ApplicationProvider
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationProvidersRequest,
@@ -4770,7 +4769,7 @@ export const listApplications: API.PaginatedOperationMethod<
   ListApplicationsRequest,
   ListApplicationsResponse,
   ListApplicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Application
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListApplicationsRequest,
@@ -4806,7 +4805,7 @@ export const listCustomerManagedPolicyReferencesInPermissionSet: API.PaginatedOp
   ListCustomerManagedPolicyReferencesInPermissionSetRequest,
   ListCustomerManagedPolicyReferencesInPermissionSetResponse,
   ListCustomerManagedPolicyReferencesInPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CustomerManagedPolicyReference
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCustomerManagedPolicyReferencesInPermissionSetRequest,
@@ -4842,7 +4841,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesRequest,
   ListInstancesResponse,
   ListInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesRequest,
@@ -4878,7 +4877,7 @@ export const listManagedPoliciesInPermissionSet: API.PaginatedOperationMethod<
   ListManagedPoliciesInPermissionSetRequest,
   ListManagedPoliciesInPermissionSetResponse,
   ListManagedPoliciesInPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AttachedManagedPolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListManagedPoliciesInPermissionSetRequest,
@@ -4915,7 +4914,7 @@ export const listPermissionSetProvisioningStatus: API.PaginatedOperationMethod<
   ListPermissionSetProvisioningStatusRequest,
   ListPermissionSetProvisioningStatusResponse,
   ListPermissionSetProvisioningStatusError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PermissionSetProvisioningStatusMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionSetProvisioningStatusRequest,
@@ -4952,7 +4951,7 @@ export const listPermissionSets: API.PaginatedOperationMethod<
   ListPermissionSetsRequest,
   ListPermissionSetsResponse,
   ListPermissionSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PermissionSetArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionSetsRequest,
@@ -4989,7 +4988,7 @@ export const listPermissionSetsProvisionedToAccount: API.PaginatedOperationMetho
   ListPermissionSetsProvisionedToAccountRequest,
   ListPermissionSetsProvisionedToAccountResponse,
   ListPermissionSetsProvisionedToAccountError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PermissionSetArn
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPermissionSetsProvisionedToAccountRequest,
@@ -5033,7 +5032,7 @@ export const listRegions: API.PaginatedOperationMethod<
   ListRegionsRequest,
   ListRegionsResponse,
   ListRegionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RegionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegionsRequest,
@@ -5069,7 +5068,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -5104,7 +5103,7 @@ export const listTrustedTokenIssuers: API.PaginatedOperationMethod<
   ListTrustedTokenIssuersRequest,
   ListTrustedTokenIssuersResponse,
   ListTrustedTokenIssuersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TrustedTokenIssuerMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustedTokenIssuersRequest,
@@ -5141,7 +5140,7 @@ export const provisionPermissionSet: API.OperationMethod<
   ProvisionPermissionSetRequest,
   ProvisionPermissionSetResponse,
   ProvisionPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ProvisionPermissionSetRequest,
   output: ProvisionPermissionSetResponse,
@@ -5173,7 +5172,7 @@ export const putApplicationAccessScope: API.OperationMethod<
   PutApplicationAccessScopeRequest,
   PutApplicationAccessScopeResponse,
   PutApplicationAccessScopeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationAccessScopeRequest,
   output: PutApplicationAccessScopeResponse,
@@ -5205,7 +5204,7 @@ export const putApplicationAssignmentConfiguration: API.OperationMethod<
   PutApplicationAssignmentConfigurationRequest,
   PutApplicationAssignmentConfigurationResponse,
   PutApplicationAssignmentConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationAssignmentConfigurationRequest,
   output: PutApplicationAssignmentConfigurationResponse,
@@ -5237,7 +5236,7 @@ export const putApplicationAuthenticationMethod: API.OperationMethod<
   PutApplicationAuthenticationMethodRequest,
   PutApplicationAuthenticationMethodResponse,
   PutApplicationAuthenticationMethodError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationAuthenticationMethodRequest,
   output: PutApplicationAuthenticationMethodResponse,
@@ -5294,7 +5293,7 @@ export const putApplicationGrant: API.OperationMethod<
   PutApplicationGrantRequest,
   PutApplicationGrantResponse,
   PutApplicationGrantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationGrantRequest,
   output: PutApplicationGrantResponse,
@@ -5328,7 +5327,7 @@ export const putApplicationSessionConfiguration: API.OperationMethod<
   PutApplicationSessionConfigurationRequest,
   PutApplicationSessionConfigurationResponse,
   PutApplicationSessionConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutApplicationSessionConfigurationRequest,
   output: PutApplicationSessionConfigurationResponse,
@@ -5363,7 +5362,7 @@ export const putInlinePolicyToPermissionSet: API.OperationMethod<
   PutInlinePolicyToPermissionSetRequest,
   PutInlinePolicyToPermissionSetResponse,
   PutInlinePolicyToPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInlinePolicyToPermissionSetRequest,
   output: PutInlinePolicyToPermissionSetResponse,
@@ -5396,7 +5395,7 @@ export const putPermissionsBoundaryToPermissionSet: API.OperationMethod<
   PutPermissionsBoundaryToPermissionSetRequest,
   PutPermissionsBoundaryToPermissionSetResponse,
   PutPermissionsBoundaryToPermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionsBoundaryToPermissionSetRequest,
   output: PutPermissionsBoundaryToPermissionSetResponse,
@@ -5436,7 +5435,7 @@ export const removeRegion: API.OperationMethod<
   RemoveRegionRequest,
   RemoveRegionResponse,
   RemoveRegionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveRegionRequest,
   output: RemoveRegionResponse,
@@ -5469,7 +5468,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5502,7 +5501,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5534,7 +5533,7 @@ export const updateApplication: API.OperationMethod<
   UpdateApplicationRequest,
   UpdateApplicationResponse,
   UpdateApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateApplicationRequest,
   output: UpdateApplicationResponse,
@@ -5566,7 +5565,7 @@ export const updateInstance: API.OperationMethod<
   UpdateInstanceRequest,
   UpdateInstanceResponse,
   UpdateInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceRequest,
   output: UpdateInstanceResponse,
@@ -5598,7 +5597,7 @@ export const updateInstanceAccessControlAttributeConfiguration: API.OperationMet
   UpdateInstanceAccessControlAttributeConfigurationRequest,
   UpdateInstanceAccessControlAttributeConfigurationResponse,
   UpdateInstanceAccessControlAttributeConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceAccessControlAttributeConfigurationRequest,
   output: UpdateInstanceAccessControlAttributeConfigurationResponse,
@@ -5630,7 +5629,7 @@ export const updatePermissionSet: API.OperationMethod<
   UpdatePermissionSetRequest,
   UpdatePermissionSetResponse,
   UpdatePermissionSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePermissionSetRequest,
   output: UpdatePermissionSetResponse,
@@ -5664,7 +5663,7 @@ export const updateTrustedTokenIssuer: API.OperationMethod<
   UpdateTrustedTokenIssuerRequest,
   UpdateTrustedTokenIssuerResponse,
   UpdateTrustedTokenIssuerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustedTokenIssuerRequest,
   output: UpdateTrustedTokenIssuerResponse,

--- a/packages/aws/src/services/sso-oidc.ts
+++ b/packages/aws/src/services/sso-oidc.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SSO OIDC",
@@ -526,7 +525,7 @@ export const createToken: API.OperationMethod<
   CreateTokenRequest,
   CreateTokenResponse,
   CreateTokenError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTokenRequest,
   output: CreateTokenResponse,
@@ -575,7 +574,7 @@ export const createTokenWithIAM: API.OperationMethod<
   CreateTokenWithIAMRequest,
   CreateTokenWithIAMResponse,
   CreateTokenWithIAMError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTokenWithIAMRequest,
   output: CreateTokenWithIAMResponse,
@@ -616,7 +615,7 @@ export const registerClient: API.OperationMethod<
   RegisterClientRequest,
   RegisterClientResponse,
   RegisterClientError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterClientRequest,
   output: RegisterClientResponse,
@@ -649,7 +648,7 @@ export const startDeviceAuthorization: API.OperationMethod<
   StartDeviceAuthorizationRequest,
   StartDeviceAuthorizationResponse,
   StartDeviceAuthorizationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDeviceAuthorizationRequest,
   output: StartDeviceAuthorizationResponse,

--- a/packages/aws/src/services/sso.ts
+++ b/packages/aws/src/services/sso.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SSO",
@@ -302,7 +301,7 @@ export const getRoleCredentials: API.OperationMethod<
   GetRoleCredentialsRequest,
   GetRoleCredentialsResponse,
   GetRoleCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRoleCredentialsRequest,
   output: GetRoleCredentialsResponse,
@@ -330,7 +329,7 @@ export const listAccountRoles: API.PaginatedOperationMethod<
   ListAccountRolesRequest,
   ListAccountRolesResponse,
   ListAccountRolesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RoleInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountRolesRequest,
@@ -367,7 +366,7 @@ export const listAccounts: API.PaginatedOperationMethod<
   ListAccountsRequest,
   ListAccountsResponse,
   ListAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountsRequest,
@@ -414,7 +413,7 @@ export const logout: API.OperationMethod<
   LogoutRequest,
   LogoutResponse,
   LogoutError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: LogoutRequest,
   output: LogoutResponse,

--- a/packages/aws/src/services/storage-gateway.ts
+++ b/packages/aws/src/services/storage-gateway.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("http://storagegateway.amazonaws.com/doc/2013-06-30");
 const svc = T.AwsApiService({
@@ -4526,7 +4525,7 @@ export const activateGateway: API.OperationMethod<
   ActivateGatewayInput,
   ActivateGatewayOutput,
   ActivateGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateGatewayInput,
   output: ActivateGatewayOutput,
@@ -4551,7 +4550,7 @@ export const addCache: API.OperationMethod<
   AddCacheInput,
   AddCacheOutput,
   AddCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddCacheInput,
   output: AddCacheOutput,
@@ -4588,7 +4587,7 @@ export const addTagsToResource: API.OperationMethod<
   AddTagsToResourceInput,
   AddTagsToResourceOutput,
   AddTagsToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddTagsToResourceInput,
   output: AddTagsToResourceOutput,
@@ -4615,7 +4614,7 @@ export const addUploadBuffer: API.OperationMethod<
   AddUploadBufferInput,
   AddUploadBufferOutput,
   AddUploadBufferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddUploadBufferInput,
   output: AddUploadBufferOutput,
@@ -4646,7 +4645,7 @@ export const addWorkingStorage: API.OperationMethod<
   AddWorkingStorageInput,
   AddWorkingStorageOutput,
   AddWorkingStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddWorkingStorageInput,
   output: AddWorkingStorageOutput,
@@ -4670,7 +4669,7 @@ export const assignTapePool: API.OperationMethod<
   AssignTapePoolInput,
   AssignTapePoolOutput,
   AssignTapePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssignTapePoolInput,
   output: AssignTapePoolOutput,
@@ -4694,7 +4693,7 @@ export const associateFileSystem: API.OperationMethod<
   AssociateFileSystemInput,
   AssociateFileSystemOutput,
   AssociateFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFileSystemInput,
   output: AssociateFileSystemOutput,
@@ -4718,7 +4717,7 @@ export const attachVolume: API.OperationMethod<
   AttachVolumeInput,
   AttachVolumeOutput,
   AttachVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AttachVolumeInput,
   output: AttachVolumeOutput,
@@ -4740,7 +4739,7 @@ export const cancelArchival: API.OperationMethod<
   CancelArchivalInput,
   CancelArchivalOutput,
   CancelArchivalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelArchivalInput,
   output: CancelArchivalOutput,
@@ -4765,7 +4764,7 @@ export const cancelCacheReport: API.OperationMethod<
   CancelCacheReportInput,
   CancelCacheReportOutput,
   CancelCacheReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelCacheReportInput,
   output: CancelCacheReportOutput,
@@ -4788,7 +4787,7 @@ export const cancelRetrieval: API.OperationMethod<
   CancelRetrievalInput,
   CancelRetrievalOutput,
   CancelRetrievalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelRetrievalInput,
   output: CancelRetrievalOutput,
@@ -4824,7 +4823,7 @@ export const createCachediSCSIVolume: API.OperationMethod<
   CreateCachediSCSIVolumeInput,
   CreateCachediSCSIVolumeOutput,
   CreateCachediSCSIVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCachediSCSIVolumeInput,
   output: CreateCachediSCSIVolumeOutput,
@@ -4859,7 +4858,7 @@ export const createNFSFileShare: API.OperationMethod<
   CreateNFSFileShareInput,
   CreateNFSFileShareOutput,
   CreateNFSFileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNFSFileShareInput,
   output: CreateNFSFileShareOutput,
@@ -4894,7 +4893,7 @@ export const createSMBFileShare: API.OperationMethod<
   CreateSMBFileShareInput,
   CreateSMBFileShareOutput,
   CreateSMBFileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSMBFileShareInput,
   output: CreateSMBFileShareOutput,
@@ -4939,7 +4938,7 @@ export const createSnapshot: API.OperationMethod<
   CreateSnapshotInput,
   CreateSnapshotOutput,
   CreateSnapshotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotInput,
   output: CreateSnapshotOutput,
@@ -4983,7 +4982,7 @@ export const createSnapshotFromVolumeRecoveryPoint: API.OperationMethod<
   CreateSnapshotFromVolumeRecoveryPointInput,
   CreateSnapshotFromVolumeRecoveryPointOutput,
   CreateSnapshotFromVolumeRecoveryPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSnapshotFromVolumeRecoveryPointInput,
   output: CreateSnapshotFromVolumeRecoveryPointOutput,
@@ -5019,7 +5018,7 @@ export const createStorediSCSIVolume: API.OperationMethod<
   CreateStorediSCSIVolumeInput,
   CreateStorediSCSIVolumeOutput,
   CreateStorediSCSIVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStorediSCSIVolumeInput,
   output: CreateStorediSCSIVolumeOutput,
@@ -5041,7 +5040,7 @@ export const createTapePool: API.OperationMethod<
   CreateTapePoolInput,
   CreateTapePoolOutput,
   CreateTapePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTapePoolInput,
   output: CreateTapePoolOutput,
@@ -5066,7 +5065,7 @@ export const createTapes: API.OperationMethod<
   CreateTapesInput,
   CreateTapesOutput,
   CreateTapesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTapesInput,
   output: CreateTapesOutput,
@@ -5093,7 +5092,7 @@ export const createTapeWithBarcode: API.OperationMethod<
   CreateTapeWithBarcodeInput,
   CreateTapeWithBarcodeOutput,
   CreateTapeWithBarcodeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTapeWithBarcodeInput,
   output: CreateTapeWithBarcodeOutput,
@@ -5116,7 +5115,7 @@ export const deleteAutomaticTapeCreationPolicy: API.OperationMethod<
   DeleteAutomaticTapeCreationPolicyInput,
   DeleteAutomaticTapeCreationPolicyOutput,
   DeleteAutomaticTapeCreationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAutomaticTapeCreationPolicyInput,
   output: DeleteAutomaticTapeCreationPolicyOutput,
@@ -5141,7 +5140,7 @@ export const deleteBandwidthRateLimit: API.OperationMethod<
   DeleteBandwidthRateLimitInput,
   DeleteBandwidthRateLimitOutput,
   DeleteBandwidthRateLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBandwidthRateLimitInput,
   output: DeleteBandwidthRateLimitOutput,
@@ -5166,7 +5165,7 @@ export const deleteCacheReport: API.OperationMethod<
   DeleteCacheReportInput,
   DeleteCacheReportOutput,
   DeleteCacheReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCacheReportInput,
   output: DeleteCacheReportOutput,
@@ -5189,7 +5188,7 @@ export const deleteChapCredentials: API.OperationMethod<
   DeleteChapCredentialsInput,
   DeleteChapCredentialsOutput,
   DeleteChapCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteChapCredentialsInput,
   output: DeleteChapCredentialsOutput,
@@ -5211,7 +5210,7 @@ export const deleteFileShare: API.OperationMethod<
   DeleteFileShareInput,
   DeleteFileShareOutput,
   DeleteFileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFileShareInput,
   output: DeleteFileShareOutput,
@@ -5247,7 +5246,7 @@ export const deleteGateway: API.OperationMethod<
   DeleteGatewayInput,
   DeleteGatewayOutput,
   DeleteGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGatewayInput,
   output: DeleteGatewayOutput,
@@ -5279,7 +5278,7 @@ export const deleteSnapshotSchedule: API.OperationMethod<
   DeleteSnapshotScheduleInput,
   DeleteSnapshotScheduleOutput,
   DeleteSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSnapshotScheduleInput,
   output: DeleteSnapshotScheduleOutput,
@@ -5301,7 +5300,7 @@ export const deleteTape: API.OperationMethod<
   DeleteTapeInput,
   DeleteTapeOutput,
   DeleteTapeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTapeInput,
   output: DeleteTapeOutput,
@@ -5323,7 +5322,7 @@ export const deleteTapeArchive: API.OperationMethod<
   DeleteTapeArchiveInput,
   DeleteTapeArchiveOutput,
   DeleteTapeArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTapeArchiveInput,
   output: DeleteTapeArchiveOutput,
@@ -5346,7 +5345,7 @@ export const deleteTapePool: API.OperationMethod<
   DeleteTapePoolInput,
   DeleteTapePoolOutput,
   DeleteTapePoolError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTapePoolInput,
   output: DeleteTapePoolOutput,
@@ -5379,7 +5378,7 @@ export const deleteVolume: API.OperationMethod<
   DeleteVolumeInput,
   DeleteVolumeOutput,
   DeleteVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVolumeInput,
   output: DeleteVolumeOutput,
@@ -5402,7 +5401,7 @@ export const describeAvailabilityMonitorTest: API.OperationMethod<
   DescribeAvailabilityMonitorTestInput,
   DescribeAvailabilityMonitorTestOutput,
   DescribeAvailabilityMonitorTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAvailabilityMonitorTestInput,
   output: DescribeAvailabilityMonitorTestOutput,
@@ -5431,7 +5430,7 @@ export const describeBandwidthRateLimit: API.OperationMethod<
   DescribeBandwidthRateLimitInput,
   DescribeBandwidthRateLimitOutput,
   DescribeBandwidthRateLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBandwidthRateLimitInput,
   output: DescribeBandwidthRateLimitOutput,
@@ -5468,7 +5467,7 @@ export const describeBandwidthRateLimitSchedule: API.OperationMethod<
   DescribeBandwidthRateLimitScheduleInput,
   DescribeBandwidthRateLimitScheduleOutput,
   DescribeBandwidthRateLimitScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBandwidthRateLimitScheduleInput,
   output: DescribeBandwidthRateLimitScheduleOutput,
@@ -5493,7 +5492,7 @@ export const describeCache: API.OperationMethod<
   DescribeCacheInput,
   DescribeCacheOutput,
   DescribeCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCacheInput,
   output: DescribeCacheOutput,
@@ -5519,7 +5518,7 @@ export const describeCachediSCSIVolumes: API.OperationMethod<
   DescribeCachediSCSIVolumesInput,
   DescribeCachediSCSIVolumesOutput,
   DescribeCachediSCSIVolumesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCachediSCSIVolumesInput,
   output: DescribeCachediSCSIVolumesOutput,
@@ -5541,7 +5540,7 @@ export const describeCacheReport: API.OperationMethod<
   DescribeCacheReportInput,
   DescribeCacheReportOutput,
   DescribeCacheReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCacheReportInput,
   output: DescribeCacheReportOutput,
@@ -5564,7 +5563,7 @@ export const describeChapCredentials: API.OperationMethod<
   DescribeChapCredentialsInput,
   DescribeChapCredentialsOutput,
   DescribeChapCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeChapCredentialsInput,
   output: DescribeChapCredentialsOutput,
@@ -5586,7 +5585,7 @@ export const describeFileSystemAssociations: API.OperationMethod<
   DescribeFileSystemAssociationsInput,
   DescribeFileSystemAssociationsOutput,
   DescribeFileSystemAssociationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFileSystemAssociationsInput,
   output: DescribeFileSystemAssociationsOutput,
@@ -5609,7 +5608,7 @@ export const describeGatewayInformation: API.OperationMethod<
   DescribeGatewayInformationInput,
   DescribeGatewayInformationOutput,
   DescribeGatewayInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGatewayInformationInput,
   output: DescribeGatewayInformationOutput,
@@ -5632,7 +5631,7 @@ export const describeMaintenanceStartTime: API.OperationMethod<
   DescribeMaintenanceStartTimeInput,
   DescribeMaintenanceStartTimeOutput,
   DescribeMaintenanceStartTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMaintenanceStartTimeInput,
   output: DescribeMaintenanceStartTimeOutput,
@@ -5654,7 +5653,7 @@ export const describeNFSFileShares: API.OperationMethod<
   DescribeNFSFileSharesInput,
   DescribeNFSFileSharesOutput,
   DescribeNFSFileSharesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeNFSFileSharesInput,
   output: DescribeNFSFileSharesOutput,
@@ -5676,7 +5675,7 @@ export const describeSMBFileShares: API.OperationMethod<
   DescribeSMBFileSharesInput,
   DescribeSMBFileSharesOutput,
   DescribeSMBFileSharesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSMBFileSharesInput,
   output: DescribeSMBFileSharesOutput,
@@ -5698,7 +5697,7 @@ export const describeSMBSettings: API.OperationMethod<
   DescribeSMBSettingsInput,
   DescribeSMBSettingsOutput,
   DescribeSMBSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSMBSettingsInput,
   output: DescribeSMBSettingsOutput,
@@ -5722,7 +5721,7 @@ export const describeSnapshotSchedule: API.OperationMethod<
   DescribeSnapshotScheduleInput,
   DescribeSnapshotScheduleOutput,
   DescribeSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSnapshotScheduleInput,
   output: DescribeSnapshotScheduleOutput,
@@ -5745,7 +5744,7 @@ export const describeStorediSCSIVolumes: API.OperationMethod<
   DescribeStorediSCSIVolumesInput,
   DescribeStorediSCSIVolumesOutput,
   DescribeStorediSCSIVolumesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeStorediSCSIVolumesInput,
   output: DescribeStorediSCSIVolumesOutput,
@@ -5770,7 +5769,7 @@ export const describeTapeArchives: API.PaginatedOperationMethod<
   DescribeTapeArchivesInput,
   DescribeTapeArchivesOutput,
   DescribeTapeArchivesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TapeArchive
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTapeArchivesInput,
@@ -5804,7 +5803,7 @@ export const describeTapeRecoveryPoints: API.PaginatedOperationMethod<
   DescribeTapeRecoveryPointsInput,
   DescribeTapeRecoveryPointsOutput,
   DescribeTapeRecoveryPointsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TapeRecoveryPointInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTapeRecoveryPointsInput,
@@ -5842,7 +5841,7 @@ export const describeTapes: API.PaginatedOperationMethod<
   DescribeTapesInput,
   DescribeTapesOutput,
   DescribeTapesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tape
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeTapesInput,
@@ -5874,7 +5873,7 @@ export const describeUploadBuffer: API.OperationMethod<
   DescribeUploadBufferInput,
   DescribeUploadBufferOutput,
   DescribeUploadBufferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUploadBufferInput,
   output: DescribeUploadBufferOutput,
@@ -5898,7 +5897,7 @@ export const describeVTLDevices: API.PaginatedOperationMethod<
   DescribeVTLDevicesInput,
   DescribeVTLDevicesOutput,
   DescribeVTLDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VTLDevice
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeVTLDevicesInput,
@@ -5934,7 +5933,7 @@ export const describeWorkingStorage: API.OperationMethod<
   DescribeWorkingStorageInput,
   DescribeWorkingStorageOutput,
   DescribeWorkingStorageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkingStorageInput,
   output: DescribeWorkingStorageOutput,
@@ -5959,7 +5958,7 @@ export const detachVolume: API.OperationMethod<
   DetachVolumeInput,
   DetachVolumeOutput,
   DetachVolumeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetachVolumeInput,
   output: DetachVolumeOutput,
@@ -5986,7 +5985,7 @@ export const disableGateway: API.OperationMethod<
   DisableGatewayInput,
   DisableGatewayOutput,
   DisableGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisableGatewayInput,
   output: DisableGatewayOutput,
@@ -6009,7 +6008,7 @@ export const disassociateFileSystem: API.OperationMethod<
   DisassociateFileSystemInput,
   DisassociateFileSystemOutput,
   DisassociateFileSystemError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFileSystemInput,
   output: DisassociateFileSystemOutput,
@@ -6041,7 +6040,7 @@ export const evictFilesFailingUpload: API.OperationMethod<
   EvictFilesFailingUploadInput,
   EvictFilesFailingUploadOutput,
   EvictFilesFailingUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvictFilesFailingUploadInput,
   output: EvictFilesFailingUploadOutput,
@@ -6072,7 +6071,7 @@ export const joinDomain: API.OperationMethod<
   JoinDomainInput,
   JoinDomainOutput,
   JoinDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: JoinDomainInput,
   output: JoinDomainOutput,
@@ -6096,7 +6095,7 @@ export const listAutomaticTapeCreationPolicies: API.OperationMethod<
   ListAutomaticTapeCreationPoliciesInput,
   ListAutomaticTapeCreationPoliciesOutput,
   ListAutomaticTapeCreationPoliciesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAutomaticTapeCreationPoliciesInput,
   output: ListAutomaticTapeCreationPoliciesOutput,
@@ -6120,7 +6119,7 @@ export const listCacheReports: API.PaginatedOperationMethod<
   ListCacheReportsInput,
   ListCacheReportsOutput,
   ListCacheReportsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CacheReportInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCacheReportsInput,
@@ -6149,7 +6148,7 @@ export const listFileShares: API.PaginatedOperationMethod<
   ListFileSharesInput,
   ListFileSharesOutput,
   ListFileSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FileShareInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFileSharesInput,
@@ -6179,7 +6178,7 @@ export const listFileSystemAssociations: API.PaginatedOperationMethod<
   ListFileSystemAssociationsInput,
   ListFileSystemAssociationsOutput,
   ListFileSystemAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FileSystemAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFileSystemAssociationsInput,
@@ -6217,7 +6216,7 @@ export const listGateways: API.PaginatedOperationMethod<
   ListGatewaysInput,
   ListGatewaysOutput,
   ListGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GatewayInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGatewaysInput,
@@ -6253,7 +6252,7 @@ export const listLocalDisks: API.OperationMethod<
   ListLocalDisksInput,
   ListLocalDisksOutput,
   ListLocalDisksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLocalDisksInput,
   output: ListLocalDisksOutput,
@@ -6275,7 +6274,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceInput,
@@ -6311,7 +6310,7 @@ export const listTapePools: API.PaginatedOperationMethod<
   ListTapePoolsInput,
   ListTapePoolsOutput,
   ListTapePoolsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PoolInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTapePoolsInput,
@@ -6349,7 +6348,7 @@ export const listTapes: API.PaginatedOperationMethod<
   ListTapesInput,
   ListTapesOutput,
   ListTapesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TapeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTapesInput,
@@ -6379,7 +6378,7 @@ export const listVolumeInitiators: API.OperationMethod<
   ListVolumeInitiatorsInput,
   ListVolumeInitiatorsOutput,
   ListVolumeInitiatorsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVolumeInitiatorsInput,
   output: ListVolumeInitiatorsOutput,
@@ -6406,7 +6405,7 @@ export const listVolumeRecoveryPoints: API.OperationMethod<
   ListVolumeRecoveryPointsInput,
   ListVolumeRecoveryPointsOutput,
   ListVolumeRecoveryPointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListVolumeRecoveryPointsInput,
   output: ListVolumeRecoveryPointsOutput,
@@ -6436,7 +6435,7 @@ export const listVolumes: API.PaginatedOperationMethod<
   ListVolumesInput,
   ListVolumesOutput,
   ListVolumesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   VolumeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVolumesInput,
@@ -6476,7 +6475,7 @@ export const notifyWhenUploaded: API.OperationMethod<
   NotifyWhenUploadedInput,
   NotifyWhenUploadedOutput,
   NotifyWhenUploadedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyWhenUploadedInput,
   output: NotifyWhenUploadedOutput,
@@ -6534,7 +6533,7 @@ export const refreshCache: API.OperationMethod<
   RefreshCacheInput,
   RefreshCacheOutput,
   RefreshCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RefreshCacheInput,
   output: RefreshCacheOutput,
@@ -6556,7 +6555,7 @@ export const removeTagsFromResource: API.OperationMethod<
   RemoveTagsFromResourceInput,
   RemoveTagsFromResourceOutput,
   RemoveTagsFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveTagsFromResourceInput,
   output: RemoveTagsFromResourceOutput,
@@ -6587,7 +6586,7 @@ export const resetCache: API.OperationMethod<
   ResetCacheInput,
   ResetCacheOutput,
   ResetCacheError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetCacheInput,
   output: ResetCacheOutput,
@@ -6615,7 +6614,7 @@ export const retrieveTapeArchive: API.OperationMethod<
   RetrieveTapeArchiveInput,
   RetrieveTapeArchiveOutput,
   RetrieveTapeArchiveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveTapeArchiveInput,
   output: RetrieveTapeArchiveOutput,
@@ -6645,7 +6644,7 @@ export const retrieveTapeRecoveryPoint: API.OperationMethod<
   RetrieveTapeRecoveryPointInput,
   RetrieveTapeRecoveryPointOutput,
   RetrieveTapeRecoveryPointError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RetrieveTapeRecoveryPointInput,
   output: RetrieveTapeRecoveryPointOutput,
@@ -6669,7 +6668,7 @@ export const setLocalConsolePassword: API.OperationMethod<
   SetLocalConsolePasswordInput,
   SetLocalConsolePasswordOutput,
   SetLocalConsolePasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetLocalConsolePasswordInput,
   output: SetLocalConsolePasswordOutput,
@@ -6692,7 +6691,7 @@ export const setSMBGuestPassword: API.OperationMethod<
   SetSMBGuestPasswordInput,
   SetSMBGuestPasswordOutput,
   SetSMBGuestPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SetSMBGuestPasswordInput,
   output: SetSMBGuestPasswordOutput,
@@ -6735,7 +6734,7 @@ export const shutdownGateway: API.OperationMethod<
   ShutdownGatewayInput,
   ShutdownGatewayOutput,
   ShutdownGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ShutdownGatewayInput,
   output: ShutdownGatewayOutput,
@@ -6762,7 +6761,7 @@ export const startAvailabilityMonitorTest: API.OperationMethod<
   StartAvailabilityMonitorTestInput,
   StartAvailabilityMonitorTestOutput,
   StartAvailabilityMonitorTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartAvailabilityMonitorTestInput,
   output: StartAvailabilityMonitorTestOutput,
@@ -6810,7 +6809,7 @@ export const startCacheReport: API.OperationMethod<
   StartCacheReportInput,
   StartCacheReportOutput,
   StartCacheReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCacheReportInput,
   output: StartCacheReportOutput,
@@ -6841,7 +6840,7 @@ export const startGateway: API.OperationMethod<
   StartGatewayInput,
   StartGatewayOutput,
   StartGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartGatewayInput,
   output: StartGatewayOutput,
@@ -6868,7 +6867,7 @@ export const updateAutomaticTapeCreationPolicy: API.OperationMethod<
   UpdateAutomaticTapeCreationPolicyInput,
   UpdateAutomaticTapeCreationPolicyOutput,
   UpdateAutomaticTapeCreationPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAutomaticTapeCreationPolicyInput,
   output: UpdateAutomaticTapeCreationPolicyOutput,
@@ -6900,7 +6899,7 @@ export const updateBandwidthRateLimit: API.OperationMethod<
   UpdateBandwidthRateLimitInput,
   UpdateBandwidthRateLimitOutput,
   UpdateBandwidthRateLimitError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBandwidthRateLimitInput,
   output: UpdateBandwidthRateLimitOutput,
@@ -6926,7 +6925,7 @@ export const updateBandwidthRateLimitSchedule: API.OperationMethod<
   UpdateBandwidthRateLimitScheduleInput,
   UpdateBandwidthRateLimitScheduleOutput,
   UpdateBandwidthRateLimitScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBandwidthRateLimitScheduleInput,
   output: UpdateBandwidthRateLimitScheduleOutput,
@@ -6953,7 +6952,7 @@ export const updateChapCredentials: API.OperationMethod<
   UpdateChapCredentialsInput,
   UpdateChapCredentialsOutput,
   UpdateChapCredentialsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateChapCredentialsInput,
   output: UpdateChapCredentialsOutput,
@@ -6975,7 +6974,7 @@ export const updateFileSystemAssociation: API.OperationMethod<
   UpdateFileSystemAssociationInput,
   UpdateFileSystemAssociationOutput,
   UpdateFileSystemAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFileSystemAssociationInput,
   output: UpdateFileSystemAssociationOutput,
@@ -7002,7 +7001,7 @@ export const updateGatewayInformation: API.OperationMethod<
   UpdateGatewayInformationInput,
   UpdateGatewayInformationOutput,
   UpdateGatewayInformationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewayInformationInput,
   output: UpdateGatewayInformationOutput,
@@ -7034,7 +7033,7 @@ export const updateGatewaySoftwareNow: API.OperationMethod<
   UpdateGatewaySoftwareNowInput,
   UpdateGatewaySoftwareNowOutput,
   UpdateGatewaySoftwareNowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGatewaySoftwareNowInput,
   output: UpdateGatewaySoftwareNowOutput,
@@ -7070,7 +7069,7 @@ export const updateMaintenanceStartTime: API.OperationMethod<
   UpdateMaintenanceStartTimeInput,
   UpdateMaintenanceStartTimeOutput,
   UpdateMaintenanceStartTimeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMaintenanceStartTimeInput,
   output: UpdateMaintenanceStartTimeOutput,
@@ -7107,7 +7106,7 @@ export const updateNFSFileShare: API.OperationMethod<
   UpdateNFSFileShareInput,
   UpdateNFSFileShareOutput,
   UpdateNFSFileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNFSFileShareInput,
   output: UpdateNFSFileShareOutput,
@@ -7143,7 +7142,7 @@ export const updateSMBFileShare: API.OperationMethod<
   UpdateSMBFileShareInput,
   UpdateSMBFileShareOutput,
   UpdateSMBFileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSMBFileShareInput,
   output: UpdateSMBFileShareOutput,
@@ -7165,7 +7164,7 @@ export const updateSMBFileShareVisibility: API.OperationMethod<
   UpdateSMBFileShareVisibilityInput,
   UpdateSMBFileShareVisibilityOutput,
   UpdateSMBFileShareVisibilityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSMBFileShareVisibilityInput,
   output: UpdateSMBFileShareVisibilityOutput,
@@ -7187,7 +7186,7 @@ export const updateSMBLocalGroups: API.OperationMethod<
   UpdateSMBLocalGroupsInput,
   UpdateSMBLocalGroupsOutput,
   UpdateSMBLocalGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSMBLocalGroupsInput,
   output: UpdateSMBLocalGroupsOutput,
@@ -7215,7 +7214,7 @@ export const updateSMBSecurityStrategy: API.OperationMethod<
   UpdateSMBSecurityStrategyInput,
   UpdateSMBSecurityStrategyOutput,
   UpdateSMBSecurityStrategyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSMBSecurityStrategyInput,
   output: UpdateSMBSecurityStrategyOutput,
@@ -7245,7 +7244,7 @@ export const updateSnapshotSchedule: API.OperationMethod<
   UpdateSnapshotScheduleInput,
   UpdateSnapshotScheduleOutput,
   UpdateSnapshotScheduleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSnapshotScheduleInput,
   output: UpdateSnapshotScheduleOutput,
@@ -7269,7 +7268,7 @@ export const updateVTLDeviceType: API.OperationMethod<
   UpdateVTLDeviceTypeInput,
   UpdateVTLDeviceTypeOutput,
   UpdateVTLDeviceTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVTLDeviceTypeInput,
   output: UpdateVTLDeviceTypeOutput,

--- a/packages/aws/src/services/sts.ts
+++ b/packages/aws/src/services/sts.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials as Creds } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("https://sts.amazonaws.com/doc/2011-06-15/");
 const svc = T.AwsApiService({
@@ -960,7 +959,7 @@ export const assumeRole: API.OperationMethod<
   AssumeRoleRequest,
   AssumeRoleResponse,
   AssumeRoleError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeRoleRequest,
   output: AssumeRoleResponse,
@@ -1113,7 +1112,7 @@ export const assumeRoleWithSAML: API.OperationMethod<
   AssumeRoleWithSAMLRequest,
   AssumeRoleWithSAMLResponse,
   AssumeRoleWithSAMLError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeRoleWithSAMLRequest,
   output: AssumeRoleWithSAMLResponse,
@@ -1263,7 +1262,7 @@ export const assumeRoleWithWebIdentity: API.OperationMethod<
   AssumeRoleWithWebIdentityRequest,
   AssumeRoleWithWebIdentityResponse,
   AssumeRoleWithWebIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeRoleWithWebIdentityRequest,
   output: AssumeRoleWithWebIdentityResponse,
@@ -1312,7 +1311,7 @@ export const assumeRoot: API.OperationMethod<
   AssumeRootRequest,
   AssumeRootResponse,
   AssumeRootError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeRootRequest,
   output: AssumeRootResponse,
@@ -1362,7 +1361,7 @@ export const decodeAuthorizationMessage: API.OperationMethod<
   DecodeAuthorizationMessageRequest,
   DecodeAuthorizationMessageResponse,
   DecodeAuthorizationMessageError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DecodeAuthorizationMessageRequest,
   output: DecodeAuthorizationMessageResponse,
@@ -1399,7 +1398,7 @@ export const getAccessKeyInfo: API.OperationMethod<
   GetAccessKeyInfoRequest,
   GetAccessKeyInfoResponse,
   GetAccessKeyInfoError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessKeyInfoRequest,
   output: GetAccessKeyInfoResponse,
@@ -1425,7 +1424,7 @@ export const getCallerIdentity: API.OperationMethod<
   GetCallerIdentityRequest,
   GetCallerIdentityResponse,
   GetCallerIdentityError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCallerIdentityRequest,
   output: GetCallerIdentityResponse,
@@ -1450,7 +1449,7 @@ export const getDelegatedAccessToken: API.OperationMethod<
   GetDelegatedAccessTokenRequest,
   GetDelegatedAccessTokenResponse,
   GetDelegatedAccessTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDelegatedAccessTokenRequest,
   output: GetDelegatedAccessTokenResponse,
@@ -1566,7 +1565,7 @@ export const getFederationToken: API.OperationMethod<
   GetFederationTokenRequest,
   GetFederationTokenResponse,
   GetFederationTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFederationTokenRequest,
   output: GetFederationTokenResponse,
@@ -1642,7 +1641,7 @@ export const getSessionToken: API.OperationMethod<
   GetSessionTokenRequest,
   GetSessionTokenResponse,
   GetSessionTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionTokenRequest,
   output: GetSessionTokenResponse,
@@ -1666,7 +1665,7 @@ export const getWebIdentityToken: API.OperationMethod<
   GetWebIdentityTokenRequest,
   GetWebIdentityTokenResponse,
   GetWebIdentityTokenError,
-  Creds | Region | HttpClient.HttpClient
+  Creds | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebIdentityTokenRequest,
   output: GetWebIdentityTokenResponse,

--- a/packages/aws/src/services/supplychain.ts
+++ b/packages/aws/src/services/supplychain.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "SupplyChain",
@@ -1854,7 +1853,7 @@ export const createBillOfMaterialsImportJob: API.OperationMethod<
   CreateBillOfMaterialsImportJobRequest,
   CreateBillOfMaterialsImportJobResponse,
   CreateBillOfMaterialsImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBillOfMaterialsImportJobRequest,
   output: CreateBillOfMaterialsImportJobResponse,
@@ -1886,7 +1885,7 @@ export const createDataIntegrationFlow: API.OperationMethod<
   CreateDataIntegrationFlowRequest,
   CreateDataIntegrationFlowResponse,
   CreateDataIntegrationFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataIntegrationFlowRequest,
   output: CreateDataIntegrationFlowResponse,
@@ -1919,7 +1918,7 @@ export const createDataLakeDataset: API.OperationMethod<
   CreateDataLakeDatasetRequest,
   CreateDataLakeDatasetResponse,
   CreateDataLakeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataLakeDatasetRequest,
   output: CreateDataLakeDatasetResponse,
@@ -1952,7 +1951,7 @@ export const createDataLakeNamespace: API.OperationMethod<
   CreateDataLakeNamespaceRequest,
   CreateDataLakeNamespaceResponse,
   CreateDataLakeNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataLakeNamespaceRequest,
   output: CreateDataLakeNamespaceResponse,
@@ -1986,7 +1985,7 @@ export const createInstance: API.OperationMethod<
   CreateInstanceRequest,
   CreateInstanceResponse,
   CreateInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateInstanceRequest,
   output: CreateInstanceResponse,
@@ -2016,7 +2015,7 @@ export const deleteDataIntegrationFlow: API.OperationMethod<
   DeleteDataIntegrationFlowRequest,
   DeleteDataIntegrationFlowResponse,
   DeleteDataIntegrationFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataIntegrationFlowRequest,
   output: DeleteDataIntegrationFlowResponse,
@@ -2045,7 +2044,7 @@ export const deleteDataLakeDataset: API.OperationMethod<
   DeleteDataLakeDatasetRequest,
   DeleteDataLakeDatasetResponse,
   DeleteDataLakeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataLakeDatasetRequest,
   output: DeleteDataLakeDatasetResponse,
@@ -2075,7 +2074,7 @@ export const deleteDataLakeNamespace: API.OperationMethod<
   DeleteDataLakeNamespaceRequest,
   DeleteDataLakeNamespaceResponse,
   DeleteDataLakeNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataLakeNamespaceRequest,
   output: DeleteDataLakeNamespaceResponse,
@@ -2107,7 +2106,7 @@ export const deleteInstance: API.OperationMethod<
   DeleteInstanceRequest,
   DeleteInstanceResponse,
   DeleteInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteInstanceRequest,
   output: DeleteInstanceResponse,
@@ -2137,7 +2136,7 @@ export const getBillOfMaterialsImportJob: API.OperationMethod<
   GetBillOfMaterialsImportJobRequest,
   GetBillOfMaterialsImportJobResponse,
   GetBillOfMaterialsImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBillOfMaterialsImportJobRequest,
   output: GetBillOfMaterialsImportJobResponse,
@@ -2167,7 +2166,7 @@ export const getDataIntegrationEvent: API.OperationMethod<
   GetDataIntegrationEventRequest,
   GetDataIntegrationEventResponse,
   GetDataIntegrationEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataIntegrationEventRequest,
   output: GetDataIntegrationEventResponse,
@@ -2197,7 +2196,7 @@ export const getDataIntegrationFlow: API.OperationMethod<
   GetDataIntegrationFlowRequest,
   GetDataIntegrationFlowResponse,
   GetDataIntegrationFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataIntegrationFlowRequest,
   output: GetDataIntegrationFlowResponse,
@@ -2227,7 +2226,7 @@ export const getDataIntegrationFlowExecution: API.OperationMethod<
   GetDataIntegrationFlowExecutionRequest,
   GetDataIntegrationFlowExecutionResponse,
   GetDataIntegrationFlowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataIntegrationFlowExecutionRequest,
   output: GetDataIntegrationFlowExecutionResponse,
@@ -2257,7 +2256,7 @@ export const getDataLakeDataset: API.OperationMethod<
   GetDataLakeDatasetRequest,
   GetDataLakeDatasetResponse,
   GetDataLakeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakeDatasetRequest,
   output: GetDataLakeDatasetResponse,
@@ -2287,7 +2286,7 @@ export const getDataLakeNamespace: API.OperationMethod<
   GetDataLakeNamespaceRequest,
   GetDataLakeNamespaceResponse,
   GetDataLakeNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataLakeNamespaceRequest,
   output: GetDataLakeNamespaceResponse,
@@ -2317,7 +2316,7 @@ export const getInstance: API.OperationMethod<
   GetInstanceRequest,
   GetInstanceResponse,
   GetInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInstanceRequest,
   output: GetInstanceResponse,
@@ -2346,7 +2345,7 @@ export const listDataIntegrationEvents: API.PaginatedOperationMethod<
   ListDataIntegrationEventsRequest,
   ListDataIntegrationEventsResponse,
   ListDataIntegrationEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataIntegrationEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIntegrationEventsRequest,
@@ -2382,7 +2381,7 @@ export const listDataIntegrationFlowExecutions: API.PaginatedOperationMethod<
   ListDataIntegrationFlowExecutionsRequest,
   ListDataIntegrationFlowExecutionsResponse,
   ListDataIntegrationFlowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataIntegrationFlowExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIntegrationFlowExecutionsRequest,
@@ -2418,7 +2417,7 @@ export const listDataIntegrationFlows: API.PaginatedOperationMethod<
   ListDataIntegrationFlowsRequest,
   ListDataIntegrationFlowsResponse,
   ListDataIntegrationFlowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataIntegrationFlow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataIntegrationFlowsRequest,
@@ -2454,7 +2453,7 @@ export const listDataLakeDatasets: API.PaginatedOperationMethod<
   ListDataLakeDatasetsRequest,
   ListDataLakeDatasetsResponse,
   ListDataLakeDatasetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataLakeDataset
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataLakeDatasetsRequest,
@@ -2490,7 +2489,7 @@ export const listDataLakeNamespaces: API.PaginatedOperationMethod<
   ListDataLakeNamespacesRequest,
   ListDataLakeNamespacesResponse,
   ListDataLakeNamespacesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataLakeNamespace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataLakeNamespacesRequest,
@@ -2525,7 +2524,7 @@ export const listInstances: API.PaginatedOperationMethod<
   ListInstancesRequest,
   ListInstancesResponse,
   ListInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Instance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstancesRequest,
@@ -2561,7 +2560,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2593,7 +2592,7 @@ export const sendDataIntegrationEvent: API.OperationMethod<
   SendDataIntegrationEventRequest,
   SendDataIntegrationEventResponse,
   SendDataIntegrationEventError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendDataIntegrationEventRequest,
   output: SendDataIntegrationEventResponse,
@@ -2625,7 +2624,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2655,7 +2654,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2685,7 +2684,7 @@ export const updateDataIntegrationFlow: API.OperationMethod<
   UpdateDataIntegrationFlowRequest,
   UpdateDataIntegrationFlowResponse,
   UpdateDataIntegrationFlowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataIntegrationFlowRequest,
   output: UpdateDataIntegrationFlowResponse,
@@ -2715,7 +2714,7 @@ export const updateDataLakeDataset: API.OperationMethod<
   UpdateDataLakeDatasetRequest,
   UpdateDataLakeDatasetResponse,
   UpdateDataLakeDatasetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataLakeDatasetRequest,
   output: UpdateDataLakeDatasetResponse,
@@ -2745,7 +2744,7 @@ export const updateDataLakeNamespace: API.OperationMethod<
   UpdateDataLakeNamespaceRequest,
   UpdateDataLakeNamespaceResponse,
   UpdateDataLakeNamespaceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataLakeNamespaceRequest,
   output: UpdateDataLakeNamespaceResponse,
@@ -2775,7 +2774,7 @@ export const updateInstance: API.OperationMethod<
   UpdateInstanceRequest,
   UpdateInstanceResponse,
   UpdateInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateInstanceRequest,
   output: UpdateInstanceResponse,

--- a/packages/aws/src/services/support-app.ts
+++ b/packages/aws/src/services/support-app.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Support App",
   serviceShapeName: "SupportApp",
@@ -535,7 +534,7 @@ export const createSlackChannelConfiguration: API.OperationMethod<
   CreateSlackChannelConfigurationRequest,
   CreateSlackChannelConfigurationResult,
   CreateSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSlackChannelConfigurationRequest,
   output: CreateSlackChannelConfigurationResult,
@@ -564,7 +563,7 @@ export const deleteAccountAlias: API.OperationMethod<
   DeleteAccountAliasRequest,
   DeleteAccountAliasResult,
   DeleteAccountAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountAliasRequest,
   output: DeleteAccountAliasResult,
@@ -593,7 +592,7 @@ export const deleteSlackChannelConfiguration: API.OperationMethod<
   DeleteSlackChannelConfigurationRequest,
   DeleteSlackChannelConfigurationResult,
   DeleteSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlackChannelConfigurationRequest,
   output: DeleteSlackChannelConfigurationResult,
@@ -624,7 +623,7 @@ export const deleteSlackWorkspaceConfiguration: API.OperationMethod<
   DeleteSlackWorkspaceConfigurationRequest,
   DeleteSlackWorkspaceConfigurationResult,
   DeleteSlackWorkspaceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSlackWorkspaceConfigurationRequest,
   output: DeleteSlackWorkspaceConfigurationResult,
@@ -649,7 +648,7 @@ export const getAccountAlias: API.OperationMethod<
   GetAccountAliasRequest,
   GetAccountAliasResult,
   GetAccountAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountAliasRequest,
   output: GetAccountAliasResult,
@@ -670,7 +669,7 @@ export const listSlackChannelConfigurations: API.PaginatedOperationMethod<
   ListSlackChannelConfigurationsRequest,
   ListSlackChannelConfigurationsResult,
   ListSlackChannelConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSlackChannelConfigurationsRequest,
@@ -693,7 +692,7 @@ export const listSlackWorkspaceConfigurations: API.PaginatedOperationMethod<
   ListSlackWorkspaceConfigurationsRequest,
   ListSlackWorkspaceConfigurationsResult,
   ListSlackWorkspaceConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSlackWorkspaceConfigurationsRequest,
@@ -719,7 +718,7 @@ export const putAccountAlias: API.OperationMethod<
   PutAccountAliasRequest,
   PutAccountAliasResult,
   PutAccountAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccountAliasRequest,
   output: PutAccountAliasResult,
@@ -767,7 +766,7 @@ export const registerSlackWorkspaceForOrganization: API.OperationMethod<
   RegisterSlackWorkspaceForOrganizationRequest,
   RegisterSlackWorkspaceForOrganizationResult,
   RegisterSlackWorkspaceForOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterSlackWorkspaceForOrganizationRequest,
   output: RegisterSlackWorkspaceForOrganizationResult,
@@ -797,7 +796,7 @@ export const updateSlackChannelConfiguration: API.OperationMethod<
   UpdateSlackChannelConfigurationRequest,
   UpdateSlackChannelConfigurationResult,
   UpdateSlackChannelConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSlackChannelConfigurationRequest,
   output: UpdateSlackChannelConfigurationResult,

--- a/packages/aws/src/services/support.ts
+++ b/packages/aws/src/services/support.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://support.amazonaws.com/doc/2013-04-15/");
 const svc = T.AwsApiService({
   sdkId: "Support",
@@ -1148,7 +1147,7 @@ export const addAttachmentsToSet: API.OperationMethod<
   AddAttachmentsToSetRequest,
   AddAttachmentsToSetResponse,
   AddAttachmentsToSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddAttachmentsToSetRequest,
   output: AddAttachmentsToSetResponse,
@@ -1189,7 +1188,7 @@ export const addCommunicationToCase: API.OperationMethod<
   AddCommunicationToCaseRequest,
   AddCommunicationToCaseResponse,
   AddCommunicationToCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddCommunicationToCaseRequest,
   output: AddCommunicationToCaseResponse,
@@ -1242,7 +1241,7 @@ export const createCase: API.OperationMethod<
   CreateCaseRequest,
   CreateCaseResponse,
   CreateCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCaseRequest,
   output: CreateCaseResponse,
@@ -1281,7 +1280,7 @@ export const describeAttachment: API.OperationMethod<
   DescribeAttachmentRequest,
   DescribeAttachmentResponse,
   DescribeAttachmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAttachmentRequest,
   output: DescribeAttachmentResponse,
@@ -1328,7 +1327,7 @@ export const describeCases: API.PaginatedOperationMethod<
   DescribeCasesRequest,
   DescribeCasesResponse,
   DescribeCasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CaseDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCasesRequest,
@@ -1375,7 +1374,7 @@ export const describeCommunications: API.PaginatedOperationMethod<
   DescribeCommunicationsRequest,
   DescribeCommunicationsResponse,
   DescribeCommunicationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Communication
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCommunicationsRequest,
@@ -1414,7 +1413,7 @@ export const describeCreateCaseOptions: API.OperationMethod<
   DescribeCreateCaseOptionsRequest,
   DescribeCreateCaseOptionsResponse,
   DescribeCreateCaseOptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCreateCaseOptionsRequest,
   output: DescribeCreateCaseOptionsResponse,
@@ -1449,7 +1448,7 @@ export const describeServices: API.OperationMethod<
   DescribeServicesRequest,
   DescribeServicesResponse,
   DescribeServicesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServicesRequest,
   output: DescribeServicesResponse,
@@ -1477,7 +1476,7 @@ export const describeSeverityLevels: API.OperationMethod<
   DescribeSeverityLevelsRequest,
   DescribeSeverityLevelsResponse,
   DescribeSeverityLevelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSeverityLevelsRequest,
   output: DescribeSeverityLevelsResponse,
@@ -1508,7 +1507,7 @@ export const describeSupportedLanguages: API.OperationMethod<
   DescribeSupportedLanguagesRequest,
   DescribeSupportedLanguagesResponse,
   DescribeSupportedLanguagesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSupportedLanguagesRequest,
   output: DescribeSupportedLanguagesResponse,
@@ -1548,7 +1547,7 @@ export const describeTrustedAdvisorCheckRefreshStatuses: API.OperationMethod<
   DescribeTrustedAdvisorCheckRefreshStatusesRequest,
   DescribeTrustedAdvisorCheckRefreshStatusesResponse,
   DescribeTrustedAdvisorCheckRefreshStatusesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrustedAdvisorCheckRefreshStatusesRequest,
   output: DescribeTrustedAdvisorCheckRefreshStatusesResponse,
@@ -1605,7 +1604,7 @@ export const describeTrustedAdvisorCheckResult: API.OperationMethod<
   DescribeTrustedAdvisorCheckResultRequest,
   DescribeTrustedAdvisorCheckResultResponse,
   DescribeTrustedAdvisorCheckResultError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrustedAdvisorCheckResultRequest,
   output: DescribeTrustedAdvisorCheckResultResponse,
@@ -1646,7 +1645,7 @@ export const describeTrustedAdvisorChecks: API.OperationMethod<
   DescribeTrustedAdvisorChecksRequest,
   DescribeTrustedAdvisorChecksResponse,
   DescribeTrustedAdvisorChecksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrustedAdvisorChecksRequest,
   output: DescribeTrustedAdvisorChecksResponse,
@@ -1684,7 +1683,7 @@ export const describeTrustedAdvisorCheckSummaries: API.OperationMethod<
   DescribeTrustedAdvisorCheckSummariesRequest,
   DescribeTrustedAdvisorCheckSummariesResponse,
   DescribeTrustedAdvisorCheckSummariesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTrustedAdvisorCheckSummariesRequest,
   output: DescribeTrustedAdvisorCheckSummariesResponse,
@@ -1726,7 +1725,7 @@ export const refreshTrustedAdvisorCheck: API.OperationMethod<
   RefreshTrustedAdvisorCheckRequest,
   RefreshTrustedAdvisorCheckResponse,
   RefreshTrustedAdvisorCheckError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RefreshTrustedAdvisorCheckRequest,
   output: RefreshTrustedAdvisorCheckResponse,
@@ -1756,7 +1755,7 @@ export const resolveCase: API.OperationMethod<
   ResolveCaseRequest,
   ResolveCaseResponse,
   ResolveCaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResolveCaseRequest,
   output: ResolveCaseResponse,

--- a/packages/aws/src/services/sustainability.ts
+++ b/packages/aws/src/services/sustainability.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Sustainability",
   serviceShapeName: "AwsSustainabilityApiService",
@@ -352,7 +351,7 @@ export const getEstimatedCarbonEmissions: API.PaginatedOperationMethod<
   GetEstimatedCarbonEmissionsRequest,
   GetEstimatedCarbonEmissionsResponse,
   GetEstimatedCarbonEmissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EstimatedCarbonEmissions
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEstimatedCarbonEmissionsRequest,
@@ -387,7 +386,7 @@ export const getEstimatedCarbonEmissionsDimensionValues: API.PaginatedOperationM
   GetEstimatedCarbonEmissionsDimensionValuesRequest,
   GetEstimatedCarbonEmissionsDimensionValuesResponse,
   GetEstimatedCarbonEmissionsDimensionValuesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DimensionEntry
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetEstimatedCarbonEmissionsDimensionValuesRequest,

--- a/packages/aws/src/services/swf.ts
+++ b/packages/aws/src/services/swf.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://swf.amazonaws.com/doc/2012-01-25");
 const svc = T.AwsApiService({
   sdkId: "SWF",
@@ -3388,7 +3387,7 @@ export const countClosedWorkflowExecutions: API.OperationMethod<
   CountClosedWorkflowExecutionsInput,
   WorkflowExecutionCount,
   CountClosedWorkflowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CountClosedWorkflowExecutionsInput,
   output: WorkflowExecutionCount,
@@ -3442,7 +3441,7 @@ export const countOpenWorkflowExecutions: API.OperationMethod<
   CountOpenWorkflowExecutionsInput,
   WorkflowExecutionCount,
   CountOpenWorkflowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CountOpenWorkflowExecutionsInput,
   output: WorkflowExecutionCount,
@@ -3486,7 +3485,7 @@ export const countPendingActivityTasks: API.OperationMethod<
   CountPendingActivityTasksInput,
   PendingTaskCount,
   CountPendingActivityTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CountPendingActivityTasksInput,
   output: PendingTaskCount,
@@ -3530,7 +3529,7 @@ export const countPendingDecisionTasks: API.OperationMethod<
   CountPendingDecisionTasksInput,
   PendingTaskCount,
   CountPendingDecisionTasksError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CountPendingDecisionTasksInput,
   output: PendingTaskCount,
@@ -3581,7 +3580,7 @@ export const deleteActivityType: API.OperationMethod<
   DeleteActivityTypeInput,
   DeleteActivityTypeResponse,
   DeleteActivityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteActivityTypeInput,
   output: DeleteActivityTypeResponse,
@@ -3637,7 +3636,7 @@ export const deleteWorkflowType: API.OperationMethod<
   DeleteWorkflowTypeInput,
   DeleteWorkflowTypeResponse,
   DeleteWorkflowTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowTypeInput,
   output: DeleteWorkflowTypeResponse,
@@ -3691,7 +3690,7 @@ export const deprecateActivityType: API.OperationMethod<
   DeprecateActivityTypeInput,
   DeprecateActivityTypeResponse,
   DeprecateActivityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateActivityTypeInput,
   output: DeprecateActivityTypeResponse,
@@ -3743,7 +3742,7 @@ export const deprecateDomain: API.OperationMethod<
   DeprecateDomainInput,
   DeprecateDomainResponse,
   DeprecateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateDomainInput,
   output: DeprecateDomainResponse,
@@ -3801,7 +3800,7 @@ export const deprecateWorkflowType: API.OperationMethod<
   DeprecateWorkflowTypeInput,
   DeprecateWorkflowTypeResponse,
   DeprecateWorkflowTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeprecateWorkflowTypeInput,
   output: DeprecateWorkflowTypeResponse,
@@ -3854,7 +3853,7 @@ export const describeActivityType: API.OperationMethod<
   DescribeActivityTypeInput,
   ActivityTypeDetail,
   DescribeActivityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeActivityTypeInput,
   output: ActivityTypeDetail,
@@ -3895,7 +3894,7 @@ export const describeDomain: API.OperationMethod<
   DescribeDomainInput,
   DomainDetail,
   DescribeDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainInput,
   output: DomainDetail,
@@ -3939,7 +3938,7 @@ export const describeWorkflowExecution: API.OperationMethod<
   DescribeWorkflowExecutionInput,
   WorkflowExecutionDetail,
   DescribeWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkflowExecutionInput,
   output: WorkflowExecutionDetail,
@@ -3988,7 +3987,7 @@ export const describeWorkflowType: API.OperationMethod<
   DescribeWorkflowTypeInput,
   WorkflowTypeDetail,
   DescribeWorkflowTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkflowTypeInput,
   output: WorkflowTypeDetail,
@@ -4033,7 +4032,7 @@ export const getWorkflowExecutionHistory: API.PaginatedOperationMethod<
   GetWorkflowExecutionHistoryInput,
   History,
   GetWorkflowExecutionHistoryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HistoryEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetWorkflowExecutionHistoryInput,
@@ -4084,7 +4083,7 @@ export const listActivityTypes: API.PaginatedOperationMethod<
   ListActivityTypesInput,
   ActivityTypeInfos,
   ListActivityTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ActivityTypeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListActivityTypesInput,
@@ -4146,7 +4145,7 @@ export const listClosedWorkflowExecutions: API.PaginatedOperationMethod<
   ListClosedWorkflowExecutionsInput,
   WorkflowExecutionInfos,
   ListClosedWorkflowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowExecutionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListClosedWorkflowExecutionsInput,
@@ -4197,7 +4196,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsInput,
   DomainInfos,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsInput,
@@ -4259,7 +4258,7 @@ export const listOpenWorkflowExecutions: API.PaginatedOperationMethod<
   ListOpenWorkflowExecutionsInput,
   WorkflowExecutionInfos,
   ListOpenWorkflowExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowExecutionInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOpenWorkflowExecutionsInput,
@@ -4288,7 +4287,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -4333,7 +4332,7 @@ export const listWorkflowTypes: API.PaginatedOperationMethod<
   ListWorkflowTypesInput,
   WorkflowTypeInfos,
   ListWorkflowTypesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkflowTypeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowTypesInput,
@@ -4392,7 +4391,7 @@ export const pollForActivityTask: API.OperationMethod<
   PollForActivityTaskInput,
   ActivityTask,
   PollForActivityTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PollForActivityTaskInput,
   output: ActivityTask,
@@ -4460,7 +4459,7 @@ export const pollForDecisionTask: API.PaginatedOperationMethod<
   PollForDecisionTaskInput,
   DecisionTask,
   PollForDecisionTaskError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   HistoryEvent
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: PollForDecisionTaskInput,
@@ -4534,7 +4533,7 @@ export const recordActivityTaskHeartbeat: API.OperationMethod<
   RecordActivityTaskHeartbeatInput,
   ActivityTaskStatus,
   RecordActivityTaskHeartbeatError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RecordActivityTaskHeartbeatInput,
   output: ActivityTaskStatus,
@@ -4590,7 +4589,7 @@ export const registerActivityType: API.OperationMethod<
   RegisterActivityTypeInput,
   RegisterActivityTypeResponse,
   RegisterActivityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterActivityTypeInput,
   output: RegisterActivityTypeResponse,
@@ -4637,7 +4636,7 @@ export const registerDomain: API.OperationMethod<
   RegisterDomainInput,
   RegisterDomainResponse,
   RegisterDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterDomainInput,
   output: RegisterDomainResponse,
@@ -4700,7 +4699,7 @@ export const registerWorkflowType: API.OperationMethod<
   RegisterWorkflowTypeInput,
   RegisterWorkflowTypeResponse,
   RegisterWorkflowTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterWorkflowTypeInput,
   output: RegisterWorkflowTypeResponse,
@@ -4756,7 +4755,7 @@ export const requestCancelWorkflowExecution: API.OperationMethod<
   RequestCancelWorkflowExecutionInput,
   RequestCancelWorkflowExecutionResponse,
   RequestCancelWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RequestCancelWorkflowExecutionInput,
   output: RequestCancelWorkflowExecutionResponse,
@@ -4811,7 +4810,7 @@ export const respondActivityTaskCanceled: API.OperationMethod<
   RespondActivityTaskCanceledInput,
   RespondActivityTaskCanceledResponse,
   RespondActivityTaskCanceledError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RespondActivityTaskCanceledInput,
   output: RespondActivityTaskCanceledResponse,
@@ -4864,7 +4863,7 @@ export const respondActivityTaskCompleted: API.OperationMethod<
   RespondActivityTaskCompletedInput,
   RespondActivityTaskCompletedResponse,
   RespondActivityTaskCompletedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RespondActivityTaskCompletedInput,
   output: RespondActivityTaskCompletedResponse,
@@ -4912,7 +4911,7 @@ export const respondActivityTaskFailed: API.OperationMethod<
   RespondActivityTaskFailedInput,
   RespondActivityTaskFailedResponse,
   RespondActivityTaskFailedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RespondActivityTaskFailedInput,
   output: RespondActivityTaskFailedResponse,
@@ -4950,7 +4949,7 @@ export const respondDecisionTaskCompleted: API.OperationMethod<
   RespondDecisionTaskCompletedInput,
   RespondDecisionTaskCompletedResponse,
   RespondDecisionTaskCompletedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RespondDecisionTaskCompletedInput,
   output: RespondDecisionTaskCompletedResponse,
@@ -5000,7 +4999,7 @@ export const signalWorkflowExecution: API.OperationMethod<
   SignalWorkflowExecutionInput,
   SignalWorkflowExecutionResponse,
   SignalWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SignalWorkflowExecutionInput,
   output: SignalWorkflowExecutionResponse,
@@ -5067,7 +5066,7 @@ export const startWorkflowExecution: API.OperationMethod<
   StartWorkflowExecutionInput,
   Run,
   StartWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkflowExecutionInput,
   output: Run,
@@ -5099,7 +5098,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceResponse,
@@ -5157,7 +5156,7 @@ export const terminateWorkflowExecution: API.OperationMethod<
   TerminateWorkflowExecutionInput,
   TerminateWorkflowExecutionResponse,
   TerminateWorkflowExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateWorkflowExecutionInput,
   output: TerminateWorkflowExecutionResponse,
@@ -5209,7 +5208,7 @@ export const undeprecateActivityType: API.OperationMethod<
   UndeprecateActivityTypeInput,
   UndeprecateActivityTypeResponse,
   UndeprecateActivityTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UndeprecateActivityTypeInput,
   output: UndeprecateActivityTypeResponse,
@@ -5258,7 +5257,7 @@ export const undeprecateDomain: API.OperationMethod<
   UndeprecateDomainInput,
   UndeprecateDomainResponse,
   UndeprecateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UndeprecateDomainInput,
   output: UndeprecateDomainResponse,
@@ -5314,7 +5313,7 @@ export const undeprecateWorkflowType: API.OperationMethod<
   UndeprecateWorkflowTypeInput,
   UndeprecateWorkflowTypeResponse,
   UndeprecateWorkflowTypeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UndeprecateWorkflowTypeInput,
   output: UndeprecateWorkflowTypeResponse,
@@ -5340,7 +5339,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/synthetics.ts
+++ b/packages/aws/src/services/synthetics.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "synthetics",
   serviceShapeName: "Synthetics",
@@ -1568,7 +1567,7 @@ export const associateResource: API.OperationMethod<
   AssociateResourceRequest,
   AssociateResourceResponse,
   AssociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateResourceRequest,
   output: AssociateResourceResponse,
@@ -1612,7 +1611,7 @@ export const createCanary: API.OperationMethod<
   CreateCanaryRequest,
   CreateCanaryResponse,
   CreateCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCanaryRequest,
   output: CreateCanaryResponse,
@@ -1654,7 +1653,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -1707,7 +1706,7 @@ export const deleteCanary: API.OperationMethod<
   DeleteCanaryRequest,
   DeleteCanaryResponse,
   DeleteCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCanaryRequest,
   output: DeleteCanaryResponse,
@@ -1739,7 +1738,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -1776,7 +1775,7 @@ export const describeCanaries: API.PaginatedOperationMethod<
   DescribeCanariesRequest,
   DescribeCanariesResponse,
   DescribeCanariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCanariesRequest,
@@ -1813,7 +1812,7 @@ export const describeCanariesLastRun: API.PaginatedOperationMethod<
   DescribeCanariesLastRunRequest,
   DescribeCanariesLastRunResponse,
   DescribeCanariesLastRunError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCanariesLastRunRequest,
@@ -1842,7 +1841,7 @@ export const describeRuntimeVersions: API.PaginatedOperationMethod<
   DescribeRuntimeVersionsRequest,
   DescribeRuntimeVersionsResponse,
   DescribeRuntimeVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRuntimeVersionsRequest,
@@ -1871,7 +1870,7 @@ export const disassociateResource: API.OperationMethod<
   DisassociateResourceRequest,
   DisassociateResourceResponse,
   DisassociateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateResourceRequest,
   output: DisassociateResourceResponse,
@@ -1900,7 +1899,7 @@ export const getCanary: API.OperationMethod<
   GetCanaryRequest,
   GetCanaryResponse,
   GetCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCanaryRequest,
   output: GetCanaryResponse,
@@ -1926,7 +1925,7 @@ export const getCanaryRuns: API.PaginatedOperationMethod<
   GetCanaryRunsRequest,
   GetCanaryRunsResponse,
   GetCanaryRunsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetCanaryRunsRequest,
@@ -1960,7 +1959,7 @@ export const getGroup: API.OperationMethod<
   GetGroupRequest,
   GetGroupResponse,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupRequest,
   output: GetGroupResponse,
@@ -1988,7 +1987,7 @@ export const listAssociatedGroups: API.PaginatedOperationMethod<
   ListAssociatedGroupsRequest,
   ListAssociatedGroupsResponse,
   ListAssociatedGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssociatedGroupsRequest,
@@ -2021,7 +2020,7 @@ export const listGroupResources: API.PaginatedOperationMethod<
   ListGroupResourcesRequest,
   ListGroupResourcesResponse,
   ListGroupResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupResourcesRequest,
@@ -2054,7 +2053,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -2084,7 +2083,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2115,7 +2114,7 @@ export const startCanary: API.OperationMethod<
   StartCanaryRequest,
   StartCanaryResponse,
   StartCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCanaryRequest,
   output: StartCanaryResponse,
@@ -2144,7 +2143,7 @@ export const startCanaryDryRun: API.OperationMethod<
   StartCanaryDryRunRequest,
   StartCanaryDryRunResponse,
   StartCanaryDryRunError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCanaryDryRunRequest,
   output: StartCanaryDryRunResponse,
@@ -2178,7 +2177,7 @@ export const stopCanary: API.OperationMethod<
   StopCanaryRequest,
   StopCanaryResponse,
   StopCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopCanaryRequest,
   output: StopCanaryResponse,
@@ -2222,7 +2221,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2252,7 +2251,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2294,7 +2293,7 @@ export const updateCanary: API.OperationMethod<
   UpdateCanaryRequest,
   UpdateCanaryResponse,
   UpdateCanaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCanaryRequest,
   output: UpdateCanaryResponse,

--- a/packages/aws/src/services/taxsettings.ts
+++ b/packages/aws/src/services/taxsettings.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "TaxSettings",
@@ -1603,7 +1602,7 @@ export const batchDeleteTaxRegistration: API.OperationMethod<
   BatchDeleteTaxRegistrationRequest,
   BatchDeleteTaxRegistrationResponse,
   BatchDeleteTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteTaxRegistrationRequest,
   output: BatchDeleteTaxRegistrationResponse,
@@ -1625,7 +1624,7 @@ export const batchGetTaxExemptions: API.OperationMethod<
   BatchGetTaxExemptionsRequest,
   BatchGetTaxExemptionsResponse,
   BatchGetTaxExemptionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetTaxExemptionsRequest,
   output: BatchGetTaxExemptionsResponse,
@@ -1785,7 +1784,7 @@ export const batchPutTaxRegistration: API.OperationMethod<
   BatchPutTaxRegistrationRequest,
   BatchPutTaxRegistrationResponse,
   BatchPutTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchPutTaxRegistrationRequest,
   output: BatchPutTaxRegistrationResponse,
@@ -1808,7 +1807,7 @@ export const deleteSupplementalTaxRegistration: API.OperationMethod<
   DeleteSupplementalTaxRegistrationRequest,
   DeleteSupplementalTaxRegistrationResponse,
   DeleteSupplementalTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSupplementalTaxRegistrationRequest,
   output: DeleteSupplementalTaxRegistrationResponse,
@@ -1838,7 +1837,7 @@ export const deleteTaxRegistration: API.OperationMethod<
   DeleteTaxRegistrationRequest,
   DeleteTaxRegistrationResponse,
   DeleteTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTaxRegistrationRequest,
   output: DeleteTaxRegistrationResponse,
@@ -1865,7 +1864,7 @@ export const getTaxExemptionTypes: API.OperationMethod<
   GetTaxExemptionTypesRequest,
   GetTaxExemptionTypesResponse,
   GetTaxExemptionTypesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaxExemptionTypesRequest,
   output: GetTaxExemptionTypesResponse,
@@ -1891,7 +1890,7 @@ export const getTaxInheritance: API.OperationMethod<
   GetTaxInheritanceRequest,
   GetTaxInheritanceResponse,
   GetTaxInheritanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaxInheritanceRequest,
   output: GetTaxInheritanceResponse,
@@ -1917,7 +1916,7 @@ export const getTaxRegistration: API.OperationMethod<
   GetTaxRegistrationRequest,
   GetTaxRegistrationResponse,
   GetTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaxRegistrationRequest,
   output: GetTaxRegistrationResponse,
@@ -1942,7 +1941,7 @@ export const getTaxRegistrationDocument: API.OperationMethod<
   GetTaxRegistrationDocumentRequest,
   GetTaxRegistrationDocumentResponse,
   GetTaxRegistrationDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTaxRegistrationDocumentRequest,
   output: GetTaxRegistrationDocumentResponse,
@@ -1964,7 +1963,7 @@ export const listSupplementalTaxRegistrations: API.PaginatedOperationMethod<
   ListSupplementalTaxRegistrationsRequest,
   ListSupplementalTaxRegistrationsResponse,
   ListSupplementalTaxRegistrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SupplementalTaxRegistration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSupplementalTaxRegistrationsRequest,
@@ -1997,7 +1996,7 @@ export const listTaxExemptions: API.PaginatedOperationMethod<
   ListTaxExemptionsRequest,
   ListTaxExemptionsResponse,
   ListTaxExemptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaxExemptionsRequest,
@@ -2030,7 +2029,7 @@ export const listTaxRegistrations: API.PaginatedOperationMethod<
   ListTaxRegistrationsRequest,
   ListTaxRegistrationsResponse,
   ListTaxRegistrationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountDetails
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTaxRegistrationsRequest,
@@ -2063,7 +2062,7 @@ export const putSupplementalTaxRegistration: API.OperationMethod<
   PutSupplementalTaxRegistrationRequest,
   PutSupplementalTaxRegistrationResponse,
   PutSupplementalTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSupplementalTaxRegistrationRequest,
   output: PutSupplementalTaxRegistrationResponse,
@@ -2088,7 +2087,7 @@ export const putTaxExemption: API.OperationMethod<
   PutTaxExemptionRequest,
   PutTaxExemptionResponse,
   PutTaxExemptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTaxExemptionRequest,
   output: PutTaxExemptionResponse,
@@ -2118,7 +2117,7 @@ export const putTaxInheritance: API.OperationMethod<
   PutTaxInheritanceRequest,
   PutTaxInheritanceResponse,
   PutTaxInheritanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTaxInheritanceRequest,
   output: PutTaxInheritanceResponse,
@@ -2279,7 +2278,7 @@ export const putTaxRegistration: API.OperationMethod<
   PutTaxRegistrationRequest,
   PutTaxRegistrationResponse,
   PutTaxRegistrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTaxRegistrationRequest,
   output: PutTaxRegistrationResponse,

--- a/packages/aws/src/services/textract.ts
+++ b/packages/aws/src/services/textract.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Textract",
   serviceShapeName: "Textract",
@@ -1815,7 +1814,7 @@ export const analyzeDocument: API.OperationMethod<
   AnalyzeDocumentRequest,
   AnalyzeDocumentResponse,
   AnalyzeDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AnalyzeDocumentRequest,
   output: AnalyzeDocumentResponse,
@@ -1865,7 +1864,7 @@ export const analyzeExpense: API.OperationMethod<
   AnalyzeExpenseRequest,
   AnalyzeExpenseResponse,
   AnalyzeExpenseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AnalyzeExpenseRequest,
   output: AnalyzeExpenseResponse,
@@ -1906,7 +1905,7 @@ export const analyzeID: API.OperationMethod<
   AnalyzeIDRequest,
   AnalyzeIDResponse,
   AnalyzeIDError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AnalyzeIDRequest,
   output: AnalyzeIDResponse,
@@ -1949,7 +1948,7 @@ export const createAdapter: API.OperationMethod<
   CreateAdapterRequest,
   CreateAdapterResponse,
   CreateAdapterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAdapterRequest,
   output: CreateAdapterResponse,
@@ -1995,7 +1994,7 @@ export const createAdapterVersion: API.OperationMethod<
   CreateAdapterVersionRequest,
   CreateAdapterVersionResponse,
   CreateAdapterVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAdapterVersionRequest,
   output: CreateAdapterVersionResponse,
@@ -2036,7 +2035,7 @@ export const deleteAdapter: API.OperationMethod<
   DeleteAdapterRequest,
   DeleteAdapterResponse,
   DeleteAdapterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAdapterRequest,
   output: DeleteAdapterResponse,
@@ -2073,7 +2072,7 @@ export const deleteAdapterVersion: API.OperationMethod<
   DeleteAdapterVersionRequest,
   DeleteAdapterVersionResponse,
   DeleteAdapterVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAdapterVersionRequest,
   output: DeleteAdapterVersionResponse,
@@ -2122,7 +2121,7 @@ export const detectDocumentText: API.OperationMethod<
   DetectDocumentTextRequest,
   DetectDocumentTextResponse,
   DetectDocumentTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DetectDocumentTextRequest,
   output: DetectDocumentTextResponse,
@@ -2159,7 +2158,7 @@ export const getAdapter: API.OperationMethod<
   GetAdapterRequest,
   GetAdapterResponse,
   GetAdapterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdapterRequest,
   output: GetAdapterResponse,
@@ -2195,7 +2194,7 @@ export const getAdapterVersion: API.OperationMethod<
   GetAdapterVersionRequest,
   GetAdapterVersionResponse,
   GetAdapterVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAdapterVersionRequest,
   output: GetAdapterVersionResponse,
@@ -2286,7 +2285,7 @@ export const getDocumentAnalysis: API.OperationMethod<
   GetDocumentAnalysisRequest,
   GetDocumentAnalysisResponse,
   GetDocumentAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentAnalysisRequest,
   output: GetDocumentAnalysisResponse,
@@ -2349,7 +2348,7 @@ export const getDocumentTextDetection: API.OperationMethod<
   GetDocumentTextDetectionRequest,
   GetDocumentTextDetectionResponse,
   GetDocumentTextDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentTextDetectionRequest,
   output: GetDocumentTextDetectionResponse,
@@ -2404,7 +2403,7 @@ export const getExpenseAnalysis: API.OperationMethod<
   GetExpenseAnalysisRequest,
   GetExpenseAnalysisResponse,
   GetExpenseAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetExpenseAnalysisRequest,
   output: GetExpenseAnalysisResponse,
@@ -2452,7 +2451,7 @@ export const getLendingAnalysis: API.OperationMethod<
   GetLendingAnalysisRequest,
   GetLendingAnalysisResponse,
   GetLendingAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLendingAnalysisRequest,
   output: GetLendingAnalysisResponse,
@@ -2501,7 +2500,7 @@ export const getLendingAnalysisSummary: API.OperationMethod<
   GetLendingAnalysisSummaryRequest,
   GetLendingAnalysisSummaryResponse,
   GetLendingAnalysisSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLendingAnalysisSummaryRequest,
   output: GetLendingAnalysisSummaryResponse,
@@ -2535,7 +2534,7 @@ export const listAdapters: API.PaginatedOperationMethod<
   ListAdaptersRequest,
   ListAdaptersResponse,
   ListAdaptersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdapterOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdaptersRequest,
@@ -2575,7 +2574,7 @@ export const listAdapterVersions: API.PaginatedOperationMethod<
   ListAdapterVersionsRequest,
   ListAdapterVersionsResponse,
   ListAdapterVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AdapterVersionOverview
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAdapterVersionsRequest,
@@ -2616,7 +2615,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2671,7 +2670,7 @@ export const startDocumentAnalysis: API.OperationMethod<
   StartDocumentAnalysisRequest,
   StartDocumentAnalysisResponse,
   StartDocumentAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDocumentAnalysisRequest,
   output: StartDocumentAnalysisResponse,
@@ -2731,7 +2730,7 @@ export const startDocumentTextDetection: API.OperationMethod<
   StartDocumentTextDetectionRequest,
   StartDocumentTextDetectionResponse,
   StartDocumentTextDetectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDocumentTextDetectionRequest,
   output: StartDocumentTextDetectionResponse,
@@ -2790,7 +2789,7 @@ export const startExpenseAnalysis: API.OperationMethod<
   StartExpenseAnalysisRequest,
   StartExpenseAnalysisResponse,
   StartExpenseAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartExpenseAnalysisRequest,
   output: StartExpenseAnalysisResponse,
@@ -2860,7 +2859,7 @@ export const startLendingAnalysis: API.OperationMethod<
   StartLendingAnalysisRequest,
   StartLendingAnalysisResponse,
   StartLendingAnalysisError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartLendingAnalysisRequest,
   output: StartLendingAnalysisResponse,
@@ -2900,7 +2899,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2935,7 +2934,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2971,7 +2970,7 @@ export const updateAdapter: API.OperationMethod<
   UpdateAdapterRequest,
   UpdateAdapterResponse,
   UpdateAdapterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAdapterRequest,
   output: UpdateAdapterResponse,

--- a/packages/aws/src/services/timestream-influxdb.ts
+++ b/packages/aws/src/services/timestream-influxdb.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Timestream InfluxDB",
@@ -1627,7 +1626,7 @@ export const createDbCluster: API.OperationMethod<
   CreateDbClusterInput,
   CreateDbClusterOutput,
   CreateDbClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDbClusterInput,
   output: CreateDbClusterOutput,
@@ -1661,7 +1660,7 @@ export const createDbInstance: API.OperationMethod<
   CreateDbInstanceInput,
   CreateDbInstanceOutput,
   CreateDbInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDbInstanceInput,
   output: CreateDbInstanceOutput,
@@ -1695,7 +1694,7 @@ export const createDbParameterGroup: API.OperationMethod<
   CreateDbParameterGroupInput,
   CreateDbParameterGroupOutput,
   CreateDbParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDbParameterGroupInput,
   output: CreateDbParameterGroupOutput,
@@ -1728,7 +1727,7 @@ export const deleteDbCluster: API.OperationMethod<
   DeleteDbClusterInput,
   DeleteDbClusterOutput,
   DeleteDbClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDbClusterInput,
   output: DeleteDbClusterOutput,
@@ -1760,7 +1759,7 @@ export const deleteDbInstance: API.OperationMethod<
   DeleteDbInstanceInput,
   DeleteDbInstanceOutput,
   DeleteDbInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDbInstanceInput,
   output: DeleteDbInstanceOutput,
@@ -1791,7 +1790,7 @@ export const getDbCluster: API.OperationMethod<
   GetDbClusterInput,
   GetDbClusterOutput,
   GetDbClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDbClusterInput,
   output: GetDbClusterOutput,
@@ -1821,7 +1820,7 @@ export const getDbInstance: API.OperationMethod<
   GetDbInstanceInput,
   GetDbInstanceOutput,
   GetDbInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDbInstanceInput,
   output: GetDbInstanceOutput,
@@ -1851,7 +1850,7 @@ export const getDbParameterGroup: API.OperationMethod<
   GetDbParameterGroupInput,
   GetDbParameterGroupOutput,
   GetDbParameterGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDbParameterGroupInput,
   output: GetDbParameterGroupOutput,
@@ -1881,7 +1880,7 @@ export const listDbClusters: API.PaginatedOperationMethod<
   ListDbClustersInput,
   ListDbClustersOutput,
   ListDbClustersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbClustersInput,
@@ -1918,7 +1917,7 @@ export const listDbInstances: API.PaginatedOperationMethod<
   ListDbInstancesInput,
   ListDbInstancesOutput,
   ListDbInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbInstanceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbInstancesInput,
@@ -1955,7 +1954,7 @@ export const listDbInstancesForCluster: API.PaginatedOperationMethod<
   ListDbInstancesForClusterInput,
   ListDbInstancesForClusterOutput,
   ListDbInstancesForClusterError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbInstanceForClusterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbInstancesForClusterInput,
@@ -1992,7 +1991,7 @@ export const listDbParameterGroups: API.PaginatedOperationMethod<
   ListDbParameterGroupsInput,
   ListDbParameterGroupsOutput,
   ListDbParameterGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DbParameterGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDbParameterGroupsInput,
@@ -2023,7 +2022,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2048,7 +2047,7 @@ export const rebootDbCluster: API.OperationMethod<
   RebootDbClusterInput,
   RebootDbClusterOutput,
   RebootDbClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDbClusterInput,
   output: RebootDbClusterOutput,
@@ -2080,7 +2079,7 @@ export const rebootDbInstance: API.OperationMethod<
   RebootDbInstanceInput,
   RebootDbInstanceOutput,
   RebootDbInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootDbInstanceInput,
   output: RebootDbInstanceOutput,
@@ -2108,7 +2107,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2126,7 +2125,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2151,7 +2150,7 @@ export const updateDbCluster: API.OperationMethod<
   UpdateDbClusterInput,
   UpdateDbClusterOutput,
   UpdateDbClusterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDbClusterInput,
   output: UpdateDbClusterOutput,
@@ -2183,7 +2182,7 @@ export const updateDbInstance: API.OperationMethod<
   UpdateDbInstanceInput,
   UpdateDbInstanceOutput,
   UpdateDbInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDbInstanceInput,
   output: UpdateDbInstanceOutput,

--- a/packages/aws/src/services/timestream-query.ts
+++ b/packages/aws/src/services/timestream-query.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Timestream Query",
@@ -1279,7 +1278,7 @@ export const cancelQuery: API.OperationMethod<
   CancelQueryRequest,
   CancelQueryResponse,
   CancelQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelQueryRequest,
   output: CancelQueryResponse,
@@ -1315,7 +1314,7 @@ export const createScheduledQuery: API.OperationMethod<
   CreateScheduledQueryRequest,
   CreateScheduledQueryResponse,
   CreateScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateScheduledQueryRequest,
   output: CreateScheduledQueryResponse,
@@ -1348,7 +1347,7 @@ export const deleteScheduledQuery: API.OperationMethod<
   DeleteScheduledQueryRequest,
   DeleteScheduledQueryResponse,
   DeleteScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteScheduledQueryRequest,
   output: DeleteScheduledQueryResponse,
@@ -1380,7 +1379,7 @@ export const describeAccountSettings: API.OperationMethod<
   DescribeAccountSettingsRequest,
   DescribeAccountSettingsResponse,
   DescribeAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountSettingsRequest,
   output: DescribeAccountSettingsResponse,
@@ -1423,7 +1422,7 @@ export const describeEndpoints: API.OperationMethod<
   DescribeEndpointsRequest,
   DescribeEndpointsResponse,
   DescribeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointsRequest,
   output: DescribeEndpointsResponse,
@@ -1453,7 +1452,7 @@ export const describeScheduledQuery: API.OperationMethod<
   DescribeScheduledQueryRequest,
   DescribeScheduledQueryResponse,
   DescribeScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeScheduledQueryRequest,
   output: DescribeScheduledQueryResponse,
@@ -1487,7 +1486,7 @@ export const executeScheduledQuery: API.OperationMethod<
   ExecuteScheduledQueryRequest,
   ExecuteScheduledQueryResponse,
   ExecuteScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExecuteScheduledQueryRequest,
   output: ExecuteScheduledQueryResponse,
@@ -1519,7 +1518,7 @@ export const listScheduledQueries: API.PaginatedOperationMethod<
   ListScheduledQueriesRequest,
   ListScheduledQueriesResponse,
   ListScheduledQueriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ScheduledQuery
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListScheduledQueriesRequest,
@@ -1555,7 +1554,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -1593,7 +1592,7 @@ export const prepareQuery: API.OperationMethod<
   PrepareQueryRequest,
   PrepareQueryResponse,
   PrepareQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PrepareQueryRequest,
   output: PrepareQueryResponse,
@@ -1655,7 +1654,7 @@ export const query: API.PaginatedOperationMethod<
   QueryRequest,
   QueryResponse,
   QueryError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Row
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryRequest,
@@ -1697,7 +1696,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1726,7 +1725,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1757,7 +1756,7 @@ export const updateAccountSettings: API.OperationMethod<
   UpdateAccountSettingsRequest,
   UpdateAccountSettingsResponse,
   UpdateAccountSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountSettingsRequest,
   output: UpdateAccountSettingsResponse,
@@ -1788,7 +1787,7 @@ export const updateScheduledQuery: API.OperationMethod<
   UpdateScheduledQueryRequest,
   UpdateScheduledQueryResponse,
   UpdateScheduledQueryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateScheduledQueryRequest,
   output: UpdateScheduledQueryResponse,

--- a/packages/aws/src/services/timestream-write.ts
+++ b/packages/aws/src/services/timestream-write.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Timestream Write",
@@ -1156,7 +1155,7 @@ export const createBatchLoadTask: API.OperationMethod<
   CreateBatchLoadTaskRequest,
   CreateBatchLoadTaskResponse,
   CreateBatchLoadTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBatchLoadTaskRequest,
   output: CreateBatchLoadTaskResponse,
@@ -1194,7 +1193,7 @@ export const createDatabase: API.OperationMethod<
   CreateDatabaseRequest,
   CreateDatabaseResponse,
   CreateDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDatabaseRequest,
   output: CreateDatabaseResponse,
@@ -1235,7 +1234,7 @@ export const createTable: API.OperationMethod<
   CreateTableRequest,
   CreateTableResponse,
   CreateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTableRequest,
   output: CreateTableResponse,
@@ -1280,7 +1279,7 @@ export const deleteDatabase: API.OperationMethod<
   DeleteDatabaseRequest,
   DeleteDatabaseResponse,
   DeleteDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDatabaseRequest,
   output: DeleteDatabaseResponse,
@@ -1320,7 +1319,7 @@ export const deleteTable: API.OperationMethod<
   DeleteTableRequest,
   DeleteTableResponse,
   DeleteTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTableRequest,
   output: DeleteTableResponse,
@@ -1354,7 +1353,7 @@ export const describeBatchLoadTask: API.OperationMethod<
   DescribeBatchLoadTaskRequest,
   DescribeBatchLoadTaskResponse,
   DescribeBatchLoadTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBatchLoadTaskRequest,
   output: DescribeBatchLoadTaskResponse,
@@ -1388,7 +1387,7 @@ export const describeDatabase: API.OperationMethod<
   DescribeDatabaseRequest,
   DescribeDatabaseResponse,
   DescribeDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDatabaseRequest,
   output: DescribeDatabaseResponse,
@@ -1434,7 +1433,7 @@ export const describeEndpoints: API.OperationMethod<
   DescribeEndpointsRequest,
   DescribeEndpointsResponse,
   DescribeEndpointsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEndpointsRequest,
   output: DescribeEndpointsResponse,
@@ -1467,7 +1466,7 @@ export const describeTable: API.OperationMethod<
   DescribeTableRequest,
   DescribeTableResponse,
   DescribeTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTableRequest,
   output: DescribeTableResponse,
@@ -1500,7 +1499,7 @@ export const listBatchLoadTasks: API.PaginatedOperationMethod<
   ListBatchLoadTasksRequest,
   ListBatchLoadTasksResponse,
   ListBatchLoadTasksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBatchLoadTasksRequest,
@@ -1538,7 +1537,7 @@ export const listDatabases: API.PaginatedOperationMethod<
   ListDatabasesRequest,
   ListDatabasesResponse,
   ListDatabasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDatabasesRequest,
@@ -1577,7 +1576,7 @@ export const listTables: API.PaginatedOperationMethod<
   ListTablesRequest,
   ListTablesResponse,
   ListTablesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTablesRequest,
@@ -1613,7 +1612,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1643,7 +1642,7 @@ export const resumeBatchLoadTask: API.OperationMethod<
   ResumeBatchLoadTaskRequest,
   ResumeBatchLoadTaskResponse,
   ResumeBatchLoadTaskError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResumeBatchLoadTaskRequest,
   output: ResumeBatchLoadTaskResponse,
@@ -1676,7 +1675,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1706,7 +1705,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1743,7 +1742,7 @@ export const updateDatabase: API.OperationMethod<
   UpdateDatabaseRequest,
   UpdateDatabaseResponse,
   UpdateDatabaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDatabaseRequest,
   output: UpdateDatabaseResponse,
@@ -1782,7 +1781,7 @@ export const updateTable: API.OperationMethod<
   UpdateTableRequest,
   UpdateTableResponse,
   UpdateTableError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTableRequest,
   output: UpdateTableResponse,
@@ -1857,7 +1856,7 @@ export const writeRecords: API.OperationMethod<
   WriteRecordsRequest,
   WriteRecordsResponse,
   WriteRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: WriteRecordsRequest,
   output: WriteRecordsResponse,

--- a/packages/aws/src/services/tnb.ts
+++ b/packages/aws/src/services/tnb.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "tnb", serviceShapeName: "TNB" });
 const auth = T.AwsAuthSigv4({ name: "tnb" });
 const ver = T.ServiceVersion("2008-10-21");
@@ -1967,7 +1966,7 @@ export const cancelSolNetworkOperation: API.OperationMethod<
   CancelSolNetworkOperationInput,
   CancelSolNetworkOperationResponse,
   CancelSolNetworkOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelSolNetworkOperationInput,
   output: CancelSolNetworkOperationResponse,
@@ -2004,7 +2003,7 @@ export const createSolFunctionPackage: API.OperationMethod<
   CreateSolFunctionPackageInput,
   CreateSolFunctionPackageOutput,
   CreateSolFunctionPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSolFunctionPackageInput,
   output: CreateSolFunctionPackageOutput,
@@ -2042,7 +2041,7 @@ export const createSolNetworkInstance: API.OperationMethod<
   CreateSolNetworkInstanceInput,
   CreateSolNetworkInstanceOutput,
   CreateSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSolNetworkInstanceInput,
   output: CreateSolNetworkInstanceOutput,
@@ -2084,7 +2083,7 @@ export const createSolNetworkPackage: API.OperationMethod<
   CreateSolNetworkPackageInput,
   CreateSolNetworkPackageOutput,
   CreateSolNetworkPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSolNetworkPackageInput,
   output: CreateSolNetworkPackageOutput,
@@ -2119,7 +2118,7 @@ export const deleteSolFunctionPackage: API.OperationMethod<
   DeleteSolFunctionPackageInput,
   DeleteSolFunctionPackageResponse,
   DeleteSolFunctionPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSolFunctionPackageInput,
   output: DeleteSolFunctionPackageResponse,
@@ -2154,7 +2153,7 @@ export const deleteSolNetworkInstance: API.OperationMethod<
   DeleteSolNetworkInstanceInput,
   DeleteSolNetworkInstanceResponse,
   DeleteSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSolNetworkInstanceInput,
   output: DeleteSolNetworkInstanceResponse,
@@ -2189,7 +2188,7 @@ export const deleteSolNetworkPackage: API.OperationMethod<
   DeleteSolNetworkPackageInput,
   DeleteSolNetworkPackageResponse,
   DeleteSolNetworkPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSolNetworkPackageInput,
   output: DeleteSolNetworkPackageResponse,
@@ -2222,7 +2221,7 @@ export const getSolFunctionInstance: API.OperationMethod<
   GetSolFunctionInstanceInput,
   GetSolFunctionInstanceOutput,
   GetSolFunctionInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolFunctionInstanceInput,
   output: GetSolFunctionInstanceOutput,
@@ -2255,7 +2254,7 @@ export const getSolFunctionPackage: API.OperationMethod<
   GetSolFunctionPackageInput,
   GetSolFunctionPackageOutput,
   GetSolFunctionPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolFunctionPackageInput,
   output: GetSolFunctionPackageOutput,
@@ -2287,7 +2286,7 @@ export const getSolFunctionPackageContent: API.OperationMethod<
   GetSolFunctionPackageContentInput,
   GetSolFunctionPackageContentOutput,
   GetSolFunctionPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolFunctionPackageContentInput,
   output: GetSolFunctionPackageContentOutput,
@@ -2321,7 +2320,7 @@ export const getSolFunctionPackageDescriptor: API.OperationMethod<
   GetSolFunctionPackageDescriptorInput,
   GetSolFunctionPackageDescriptorOutput,
   GetSolFunctionPackageDescriptorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolFunctionPackageDescriptorInput,
   output: GetSolFunctionPackageDescriptorOutput,
@@ -2353,7 +2352,7 @@ export const getSolNetworkInstance: API.OperationMethod<
   GetSolNetworkInstanceInput,
   GetSolNetworkInstanceOutput,
   GetSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolNetworkInstanceInput,
   output: GetSolNetworkInstanceOutput,
@@ -2386,7 +2385,7 @@ export const getSolNetworkOperation: API.OperationMethod<
   GetSolNetworkOperationInput,
   GetSolNetworkOperationOutput,
   GetSolNetworkOperationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolNetworkOperationInput,
   output: GetSolNetworkOperationOutput,
@@ -2418,7 +2417,7 @@ export const getSolNetworkPackage: API.OperationMethod<
   GetSolNetworkPackageInput,
   GetSolNetworkPackageOutput,
   GetSolNetworkPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolNetworkPackageInput,
   output: GetSolNetworkPackageOutput,
@@ -2450,7 +2449,7 @@ export const getSolNetworkPackageContent: API.OperationMethod<
   GetSolNetworkPackageContentInput,
   GetSolNetworkPackageContentOutput,
   GetSolNetworkPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolNetworkPackageContentInput,
   output: GetSolNetworkPackageContentOutput,
@@ -2482,7 +2481,7 @@ export const getSolNetworkPackageDescriptor: API.OperationMethod<
   GetSolNetworkPackageDescriptorInput,
   GetSolNetworkPackageDescriptorOutput,
   GetSolNetworkPackageDescriptorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSolNetworkPackageDescriptorInput,
   output: GetSolNetworkPackageDescriptorOutput,
@@ -2518,7 +2517,7 @@ export const instantiateSolNetworkInstance: API.OperationMethod<
   InstantiateSolNetworkInstanceInput,
   InstantiateSolNetworkInstanceOutput,
   InstantiateSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InstantiateSolNetworkInstanceInput,
   output: InstantiateSolNetworkInstanceOutput,
@@ -2550,7 +2549,7 @@ export const listSolFunctionInstances: API.PaginatedOperationMethod<
   ListSolFunctionInstancesInput,
   ListSolFunctionInstancesOutput,
   ListSolFunctionInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSolFunctionInstanceInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolFunctionInstancesInput,
@@ -2587,7 +2586,7 @@ export const listSolFunctionPackages: API.PaginatedOperationMethod<
   ListSolFunctionPackagesInput,
   ListSolFunctionPackagesOutput,
   ListSolFunctionPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSolFunctionPackageInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolFunctionPackagesInput,
@@ -2624,7 +2623,7 @@ export const listSolNetworkInstances: API.PaginatedOperationMethod<
   ListSolNetworkInstancesInput,
   ListSolNetworkInstancesOutput,
   ListSolNetworkInstancesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSolNetworkInstanceInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolNetworkInstancesInput,
@@ -2662,7 +2661,7 @@ export const listSolNetworkOperations: API.PaginatedOperationMethod<
   ListSolNetworkOperationsInput,
   ListSolNetworkOperationsOutput,
   ListSolNetworkOperationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSolNetworkOperationsInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolNetworkOperationsInput,
@@ -2699,7 +2698,7 @@ export const listSolNetworkPackages: API.PaginatedOperationMethod<
   ListSolNetworkPackagesInput,
   ListSolNetworkPackagesOutput,
   ListSolNetworkPackagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListSolNetworkPackageInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSolNetworkPackagesInput,
@@ -2735,7 +2734,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -2767,7 +2766,7 @@ export const putSolFunctionPackageContent: API.OperationMethod<
   PutSolFunctionPackageContentInput,
   PutSolFunctionPackageContentOutput,
   PutSolFunctionPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSolFunctionPackageContentInput,
   output: PutSolFunctionPackageContentOutput,
@@ -2799,7 +2798,7 @@ export const putSolNetworkPackageContent: API.OperationMethod<
   PutSolNetworkPackageContentInput,
   PutSolNetworkPackageContentOutput,
   PutSolNetworkPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSolNetworkPackageContentInput,
   output: PutSolNetworkPackageContentOutput,
@@ -2831,7 +2830,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -2866,7 +2865,7 @@ export const terminateSolNetworkInstance: API.OperationMethod<
   TerminateSolNetworkInstanceInput,
   TerminateSolNetworkInstanceOutput,
   TerminateSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateSolNetworkInstanceInput,
   output: TerminateSolNetworkInstanceOutput,
@@ -2899,7 +2898,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -2931,7 +2930,7 @@ export const updateSolFunctionPackage: API.OperationMethod<
   UpdateSolFunctionPackageInput,
   UpdateSolFunctionPackageOutput,
   UpdateSolFunctionPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSolFunctionPackageInput,
   output: UpdateSolFunctionPackageOutput,
@@ -2966,7 +2965,7 @@ export const updateSolNetworkInstance: API.OperationMethod<
   UpdateSolNetworkInstanceInput,
   UpdateSolNetworkInstanceOutput,
   UpdateSolNetworkInstanceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSolNetworkInstanceInput,
   output: UpdateSolNetworkInstanceOutput,
@@ -3001,7 +3000,7 @@ export const updateSolNetworkPackage: API.OperationMethod<
   UpdateSolNetworkPackageInput,
   UpdateSolNetworkPackageOutput,
   UpdateSolNetworkPackageError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSolNetworkPackageInput,
   output: UpdateSolNetworkPackageOutput,
@@ -3034,7 +3033,7 @@ export const validateSolFunctionPackageContent: API.OperationMethod<
   ValidateSolFunctionPackageContentInput,
   ValidateSolFunctionPackageContentOutput,
   ValidateSolFunctionPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateSolFunctionPackageContentInput,
   output: ValidateSolFunctionPackageContentOutput,
@@ -3067,7 +3066,7 @@ export const validateSolNetworkPackageContent: API.OperationMethod<
   ValidateSolNetworkPackageContentInput,
   ValidateSolNetworkPackageContentOutput,
   ValidateSolNetworkPackageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ValidateSolNetworkPackageContentInput,
   output: ValidateSolNetworkPackageContentOutput,

--- a/packages/aws/src/services/transcribe-streaming.ts
+++ b/packages/aws/src/services/transcribe-streaming.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Transcribe Streaming",
   serviceShapeName: "Transcribe",
@@ -2002,7 +2001,7 @@ export const getMedicalScribeStream: API.OperationMethod<
   GetMedicalScribeStreamRequest,
   GetMedicalScribeStreamResponse,
   GetMedicalScribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMedicalScribeStreamRequest,
   output: GetMedicalScribeStreamResponse,
@@ -2043,7 +2042,7 @@ export const startCallAnalyticsStreamTranscription: API.OperationMethod<
   StartCallAnalyticsStreamTranscriptionRequest,
   StartCallAnalyticsStreamTranscriptionResponse,
   StartCallAnalyticsStreamTranscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCallAnalyticsStreamTranscriptionRequest,
   output: StartCallAnalyticsStreamTranscriptionResponse,
@@ -2101,7 +2100,7 @@ export const startMedicalScribeStream: API.OperationMethod<
   StartMedicalScribeStreamRequest,
   StartMedicalScribeStreamResponse,
   StartMedicalScribeStreamError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMedicalScribeStreamRequest,
   output: StartMedicalScribeStreamResponse,
@@ -2145,7 +2144,7 @@ export const startMedicalStreamTranscription: API.OperationMethod<
   StartMedicalStreamTranscriptionRequest,
   StartMedicalStreamTranscriptionResponse,
   StartMedicalStreamTranscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMedicalStreamTranscriptionRequest,
   output: StartMedicalStreamTranscriptionResponse,
@@ -2186,7 +2185,7 @@ export const startStreamTranscription: API.OperationMethod<
   StartStreamTranscriptionRequest,
   StartStreamTranscriptionResponse,
   StartStreamTranscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartStreamTranscriptionRequest,
   output: StartStreamTranscriptionResponse,

--- a/packages/aws/src/services/transcribe.ts
+++ b/packages/aws/src/services/transcribe.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "Transcribe",
   serviceShapeName: "Transcribe",
@@ -2921,7 +2920,7 @@ export const createCallAnalyticsCategory: API.OperationMethod<
   CreateCallAnalyticsCategoryRequest,
   CreateCallAnalyticsCategoryResponse,
   CreateCallAnalyticsCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCallAnalyticsCategoryRequest,
   output: CreateCallAnalyticsCategoryResponse,
@@ -2960,7 +2959,7 @@ export const createLanguageModel: API.OperationMethod<
   CreateLanguageModelRequest,
   CreateLanguageModelResponse,
   CreateLanguageModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLanguageModelRequest,
   output: CreateLanguageModelResponse,
@@ -3003,7 +3002,7 @@ export const createMedicalVocabulary: API.OperationMethod<
   CreateMedicalVocabularyRequest,
   CreateMedicalVocabularyResponse,
   CreateMedicalVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMedicalVocabularyRequest,
   output: CreateMedicalVocabularyResponse,
@@ -3044,7 +3043,7 @@ export const createVocabulary: API.OperationMethod<
   CreateVocabularyRequest,
   CreateVocabularyResponse,
   CreateVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVocabularyRequest,
   output: CreateVocabularyResponse,
@@ -3084,7 +3083,7 @@ export const createVocabularyFilter: API.OperationMethod<
   CreateVocabularyFilterRequest,
   CreateVocabularyFilterResponse,
   CreateVocabularyFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVocabularyFilterRequest,
   output: CreateVocabularyFilterResponse,
@@ -3114,7 +3113,7 @@ export const deleteCallAnalyticsCategory: API.OperationMethod<
   DeleteCallAnalyticsCategoryRequest,
   DeleteCallAnalyticsCategoryResponse,
   DeleteCallAnalyticsCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCallAnalyticsCategoryRequest,
   output: DeleteCallAnalyticsCategoryResponse,
@@ -3143,7 +3142,7 @@ export const deleteCallAnalyticsJob: API.OperationMethod<
   DeleteCallAnalyticsJobRequest,
   DeleteCallAnalyticsJobResponse,
   DeleteCallAnalyticsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCallAnalyticsJobRequest,
   output: DeleteCallAnalyticsJobResponse,
@@ -3171,7 +3170,7 @@ export const deleteLanguageModel: API.OperationMethod<
   DeleteLanguageModelRequest,
   DeleteLanguageModelResponse,
   DeleteLanguageModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLanguageModelRequest,
   output: DeleteLanguageModelResponse,
@@ -3199,7 +3198,7 @@ export const deleteMedicalScribeJob: API.OperationMethod<
   DeleteMedicalScribeJobRequest,
   DeleteMedicalScribeJobResponse,
   DeleteMedicalScribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMedicalScribeJobRequest,
   output: DeleteMedicalScribeJobResponse,
@@ -3227,7 +3226,7 @@ export const deleteMedicalTranscriptionJob: API.OperationMethod<
   DeleteMedicalTranscriptionJobRequest,
   DeleteMedicalTranscriptionJobResponse,
   DeleteMedicalTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMedicalTranscriptionJobRequest,
   output: DeleteMedicalTranscriptionJobResponse,
@@ -3256,7 +3255,7 @@ export const deleteMedicalVocabulary: API.OperationMethod<
   DeleteMedicalVocabularyRequest,
   DeleteMedicalVocabularyResponse,
   DeleteMedicalVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMedicalVocabularyRequest,
   output: DeleteMedicalVocabularyResponse,
@@ -3285,7 +3284,7 @@ export const deleteTranscriptionJob: API.OperationMethod<
   DeleteTranscriptionJobRequest,
   DeleteTranscriptionJobResponse,
   DeleteTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTranscriptionJobRequest,
   output: DeleteTranscriptionJobResponse,
@@ -3314,7 +3313,7 @@ export const deleteVocabulary: API.OperationMethod<
   DeleteVocabularyRequest,
   DeleteVocabularyResponse,
   DeleteVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVocabularyRequest,
   output: DeleteVocabularyResponse,
@@ -3344,7 +3343,7 @@ export const deleteVocabularyFilter: API.OperationMethod<
   DeleteVocabularyFilterRequest,
   DeleteVocabularyFilterResponse,
   DeleteVocabularyFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVocabularyFilterRequest,
   output: DeleteVocabularyFilterResponse,
@@ -3380,7 +3379,7 @@ export const describeLanguageModel: API.OperationMethod<
   DescribeLanguageModelRequest,
   DescribeLanguageModelResponse,
   DescribeLanguageModelError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeLanguageModelRequest,
   output: DescribeLanguageModelResponse,
@@ -3410,7 +3409,7 @@ export const getCallAnalyticsCategory: API.OperationMethod<
   GetCallAnalyticsCategoryRequest,
   GetCallAnalyticsCategoryResponse,
   GetCallAnalyticsCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCallAnalyticsCategoryRequest,
   output: GetCallAnalyticsCategoryResponse,
@@ -3453,7 +3452,7 @@ export const getCallAnalyticsJob: API.OperationMethod<
   GetCallAnalyticsJobRequest,
   GetCallAnalyticsJobResponse,
   GetCallAnalyticsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCallAnalyticsJobRequest,
   output: GetCallAnalyticsJobResponse,
@@ -3490,7 +3489,7 @@ export const getMedicalScribeJob: API.OperationMethod<
   GetMedicalScribeJobRequest,
   GetMedicalScribeJobResponse,
   GetMedicalScribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMedicalScribeJobRequest,
   output: GetMedicalScribeJobResponse,
@@ -3527,7 +3526,7 @@ export const getMedicalTranscriptionJob: API.OperationMethod<
   GetMedicalTranscriptionJobRequest,
   GetMedicalTranscriptionJobResponse,
   GetMedicalTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMedicalTranscriptionJobRequest,
   output: GetMedicalTranscriptionJobResponse,
@@ -3562,7 +3561,7 @@ export const getMedicalVocabulary: API.OperationMethod<
   GetMedicalVocabularyRequest,
   GetMedicalVocabularyResponse,
   GetMedicalVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMedicalVocabularyRequest,
   output: GetMedicalVocabularyResponse,
@@ -3602,7 +3601,7 @@ export const getTranscriptionJob: API.OperationMethod<
   GetTranscriptionJobRequest,
   GetTranscriptionJobResponse,
   GetTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTranscriptionJobRequest,
   output: GetTranscriptionJobResponse,
@@ -3638,7 +3637,7 @@ export const getVocabulary: API.OperationMethod<
   GetVocabularyRequest,
   GetVocabularyResponse,
   GetVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVocabularyRequest,
   output: GetVocabularyResponse,
@@ -3668,7 +3667,7 @@ export const getVocabularyFilter: API.OperationMethod<
   GetVocabularyFilterRequest,
   GetVocabularyFilterResponse,
   GetVocabularyFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetVocabularyFilterRequest,
   output: GetVocabularyFilterResponse,
@@ -3698,7 +3697,7 @@ export const listCallAnalyticsCategories: API.PaginatedOperationMethod<
   ListCallAnalyticsCategoriesRequest,
   ListCallAnalyticsCategoriesResponse,
   ListCallAnalyticsCategoriesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCallAnalyticsCategoriesRequest,
@@ -3733,7 +3732,7 @@ export const listCallAnalyticsJobs: API.PaginatedOperationMethod<
   ListCallAnalyticsJobsRequest,
   ListCallAnalyticsJobsResponse,
   ListCallAnalyticsJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCallAnalyticsJobsRequest,
@@ -3768,7 +3767,7 @@ export const listLanguageModels: API.PaginatedOperationMethod<
   ListLanguageModelsRequest,
   ListLanguageModelsResponse,
   ListLanguageModelsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLanguageModelsRequest,
@@ -3803,7 +3802,7 @@ export const listMedicalScribeJobs: API.PaginatedOperationMethod<
   ListMedicalScribeJobsRequest,
   ListMedicalScribeJobsResponse,
   ListMedicalScribeJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMedicalScribeJobsRequest,
@@ -3838,7 +3837,7 @@ export const listMedicalTranscriptionJobs: API.PaginatedOperationMethod<
   ListMedicalTranscriptionJobsRequest,
   ListMedicalTranscriptionJobsResponse,
   ListMedicalTranscriptionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMedicalTranscriptionJobsRequest,
@@ -3873,7 +3872,7 @@ export const listMedicalVocabularies: API.PaginatedOperationMethod<
   ListMedicalVocabulariesRequest,
   ListMedicalVocabulariesResponse,
   ListMedicalVocabulariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMedicalVocabulariesRequest,
@@ -3910,7 +3909,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3940,7 +3939,7 @@ export const listTranscriptionJobs: API.PaginatedOperationMethod<
   ListTranscriptionJobsRequest,
   ListTranscriptionJobsResponse,
   ListTranscriptionJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTranscriptionJobsRequest,
@@ -3975,7 +3974,7 @@ export const listVocabularies: API.PaginatedOperationMethod<
   ListVocabulariesRequest,
   ListVocabulariesResponse,
   ListVocabulariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVocabulariesRequest,
@@ -4010,7 +4009,7 @@ export const listVocabularyFilters: API.PaginatedOperationMethod<
   ListVocabularyFiltersRequest,
   ListVocabularyFiltersResponse,
   ListVocabularyFiltersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListVocabularyFiltersRequest,
@@ -4085,7 +4084,7 @@ export const startCallAnalyticsJob: API.OperationMethod<
   StartCallAnalyticsJobRequest,
   StartCallAnalyticsJobResponse,
   StartCallAnalyticsJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartCallAnalyticsJobRequest,
   output: StartCallAnalyticsJobResponse,
@@ -4144,7 +4143,7 @@ export const startMedicalScribeJob: API.OperationMethod<
   StartMedicalScribeJobRequest,
   StartMedicalScribeJobResponse,
   StartMedicalScribeJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMedicalScribeJobRequest,
   output: StartMedicalScribeJobResponse,
@@ -4207,7 +4206,7 @@ export const startMedicalTranscriptionJob: API.OperationMethod<
   StartMedicalTranscriptionJobRequest,
   StartMedicalTranscriptionJobResponse,
   StartMedicalTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMedicalTranscriptionJobRequest,
   output: StartMedicalTranscriptionJobResponse,
@@ -4262,7 +4261,7 @@ export const startTranscriptionJob: API.OperationMethod<
   StartTranscriptionJobRequest,
   StartTranscriptionJobResponse,
   StartTranscriptionJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTranscriptionJobRequest,
   output: StartTranscriptionJobResponse,
@@ -4295,7 +4294,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -4328,7 +4327,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -4363,7 +4362,7 @@ export const updateCallAnalyticsCategory: API.OperationMethod<
   UpdateCallAnalyticsCategoryRequest,
   UpdateCallAnalyticsCategoryResponse,
   UpdateCallAnalyticsCategoryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCallAnalyticsCategoryRequest,
   output: UpdateCallAnalyticsCategoryResponse,
@@ -4395,7 +4394,7 @@ export const updateMedicalVocabulary: API.OperationMethod<
   UpdateMedicalVocabularyRequest,
   UpdateMedicalVocabularyResponse,
   UpdateMedicalVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMedicalVocabularyRequest,
   output: UpdateMedicalVocabularyResponse,
@@ -4427,7 +4426,7 @@ export const updateVocabulary: API.OperationMethod<
   UpdateVocabularyRequest,
   UpdateVocabularyResponse,
   UpdateVocabularyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVocabularyRequest,
   output: UpdateVocabularyResponse,
@@ -4458,7 +4457,7 @@ export const updateVocabularyFilter: API.OperationMethod<
   UpdateVocabularyFilterRequest,
   UpdateVocabularyFilterResponse,
   UpdateVocabularyFilterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateVocabularyFilterRequest,
   output: UpdateVocabularyFilterResponse,

--- a/packages/aws/src/services/transfer.ts
+++ b/packages/aws/src/services/transfer.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString, SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Transfer",
@@ -3596,7 +3595,7 @@ export const createAccess: API.OperationMethod<
   CreateAccessRequest,
   CreateAccessResponse,
   CreateAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessRequest,
   output: CreateAccessResponse,
@@ -3631,7 +3630,7 @@ export const createAgreement: API.OperationMethod<
   CreateAgreementRequest,
   CreateAgreementResponse,
   CreateAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAgreementRequest,
   output: CreateAgreementResponse,
@@ -3665,7 +3664,7 @@ export const createConnector: API.OperationMethod<
   CreateConnectorRequest,
   CreateConnectorResponse,
   CreateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectorRequest,
   output: CreateConnectorResponse,
@@ -3696,7 +3695,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileRequest,
   CreateProfileResponse,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileRequest,
   output: CreateProfileResponse,
@@ -3728,7 +3727,7 @@ export const createServer: API.OperationMethod<
   CreateServerRequest,
   CreateServerResponse,
   CreateServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServerRequest,
   output: CreateServerResponse,
@@ -3760,7 +3759,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -3792,7 +3791,7 @@ export const createWebApp: API.OperationMethod<
   CreateWebAppRequest,
   CreateWebAppResponse,
   CreateWebAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebAppRequest,
   output: CreateWebAppResponse,
@@ -3823,7 +3822,7 @@ export const createWorkflow: API.OperationMethod<
   CreateWorkflowRequest,
   CreateWorkflowResponse,
   CreateWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkflowRequest,
   output: CreateWorkflowResponse,
@@ -3853,7 +3852,7 @@ export const deleteAccess: API.OperationMethod<
   DeleteAccessRequest,
   DeleteAccessResponse,
   DeleteAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessRequest,
   output: DeleteAccessResponse,
@@ -3881,7 +3880,7 @@ export const deleteAgreement: API.OperationMethod<
   DeleteAgreementRequest,
   DeleteAgreementResponse,
   DeleteAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAgreementRequest,
   output: DeleteAgreementResponse,
@@ -3909,7 +3908,7 @@ export const deleteCertificate: API.OperationMethod<
   DeleteCertificateRequest,
   DeleteCertificateResponse,
   DeleteCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCertificateRequest,
   output: DeleteCertificateResponse,
@@ -3937,7 +3936,7 @@ export const deleteConnector: API.OperationMethod<
   DeleteConnectorRequest,
   DeleteConnectorResponse,
   DeleteConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectorRequest,
   output: DeleteConnectorResponse,
@@ -3966,7 +3965,7 @@ export const deleteHostKey: API.OperationMethod<
   DeleteHostKeyRequest,
   DeleteHostKeyResponse,
   DeleteHostKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteHostKeyRequest,
   output: DeleteHostKeyResponse,
@@ -3995,7 +3994,7 @@ export const deleteProfile: API.OperationMethod<
   DeleteProfileRequest,
   DeleteProfileResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileRequest,
   output: DeleteProfileResponse,
@@ -4026,7 +4025,7 @@ export const deleteServer: API.OperationMethod<
   DeleteServerRequest,
   DeleteServerResponse,
   DeleteServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServerRequest,
   output: DeleteServerResponse,
@@ -4056,7 +4055,7 @@ export const deleteSshPublicKey: API.OperationMethod<
   DeleteSshPublicKeyRequest,
   DeleteSshPublicKeyResponse,
   DeleteSshPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSshPublicKeyRequest,
   output: DeleteSshPublicKeyResponse,
@@ -4089,7 +4088,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -4118,7 +4117,7 @@ export const deleteWebApp: API.OperationMethod<
   DeleteWebAppRequest,
   DeleteWebAppResponse,
   DeleteWebAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebAppRequest,
   output: DeleteWebAppResponse,
@@ -4149,7 +4148,7 @@ export const deleteWebAppCustomization: API.OperationMethod<
   DeleteWebAppCustomizationRequest,
   DeleteWebAppCustomizationResponse,
   DeleteWebAppCustomizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebAppCustomizationRequest,
   output: DeleteWebAppCustomizationResponse,
@@ -4180,7 +4179,7 @@ export const deleteWorkflow: API.OperationMethod<
   DeleteWorkflowRequest,
   DeleteWorkflowResponse,
   DeleteWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkflowRequest,
   output: DeleteWorkflowResponse,
@@ -4211,7 +4210,7 @@ export const describeAccess: API.OperationMethod<
   DescribeAccessRequest,
   DescribeAccessResponse,
   DescribeAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccessRequest,
   output: DescribeAccessResponse,
@@ -4239,7 +4238,7 @@ export const describeAgreement: API.OperationMethod<
   DescribeAgreementRequest,
   DescribeAgreementResponse,
   DescribeAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAgreementRequest,
   output: DescribeAgreementResponse,
@@ -4269,7 +4268,7 @@ export const describeCertificate: API.OperationMethod<
   DescribeCertificateRequest,
   DescribeCertificateResponse,
   DescribeCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCertificateRequest,
   output: DescribeCertificateResponse,
@@ -4297,7 +4296,7 @@ export const describeConnector: API.OperationMethod<
   DescribeConnectorRequest,
   DescribeConnectorResponse,
   DescribeConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectorRequest,
   output: DescribeConnectorResponse,
@@ -4329,7 +4328,7 @@ export const describeExecution: API.OperationMethod<
   DescribeExecutionRequest,
   DescribeExecutionResponse,
   DescribeExecutionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeExecutionRequest,
   output: DescribeExecutionResponse,
@@ -4357,7 +4356,7 @@ export const describeHostKey: API.OperationMethod<
   DescribeHostKeyRequest,
   DescribeHostKeyResponse,
   DescribeHostKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeHostKeyRequest,
   output: DescribeHostKeyResponse,
@@ -4385,7 +4384,7 @@ export const describeProfile: API.OperationMethod<
   DescribeProfileRequest,
   DescribeProfileResponse,
   DescribeProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeProfileRequest,
   output: DescribeProfileResponse,
@@ -4413,7 +4412,7 @@ export const describeSecurityPolicy: API.OperationMethod<
   DescribeSecurityPolicyRequest,
   DescribeSecurityPolicyResponse,
   DescribeSecurityPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSecurityPolicyRequest,
   output: DescribeSecurityPolicyResponse,
@@ -4443,7 +4442,7 @@ export const describeServer: API.OperationMethod<
   DescribeServerRequest,
   DescribeServerResponse,
   DescribeServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeServerRequest,
   output: DescribeServerResponse,
@@ -4473,7 +4472,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -4504,7 +4503,7 @@ export const describeWebApp: API.OperationMethod<
   DescribeWebAppRequest,
   DescribeWebAppResponse,
   DescribeWebAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWebAppRequest,
   output: DescribeWebAppResponse,
@@ -4534,7 +4533,7 @@ export const describeWebAppCustomization: API.OperationMethod<
   DescribeWebAppCustomizationRequest,
   DescribeWebAppCustomizationResponse,
   DescribeWebAppCustomizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWebAppCustomizationRequest,
   output: DescribeWebAppCustomizationResponse,
@@ -4563,7 +4562,7 @@ export const describeWorkflow: API.OperationMethod<
   DescribeWorkflowRequest,
   DescribeWorkflowResponse,
   DescribeWorkflowError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkflowRequest,
   output: DescribeWorkflowResponse,
@@ -4611,7 +4610,7 @@ export const importCertificate: API.OperationMethod<
   ImportCertificateRequest,
   ImportCertificateResponse,
   ImportCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCertificateRequest,
   output: ImportCertificateResponse,
@@ -4641,7 +4640,7 @@ export const importHostKey: API.OperationMethod<
   ImportHostKeyRequest,
   ImportHostKeyResponse,
   ImportHostKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportHostKeyRequest,
   output: ImportHostKeyResponse,
@@ -4675,7 +4674,7 @@ export const importSshPublicKey: API.OperationMethod<
   ImportSshPublicKeyRequest,
   ImportSshPublicKeyResponse,
   ImportSshPublicKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportSshPublicKeyRequest,
   output: ImportSshPublicKeyResponse,
@@ -4706,7 +4705,7 @@ export const listAccesses: API.PaginatedOperationMethod<
   ListAccessesRequest,
   ListAccessesResponse,
   ListAccessesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedAccess
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessesRequest,
@@ -4743,7 +4742,7 @@ export const listAgreements: API.PaginatedOperationMethod<
   ListAgreementsRequest,
   ListAgreementsResponse,
   ListAgreementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedAgreement
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAgreementsRequest,
@@ -4780,7 +4779,7 @@ export const listCertificates: API.PaginatedOperationMethod<
   ListCertificatesRequest,
   ListCertificatesResponse,
   ListCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedCertificate
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCertificatesRequest,
@@ -4817,7 +4816,7 @@ export const listConnectors: API.PaginatedOperationMethod<
   ListConnectorsRequest,
   ListConnectorsResponse,
   ListConnectorsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedConnector
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListConnectorsRequest,
@@ -4856,7 +4855,7 @@ export const listExecutions: API.PaginatedOperationMethod<
   ListExecutionsRequest,
   ListExecutionsResponse,
   ListExecutionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedExecution
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListExecutionsRequest,
@@ -4894,7 +4893,7 @@ export const listFileTransferResults: API.PaginatedOperationMethod<
   ListFileTransferResultsRequest,
   ListFileTransferResultsResponse,
   ListFileTransferResultsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ConnectorFileTransferResult
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFileTransferResultsRequest,
@@ -4930,7 +4929,7 @@ export const listHostKeys: API.OperationMethod<
   ListHostKeysRequest,
   ListHostKeysResponse,
   ListHostKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListHostKeysRequest,
   output: ListHostKeysResponse,
@@ -4960,7 +4959,7 @@ export const listProfiles: API.PaginatedOperationMethod<
   ListProfilesRequest,
   ListProfilesResponse,
   ListProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedProfile
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilesRequest,
@@ -4996,7 +4995,7 @@ export const listSecurityPolicies: API.PaginatedOperationMethod<
   ListSecurityPoliciesRequest,
   ListSecurityPoliciesResponse,
   ListSecurityPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityPolicyName
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityPoliciesRequest,
@@ -5031,7 +5030,7 @@ export const listServers: API.PaginatedOperationMethod<
   ListServersRequest,
   ListServersResponse,
   ListServersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedServer
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServersRequest,
@@ -5066,7 +5065,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -5102,7 +5101,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedUser
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -5140,7 +5139,7 @@ export const listWebApps: API.PaginatedOperationMethod<
   ListWebAppsRequest,
   ListWebAppsResponse,
   ListWebAppsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedWebApp
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWebAppsRequest,
@@ -5175,7 +5174,7 @@ export const listWorkflows: API.PaginatedOperationMethod<
   ListWorkflowsRequest,
   ListWorkflowsResponse,
   ListWorkflowsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListedWorkflow
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkflowsRequest,
@@ -5214,7 +5213,7 @@ export const sendWorkflowStepState: API.OperationMethod<
   SendWorkflowStepStateRequest,
   SendWorkflowStepStateResponse,
   SendWorkflowStepStateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: SendWorkflowStepStateRequest,
   output: SendWorkflowStepStateResponse,
@@ -5259,7 +5258,7 @@ export const startDirectoryListing: API.OperationMethod<
   StartDirectoryListingRequest,
   StartDirectoryListingResponse,
   StartDirectoryListingError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDirectoryListingRequest,
   output: StartDirectoryListingResponse,
@@ -5297,7 +5296,7 @@ export const startFileTransfer: API.OperationMethod<
   StartFileTransferRequest,
   StartFileTransferResponse,
   StartFileTransferError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFileTransferRequest,
   output: StartFileTransferResponse,
@@ -5327,7 +5326,7 @@ export const startRemoteDelete: API.OperationMethod<
   StartRemoteDeleteRequest,
   StartRemoteDeleteResponse,
   StartRemoteDeleteError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRemoteDeleteRequest,
   output: StartRemoteDeleteResponse,
@@ -5357,7 +5356,7 @@ export const startRemoteMove: API.OperationMethod<
   StartRemoteMoveRequest,
   StartRemoteMoveResponse,
   StartRemoteMoveError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartRemoteMoveRequest,
   output: StartRemoteMoveResponse,
@@ -5391,7 +5390,7 @@ export const startServer: API.OperationMethod<
   StartServerRequest,
   StartServerResponse,
   StartServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartServerRequest,
   output: StartServerResponse,
@@ -5427,7 +5426,7 @@ export const stopServer: API.OperationMethod<
   StopServerRequest,
   StopServerResponse,
   StopServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopServerRequest,
   output: StopServerResponse,
@@ -5458,7 +5457,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5486,7 +5485,7 @@ export const testConnection: API.OperationMethod<
   TestConnectionRequest,
   TestConnectionResponse,
   TestConnectionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestConnectionRequest,
   output: TestConnectionResponse,
@@ -5536,7 +5535,7 @@ export const testIdentityProvider: API.OperationMethod<
   TestIdentityProviderRequest,
   TestIdentityProviderResponse,
   TestIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestIdentityProviderRequest,
   output: TestIdentityProviderResponse,
@@ -5566,7 +5565,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5596,7 +5595,7 @@ export const updateAccess: API.OperationMethod<
   UpdateAccessRequest,
   UpdateAccessResponse,
   UpdateAccessError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessRequest,
   output: UpdateAccessResponse,
@@ -5632,7 +5631,7 @@ export const updateAgreement: API.OperationMethod<
   UpdateAgreementRequest,
   UpdateAgreementResponse,
   UpdateAgreementError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAgreementRequest,
   output: UpdateAgreementResponse,
@@ -5663,7 +5662,7 @@ export const updateCertificate: API.OperationMethod<
   UpdateCertificateRequest,
   UpdateCertificateResponse,
   UpdateCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateCertificateRequest,
   output: UpdateCertificateResponse,
@@ -5694,7 +5693,7 @@ export const updateConnector: API.OperationMethod<
   UpdateConnectorRequest,
   UpdateConnectorResponse,
   UpdateConnectorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectorRequest,
   output: UpdateConnectorResponse,
@@ -5725,7 +5724,7 @@ export const updateHostKey: API.OperationMethod<
   UpdateHostKeyRequest,
   UpdateHostKeyResponse,
   UpdateHostKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateHostKeyRequest,
   output: UpdateHostKeyResponse,
@@ -5755,7 +5754,7 @@ export const updateProfile: API.OperationMethod<
   UpdateProfileRequest,
   UpdateProfileResponse,
   UpdateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileRequest,
   output: UpdateProfileResponse,
@@ -5790,7 +5789,7 @@ export const updateServer: API.OperationMethod<
   UpdateServerRequest,
   UpdateServerResponse,
   UpdateServerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServerRequest,
   output: UpdateServerResponse,
@@ -5831,7 +5830,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,
@@ -5864,7 +5863,7 @@ export const updateWebApp: API.OperationMethod<
   UpdateWebAppRequest,
   UpdateWebAppResponse,
   UpdateWebAppError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebAppRequest,
   output: UpdateWebAppResponse,
@@ -5896,7 +5895,7 @@ export const updateWebAppCustomization: API.OperationMethod<
   UpdateWebAppCustomizationRequest,
   UpdateWebAppCustomizationResponse,
   UpdateWebAppCustomizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebAppCustomizationRequest,
   output: UpdateWebAppCustomizationResponse,

--- a/packages/aws/src/services/translate.ts
+++ b/packages/aws/src/services/translate.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveBlob } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Translate",
@@ -1118,7 +1117,7 @@ export const createParallelData: API.OperationMethod<
   CreateParallelDataRequest,
   CreateParallelDataResponse,
   CreateParallelDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateParallelDataRequest,
   output: CreateParallelDataResponse,
@@ -1150,7 +1149,7 @@ export const deleteParallelData: API.OperationMethod<
   DeleteParallelDataRequest,
   DeleteParallelDataResponse,
   DeleteParallelDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteParallelDataRequest,
   output: DeleteParallelDataResponse,
@@ -1178,7 +1177,7 @@ export const deleteTerminology: API.OperationMethod<
   DeleteTerminologyRequest,
   DeleteTerminologyResponse,
   DeleteTerminologyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTerminologyRequest,
   output: DeleteTerminologyResponse,
@@ -1206,7 +1205,7 @@ export const describeTextTranslationJob: API.OperationMethod<
   DescribeTextTranslationJobRequest,
   DescribeTextTranslationJobResponse,
   DescribeTextTranslationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTextTranslationJobRequest,
   output: DescribeTextTranslationJobResponse,
@@ -1233,7 +1232,7 @@ export const getParallelData: API.OperationMethod<
   GetParallelDataRequest,
   GetParallelDataResponse,
   GetParallelDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetParallelDataRequest,
   output: GetParallelDataResponse,
@@ -1261,7 +1260,7 @@ export const getTerminology: API.OperationMethod<
   GetTerminologyRequest,
   GetTerminologyResponse,
   GetTerminologyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTerminologyRequest,
   output: GetTerminologyResponse,
@@ -1299,7 +1298,7 @@ export const importTerminology: API.OperationMethod<
   ImportTerminologyRequest,
   ImportTerminologyResponse,
   ImportTerminologyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportTerminologyRequest,
   output: ImportTerminologyResponse,
@@ -1329,7 +1328,7 @@ export const listLanguages: API.PaginatedOperationMethod<
   ListLanguagesRequest,
   ListLanguagesResponse,
   ListLanguagesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLanguagesRequest,
@@ -1362,7 +1361,7 @@ export const listParallelData: API.PaginatedOperationMethod<
   ListParallelDataRequest,
   ListParallelDataResponse,
   ListParallelDataError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListParallelDataRequest,
@@ -1396,7 +1395,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1422,7 +1421,7 @@ export const listTerminologies: API.PaginatedOperationMethod<
   ListTerminologiesRequest,
   ListTerminologiesResponse,
   ListTerminologiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTerminologiesRequest,
@@ -1455,7 +1454,7 @@ export const listTextTranslationJobs: API.PaginatedOperationMethod<
   ListTextTranslationJobsRequest,
   ListTextTranslationJobsResponse,
   ListTextTranslationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTextTranslationJobsRequest,
@@ -1499,7 +1498,7 @@ export const startTextTranslationJob: API.OperationMethod<
   StartTextTranslationJobRequest,
   StartTextTranslationJobResponse,
   StartTextTranslationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTextTranslationJobRequest,
   output: StartTextTranslationJobResponse,
@@ -1536,7 +1535,7 @@ export const stopTextTranslationJob: API.OperationMethod<
   StopTextTranslationJobRequest,
   StopTextTranslationJobResponse,
   StopTextTranslationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopTextTranslationJobRequest,
   output: StopTextTranslationJobResponse,
@@ -1567,7 +1566,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1608,7 +1607,7 @@ export const translateDocument: API.OperationMethod<
   TranslateDocumentRequest,
   TranslateDocumentResponse,
   TranslateDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TranslateDocumentRequest,
   output: TranslateDocumentResponse,
@@ -1644,7 +1643,7 @@ export const translateText: API.OperationMethod<
   TranslateTextRequest,
   TranslateTextResponse,
   TranslateTextError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TranslateTextRequest,
   output: TranslateTextResponse,
@@ -1678,7 +1677,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1711,7 +1710,7 @@ export const updateParallelData: API.OperationMethod<
   UpdateParallelDataRequest,
   UpdateParallelDataResponse,
   UpdateParallelDataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateParallelDataRequest,
   output: UpdateParallelDataResponse,

--- a/packages/aws/src/services/trustedadvisor.ts
+++ b/packages/aws/src/services/trustedadvisor.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "TrustedAdvisor",
@@ -1136,7 +1135,7 @@ export const batchUpdateRecommendationResourceExclusion: API.OperationMethod<
   BatchUpdateRecommendationResourceExclusionRequest,
   BatchUpdateRecommendationResourceExclusionResponse,
   BatchUpdateRecommendationResourceExclusionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateRecommendationResourceExclusionRequest,
   output: BatchUpdateRecommendationResourceExclusionResponse,
@@ -1166,7 +1165,7 @@ export const getOrganizationRecommendation: API.OperationMethod<
   GetOrganizationRecommendationRequest,
   GetOrganizationRecommendationResponse,
   GetOrganizationRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOrganizationRecommendationRequest,
   output: GetOrganizationRecommendationResponse,
@@ -1196,7 +1195,7 @@ export const getRecommendation: API.OperationMethod<
   GetRecommendationRequest,
   GetRecommendationResponse,
   GetRecommendationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationRequest,
   output: GetRecommendationResponse,
@@ -1225,7 +1224,7 @@ export const listChecks: API.PaginatedOperationMethod<
   ListChecksRequest,
   ListChecksResponse,
   ListChecksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   CheckSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListChecksRequest,
@@ -1261,7 +1260,7 @@ export const listOrganizationRecommendationAccounts: API.PaginatedOperationMetho
   ListOrganizationRecommendationAccountsRequest,
   ListOrganizationRecommendationAccountsResponse,
   ListOrganizationRecommendationAccountsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountRecommendationLifecycleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationRecommendationAccountsRequest,
@@ -1298,7 +1297,7 @@ export const listOrganizationRecommendationResources: API.PaginatedOperationMeth
   ListOrganizationRecommendationResourcesRequest,
   ListOrganizationRecommendationResourcesResponse,
   ListOrganizationRecommendationResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationRecommendationResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationRecommendationResourcesRequest,
@@ -1334,7 +1333,7 @@ export const listOrganizationRecommendations: API.PaginatedOperationMethod<
   ListOrganizationRecommendationsRequest,
   ListOrganizationRecommendationsResponse,
   ListOrganizationRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   OrganizationRecommendationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationRecommendationsRequest,
@@ -1370,7 +1369,7 @@ export const listRecommendationResources: API.PaginatedOperationMethod<
   ListRecommendationResourcesRequest,
   ListRecommendationResourcesResponse,
   ListRecommendationResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationResourceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationResourcesRequest,
@@ -1406,7 +1405,7 @@ export const listRecommendations: API.PaginatedOperationMethod<
   ListRecommendationsRequest,
   ListRecommendationsResponse,
   ListRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RecommendationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRecommendationsRequest,
@@ -1443,7 +1442,7 @@ export const updateOrganizationRecommendationLifecycle: API.OperationMethod<
   UpdateOrganizationRecommendationLifecycleRequest,
   UpdateOrganizationRecommendationLifecycleResponse,
   UpdateOrganizationRecommendationLifecycleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateOrganizationRecommendationLifecycleRequest,
   output: UpdateOrganizationRecommendationLifecycleResponse,
@@ -1475,7 +1474,7 @@ export const updateRecommendationLifecycle: API.OperationMethod<
   UpdateRecommendationLifecycleRequest,
   UpdateRecommendationLifecycleResponse,
   UpdateRecommendationLifecycleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRecommendationLifecycleRequest,
   output: UpdateRecommendationLifecycleResponse,

--- a/packages/aws/src/services/uxc.ts
+++ b/packages/aws/src/services/uxc.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "uxc",
   serviceShapeName: "AWSAccountUXSetting",
@@ -230,7 +229,7 @@ export const getAccountCustomizations: API.OperationMethod<
   GetAccountCustomizationsInput,
   GetAccountCustomizationsOutput,
   GetAccountCustomizationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountCustomizationsInput,
   output: GetAccountCustomizationsOutput,
@@ -260,7 +259,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesInput,
   ListServicesOutput,
   ListServicesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Service
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesInput,
@@ -296,7 +295,7 @@ export const updateAccountCustomizations: API.OperationMethod<
   UpdateAccountCustomizationsInput,
   UpdateAccountCustomizationsOutput,
   UpdateAccountCustomizationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccountCustomizationsInput,
   output: UpdateAccountCustomizationsOutput,

--- a/packages/aws/src/services/verifiedpermissions.ts
+++ b/packages/aws/src/services/verifiedpermissions.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "VerifiedPermissions",
@@ -2574,7 +2573,7 @@ export const batchGetPolicy: API.OperationMethod<
   BatchGetPolicyInput,
   BatchGetPolicyOutput,
   BatchGetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchGetPolicyInput,
   output: BatchGetPolicyOutput,
@@ -2601,7 +2600,7 @@ export const batchIsAuthorized: API.OperationMethod<
   BatchIsAuthorizedInput,
   BatchIsAuthorizedOutput,
   BatchIsAuthorizedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchIsAuthorizedInput,
   output: BatchIsAuthorizedOutput,
@@ -2628,7 +2627,7 @@ export const batchIsAuthorizedWithToken: API.OperationMethod<
   BatchIsAuthorizedWithTokenInput,
   BatchIsAuthorizedWithTokenOutput,
   BatchIsAuthorizedWithTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchIsAuthorizedWithTokenInput,
   output: BatchIsAuthorizedWithTokenOutput,
@@ -2663,7 +2662,7 @@ export const createIdentitySource: API.OperationMethod<
   CreateIdentitySourceInput,
   CreateIdentitySourceOutput,
   CreateIdentitySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentitySourceInput,
   output: CreateIdentitySourceOutput,
@@ -2699,7 +2698,7 @@ export const createPolicy: API.OperationMethod<
   CreatePolicyInput,
   CreatePolicyOutput,
   CreatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyInput,
   output: CreatePolicyOutput,
@@ -2730,7 +2729,7 @@ export const createPolicyStore: API.OperationMethod<
   CreatePolicyStoreInput,
   CreatePolicyStoreOutput,
   CreatePolicyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyStoreInput,
   output: CreatePolicyStoreOutput,
@@ -2761,7 +2760,7 @@ export const createPolicyStoreAlias: API.OperationMethod<
   CreatePolicyStoreAliasInput,
   CreatePolicyStoreAliasOutput,
   CreatePolicyStoreAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyStoreAliasInput,
   output: CreatePolicyStoreAliasOutput,
@@ -2791,7 +2790,7 @@ export const createPolicyTemplate: API.OperationMethod<
   CreatePolicyTemplateInput,
   CreatePolicyTemplateOutput,
   CreatePolicyTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePolicyTemplateInput,
   output: CreatePolicyTemplateOutput,
@@ -2817,7 +2816,7 @@ export const deleteIdentitySource: API.OperationMethod<
   DeleteIdentitySourceInput,
   DeleteIdentitySourceOutput,
   DeleteIdentitySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentitySourceInput,
   output: DeleteIdentitySourceOutput,
@@ -2840,7 +2839,7 @@ export const deletePolicy: API.OperationMethod<
   DeletePolicyInput,
   DeletePolicyOutput,
   DeletePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyInput,
   output: DeletePolicyOutput,
@@ -2860,7 +2859,7 @@ export const deletePolicyStore: API.OperationMethod<
   DeletePolicyStoreInput,
   DeletePolicyStoreOutput,
   DeletePolicyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyStoreInput,
   output: DeletePolicyStoreOutput,
@@ -2890,7 +2889,7 @@ export const deletePolicyStoreAlias: API.OperationMethod<
   DeletePolicyStoreAliasInput,
   DeletePolicyStoreAliasOutput,
   DeletePolicyStoreAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyStoreAliasInput,
   output: DeletePolicyStoreAliasOutput,
@@ -2917,7 +2916,7 @@ export const deletePolicyTemplate: API.OperationMethod<
   DeletePolicyTemplateInput,
   DeletePolicyTemplateOutput,
   DeletePolicyTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePolicyTemplateInput,
   output: DeletePolicyTemplateOutput,
@@ -2935,7 +2934,7 @@ export const getIdentitySource: API.OperationMethod<
   GetIdentitySourceInput,
   GetIdentitySourceOutput,
   GetIdentitySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentitySourceInput,
   output: GetIdentitySourceOutput,
@@ -2956,7 +2955,7 @@ export const getPolicy: API.OperationMethod<
   GetPolicyInput,
   GetPolicyOutput,
   GetPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyInput,
   output: GetPolicyOutput,
@@ -2977,7 +2976,7 @@ export const getPolicyStore: API.OperationMethod<
   GetPolicyStoreInput,
   GetPolicyStoreOutput,
   GetPolicyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyStoreInput,
   output: GetPolicyStoreOutput,
@@ -2995,7 +2994,7 @@ export const getPolicyStoreAlias: API.OperationMethod<
   GetPolicyStoreAliasInput,
   GetPolicyStoreAliasOutput,
   GetPolicyStoreAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyStoreAliasInput,
   output: GetPolicyStoreAliasOutput,
@@ -3013,7 +3012,7 @@ export const getPolicyTemplate: API.OperationMethod<
   GetPolicyTemplateInput,
   GetPolicyTemplateOutput,
   GetPolicyTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPolicyTemplateInput,
   output: GetPolicyTemplateOutput,
@@ -3034,7 +3033,7 @@ export const getSchema: API.OperationMethod<
   GetSchemaInput,
   GetSchemaOutput,
   GetSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSchemaInput,
   output: GetSchemaOutput,
@@ -3055,7 +3054,7 @@ export const isAuthorized: API.OperationMethod<
   IsAuthorizedInput,
   IsAuthorizedOutput,
   IsAuthorizedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IsAuthorizedInput,
   output: IsAuthorizedOutput,
@@ -3080,7 +3079,7 @@ export const isAuthorizedWithToken: API.OperationMethod<
   IsAuthorizedWithTokenInput,
   IsAuthorizedWithTokenOutput,
   IsAuthorizedWithTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: IsAuthorizedWithTokenInput,
   output: IsAuthorizedWithTokenOutput,
@@ -3098,7 +3097,7 @@ export const listIdentitySources: API.PaginatedOperationMethod<
   ListIdentitySourcesInput,
   ListIdentitySourcesOutput,
   ListIdentitySourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   IdentitySourceItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentitySourcesInput,
@@ -3123,7 +3122,7 @@ export const listPolicies: API.PaginatedOperationMethod<
   ListPoliciesInput,
   ListPoliciesOutput,
   ListPoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPoliciesInput,
@@ -3148,7 +3147,7 @@ export const listPolicyStoreAliases: API.PaginatedOperationMethod<
   ListPolicyStoreAliasesInput,
   ListPolicyStoreAliasesOutput,
   ListPolicyStoreAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyStoreAliasItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyStoreAliasesInput,
@@ -3173,7 +3172,7 @@ export const listPolicyStores: API.PaginatedOperationMethod<
   ListPolicyStoresInput,
   ListPolicyStoresOutput,
   ListPolicyStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyStoreItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyStoresInput,
@@ -3198,7 +3197,7 @@ export const listPolicyTemplates: API.PaginatedOperationMethod<
   ListPolicyTemplatesInput,
   ListPolicyTemplatesOutput,
   ListPolicyTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PolicyTemplateItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPolicyTemplatesInput,
@@ -3228,7 +3227,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -3258,7 +3257,7 @@ export const putSchema: API.OperationMethod<
   PutSchemaInput,
   PutSchemaOutput,
   PutSchemaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutSchemaInput,
   output: PutSchemaOutput,
@@ -3293,7 +3292,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -3322,7 +3321,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -3351,7 +3350,7 @@ export const updateIdentitySource: API.OperationMethod<
   UpdateIdentitySourceInput,
   UpdateIdentitySourceOutput,
   UpdateIdentitySourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdentitySourceInput,
   output: UpdateIdentitySourceOutput,
@@ -3396,7 +3395,7 @@ export const updatePolicy: API.OperationMethod<
   UpdatePolicyInput,
   UpdatePolicyOutput,
   UpdatePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyInput,
   output: UpdatePolicyOutput,
@@ -3425,7 +3424,7 @@ export const updatePolicyStore: API.OperationMethod<
   UpdatePolicyStoreInput,
   UpdatePolicyStoreOutput,
   UpdatePolicyStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyStoreInput,
   output: UpdatePolicyStoreOutput,
@@ -3451,7 +3450,7 @@ export const updatePolicyTemplate: API.OperationMethod<
   UpdatePolicyTemplateInput,
   UpdatePolicyTemplateOutput,
   UpdatePolicyTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePolicyTemplateInput,
   output: UpdatePolicyTemplateOutput,

--- a/packages/aws/src/services/voice-id.ts
+++ b/packages/aws/src/services/voice-id.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({ sdkId: "Voice ID", serviceShapeName: "VoiceID" });
 const auth = T.AwsAuthSigv4({ name: "voiceid" });
@@ -1390,7 +1389,7 @@ export const associateFraudster: API.OperationMethod<
   AssociateFraudsterRequest,
   AssociateFraudsterResponse,
   AssociateFraudsterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateFraudsterRequest,
   output: AssociateFraudsterResponse,
@@ -1425,7 +1424,7 @@ export const createDomain: API.OperationMethod<
   CreateDomainRequest,
   CreateDomainResponse,
   CreateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDomainRequest,
   output: CreateDomainResponse,
@@ -1459,7 +1458,7 @@ export const createWatchlist: API.OperationMethod<
   CreateWatchlistRequest,
   CreateWatchlistResponse,
   CreateWatchlistError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWatchlistRequest,
   output: CreateWatchlistResponse,
@@ -1492,7 +1491,7 @@ export const deleteDomain: API.OperationMethod<
   DeleteDomainRequest,
   DeleteDomainResponse,
   DeleteDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainRequest,
   output: DeleteDomainResponse,
@@ -1524,7 +1523,7 @@ export const deleteFraudster: API.OperationMethod<
   DeleteFraudsterRequest,
   DeleteFraudsterResponse,
   DeleteFraudsterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFraudsterRequest,
   output: DeleteFraudsterResponse,
@@ -1556,7 +1555,7 @@ export const deleteSpeaker: API.OperationMethod<
   DeleteSpeakerRequest,
   DeleteSpeakerResponse,
   DeleteSpeakerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSpeakerRequest,
   output: DeleteSpeakerResponse,
@@ -1590,7 +1589,7 @@ export const deleteWatchlist: API.OperationMethod<
   DeleteWatchlistRequest,
   DeleteWatchlistResponse,
   DeleteWatchlistError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWatchlistRequest,
   output: DeleteWatchlistResponse,
@@ -1621,7 +1620,7 @@ export const describeDomain: API.OperationMethod<
   DescribeDomainRequest,
   DescribeDomainResponse,
   DescribeDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeDomainRequest,
   output: DescribeDomainResponse,
@@ -1651,7 +1650,7 @@ export const describeFraudster: API.OperationMethod<
   DescribeFraudsterRequest,
   DescribeFraudsterResponse,
   DescribeFraudsterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFraudsterRequest,
   output: DescribeFraudsterResponse,
@@ -1681,7 +1680,7 @@ export const describeFraudsterRegistrationJob: API.OperationMethod<
   DescribeFraudsterRegistrationJobRequest,
   DescribeFraudsterRegistrationJobResponse,
   DescribeFraudsterRegistrationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeFraudsterRegistrationJobRequest,
   output: DescribeFraudsterRegistrationJobResponse,
@@ -1711,7 +1710,7 @@ export const describeSpeaker: API.OperationMethod<
   DescribeSpeakerRequest,
   DescribeSpeakerResponse,
   DescribeSpeakerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpeakerRequest,
   output: DescribeSpeakerResponse,
@@ -1741,7 +1740,7 @@ export const describeSpeakerEnrollmentJob: API.OperationMethod<
   DescribeSpeakerEnrollmentJobRequest,
   DescribeSpeakerEnrollmentJobResponse,
   DescribeSpeakerEnrollmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeSpeakerEnrollmentJobRequest,
   output: DescribeSpeakerEnrollmentJobResponse,
@@ -1771,7 +1770,7 @@ export const describeWatchlist: API.OperationMethod<
   DescribeWatchlistRequest,
   DescribeWatchlistResponse,
   DescribeWatchlistError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWatchlistRequest,
   output: DescribeWatchlistResponse,
@@ -1804,7 +1803,7 @@ export const disassociateFraudster: API.OperationMethod<
   DisassociateFraudsterRequest,
   DisassociateFraudsterResponse,
   DisassociateFraudsterError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateFraudsterRequest,
   output: DisassociateFraudsterResponse,
@@ -1837,7 +1836,7 @@ export const evaluateSession: API.OperationMethod<
   EvaluateSessionRequest,
   EvaluateSessionResponse,
   EvaluateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: EvaluateSessionRequest,
   output: EvaluateSessionResponse,
@@ -1867,7 +1866,7 @@ export const listDomains: API.PaginatedOperationMethod<
   ListDomainsRequest,
   ListDomainsResponse,
   ListDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainsRequest,
@@ -1905,7 +1904,7 @@ export const listFraudsterRegistrationJobs: API.PaginatedOperationMethod<
   ListFraudsterRegistrationJobsRequest,
   ListFraudsterRegistrationJobsResponse,
   ListFraudsterRegistrationJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FraudsterRegistrationJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFraudsterRegistrationJobsRequest,
@@ -1942,7 +1941,7 @@ export const listFraudsters: API.PaginatedOperationMethod<
   ListFraudstersRequest,
   ListFraudstersResponse,
   ListFraudstersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FraudsterSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListFraudstersRequest,
@@ -1981,7 +1980,7 @@ export const listSpeakerEnrollmentJobs: API.PaginatedOperationMethod<
   ListSpeakerEnrollmentJobsRequest,
   ListSpeakerEnrollmentJobsResponse,
   ListSpeakerEnrollmentJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpeakerEnrollmentJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpeakerEnrollmentJobsRequest,
@@ -2018,7 +2017,7 @@ export const listSpeakers: API.PaginatedOperationMethod<
   ListSpeakersRequest,
   ListSpeakersResponse,
   ListSpeakersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SpeakerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSpeakersRequest,
@@ -2055,7 +2054,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -2085,7 +2084,7 @@ export const listWatchlists: API.PaginatedOperationMethod<
   ListWatchlistsRequest,
   ListWatchlistsResponse,
   ListWatchlistsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WatchlistSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWatchlistsRequest,
@@ -2129,7 +2128,7 @@ export const optOutSpeaker: API.OperationMethod<
   OptOutSpeakerRequest,
   OptOutSpeakerResponse,
   OptOutSpeakerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: OptOutSpeakerRequest,
   output: OptOutSpeakerResponse,
@@ -2163,7 +2162,7 @@ export const startFraudsterRegistrationJob: API.OperationMethod<
   StartFraudsterRegistrationJobRequest,
   StartFraudsterRegistrationJobResponse,
   StartFraudsterRegistrationJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartFraudsterRegistrationJobRequest,
   output: StartFraudsterRegistrationJobResponse,
@@ -2197,7 +2196,7 @@ export const startSpeakerEnrollmentJob: API.OperationMethod<
   StartSpeakerEnrollmentJobRequest,
   StartSpeakerEnrollmentJobResponse,
   StartSpeakerEnrollmentJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartSpeakerEnrollmentJobRequest,
   output: StartSpeakerEnrollmentJobResponse,
@@ -2230,7 +2229,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -2262,7 +2261,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -2296,7 +2295,7 @@ export const updateDomain: API.OperationMethod<
   UpdateDomainRequest,
   UpdateDomainResponse,
   UpdateDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDomainRequest,
   output: UpdateDomainResponse,
@@ -2328,7 +2327,7 @@ export const updateWatchlist: API.OperationMethod<
   UpdateWatchlistRequest,
   UpdateWatchlistResponse,
   UpdateWatchlistError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWatchlistRequest,
   output: UpdateWatchlistResponse,

--- a/packages/aws/src/services/vpc-lattice.ts
+++ b/packages/aws/src/services/vpc-lattice.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "VPC Lattice",
   serviceShapeName: "MercuryControlPlane",
@@ -4320,7 +4319,7 @@ export const batchUpdateRule: API.OperationMethod<
   BatchUpdateRuleRequest,
   BatchUpdateRuleResponse,
   BatchUpdateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchUpdateRuleRequest,
   output: BatchUpdateRuleResponse,
@@ -4352,7 +4351,7 @@ export const createAccessLogSubscription: API.OperationMethod<
   CreateAccessLogSubscriptionRequest,
   CreateAccessLogSubscriptionResponse,
   CreateAccessLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessLogSubscriptionRequest,
   output: CreateAccessLogSubscriptionResponse,
@@ -4385,7 +4384,7 @@ export const createListener: API.OperationMethod<
   CreateListenerRequest,
   CreateListenerResponse,
   CreateListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateListenerRequest,
   output: CreateListenerResponse,
@@ -4419,7 +4418,7 @@ export const createResourceConfiguration: API.OperationMethod<
   CreateResourceConfigurationRequest,
   CreateResourceConfigurationResponse,
   CreateResourceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceConfigurationRequest,
   output: CreateResourceConfigurationResponse,
@@ -4453,7 +4452,7 @@ export const createResourceGateway: API.OperationMethod<
   CreateResourceGatewayRequest,
   CreateResourceGatewayResponse,
   CreateResourceGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceGatewayRequest,
   output: CreateResourceGatewayResponse,
@@ -4487,7 +4486,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResponse,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
@@ -4523,7 +4522,7 @@ export const createService: API.OperationMethod<
   CreateServiceRequest,
   CreateServiceResponse,
   CreateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceRequest,
   output: CreateServiceResponse,
@@ -4559,7 +4558,7 @@ export const createServiceNetwork: API.OperationMethod<
   CreateServiceNetworkRequest,
   CreateServiceNetworkResponse,
   CreateServiceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceNetworkRequest,
   output: CreateServiceNetworkResponse,
@@ -4593,7 +4592,7 @@ export const createServiceNetworkResourceAssociation: API.OperationMethod<
   CreateServiceNetworkResourceAssociationRequest,
   CreateServiceNetworkResourceAssociationResponse,
   CreateServiceNetworkResourceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceNetworkResourceAssociationRequest,
   output: CreateServiceNetworkResourceAssociationResponse,
@@ -4633,7 +4632,7 @@ export const createServiceNetworkServiceAssociation: API.OperationMethod<
   CreateServiceNetworkServiceAssociationRequest,
   CreateServiceNetworkServiceAssociationResponse,
   CreateServiceNetworkServiceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceNetworkServiceAssociationRequest,
   output: CreateServiceNetworkServiceAssociationResponse,
@@ -4673,7 +4672,7 @@ export const createServiceNetworkVpcAssociation: API.OperationMethod<
   CreateServiceNetworkVpcAssociationRequest,
   CreateServiceNetworkVpcAssociationResponse,
   CreateServiceNetworkVpcAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateServiceNetworkVpcAssociationRequest,
   output: CreateServiceNetworkVpcAssociationResponse,
@@ -4709,7 +4708,7 @@ export const createTargetGroup: API.OperationMethod<
   CreateTargetGroupRequest,
   CreateTargetGroupResponse,
   CreateTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTargetGroupRequest,
   output: CreateTargetGroupResponse,
@@ -4741,7 +4740,7 @@ export const deleteAccessLogSubscription: API.OperationMethod<
   DeleteAccessLogSubscriptionRequest,
   DeleteAccessLogSubscriptionResponse,
   DeleteAccessLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessLogSubscriptionRequest,
   output: DeleteAccessLogSubscriptionResponse,
@@ -4771,7 +4770,7 @@ export const deleteAuthPolicy: API.OperationMethod<
   DeleteAuthPolicyRequest,
   DeleteAuthPolicyResponse,
   DeleteAuthPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAuthPolicyRequest,
   output: DeleteAuthPolicyResponse,
@@ -4801,7 +4800,7 @@ export const deleteDomainVerification: API.OperationMethod<
   DeleteDomainVerificationRequest,
   DeleteDomainVerificationResponse,
   DeleteDomainVerificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDomainVerificationRequest,
   output: DeleteDomainVerificationResponse,
@@ -4832,7 +4831,7 @@ export const deleteListener: API.OperationMethod<
   DeleteListenerRequest,
   DeleteListenerResponse,
   DeleteListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteListenerRequest,
   output: DeleteListenerResponse,
@@ -4864,7 +4863,7 @@ export const deleteResourceConfiguration: API.OperationMethod<
   DeleteResourceConfigurationRequest,
   DeleteResourceConfigurationResponse,
   DeleteResourceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceConfigurationRequest,
   output: DeleteResourceConfigurationResponse,
@@ -4895,7 +4894,7 @@ export const deleteResourceEndpointAssociation: API.OperationMethod<
   DeleteResourceEndpointAssociationRequest,
   DeleteResourceEndpointAssociationResponse,
   DeleteResourceEndpointAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceEndpointAssociationRequest,
   output: DeleteResourceEndpointAssociationResponse,
@@ -4926,7 +4925,7 @@ export const deleteResourceGateway: API.OperationMethod<
   DeleteResourceGatewayRequest,
   DeleteResourceGatewayResponse,
   DeleteResourceGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceGatewayRequest,
   output: DeleteResourceGatewayResponse,
@@ -4957,7 +4956,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResponse,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResponse,
@@ -4990,7 +4989,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -5022,7 +5021,7 @@ export const deleteService: API.OperationMethod<
   DeleteServiceRequest,
   DeleteServiceResponse,
   DeleteServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceRequest,
   output: DeleteServiceResponse,
@@ -5054,7 +5053,7 @@ export const deleteServiceNetwork: API.OperationMethod<
   DeleteServiceNetworkRequest,
   DeleteServiceNetworkResponse,
   DeleteServiceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceNetworkRequest,
   output: DeleteServiceNetworkResponse,
@@ -5086,7 +5085,7 @@ export const deleteServiceNetworkResourceAssociation: API.OperationMethod<
   DeleteServiceNetworkResourceAssociationRequest,
   DeleteServiceNetworkResourceAssociationResponse,
   DeleteServiceNetworkResourceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceNetworkResourceAssociationRequest,
   output: DeleteServiceNetworkResourceAssociationResponse,
@@ -5118,7 +5117,7 @@ export const deleteServiceNetworkServiceAssociation: API.OperationMethod<
   DeleteServiceNetworkServiceAssociationRequest,
   DeleteServiceNetworkServiceAssociationResponse,
   DeleteServiceNetworkServiceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceNetworkServiceAssociationRequest,
   output: DeleteServiceNetworkServiceAssociationResponse,
@@ -5150,7 +5149,7 @@ export const deleteServiceNetworkVpcAssociation: API.OperationMethod<
   DeleteServiceNetworkVpcAssociationRequest,
   DeleteServiceNetworkVpcAssociationResponse,
   DeleteServiceNetworkVpcAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteServiceNetworkVpcAssociationRequest,
   output: DeleteServiceNetworkVpcAssociationResponse,
@@ -5181,7 +5180,7 @@ export const deleteTargetGroup: API.OperationMethod<
   DeleteTargetGroupRequest,
   DeleteTargetGroupResponse,
   DeleteTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTargetGroupRequest,
   output: DeleteTargetGroupResponse,
@@ -5212,7 +5211,7 @@ export const deregisterTargets: API.OperationMethod<
   DeregisterTargetsRequest,
   DeregisterTargetsResponse,
   DeregisterTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterTargetsRequest,
   output: DeregisterTargetsResponse,
@@ -5243,7 +5242,7 @@ export const getAccessLogSubscription: API.OperationMethod<
   GetAccessLogSubscriptionRequest,
   GetAccessLogSubscriptionResponse,
   GetAccessLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessLogSubscriptionRequest,
   output: GetAccessLogSubscriptionResponse,
@@ -5273,7 +5272,7 @@ export const getAuthPolicy: API.OperationMethod<
   GetAuthPolicyRequest,
   GetAuthPolicyResponse,
   GetAuthPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAuthPolicyRequest,
   output: GetAuthPolicyResponse,
@@ -5303,7 +5302,7 @@ export const getDomainVerification: API.OperationMethod<
   GetDomainVerificationRequest,
   GetDomainVerificationResponse,
   GetDomainVerificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDomainVerificationRequest,
   output: GetDomainVerificationResponse,
@@ -5333,7 +5332,7 @@ export const getListener: API.OperationMethod<
   GetListenerRequest,
   GetListenerResponse,
   GetListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetListenerRequest,
   output: GetListenerResponse,
@@ -5363,7 +5362,7 @@ export const getResourceConfiguration: API.OperationMethod<
   GetResourceConfigurationRequest,
   GetResourceConfigurationResponse,
   GetResourceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceConfigurationRequest,
   output: GetResourceConfigurationResponse,
@@ -5393,7 +5392,7 @@ export const getResourceGateway: API.OperationMethod<
   GetResourceGatewayRequest,
   GetResourceGatewayResponse,
   GetResourceGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourceGatewayRequest,
   output: GetResourceGatewayResponse,
@@ -5423,7 +5422,7 @@ export const getResourcePolicy: API.OperationMethod<
   GetResourcePolicyRequest,
   GetResourcePolicyResponse,
   GetResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcePolicyRequest,
   output: GetResourcePolicyResponse,
@@ -5453,7 +5452,7 @@ export const getRule: API.OperationMethod<
   GetRuleRequest,
   GetRuleResponse,
   GetRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleRequest,
   output: GetRuleResponse,
@@ -5483,7 +5482,7 @@ export const getService: API.OperationMethod<
   GetServiceRequest,
   GetServiceResponse,
   GetServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceRequest,
   output: GetServiceResponse,
@@ -5513,7 +5512,7 @@ export const getServiceNetwork: API.OperationMethod<
   GetServiceNetworkRequest,
   GetServiceNetworkResponse,
   GetServiceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceNetworkRequest,
   output: GetServiceNetworkResponse,
@@ -5543,7 +5542,7 @@ export const getServiceNetworkResourceAssociation: API.OperationMethod<
   GetServiceNetworkResourceAssociationRequest,
   GetServiceNetworkResourceAssociationResponse,
   GetServiceNetworkResourceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceNetworkResourceAssociationRequest,
   output: GetServiceNetworkResourceAssociationResponse,
@@ -5573,7 +5572,7 @@ export const getServiceNetworkServiceAssociation: API.OperationMethod<
   GetServiceNetworkServiceAssociationRequest,
   GetServiceNetworkServiceAssociationResponse,
   GetServiceNetworkServiceAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceNetworkServiceAssociationRequest,
   output: GetServiceNetworkServiceAssociationResponse,
@@ -5603,7 +5602,7 @@ export const getServiceNetworkVpcAssociation: API.OperationMethod<
   GetServiceNetworkVpcAssociationRequest,
   GetServiceNetworkVpcAssociationResponse,
   GetServiceNetworkVpcAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetServiceNetworkVpcAssociationRequest,
   output: GetServiceNetworkVpcAssociationResponse,
@@ -5633,7 +5632,7 @@ export const getTargetGroup: API.OperationMethod<
   GetTargetGroupRequest,
   GetTargetGroupResponse,
   GetTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTargetGroupRequest,
   output: GetTargetGroupResponse,
@@ -5663,7 +5662,7 @@ export const listAccessLogSubscriptions: API.PaginatedOperationMethod<
   ListAccessLogSubscriptionsRequest,
   ListAccessLogSubscriptionsResponse,
   ListAccessLogSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccessLogSubscriptionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccessLogSubscriptionsRequest,
@@ -5700,7 +5699,7 @@ export const listDomainVerifications: API.PaginatedOperationMethod<
   ListDomainVerificationsRequest,
   ListDomainVerificationsResponse,
   ListDomainVerificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DomainVerificationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDomainVerificationsRequest,
@@ -5737,7 +5736,7 @@ export const listListeners: API.PaginatedOperationMethod<
   ListListenersRequest,
   ListListenersResponse,
   ListListenersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ListenerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListListenersRequest,
@@ -5773,7 +5772,7 @@ export const listResourceConfigurations: API.PaginatedOperationMethod<
   ListResourceConfigurationsRequest,
   ListResourceConfigurationsResponse,
   ListResourceConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceConfigurationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceConfigurationsRequest,
@@ -5808,7 +5807,7 @@ export const listResourceEndpointAssociations: API.PaginatedOperationMethod<
   ListResourceEndpointAssociationsRequest,
   ListResourceEndpointAssociationsResponse,
   ListResourceEndpointAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceEndpointAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceEndpointAssociationsRequest,
@@ -5843,7 +5842,7 @@ export const listResourceGateways: API.PaginatedOperationMethod<
   ListResourceGatewaysRequest,
   ListResourceGatewaysResponse,
   ListResourceGatewaysError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourceGatewaySummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceGatewaysRequest,
@@ -5879,7 +5878,7 @@ export const listRules: API.PaginatedOperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   RuleSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRulesRequest,
@@ -5915,7 +5914,7 @@ export const listServiceNetworkResourceAssociations: API.PaginatedOperationMetho
   ListServiceNetworkResourceAssociationsRequest,
   ListServiceNetworkResourceAssociationsResponse,
   ListServiceNetworkResourceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceNetworkResourceAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceNetworkResourceAssociationsRequest,
@@ -5950,7 +5949,7 @@ export const listServiceNetworks: API.PaginatedOperationMethod<
   ListServiceNetworksRequest,
   ListServiceNetworksResponse,
   ListServiceNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceNetworkSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceNetworksRequest,
@@ -5987,7 +5986,7 @@ export const listServiceNetworkServiceAssociations: API.PaginatedOperationMethod
   ListServiceNetworkServiceAssociationsRequest,
   ListServiceNetworkServiceAssociationsResponse,
   ListServiceNetworkServiceAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceNetworkServiceAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceNetworkServiceAssociationsRequest,
@@ -6022,7 +6021,7 @@ export const listServiceNetworkVpcAssociations: API.PaginatedOperationMethod<
   ListServiceNetworkVpcAssociationsRequest,
   ListServiceNetworkVpcAssociationsResponse,
   ListServiceNetworkVpcAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceNetworkVpcAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceNetworkVpcAssociationsRequest,
@@ -6057,7 +6056,7 @@ export const listServiceNetworkVpcEndpointAssociations: API.PaginatedOperationMe
   ListServiceNetworkVpcEndpointAssociationsRequest,
   ListServiceNetworkVpcEndpointAssociationsResponse,
   ListServiceNetworkVpcEndpointAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceNetworkEndpointAssociation
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServiceNetworkVpcEndpointAssociationsRequest,
@@ -6092,7 +6091,7 @@ export const listServices: API.PaginatedOperationMethod<
   ListServicesRequest,
   ListServicesResponse,
   ListServicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ServiceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListServicesRequest,
@@ -6127,7 +6126,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6155,7 +6154,7 @@ export const listTargetGroups: API.PaginatedOperationMethod<
   ListTargetGroupsRequest,
   ListTargetGroupsResponse,
   ListTargetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetGroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetGroupsRequest,
@@ -6191,7 +6190,7 @@ export const listTargets: API.PaginatedOperationMethod<
   ListTargetsRequest,
   ListTargetsResponse,
   ListTargetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TargetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTargetsRequest,
@@ -6230,7 +6229,7 @@ export const putAuthPolicy: API.OperationMethod<
   PutAuthPolicyRequest,
   PutAuthPolicyResponse,
   PutAuthPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAuthPolicyRequest,
   output: PutAuthPolicyResponse,
@@ -6260,7 +6259,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResponse,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResponse,
@@ -6292,7 +6291,7 @@ export const registerTargets: API.OperationMethod<
   RegisterTargetsRequest,
   RegisterTargetsResponse,
   RegisterTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterTargetsRequest,
   output: RegisterTargetsResponse,
@@ -6325,7 +6324,7 @@ export const startDomainVerification: API.OperationMethod<
   StartDomainVerificationRequest,
   StartDomainVerificationResponse,
   StartDomainVerificationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartDomainVerificationRequest,
   output: StartDomainVerificationResponse,
@@ -6356,7 +6355,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6385,7 +6384,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6415,7 +6414,7 @@ export const updateAccessLogSubscription: API.OperationMethod<
   UpdateAccessLogSubscriptionRequest,
   UpdateAccessLogSubscriptionResponse,
   UpdateAccessLogSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAccessLogSubscriptionRequest,
   output: UpdateAccessLogSubscriptionResponse,
@@ -6448,7 +6447,7 @@ export const updateListener: API.OperationMethod<
   UpdateListenerRequest,
   UpdateListenerResponse,
   UpdateListenerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateListenerRequest,
   output: UpdateListenerResponse,
@@ -6481,7 +6480,7 @@ export const updateResourceConfiguration: API.OperationMethod<
   UpdateResourceConfigurationRequest,
   UpdateResourceConfigurationResponse,
   UpdateResourceConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceConfigurationRequest,
   output: UpdateResourceConfigurationResponse,
@@ -6513,7 +6512,7 @@ export const updateResourceGateway: API.OperationMethod<
   UpdateResourceGatewayRequest,
   UpdateResourceGatewayResponse,
   UpdateResourceGatewayError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceGatewayRequest,
   output: UpdateResourceGatewayResponse,
@@ -6546,7 +6545,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
   UpdateRuleResponse,
   UpdateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,
@@ -6580,7 +6579,7 @@ export const updateService: API.OperationMethod<
   UpdateServiceRequest,
   UpdateServiceResponse,
   UpdateServiceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceRequest,
   output: UpdateServiceResponse,
@@ -6613,7 +6612,7 @@ export const updateServiceNetwork: API.OperationMethod<
   UpdateServiceNetworkRequest,
   UpdateServiceNetworkResponse,
   UpdateServiceNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceNetworkRequest,
   output: UpdateServiceNetworkResponse,
@@ -6645,7 +6644,7 @@ export const updateServiceNetworkVpcAssociation: API.OperationMethod<
   UpdateServiceNetworkVpcAssociationRequest,
   UpdateServiceNetworkVpcAssociationResponse,
   UpdateServiceNetworkVpcAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateServiceNetworkVpcAssociationRequest,
   output: UpdateServiceNetworkVpcAssociationResponse,
@@ -6678,7 +6677,7 @@ export const updateTargetGroup: API.OperationMethod<
   UpdateTargetGroupRequest,
   UpdateTargetGroupResponse,
   UpdateTargetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTargetGroupRequest,
   output: UpdateTargetGroupResponse,

--- a/packages/aws/src/services/waf-regional.ts
+++ b/packages/aws/src/services/waf-regional.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://waf.amazonaws.com/doc/2015-08-24/");
 const svc = T.AwsApiService({
   sdkId: "WAF Regional",
@@ -3760,7 +3759,7 @@ export const associateWebACL: API.OperationMethod<
   AssociateWebACLRequest,
   AssociateWebACLResponse,
   AssociateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWebACLRequest,
   output: AssociateWebACLResponse,
@@ -3817,7 +3816,7 @@ export const createByteMatchSet: API.OperationMethod<
   CreateByteMatchSetRequest,
   CreateByteMatchSetResponse,
   CreateByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateByteMatchSetRequest,
   output: CreateByteMatchSetResponse,
@@ -3872,7 +3871,7 @@ export const createGeoMatchSet: API.OperationMethod<
   CreateGeoMatchSetRequest,
   CreateGeoMatchSetResponse,
   CreateGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGeoMatchSetRequest,
   output: CreateGeoMatchSetResponse,
@@ -3932,7 +3931,7 @@ export const createIPSet: API.OperationMethod<
   CreateIPSetRequest,
   CreateIPSetResponse,
   CreateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIPSetRequest,
   output: CreateIPSetResponse,
@@ -4040,7 +4039,7 @@ export const createRateBasedRule: API.OperationMethod<
   CreateRateBasedRuleRequest,
   CreateRateBasedRuleResponse,
   CreateRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRateBasedRuleRequest,
   output: CreateRateBasedRuleResponse,
@@ -4098,7 +4097,7 @@ export const createRegexMatchSet: API.OperationMethod<
   CreateRegexMatchSetRequest,
   CreateRegexMatchSetResponse,
   CreateRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegexMatchSetRequest,
   output: CreateRegexMatchSetResponse,
@@ -4148,7 +4147,7 @@ export const createRegexPatternSet: API.OperationMethod<
   CreateRegexPatternSetRequest,
   CreateRegexPatternSetResponse,
   CreateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegexPatternSetRequest,
   output: CreateRegexPatternSetResponse,
@@ -4220,7 +4219,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResponse,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
@@ -4273,7 +4272,7 @@ export const createRuleGroup: API.OperationMethod<
   CreateRuleGroupRequest,
   CreateRuleGroupResponse,
   CreateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleGroupRequest,
   output: CreateRuleGroupResponse,
@@ -4332,7 +4331,7 @@ export const createSizeConstraintSet: API.OperationMethod<
   CreateSizeConstraintSetRequest,
   CreateSizeConstraintSetResponse,
   CreateSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSizeConstraintSetRequest,
   output: CreateSizeConstraintSetResponse,
@@ -4388,7 +4387,7 @@ export const createSqlInjectionMatchSet: API.OperationMethod<
   CreateSqlInjectionMatchSetRequest,
   CreateSqlInjectionMatchSetResponse,
   CreateSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSqlInjectionMatchSetRequest,
   output: CreateSqlInjectionMatchSetResponse,
@@ -4456,7 +4455,7 @@ export const createWebACL: API.OperationMethod<
   CreateWebACLRequest,
   CreateWebACLResponse,
   CreateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebACLRequest,
   output: CreateWebACLResponse,
@@ -4498,7 +4497,7 @@ export const createWebACLMigrationStack: API.OperationMethod<
   CreateWebACLMigrationStackRequest,
   CreateWebACLMigrationStackResponse,
   CreateWebACLMigrationStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebACLMigrationStackRequest,
   output: CreateWebACLMigrationStackResponse,
@@ -4553,7 +4552,7 @@ export const createXssMatchSet: API.OperationMethod<
   CreateXssMatchSetRequest,
   CreateXssMatchSetResponse,
   CreateXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateXssMatchSetRequest,
   output: CreateXssMatchSetResponse,
@@ -4604,7 +4603,7 @@ export const deleteByteMatchSet: API.OperationMethod<
   DeleteByteMatchSetRequest,
   DeleteByteMatchSetResponse,
   DeleteByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteByteMatchSetRequest,
   output: DeleteByteMatchSetResponse,
@@ -4655,7 +4654,7 @@ export const deleteGeoMatchSet: API.OperationMethod<
   DeleteGeoMatchSetRequest,
   DeleteGeoMatchSetResponse,
   DeleteGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGeoMatchSetRequest,
   output: DeleteGeoMatchSetResponse,
@@ -4706,7 +4705,7 @@ export const deleteIPSet: API.OperationMethod<
   DeleteIPSetRequest,
   DeleteIPSetResponse,
   DeleteIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIPSetRequest,
   output: DeleteIPSetResponse,
@@ -4743,7 +4742,7 @@ export const deleteLoggingConfiguration: API.OperationMethod<
   DeleteLoggingConfigurationRequest,
   DeleteLoggingConfigurationResponse,
   DeleteLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggingConfigurationRequest,
   output: DeleteLoggingConfigurationResponse,
@@ -4778,7 +4777,7 @@ export const deletePermissionPolicy: API.OperationMethod<
   DeletePermissionPolicyRequest,
   DeletePermissionPolicyResponse,
   DeletePermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionPolicyRequest,
   output: DeletePermissionPolicyResponse,
@@ -4832,7 +4831,7 @@ export const deleteRateBasedRule: API.OperationMethod<
   DeleteRateBasedRuleRequest,
   DeleteRateBasedRuleResponse,
   DeleteRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRateBasedRuleRequest,
   output: DeleteRateBasedRuleResponse,
@@ -4885,7 +4884,7 @@ export const deleteRegexMatchSet: API.OperationMethod<
   DeleteRegexMatchSetRequest,
   DeleteRegexMatchSetResponse,
   DeleteRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegexMatchSetRequest,
   output: DeleteRegexMatchSetResponse,
@@ -4925,7 +4924,7 @@ export const deleteRegexPatternSet: API.OperationMethod<
   DeleteRegexPatternSetRequest,
   DeleteRegexPatternSetResponse,
   DeleteRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegexPatternSetRequest,
   output: DeleteRegexPatternSetResponse,
@@ -4978,7 +4977,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -5033,7 +5032,7 @@ export const deleteRuleGroup: API.OperationMethod<
   DeleteRuleGroupRequest,
   DeleteRuleGroupResponse,
   DeleteRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleGroupRequest,
   output: DeleteRuleGroupResponse,
@@ -5086,7 +5085,7 @@ export const deleteSizeConstraintSet: API.OperationMethod<
   DeleteSizeConstraintSetRequest,
   DeleteSizeConstraintSetResponse,
   DeleteSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSizeConstraintSetRequest,
   output: DeleteSizeConstraintSetResponse,
@@ -5138,7 +5137,7 @@ export const deleteSqlInjectionMatchSet: API.OperationMethod<
   DeleteSqlInjectionMatchSetRequest,
   DeleteSqlInjectionMatchSetResponse,
   DeleteSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSqlInjectionMatchSetRequest,
   output: DeleteSqlInjectionMatchSetResponse,
@@ -5188,7 +5187,7 @@ export const deleteWebACL: API.OperationMethod<
   DeleteWebACLRequest,
   DeleteWebACLResponse,
   DeleteWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebACLRequest,
   output: DeleteWebACLResponse,
@@ -5242,7 +5241,7 @@ export const deleteXssMatchSet: API.OperationMethod<
   DeleteXssMatchSetRequest,
   DeleteXssMatchSetResponse,
   DeleteXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteXssMatchSetRequest,
   output: DeleteXssMatchSetResponse,
@@ -5279,7 +5278,7 @@ export const disassociateWebACL: API.OperationMethod<
   DisassociateWebACLRequest,
   DisassociateWebACLResponse,
   DisassociateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWebACLRequest,
   output: DisassociateWebACLResponse,
@@ -5313,7 +5312,7 @@ export const getByteMatchSet: API.OperationMethod<
   GetByteMatchSetRequest,
   GetByteMatchSetResponse,
   GetByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetByteMatchSetRequest,
   output: GetByteMatchSetResponse,
@@ -5350,7 +5349,7 @@ export const getChangeToken: API.OperationMethod<
   GetChangeTokenRequest,
   GetChangeTokenResponse,
   GetChangeTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangeTokenRequest,
   output: GetChangeTokenResponse,
@@ -5386,7 +5385,7 @@ export const getChangeTokenStatus: API.OperationMethod<
   GetChangeTokenStatusRequest,
   GetChangeTokenStatusResponse,
   GetChangeTokenStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangeTokenStatusRequest,
   output: GetChangeTokenStatusResponse,
@@ -5415,7 +5414,7 @@ export const getGeoMatchSet: API.OperationMethod<
   GetGeoMatchSetRequest,
   GetGeoMatchSetResponse,
   GetGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeoMatchSetRequest,
   output: GetGeoMatchSetResponse,
@@ -5448,7 +5447,7 @@ export const getIPSet: API.OperationMethod<
   GetIPSetRequest,
   GetIPSetResponse,
   GetIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIPSetRequest,
   output: GetIPSetResponse,
@@ -5480,7 +5479,7 @@ export const getLoggingConfiguration: API.OperationMethod<
   GetLoggingConfigurationRequest,
   GetLoggingConfigurationResponse,
   GetLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingConfigurationRequest,
   output: GetLoggingConfigurationResponse,
@@ -5508,7 +5507,7 @@ export const getPermissionPolicy: API.OperationMethod<
   GetPermissionPolicyRequest,
   GetPermissionPolicyResponse,
   GetPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionPolicyRequest,
   output: GetPermissionPolicyResponse,
@@ -5539,7 +5538,7 @@ export const getRateBasedRule: API.OperationMethod<
   GetRateBasedRuleRequest,
   GetRateBasedRuleResponse,
   GetRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRateBasedRuleRequest,
   output: GetRateBasedRuleResponse,
@@ -5575,7 +5574,7 @@ export const getRateBasedRuleManagedKeys: API.OperationMethod<
   GetRateBasedRuleManagedKeysRequest,
   GetRateBasedRuleManagedKeysResponse,
   GetRateBasedRuleManagedKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRateBasedRuleManagedKeysRequest,
   output: GetRateBasedRuleManagedKeysResponse,
@@ -5609,7 +5608,7 @@ export const getRegexMatchSet: API.OperationMethod<
   GetRegexMatchSetRequest,
   GetRegexMatchSetResponse,
   GetRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegexMatchSetRequest,
   output: GetRegexMatchSetResponse,
@@ -5642,7 +5641,7 @@ export const getRegexPatternSet: API.OperationMethod<
   GetRegexPatternSetRequest,
   GetRegexPatternSetResponse,
   GetRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegexPatternSetRequest,
   output: GetRegexPatternSetResponse,
@@ -5675,7 +5674,7 @@ export const getRule: API.OperationMethod<
   GetRuleRequest,
   GetRuleResponse,
   GetRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleRequest,
   output: GetRuleResponse,
@@ -5709,7 +5708,7 @@ export const getRuleGroup: API.OperationMethod<
   GetRuleGroupRequest,
   GetRuleGroupResponse,
   GetRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleGroupRequest,
   output: GetRuleGroupResponse,
@@ -5741,7 +5740,7 @@ export const getSampledRequests: API.OperationMethod<
   GetSampledRequestsRequest,
   GetSampledRequestsResponse,
   GetSampledRequestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSampledRequestsRequest,
   output: GetSampledRequestsResponse,
@@ -5770,7 +5769,7 @@ export const getSizeConstraintSet: API.OperationMethod<
   GetSizeConstraintSetRequest,
   GetSizeConstraintSetResponse,
   GetSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSizeConstraintSetRequest,
   output: GetSizeConstraintSetResponse,
@@ -5803,7 +5802,7 @@ export const getSqlInjectionMatchSet: API.OperationMethod<
   GetSqlInjectionMatchSetRequest,
   GetSqlInjectionMatchSetResponse,
   GetSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSqlInjectionMatchSetRequest,
   output: GetSqlInjectionMatchSetResponse,
@@ -5836,7 +5835,7 @@ export const getWebACL: API.OperationMethod<
   GetWebACLRequest,
   GetWebACLResponse,
   GetWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebACLRequest,
   output: GetWebACLResponse,
@@ -5871,7 +5870,7 @@ export const getWebACLForResource: API.OperationMethod<
   GetWebACLForResourceRequest,
   GetWebACLForResourceResponse,
   GetWebACLForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebACLForResourceRequest,
   output: GetWebACLForResourceResponse,
@@ -5906,7 +5905,7 @@ export const getXssMatchSet: API.OperationMethod<
   GetXssMatchSetRequest,
   GetXssMatchSetResponse,
   GetXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetXssMatchSetRequest,
   output: GetXssMatchSetResponse,
@@ -5939,7 +5938,7 @@ export const listActivatedRulesInRuleGroup: API.OperationMethod<
   ListActivatedRulesInRuleGroupRequest,
   ListActivatedRulesInRuleGroupResponse,
   ListActivatedRulesInRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListActivatedRulesInRuleGroupRequest,
   output: ListActivatedRulesInRuleGroupResponse,
@@ -5971,7 +5970,7 @@ export const listByteMatchSets: API.OperationMethod<
   ListByteMatchSetsRequest,
   ListByteMatchSetsResponse,
   ListByteMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListByteMatchSetsRequest,
   output: ListByteMatchSetsResponse,
@@ -5999,7 +5998,7 @@ export const listGeoMatchSets: API.OperationMethod<
   ListGeoMatchSetsRequest,
   ListGeoMatchSetsResponse,
   ListGeoMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGeoMatchSetsRequest,
   output: ListGeoMatchSetsResponse,
@@ -6027,7 +6026,7 @@ export const listIPSets: API.OperationMethod<
   ListIPSetsRequest,
   ListIPSetsResponse,
   ListIPSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIPSetsRequest,
   output: ListIPSetsResponse,
@@ -6056,7 +6055,7 @@ export const listLoggingConfigurations: API.OperationMethod<
   ListLoggingConfigurationsRequest,
   ListLoggingConfigurationsResponse,
   ListLoggingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoggingConfigurationsRequest,
   output: ListLoggingConfigurationsResponse,
@@ -6088,7 +6087,7 @@ export const listRateBasedRules: API.OperationMethod<
   ListRateBasedRulesRequest,
   ListRateBasedRulesResponse,
   ListRateBasedRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRateBasedRulesRequest,
   output: ListRateBasedRulesResponse,
@@ -6116,7 +6115,7 @@ export const listRegexMatchSets: API.OperationMethod<
   ListRegexMatchSetsRequest,
   ListRegexMatchSetsResponse,
   ListRegexMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRegexMatchSetsRequest,
   output: ListRegexMatchSetsResponse,
@@ -6144,7 +6143,7 @@ export const listRegexPatternSets: API.OperationMethod<
   ListRegexPatternSetsRequest,
   ListRegexPatternSetsResponse,
   ListRegexPatternSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRegexPatternSetsRequest,
   output: ListRegexPatternSetsResponse,
@@ -6174,7 +6173,7 @@ export const listResourcesForWebACL: API.OperationMethod<
   ListResourcesForWebACLRequest,
   ListResourcesForWebACLResponse,
   ListResourcesForWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourcesForWebACLRequest,
   output: ListResourcesForWebACLResponse,
@@ -6204,7 +6203,7 @@ export const listRuleGroups: API.OperationMethod<
   ListRuleGroupsRequest,
   ListRuleGroupsResponse,
   ListRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleGroupsRequest,
   output: ListRuleGroupsResponse,
@@ -6232,7 +6231,7 @@ export const listRules: API.OperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRulesRequest,
   output: ListRulesResponse,
@@ -6260,7 +6259,7 @@ export const listSizeConstraintSets: API.OperationMethod<
   ListSizeConstraintSetsRequest,
   ListSizeConstraintSetsResponse,
   ListSizeConstraintSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSizeConstraintSetsRequest,
   output: ListSizeConstraintSetsResponse,
@@ -6288,7 +6287,7 @@ export const listSqlInjectionMatchSets: API.OperationMethod<
   ListSqlInjectionMatchSetsRequest,
   ListSqlInjectionMatchSetsResponse,
   ListSqlInjectionMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSqlInjectionMatchSetsRequest,
   output: ListSqlInjectionMatchSetsResponse,
@@ -6316,7 +6315,7 @@ export const listSubscribedRuleGroups: API.OperationMethod<
   ListSubscribedRuleGroupsRequest,
   ListSubscribedRuleGroupsResponse,
   ListSubscribedRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSubscribedRuleGroupsRequest,
   output: ListSubscribedRuleGroupsResponse,
@@ -6350,7 +6349,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6385,7 +6384,7 @@ export const listWebACLs: API.OperationMethod<
   ListWebACLsRequest,
   ListWebACLsResponse,
   ListWebACLsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebACLsRequest,
   output: ListWebACLsResponse,
@@ -6413,7 +6412,7 @@ export const listXssMatchSets: API.OperationMethod<
   ListXssMatchSetsRequest,
   ListXssMatchSetsResponse,
   ListXssMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListXssMatchSetsRequest,
   output: ListXssMatchSetsResponse,
@@ -6457,7 +6456,7 @@ export const putLoggingConfiguration: API.OperationMethod<
   PutLoggingConfigurationRequest,
   PutLoggingConfigurationResponse,
   PutLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingConfigurationRequest,
   output: PutLoggingConfigurationResponse,
@@ -6514,7 +6513,7 @@ export const putPermissionPolicy: API.OperationMethod<
   PutPermissionPolicyRequest,
   PutPermissionPolicyResponse,
   PutPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionPolicyRequest,
   output: PutPermissionPolicyResponse,
@@ -6554,7 +6553,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6592,7 +6591,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6662,7 +6661,7 @@ export const updateByteMatchSet: API.OperationMethod<
   UpdateByteMatchSetRequest,
   UpdateByteMatchSetResponse,
   UpdateByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateByteMatchSetRequest,
   output: UpdateByteMatchSetResponse,
@@ -6728,7 +6727,7 @@ export const updateGeoMatchSet: API.OperationMethod<
   UpdateGeoMatchSetRequest,
   UpdateGeoMatchSetResponse,
   UpdateGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGeoMatchSetRequest,
   output: UpdateGeoMatchSetResponse,
@@ -6829,7 +6828,7 @@ export const updateIPSet: API.OperationMethod<
   UpdateIPSetRequest,
   UpdateIPSetResponse,
   UpdateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIPSetRequest,
   output: UpdateIPSetResponse,
@@ -6911,7 +6910,7 @@ export const updateRateBasedRule: API.OperationMethod<
   UpdateRateBasedRuleRequest,
   UpdateRateBasedRuleResponse,
   UpdateRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRateBasedRuleRequest,
   output: UpdateRateBasedRuleResponse,
@@ -6981,7 +6980,7 @@ export const updateRegexMatchSet: API.OperationMethod<
   UpdateRegexMatchSetRequest,
   UpdateRegexMatchSetResponse,
   UpdateRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegexMatchSetRequest,
   output: UpdateRegexMatchSetResponse,
@@ -7051,7 +7050,7 @@ export const updateRegexPatternSet: API.OperationMethod<
   UpdateRegexPatternSetRequest,
   UpdateRegexPatternSetResponse,
   UpdateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegexPatternSetRequest,
   output: UpdateRegexPatternSetResponse,
@@ -7128,7 +7127,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
   UpdateRuleResponse,
   UpdateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,
@@ -7192,7 +7191,7 @@ export const updateRuleGroup: API.OperationMethod<
   UpdateRuleGroupRequest,
   UpdateRuleGroupResponse,
   UpdateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleGroupRequest,
   output: UpdateRuleGroupResponse,
@@ -7269,7 +7268,7 @@ export const updateSizeConstraintSet: API.OperationMethod<
   UpdateSizeConstraintSetRequest,
   UpdateSizeConstraintSetResponse,
   UpdateSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSizeConstraintSetRequest,
   output: UpdateSizeConstraintSetResponse,
@@ -7345,7 +7344,7 @@ export const updateSqlInjectionMatchSet: API.OperationMethod<
   UpdateSqlInjectionMatchSetRequest,
   UpdateSqlInjectionMatchSetResponse,
   UpdateSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSqlInjectionMatchSetRequest,
   output: UpdateSqlInjectionMatchSetResponse,
@@ -7451,7 +7450,7 @@ export const updateWebACL: API.OperationMethod<
   UpdateWebACLRequest,
   UpdateWebACLResponse,
   UpdateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebACLRequest,
   output: UpdateWebACLResponse,
@@ -7530,7 +7529,7 @@ export const updateXssMatchSet: API.OperationMethod<
   UpdateXssMatchSetRequest,
   UpdateXssMatchSetResponse,
   UpdateXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateXssMatchSetRequest,
   output: UpdateXssMatchSetResponse,

--- a/packages/aws/src/services/waf.ts
+++ b/packages/aws/src/services/waf.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://waf.amazonaws.com/doc/2015-08-24/");
 const svc = T.AwsApiService({
   sdkId: "WAF",
@@ -3684,7 +3683,7 @@ export const createByteMatchSet: API.OperationMethod<
   CreateByteMatchSetRequest,
   CreateByteMatchSetResponse,
   CreateByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateByteMatchSetRequest,
   output: CreateByteMatchSetResponse,
@@ -3739,7 +3738,7 @@ export const createGeoMatchSet: API.OperationMethod<
   CreateGeoMatchSetRequest,
   CreateGeoMatchSetResponse,
   CreateGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGeoMatchSetRequest,
   output: CreateGeoMatchSetResponse,
@@ -3799,7 +3798,7 @@ export const createIPSet: API.OperationMethod<
   CreateIPSetRequest,
   CreateIPSetResponse,
   CreateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIPSetRequest,
   output: CreateIPSetResponse,
@@ -3907,7 +3906,7 @@ export const createRateBasedRule: API.OperationMethod<
   CreateRateBasedRuleRequest,
   CreateRateBasedRuleResponse,
   CreateRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRateBasedRuleRequest,
   output: CreateRateBasedRuleResponse,
@@ -3965,7 +3964,7 @@ export const createRegexMatchSet: API.OperationMethod<
   CreateRegexMatchSetRequest,
   CreateRegexMatchSetResponse,
   CreateRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegexMatchSetRequest,
   output: CreateRegexMatchSetResponse,
@@ -4015,7 +4014,7 @@ export const createRegexPatternSet: API.OperationMethod<
   CreateRegexPatternSetRequest,
   CreateRegexPatternSetResponse,
   CreateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegexPatternSetRequest,
   output: CreateRegexPatternSetResponse,
@@ -4087,7 +4086,7 @@ export const createRule: API.OperationMethod<
   CreateRuleRequest,
   CreateRuleResponse,
   CreateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
@@ -4140,7 +4139,7 @@ export const createRuleGroup: API.OperationMethod<
   CreateRuleGroupRequest,
   CreateRuleGroupResponse,
   CreateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleGroupRequest,
   output: CreateRuleGroupResponse,
@@ -4199,7 +4198,7 @@ export const createSizeConstraintSet: API.OperationMethod<
   CreateSizeConstraintSetRequest,
   CreateSizeConstraintSetResponse,
   CreateSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSizeConstraintSetRequest,
   output: CreateSizeConstraintSetResponse,
@@ -4255,7 +4254,7 @@ export const createSqlInjectionMatchSet: API.OperationMethod<
   CreateSqlInjectionMatchSetRequest,
   CreateSqlInjectionMatchSetResponse,
   CreateSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSqlInjectionMatchSetRequest,
   output: CreateSqlInjectionMatchSetResponse,
@@ -4323,7 +4322,7 @@ export const createWebACL: API.OperationMethod<
   CreateWebACLRequest,
   CreateWebACLResponse,
   CreateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebACLRequest,
   output: CreateWebACLResponse,
@@ -4365,7 +4364,7 @@ export const createWebACLMigrationStack: API.OperationMethod<
   CreateWebACLMigrationStackRequest,
   CreateWebACLMigrationStackResponse,
   CreateWebACLMigrationStackError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebACLMigrationStackRequest,
   output: CreateWebACLMigrationStackResponse,
@@ -4420,7 +4419,7 @@ export const createXssMatchSet: API.OperationMethod<
   CreateXssMatchSetRequest,
   CreateXssMatchSetResponse,
   CreateXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateXssMatchSetRequest,
   output: CreateXssMatchSetResponse,
@@ -4471,7 +4470,7 @@ export const deleteByteMatchSet: API.OperationMethod<
   DeleteByteMatchSetRequest,
   DeleteByteMatchSetResponse,
   DeleteByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteByteMatchSetRequest,
   output: DeleteByteMatchSetResponse,
@@ -4522,7 +4521,7 @@ export const deleteGeoMatchSet: API.OperationMethod<
   DeleteGeoMatchSetRequest,
   DeleteGeoMatchSetResponse,
   DeleteGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGeoMatchSetRequest,
   output: DeleteGeoMatchSetResponse,
@@ -4573,7 +4572,7 @@ export const deleteIPSet: API.OperationMethod<
   DeleteIPSetRequest,
   DeleteIPSetResponse,
   DeleteIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIPSetRequest,
   output: DeleteIPSetResponse,
@@ -4610,7 +4609,7 @@ export const deleteLoggingConfiguration: API.OperationMethod<
   DeleteLoggingConfigurationRequest,
   DeleteLoggingConfigurationResponse,
   DeleteLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggingConfigurationRequest,
   output: DeleteLoggingConfigurationResponse,
@@ -4645,7 +4644,7 @@ export const deletePermissionPolicy: API.OperationMethod<
   DeletePermissionPolicyRequest,
   DeletePermissionPolicyResponse,
   DeletePermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionPolicyRequest,
   output: DeletePermissionPolicyResponse,
@@ -4699,7 +4698,7 @@ export const deleteRateBasedRule: API.OperationMethod<
   DeleteRateBasedRuleRequest,
   DeleteRateBasedRuleResponse,
   DeleteRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRateBasedRuleRequest,
   output: DeleteRateBasedRuleResponse,
@@ -4752,7 +4751,7 @@ export const deleteRegexMatchSet: API.OperationMethod<
   DeleteRegexMatchSetRequest,
   DeleteRegexMatchSetResponse,
   DeleteRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegexMatchSetRequest,
   output: DeleteRegexMatchSetResponse,
@@ -4792,7 +4791,7 @@ export const deleteRegexPatternSet: API.OperationMethod<
   DeleteRegexPatternSetRequest,
   DeleteRegexPatternSetResponse,
   DeleteRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegexPatternSetRequest,
   output: DeleteRegexPatternSetResponse,
@@ -4845,7 +4844,7 @@ export const deleteRule: API.OperationMethod<
   DeleteRuleRequest,
   DeleteRuleResponse,
   DeleteRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleRequest,
   output: DeleteRuleResponse,
@@ -4900,7 +4899,7 @@ export const deleteRuleGroup: API.OperationMethod<
   DeleteRuleGroupRequest,
   DeleteRuleGroupResponse,
   DeleteRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleGroupRequest,
   output: DeleteRuleGroupResponse,
@@ -4953,7 +4952,7 @@ export const deleteSizeConstraintSet: API.OperationMethod<
   DeleteSizeConstraintSetRequest,
   DeleteSizeConstraintSetResponse,
   DeleteSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSizeConstraintSetRequest,
   output: DeleteSizeConstraintSetResponse,
@@ -5005,7 +5004,7 @@ export const deleteSqlInjectionMatchSet: API.OperationMethod<
   DeleteSqlInjectionMatchSetRequest,
   DeleteSqlInjectionMatchSetResponse,
   DeleteSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSqlInjectionMatchSetRequest,
   output: DeleteSqlInjectionMatchSetResponse,
@@ -5055,7 +5054,7 @@ export const deleteWebACL: API.OperationMethod<
   DeleteWebACLRequest,
   DeleteWebACLResponse,
   DeleteWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebACLRequest,
   output: DeleteWebACLResponse,
@@ -5109,7 +5108,7 @@ export const deleteXssMatchSet: API.OperationMethod<
   DeleteXssMatchSetRequest,
   DeleteXssMatchSetResponse,
   DeleteXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteXssMatchSetRequest,
   output: DeleteXssMatchSetResponse,
@@ -5145,7 +5144,7 @@ export const getByteMatchSet: API.OperationMethod<
   GetByteMatchSetRequest,
   GetByteMatchSetResponse,
   GetByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetByteMatchSetRequest,
   output: GetByteMatchSetResponse,
@@ -5182,7 +5181,7 @@ export const getChangeToken: API.OperationMethod<
   GetChangeTokenRequest,
   GetChangeTokenResponse,
   GetChangeTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangeTokenRequest,
   output: GetChangeTokenResponse,
@@ -5218,7 +5217,7 @@ export const getChangeTokenStatus: API.OperationMethod<
   GetChangeTokenStatusRequest,
   GetChangeTokenStatusResponse,
   GetChangeTokenStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetChangeTokenStatusRequest,
   output: GetChangeTokenStatusResponse,
@@ -5247,7 +5246,7 @@ export const getGeoMatchSet: API.OperationMethod<
   GetGeoMatchSetRequest,
   GetGeoMatchSetResponse,
   GetGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGeoMatchSetRequest,
   output: GetGeoMatchSetResponse,
@@ -5280,7 +5279,7 @@ export const getIPSet: API.OperationMethod<
   GetIPSetRequest,
   GetIPSetResponse,
   GetIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIPSetRequest,
   output: GetIPSetResponse,
@@ -5312,7 +5311,7 @@ export const getLoggingConfiguration: API.OperationMethod<
   GetLoggingConfigurationRequest,
   GetLoggingConfigurationResponse,
   GetLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingConfigurationRequest,
   output: GetLoggingConfigurationResponse,
@@ -5340,7 +5339,7 @@ export const getPermissionPolicy: API.OperationMethod<
   GetPermissionPolicyRequest,
   GetPermissionPolicyResponse,
   GetPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionPolicyRequest,
   output: GetPermissionPolicyResponse,
@@ -5371,7 +5370,7 @@ export const getRateBasedRule: API.OperationMethod<
   GetRateBasedRuleRequest,
   GetRateBasedRuleResponse,
   GetRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRateBasedRuleRequest,
   output: GetRateBasedRuleResponse,
@@ -5407,7 +5406,7 @@ export const getRateBasedRuleManagedKeys: API.OperationMethod<
   GetRateBasedRuleManagedKeysRequest,
   GetRateBasedRuleManagedKeysResponse,
   GetRateBasedRuleManagedKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRateBasedRuleManagedKeysRequest,
   output: GetRateBasedRuleManagedKeysResponse,
@@ -5441,7 +5440,7 @@ export const getRegexMatchSet: API.OperationMethod<
   GetRegexMatchSetRequest,
   GetRegexMatchSetResponse,
   GetRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegexMatchSetRequest,
   output: GetRegexMatchSetResponse,
@@ -5474,7 +5473,7 @@ export const getRegexPatternSet: API.OperationMethod<
   GetRegexPatternSetRequest,
   GetRegexPatternSetResponse,
   GetRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegexPatternSetRequest,
   output: GetRegexPatternSetResponse,
@@ -5507,7 +5506,7 @@ export const getRule: API.OperationMethod<
   GetRuleRequest,
   GetRuleResponse,
   GetRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleRequest,
   output: GetRuleResponse,
@@ -5541,7 +5540,7 @@ export const getRuleGroup: API.OperationMethod<
   GetRuleGroupRequest,
   GetRuleGroupResponse,
   GetRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleGroupRequest,
   output: GetRuleGroupResponse,
@@ -5573,7 +5572,7 @@ export const getSampledRequests: API.OperationMethod<
   GetSampledRequestsRequest,
   GetSampledRequestsResponse,
   GetSampledRequestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSampledRequestsRequest,
   output: GetSampledRequestsResponse,
@@ -5602,7 +5601,7 @@ export const getSizeConstraintSet: API.OperationMethod<
   GetSizeConstraintSetRequest,
   GetSizeConstraintSetResponse,
   GetSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSizeConstraintSetRequest,
   output: GetSizeConstraintSetResponse,
@@ -5635,7 +5634,7 @@ export const getSqlInjectionMatchSet: API.OperationMethod<
   GetSqlInjectionMatchSetRequest,
   GetSqlInjectionMatchSetResponse,
   GetSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSqlInjectionMatchSetRequest,
   output: GetSqlInjectionMatchSetResponse,
@@ -5668,7 +5667,7 @@ export const getWebACL: API.OperationMethod<
   GetWebACLRequest,
   GetWebACLResponse,
   GetWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebACLRequest,
   output: GetWebACLResponse,
@@ -5701,7 +5700,7 @@ export const getXssMatchSet: API.OperationMethod<
   GetXssMatchSetRequest,
   GetXssMatchSetResponse,
   GetXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetXssMatchSetRequest,
   output: GetXssMatchSetResponse,
@@ -5734,7 +5733,7 @@ export const listActivatedRulesInRuleGroup: API.OperationMethod<
   ListActivatedRulesInRuleGroupRequest,
   ListActivatedRulesInRuleGroupResponse,
   ListActivatedRulesInRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListActivatedRulesInRuleGroupRequest,
   output: ListActivatedRulesInRuleGroupResponse,
@@ -5766,7 +5765,7 @@ export const listByteMatchSets: API.OperationMethod<
   ListByteMatchSetsRequest,
   ListByteMatchSetsResponse,
   ListByteMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListByteMatchSetsRequest,
   output: ListByteMatchSetsResponse,
@@ -5794,7 +5793,7 @@ export const listGeoMatchSets: API.OperationMethod<
   ListGeoMatchSetsRequest,
   ListGeoMatchSetsResponse,
   ListGeoMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListGeoMatchSetsRequest,
   output: ListGeoMatchSetsResponse,
@@ -5822,7 +5821,7 @@ export const listIPSets: API.OperationMethod<
   ListIPSetsRequest,
   ListIPSetsResponse,
   ListIPSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIPSetsRequest,
   output: ListIPSetsResponse,
@@ -5851,7 +5850,7 @@ export const listLoggingConfigurations: API.OperationMethod<
   ListLoggingConfigurationsRequest,
   ListLoggingConfigurationsResponse,
   ListLoggingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoggingConfigurationsRequest,
   output: ListLoggingConfigurationsResponse,
@@ -5883,7 +5882,7 @@ export const listRateBasedRules: API.OperationMethod<
   ListRateBasedRulesRequest,
   ListRateBasedRulesResponse,
   ListRateBasedRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRateBasedRulesRequest,
   output: ListRateBasedRulesResponse,
@@ -5911,7 +5910,7 @@ export const listRegexMatchSets: API.OperationMethod<
   ListRegexMatchSetsRequest,
   ListRegexMatchSetsResponse,
   ListRegexMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRegexMatchSetsRequest,
   output: ListRegexMatchSetsResponse,
@@ -5939,7 +5938,7 @@ export const listRegexPatternSets: API.OperationMethod<
   ListRegexPatternSetsRequest,
   ListRegexPatternSetsResponse,
   ListRegexPatternSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRegexPatternSetsRequest,
   output: ListRegexPatternSetsResponse,
@@ -5964,7 +5963,7 @@ export const listRuleGroups: API.OperationMethod<
   ListRuleGroupsRequest,
   ListRuleGroupsResponse,
   ListRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleGroupsRequest,
   output: ListRuleGroupsResponse,
@@ -5992,7 +5991,7 @@ export const listRules: API.OperationMethod<
   ListRulesRequest,
   ListRulesResponse,
   ListRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRulesRequest,
   output: ListRulesResponse,
@@ -6020,7 +6019,7 @@ export const listSizeConstraintSets: API.OperationMethod<
   ListSizeConstraintSetsRequest,
   ListSizeConstraintSetsResponse,
   ListSizeConstraintSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSizeConstraintSetsRequest,
   output: ListSizeConstraintSetsResponse,
@@ -6048,7 +6047,7 @@ export const listSqlInjectionMatchSets: API.OperationMethod<
   ListSqlInjectionMatchSetsRequest,
   ListSqlInjectionMatchSetsResponse,
   ListSqlInjectionMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSqlInjectionMatchSetsRequest,
   output: ListSqlInjectionMatchSetsResponse,
@@ -6076,7 +6075,7 @@ export const listSubscribedRuleGroups: API.OperationMethod<
   ListSubscribedRuleGroupsRequest,
   ListSubscribedRuleGroupsResponse,
   ListSubscribedRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSubscribedRuleGroupsRequest,
   output: ListSubscribedRuleGroupsResponse,
@@ -6110,7 +6109,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6145,7 +6144,7 @@ export const listWebACLs: API.OperationMethod<
   ListWebACLsRequest,
   ListWebACLsResponse,
   ListWebACLsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebACLsRequest,
   output: ListWebACLsResponse,
@@ -6173,7 +6172,7 @@ export const listXssMatchSets: API.OperationMethod<
   ListXssMatchSetsRequest,
   ListXssMatchSetsResponse,
   ListXssMatchSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListXssMatchSetsRequest,
   output: ListXssMatchSetsResponse,
@@ -6217,7 +6216,7 @@ export const putLoggingConfiguration: API.OperationMethod<
   PutLoggingConfigurationRequest,
   PutLoggingConfigurationResponse,
   PutLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingConfigurationRequest,
   output: PutLoggingConfigurationResponse,
@@ -6274,7 +6273,7 @@ export const putPermissionPolicy: API.OperationMethod<
   PutPermissionPolicyRequest,
   PutPermissionPolicyResponse,
   PutPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionPolicyRequest,
   output: PutPermissionPolicyResponse,
@@ -6314,7 +6313,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6352,7 +6351,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -6422,7 +6421,7 @@ export const updateByteMatchSet: API.OperationMethod<
   UpdateByteMatchSetRequest,
   UpdateByteMatchSetResponse,
   UpdateByteMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateByteMatchSetRequest,
   output: UpdateByteMatchSetResponse,
@@ -6488,7 +6487,7 @@ export const updateGeoMatchSet: API.OperationMethod<
   UpdateGeoMatchSetRequest,
   UpdateGeoMatchSetResponse,
   UpdateGeoMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGeoMatchSetRequest,
   output: UpdateGeoMatchSetResponse,
@@ -6589,7 +6588,7 @@ export const updateIPSet: API.OperationMethod<
   UpdateIPSetRequest,
   UpdateIPSetResponse,
   UpdateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIPSetRequest,
   output: UpdateIPSetResponse,
@@ -6671,7 +6670,7 @@ export const updateRateBasedRule: API.OperationMethod<
   UpdateRateBasedRuleRequest,
   UpdateRateBasedRuleResponse,
   UpdateRateBasedRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRateBasedRuleRequest,
   output: UpdateRateBasedRuleResponse,
@@ -6741,7 +6740,7 @@ export const updateRegexMatchSet: API.OperationMethod<
   UpdateRegexMatchSetRequest,
   UpdateRegexMatchSetResponse,
   UpdateRegexMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegexMatchSetRequest,
   output: UpdateRegexMatchSetResponse,
@@ -6811,7 +6810,7 @@ export const updateRegexPatternSet: API.OperationMethod<
   UpdateRegexPatternSetRequest,
   UpdateRegexPatternSetResponse,
   UpdateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegexPatternSetRequest,
   output: UpdateRegexPatternSetResponse,
@@ -6888,7 +6887,7 @@ export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
   UpdateRuleResponse,
   UpdateRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,
@@ -6952,7 +6951,7 @@ export const updateRuleGroup: API.OperationMethod<
   UpdateRuleGroupRequest,
   UpdateRuleGroupResponse,
   UpdateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleGroupRequest,
   output: UpdateRuleGroupResponse,
@@ -7029,7 +7028,7 @@ export const updateSizeConstraintSet: API.OperationMethod<
   UpdateSizeConstraintSetRequest,
   UpdateSizeConstraintSetResponse,
   UpdateSizeConstraintSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSizeConstraintSetRequest,
   output: UpdateSizeConstraintSetResponse,
@@ -7105,7 +7104,7 @@ export const updateSqlInjectionMatchSet: API.OperationMethod<
   UpdateSqlInjectionMatchSetRequest,
   UpdateSqlInjectionMatchSetResponse,
   UpdateSqlInjectionMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSqlInjectionMatchSetRequest,
   output: UpdateSqlInjectionMatchSetResponse,
@@ -7211,7 +7210,7 @@ export const updateWebACL: API.OperationMethod<
   UpdateWebACLRequest,
   UpdateWebACLResponse,
   UpdateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebACLRequest,
   output: UpdateWebACLResponse,
@@ -7290,7 +7289,7 @@ export const updateXssMatchSet: API.OperationMethod<
   UpdateXssMatchSetRequest,
   UpdateXssMatchSetResponse,
   UpdateXssMatchSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateXssMatchSetRequest,
   output: UpdateXssMatchSetResponse,

--- a/packages/aws/src/services/wafv2.ts
+++ b/packages/aws/src/services/wafv2.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const ns = T.XmlNamespace("http://waf.amazonaws.com/doc/2019-07-29/");
 const svc = T.AwsApiService({
   sdkId: "WAFV2",
@@ -5160,7 +5159,7 @@ export const associateWebACL: API.OperationMethod<
   AssociateWebACLRequest,
   AssociateWebACLResponse,
   AssociateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWebACLRequest,
   output: AssociateWebACLResponse,
@@ -5207,7 +5206,7 @@ export const checkCapacity: API.OperationMethod<
   CheckCapacityRequest,
   CheckCapacityResponse,
   CheckCapacityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CheckCapacityRequest,
   output: CheckCapacityResponse,
@@ -5247,7 +5246,7 @@ export const createAPIKey: API.OperationMethod<
   CreateAPIKeyRequest,
   CreateAPIKeyResponse,
   CreateAPIKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAPIKeyRequest,
   output: CreateAPIKeyResponse,
@@ -5282,7 +5281,7 @@ export const createIPSet: API.OperationMethod<
   CreateIPSetRequest,
   CreateIPSetResponse,
   CreateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIPSetRequest,
   output: CreateIPSetResponse,
@@ -5319,7 +5318,7 @@ export const createRegexPatternSet: API.OperationMethod<
   CreateRegexPatternSetRequest,
   CreateRegexPatternSetResponse,
   CreateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRegexPatternSetRequest,
   output: CreateRegexPatternSetResponse,
@@ -5360,7 +5359,7 @@ export const createRuleGroup: API.OperationMethod<
   CreateRuleGroupRequest,
   CreateRuleGroupResponse,
   CreateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleGroupRequest,
   output: CreateRuleGroupResponse,
@@ -5407,7 +5406,7 @@ export const createWebACL: API.OperationMethod<
   CreateWebACLRequest,
   CreateWebACLResponse,
   CreateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWebACLRequest,
   output: CreateWebACLResponse,
@@ -5448,7 +5447,7 @@ export const deleteAPIKey: API.OperationMethod<
   DeleteAPIKeyRequest,
   DeleteAPIKeyResponse,
   DeleteAPIKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAPIKeyRequest,
   output: DeleteAPIKeyResponse,
@@ -5480,7 +5479,7 @@ export const deleteFirewallManagerRuleGroups: API.OperationMethod<
   DeleteFirewallManagerRuleGroupsRequest,
   DeleteFirewallManagerRuleGroupsResponse,
   DeleteFirewallManagerRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFirewallManagerRuleGroupsRequest,
   output: DeleteFirewallManagerRuleGroupsResponse,
@@ -5513,7 +5512,7 @@ export const deleteIPSet: API.OperationMethod<
   DeleteIPSetRequest,
   DeleteIPSetResponse,
   DeleteIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIPSetRequest,
   output: DeleteIPSetResponse,
@@ -5546,7 +5545,7 @@ export const deleteLoggingConfiguration: API.OperationMethod<
   DeleteLoggingConfigurationRequest,
   DeleteLoggingConfigurationResponse,
   DeleteLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLoggingConfigurationRequest,
   output: DeleteLoggingConfigurationResponse,
@@ -5576,7 +5575,7 @@ export const deletePermissionPolicy: API.OperationMethod<
   DeletePermissionPolicyRequest,
   DeletePermissionPolicyResponse,
   DeletePermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePermissionPolicyRequest,
   output: DeletePermissionPolicyResponse,
@@ -5607,7 +5606,7 @@ export const deleteRegexPatternSet: API.OperationMethod<
   DeleteRegexPatternSetRequest,
   DeleteRegexPatternSetResponse,
   DeleteRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRegexPatternSetRequest,
   output: DeleteRegexPatternSetResponse,
@@ -5643,7 +5642,7 @@ export const deleteRuleGroup: API.OperationMethod<
   DeleteRuleGroupRequest,
   DeleteRuleGroupResponse,
   DeleteRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRuleGroupRequest,
   output: DeleteRuleGroupResponse,
@@ -5700,7 +5699,7 @@ export const deleteWebACL: API.OperationMethod<
   DeleteWebACLRequest,
   DeleteWebACLResponse,
   DeleteWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWebACLRequest,
   output: DeleteWebACLResponse,
@@ -5731,7 +5730,7 @@ export const describeAllManagedProducts: API.OperationMethod<
   DescribeAllManagedProductsRequest,
   DescribeAllManagedProductsResponse,
   DescribeAllManagedProductsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAllManagedProductsRequest,
   output: DescribeAllManagedProductsResponse,
@@ -5757,7 +5756,7 @@ export const describeManagedProductsByVendor: API.OperationMethod<
   DescribeManagedProductsByVendorRequest,
   DescribeManagedProductsByVendorResponse,
   DescribeManagedProductsByVendorError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedProductsByVendorRequest,
   output: DescribeManagedProductsByVendorResponse,
@@ -5786,7 +5785,7 @@ export const describeManagedRuleGroup: API.OperationMethod<
   DescribeManagedRuleGroupRequest,
   DescribeManagedRuleGroupResponse,
   DescribeManagedRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeManagedRuleGroupRequest,
   output: DescribeManagedRuleGroupResponse,
@@ -5825,7 +5824,7 @@ export const disassociateWebACL: API.OperationMethod<
   DisassociateWebACLRequest,
   DisassociateWebACLResponse,
   DisassociateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWebACLRequest,
   output: DisassociateWebACLResponse,
@@ -5857,7 +5856,7 @@ export const generateMobileSdkReleaseUrl: API.OperationMethod<
   GenerateMobileSdkReleaseUrlRequest,
   GenerateMobileSdkReleaseUrlResponse,
   GenerateMobileSdkReleaseUrlError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GenerateMobileSdkReleaseUrlRequest,
   output: GenerateMobileSdkReleaseUrlResponse,
@@ -5890,7 +5889,7 @@ export const getDecryptedAPIKey: API.OperationMethod<
   GetDecryptedAPIKeyRequest,
   GetDecryptedAPIKeyResponse,
   GetDecryptedAPIKeyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDecryptedAPIKeyRequest,
   output: GetDecryptedAPIKeyResponse,
@@ -5919,7 +5918,7 @@ export const getIPSet: API.OperationMethod<
   GetIPSetRequest,
   GetIPSetResponse,
   GetIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIPSetRequest,
   output: GetIPSetResponse,
@@ -5947,7 +5946,7 @@ export const getLoggingConfiguration: API.OperationMethod<
   GetLoggingConfigurationRequest,
   GetLoggingConfigurationResponse,
   GetLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLoggingConfigurationRequest,
   output: GetLoggingConfigurationResponse,
@@ -5979,7 +5978,7 @@ export const getManagedRuleSet: API.OperationMethod<
   GetManagedRuleSetRequest,
   GetManagedRuleSetResponse,
   GetManagedRuleSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetManagedRuleSetRequest,
   output: GetManagedRuleSetResponse,
@@ -6011,7 +6010,7 @@ export const getMobileSdkRelease: API.OperationMethod<
   GetMobileSdkReleaseRequest,
   GetMobileSdkReleaseResponse,
   GetMobileSdkReleaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMobileSdkReleaseRequest,
   output: GetMobileSdkReleaseResponse,
@@ -6040,7 +6039,7 @@ export const getPermissionPolicy: API.OperationMethod<
   GetPermissionPolicyRequest,
   GetPermissionPolicyResponse,
   GetPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPermissionPolicyRequest,
   output: GetPermissionPolicyResponse,
@@ -6087,7 +6086,7 @@ export const getRateBasedStatementManagedKeys: API.OperationMethod<
   GetRateBasedStatementManagedKeysRequest,
   GetRateBasedStatementManagedKeysResponse,
   GetRateBasedStatementManagedKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRateBasedStatementManagedKeysRequest,
   output: GetRateBasedStatementManagedKeysResponse,
@@ -6116,7 +6115,7 @@ export const getRegexPatternSet: API.OperationMethod<
   GetRegexPatternSetRequest,
   GetRegexPatternSetResponse,
   GetRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRegexPatternSetRequest,
   output: GetRegexPatternSetResponse,
@@ -6144,7 +6143,7 @@ export const getRevenueStatistics: API.OperationMethod<
   GetRevenueStatisticsRequest,
   GetRevenueStatisticsResponse,
   GetRevenueStatisticsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevenueStatisticsRequest,
   output: GetRevenueStatisticsResponse,
@@ -6172,7 +6171,7 @@ export const getRevenueStatisticsSummary: API.OperationMethod<
   GetRevenueStatisticsSummaryRequest,
   GetRevenueStatisticsSummaryResponse,
   GetRevenueStatisticsSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevenueStatisticsSummaryRequest,
   output: GetRevenueStatisticsSummaryResponse,
@@ -6200,7 +6199,7 @@ export const getRevenueStatisticsTimeSeries: API.OperationMethod<
   GetRevenueStatisticsTimeSeriesRequest,
   GetRevenueStatisticsTimeSeriesResponse,
   GetRevenueStatisticsTimeSeriesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRevenueStatisticsTimeSeriesRequest,
   output: GetRevenueStatisticsTimeSeriesResponse,
@@ -6228,7 +6227,7 @@ export const getRuleGroup: API.OperationMethod<
   GetRuleGroupRequest,
   GetRuleGroupResponse,
   GetRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleGroupRequest,
   output: GetRuleGroupResponse,
@@ -6264,7 +6263,7 @@ export const getSampledRequests: API.OperationMethod<
   GetSampledRequestsRequest,
   GetSampledRequestsResponse,
   GetSampledRequestsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSampledRequestsRequest,
   output: GetSampledRequestsResponse,
@@ -6294,7 +6293,7 @@ export const getTopPathStatisticsByTraffic: API.OperationMethod<
   GetTopPathStatisticsByTrafficRequest,
   GetTopPathStatisticsByTrafficResponse,
   GetTopPathStatisticsByTrafficError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTopPathStatisticsByTrafficRequest,
   output: GetTopPathStatisticsByTrafficResponse,
@@ -6323,7 +6322,7 @@ export const getWebACL: API.OperationMethod<
   GetWebACLRequest,
   GetWebACLResponse,
   GetWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebACLRequest,
   output: GetWebACLResponse,
@@ -6364,7 +6363,7 @@ export const getWebACLForResource: API.OperationMethod<
   GetWebACLForResourceRequest,
   GetWebACLForResourceResponse,
   GetWebACLForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWebACLForResourceRequest,
   output: GetWebACLForResourceResponse,
@@ -6397,7 +6396,7 @@ export const listAPIKeys: API.OperationMethod<
   ListAPIKeysRequest,
   ListAPIKeysResponse,
   ListAPIKeysError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAPIKeysRequest,
   output: ListAPIKeysResponse,
@@ -6426,7 +6425,7 @@ export const listAvailableManagedRuleGroups: API.OperationMethod<
   ListAvailableManagedRuleGroupsRequest,
   ListAvailableManagedRuleGroupsResponse,
   ListAvailableManagedRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableManagedRuleGroupsRequest,
   output: ListAvailableManagedRuleGroupsResponse,
@@ -6453,7 +6452,7 @@ export const listAvailableManagedRuleGroupVersions: API.OperationMethod<
   ListAvailableManagedRuleGroupVersionsRequest,
   ListAvailableManagedRuleGroupVersionsResponse,
   ListAvailableManagedRuleGroupVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableManagedRuleGroupVersionsRequest,
   output: ListAvailableManagedRuleGroupVersionsResponse,
@@ -6481,7 +6480,7 @@ export const listIPSets: API.OperationMethod<
   ListIPSetsRequest,
   ListIPSetsResponse,
   ListIPSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListIPSetsRequest,
   output: ListIPSetsResponse,
@@ -6507,7 +6506,7 @@ export const listLoggingConfigurations: API.OperationMethod<
   ListLoggingConfigurationsRequest,
   ListLoggingConfigurationsResponse,
   ListLoggingConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListLoggingConfigurationsRequest,
   output: ListLoggingConfigurationsResponse,
@@ -6537,7 +6536,7 @@ export const listManagedRuleSets: API.OperationMethod<
   ListManagedRuleSetsRequest,
   ListManagedRuleSetsResponse,
   ListManagedRuleSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListManagedRuleSetsRequest,
   output: ListManagedRuleSetsResponse,
@@ -6567,7 +6566,7 @@ export const listMobileSdkReleases: API.OperationMethod<
   ListMobileSdkReleasesRequest,
   ListMobileSdkReleasesResponse,
   ListMobileSdkReleasesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMobileSdkReleasesRequest,
   output: ListMobileSdkReleasesResponse,
@@ -6594,7 +6593,7 @@ export const listRegexPatternSets: API.OperationMethod<
   ListRegexPatternSetsRequest,
   ListRegexPatternSetsResponse,
   ListRegexPatternSetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRegexPatternSetsRequest,
   output: ListRegexPatternSetsResponse,
@@ -6631,7 +6630,7 @@ export const listResourcesForWebACL: API.OperationMethod<
   ListResourcesForWebACLRequest,
   ListResourcesForWebACLResponse,
   ListResourcesForWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListResourcesForWebACLRequest,
   output: ListResourcesForWebACLResponse,
@@ -6659,7 +6658,7 @@ export const listRuleGroups: API.OperationMethod<
   ListRuleGroupsRequest,
   ListRuleGroupsResponse,
   ListRuleGroupsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRuleGroupsRequest,
   output: ListRuleGroupsResponse,
@@ -6686,7 +6685,7 @@ export const listSettlementRecords: API.OperationMethod<
   ListSettlementRecordsRequest,
   ListSettlementRecordsResponse,
   ListSettlementRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListSettlementRecordsRequest,
   output: ListSettlementRecordsResponse,
@@ -6724,7 +6723,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -6754,7 +6753,7 @@ export const listWebACLs: API.OperationMethod<
   ListWebACLsRequest,
   ListWebACLsResponse,
   ListWebACLsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListWebACLsRequest,
   output: ListWebACLsResponse,
@@ -6824,7 +6823,7 @@ export const putLoggingConfiguration: API.OperationMethod<
   PutLoggingConfigurationRequest,
   PutLoggingConfigurationResponse,
   PutLoggingConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutLoggingConfigurationRequest,
   output: PutLoggingConfigurationResponse,
@@ -6871,7 +6870,7 @@ export const putManagedRuleSetVersions: API.OperationMethod<
   PutManagedRuleSetVersionsRequest,
   PutManagedRuleSetVersionsResponse,
   PutManagedRuleSetVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutManagedRuleSetVersionsRequest,
   output: PutManagedRuleSetVersionsResponse,
@@ -6916,7 +6915,7 @@ export const putPermissionPolicy: API.OperationMethod<
   PutPermissionPolicyRequest,
   PutPermissionPolicyResponse,
   PutPermissionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutPermissionPolicyRequest,
   output: PutPermissionPolicyResponse,
@@ -6955,7 +6954,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -6991,7 +6990,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -7048,7 +7047,7 @@ export const updateIPSet: API.OperationMethod<
   UpdateIPSetRequest,
   UpdateIPSetResponse,
   UpdateIPSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIPSetRequest,
   output: UpdateIPSetResponse,
@@ -7086,7 +7085,7 @@ export const updateManagedRuleSetVersionExpiryDate: API.OperationMethod<
   UpdateManagedRuleSetVersionExpiryDateRequest,
   UpdateManagedRuleSetVersionExpiryDateResponse,
   UpdateManagedRuleSetVersionExpiryDateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateManagedRuleSetVersionExpiryDateRequest,
   output: UpdateManagedRuleSetVersionExpiryDateResponse,
@@ -7142,7 +7141,7 @@ export const updateRegexPatternSet: API.OperationMethod<
   UpdateRegexPatternSetRequest,
   UpdateRegexPatternSetResponse,
   UpdateRegexPatternSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRegexPatternSetRequest,
   output: UpdateRegexPatternSetResponse,
@@ -7205,7 +7204,7 @@ export const updateRuleGroup: API.OperationMethod<
   UpdateRuleGroupRequest,
   UpdateRuleGroupResponse,
   UpdateRuleGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleGroupRequest,
   output: UpdateRuleGroupResponse,
@@ -7275,7 +7274,7 @@ export const updateWebACL: API.OperationMethod<
   UpdateWebACLRequest,
   UpdateWebACLResponse,
   UpdateWebACLError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWebACLRequest,
   output: UpdateWebACLResponse,

--- a/packages/aws/src/services/wellarchitected.ts
+++ b/packages/aws/src/services/wellarchitected.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "WellArchitected",
   serviceShapeName: "WellArchitectedApiServiceLambda",
@@ -4557,7 +4556,7 @@ export const associateLenses: API.OperationMethod<
   AssociateLensesInput,
   AssociateLensesResponse,
   AssociateLensesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateLensesInput,
   output: AssociateLensesResponse,
@@ -4589,7 +4588,7 @@ export const associateProfiles: API.OperationMethod<
   AssociateProfilesInput,
   AssociateProfilesResponse,
   AssociateProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateProfilesInput,
   output: AssociateProfilesResponse,
@@ -4643,7 +4642,7 @@ export const createLensShare: API.OperationMethod<
   CreateLensShareInput,
   CreateLensShareOutput,
   CreateLensShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLensShareInput,
   output: CreateLensShareOutput,
@@ -4684,7 +4683,7 @@ export const createLensVersion: API.OperationMethod<
   CreateLensVersionInput,
   CreateLensVersionOutput,
   CreateLensVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLensVersionInput,
   output: CreateLensVersionOutput,
@@ -4718,7 +4717,7 @@ export const createMilestone: API.OperationMethod<
   CreateMilestoneInput,
   CreateMilestoneOutput,
   CreateMilestoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMilestoneInput,
   output: CreateMilestoneOutput,
@@ -4751,7 +4750,7 @@ export const createProfile: API.OperationMethod<
   CreateProfileInput,
   CreateProfileOutput,
   CreateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileInput,
   output: CreateProfileOutput,
@@ -4784,7 +4783,7 @@ export const createProfileShare: API.OperationMethod<
   CreateProfileShareInput,
   CreateProfileShareOutput,
   CreateProfileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateProfileShareInput,
   output: CreateProfileShareOutput,
@@ -4827,7 +4826,7 @@ export const createReviewTemplate: API.OperationMethod<
   CreateReviewTemplateInput,
   CreateReviewTemplateOutput,
   CreateReviewTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateReviewTemplateInput,
   output: CreateReviewTemplateOutput,
@@ -4876,7 +4875,7 @@ export const createTemplateShare: API.OperationMethod<
   CreateTemplateShareInput,
   CreateTemplateShareOutput,
   CreateTemplateShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTemplateShareInput,
   output: CreateTemplateShareOutput,
@@ -4933,7 +4932,7 @@ export const createWorkload: API.OperationMethod<
   CreateWorkloadInput,
   CreateWorkloadOutput,
   CreateWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkloadInput,
   output: CreateWorkloadOutput,
@@ -4977,7 +4976,7 @@ export const createWorkloadShare: API.OperationMethod<
   CreateWorkloadShareInput,
   CreateWorkloadShareOutput,
   CreateWorkloadShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkloadShareInput,
   output: CreateWorkloadShareOutput,
@@ -5022,7 +5021,7 @@ export const deleteLens: API.OperationMethod<
   DeleteLensInput,
   DeleteLensResponse,
   DeleteLensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLensInput,
   output: DeleteLensResponse,
@@ -5067,7 +5066,7 @@ export const deleteLensShare: API.OperationMethod<
   DeleteLensShareInput,
   DeleteLensShareResponse,
   DeleteLensShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLensShareInput,
   output: DeleteLensShareResponse,
@@ -5108,7 +5107,7 @@ export const deleteProfile: API.OperationMethod<
   DeleteProfileInput,
   DeleteProfileResponse,
   DeleteProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileInput,
   output: DeleteProfileResponse,
@@ -5140,7 +5139,7 @@ export const deleteProfileShare: API.OperationMethod<
   DeleteProfileShareInput,
   DeleteProfileShareResponse,
   DeleteProfileShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProfileShareInput,
   output: DeleteProfileShareResponse,
@@ -5178,7 +5177,7 @@ export const deleteReviewTemplate: API.OperationMethod<
   DeleteReviewTemplateInput,
   DeleteReviewTemplateResponse,
   DeleteReviewTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteReviewTemplateInput,
   output: DeleteReviewTemplateResponse,
@@ -5214,7 +5213,7 @@ export const deleteTemplateShare: API.OperationMethod<
   DeleteTemplateShareInput,
   DeleteTemplateShareResponse,
   DeleteTemplateShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTemplateShareInput,
   output: DeleteTemplateShareResponse,
@@ -5246,7 +5245,7 @@ export const deleteWorkload: API.OperationMethod<
   DeleteWorkloadInput,
   DeleteWorkloadResponse,
   DeleteWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkloadInput,
   output: DeleteWorkloadResponse,
@@ -5278,7 +5277,7 @@ export const deleteWorkloadShare: API.OperationMethod<
   DeleteWorkloadShareInput,
   DeleteWorkloadShareResponse,
   DeleteWorkloadShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkloadShareInput,
   output: DeleteWorkloadShareResponse,
@@ -5315,7 +5314,7 @@ export const disassociateLenses: API.OperationMethod<
   DisassociateLensesInput,
   DisassociateLensesResponse,
   DisassociateLensesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateLensesInput,
   output: DisassociateLensesResponse,
@@ -5347,7 +5346,7 @@ export const disassociateProfiles: API.OperationMethod<
   DisassociateProfilesInput,
   DisassociateProfilesResponse,
   DisassociateProfilesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateProfilesInput,
   output: DisassociateProfilesResponse,
@@ -5393,7 +5392,7 @@ export const exportLens: API.OperationMethod<
   ExportLensInput,
   ExportLensOutput,
   ExportLensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExportLensInput,
   output: ExportLensOutput,
@@ -5423,7 +5422,7 @@ export const getAnswer: API.OperationMethod<
   GetAnswerInput,
   GetAnswerOutput,
   GetAnswerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAnswerInput,
   output: GetAnswerOutput,
@@ -5455,7 +5454,7 @@ export const getConsolidatedReport: API.PaginatedOperationMethod<
   GetConsolidatedReportInput,
   GetConsolidatedReportOutput,
   GetConsolidatedReportError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetConsolidatedReportInput,
@@ -5490,7 +5489,7 @@ export const getGlobalSettings: API.OperationMethod<
   GetGlobalSettingsRequest,
   GetGlobalSettingsOutput,
   GetGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGlobalSettingsRequest,
   output: GetGlobalSettingsOutput,
@@ -5519,7 +5518,7 @@ export const getLens: API.OperationMethod<
   GetLensInput,
   GetLensOutput,
   GetLensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLensInput,
   output: GetLensOutput,
@@ -5549,7 +5548,7 @@ export const getLensReview: API.OperationMethod<
   GetLensReviewInput,
   GetLensReviewOutput,
   GetLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLensReviewInput,
   output: GetLensReviewOutput,
@@ -5579,7 +5578,7 @@ export const getLensReviewReport: API.OperationMethod<
   GetLensReviewReportInput,
   GetLensReviewReportOutput,
   GetLensReviewReportError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLensReviewReportInput,
   output: GetLensReviewReportOutput,
@@ -5609,7 +5608,7 @@ export const getLensVersionDifference: API.OperationMethod<
   GetLensVersionDifferenceInput,
   GetLensVersionDifferenceOutput,
   GetLensVersionDifferenceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetLensVersionDifferenceInput,
   output: GetLensVersionDifferenceOutput,
@@ -5639,7 +5638,7 @@ export const getMilestone: API.OperationMethod<
   GetMilestoneInput,
   GetMilestoneOutput,
   GetMilestoneError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMilestoneInput,
   output: GetMilestoneOutput,
@@ -5669,7 +5668,7 @@ export const getProfile: API.OperationMethod<
   GetProfileInput,
   GetProfileOutput,
   GetProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileInput,
   output: GetProfileOutput,
@@ -5699,7 +5698,7 @@ export const getProfileTemplate: API.OperationMethod<
   GetProfileTemplateInput,
   GetProfileTemplateOutput,
   GetProfileTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetProfileTemplateInput,
   output: GetProfileTemplateOutput,
@@ -5729,7 +5728,7 @@ export const getReviewTemplate: API.OperationMethod<
   GetReviewTemplateInput,
   GetReviewTemplateOutput,
   GetReviewTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReviewTemplateInput,
   output: GetReviewTemplateOutput,
@@ -5759,7 +5758,7 @@ export const getReviewTemplateAnswer: API.OperationMethod<
   GetReviewTemplateAnswerInput,
   GetReviewTemplateAnswerOutput,
   GetReviewTemplateAnswerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReviewTemplateAnswerInput,
   output: GetReviewTemplateAnswerOutput,
@@ -5789,7 +5788,7 @@ export const getReviewTemplateLensReview: API.OperationMethod<
   GetReviewTemplateLensReviewInput,
   GetReviewTemplateLensReviewOutput,
   GetReviewTemplateLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetReviewTemplateLensReviewInput,
   output: GetReviewTemplateLensReviewOutput,
@@ -5819,7 +5818,7 @@ export const getWorkload: API.OperationMethod<
   GetWorkloadInput,
   GetWorkloadOutput,
   GetWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkloadInput,
   output: GetWorkloadOutput,
@@ -5872,7 +5871,7 @@ export const importLens: API.OperationMethod<
   ImportLensInput,
   ImportLensOutput,
   ImportLensError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportLensInput,
   output: ImportLensOutput,
@@ -5904,7 +5903,7 @@ export const listAnswers: API.PaginatedOperationMethod<
   ListAnswersInput,
   ListAnswersOutput,
   ListAnswersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAnswersInput,
@@ -5940,7 +5939,7 @@ export const listCheckDetails: API.PaginatedOperationMethod<
   ListCheckDetailsInput,
   ListCheckDetailsOutput,
   ListCheckDetailsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCheckDetailsInput,
@@ -5976,7 +5975,7 @@ export const listCheckSummaries: API.PaginatedOperationMethod<
   ListCheckSummariesInput,
   ListCheckSummariesOutput,
   ListCheckSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListCheckSummariesInput,
@@ -6011,7 +6010,7 @@ export const listLenses: API.PaginatedOperationMethod<
   ListLensesInput,
   ListLensesOutput,
   ListLensesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLensesInput,
@@ -6046,7 +6045,7 @@ export const listLensReviewImprovements: API.PaginatedOperationMethod<
   ListLensReviewImprovementsInput,
   ListLensReviewImprovementsOutput,
   ListLensReviewImprovementsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLensReviewImprovementsInput,
@@ -6082,7 +6081,7 @@ export const listLensReviews: API.PaginatedOperationMethod<
   ListLensReviewsInput,
   ListLensReviewsOutput,
   ListLensReviewsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLensReviewsInput,
@@ -6118,7 +6117,7 @@ export const listLensShares: API.PaginatedOperationMethod<
   ListLensSharesInput,
   ListLensSharesOutput,
   ListLensSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListLensSharesInput,
@@ -6154,7 +6153,7 @@ export const listMilestones: API.PaginatedOperationMethod<
   ListMilestonesInput,
   ListMilestonesOutput,
   ListMilestonesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMilestonesInput,
@@ -6189,7 +6188,7 @@ export const listNotifications: API.PaginatedOperationMethod<
   ListNotificationsInput,
   ListNotificationsOutput,
   ListNotificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNotificationsInput,
@@ -6223,7 +6222,7 @@ export const listProfileNotifications: API.PaginatedOperationMethod<
   ListProfileNotificationsInput,
   ListProfileNotificationsOutput,
   ListProfileNotificationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfileNotificationsInput,
@@ -6257,7 +6256,7 @@ export const listProfiles: API.PaginatedOperationMethod<
   ListProfilesInput,
   ListProfilesOutput,
   ListProfilesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfilesInput,
@@ -6292,7 +6291,7 @@ export const listProfileShares: API.PaginatedOperationMethod<
   ListProfileSharesInput,
   ListProfileSharesOutput,
   ListProfileSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListProfileSharesInput,
@@ -6328,7 +6327,7 @@ export const listReviewTemplateAnswers: API.PaginatedOperationMethod<
   ListReviewTemplateAnswersInput,
   ListReviewTemplateAnswersOutput,
   ListReviewTemplateAnswersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReviewTemplateAnswersInput,
@@ -6363,7 +6362,7 @@ export const listReviewTemplates: API.PaginatedOperationMethod<
   ListReviewTemplatesInput,
   ListReviewTemplatesOutput,
   ListReviewTemplatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListReviewTemplatesInput,
@@ -6401,7 +6400,7 @@ export const listShareInvitations: API.PaginatedOperationMethod<
   ListShareInvitationsInput,
   ListShareInvitationsOutput,
   ListShareInvitationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListShareInvitationsInput,
@@ -6435,7 +6434,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceInput,
   ListTagsForResourceOutput,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceInput,
   output: ListTagsForResourceOutput,
@@ -6459,7 +6458,7 @@ export const listTemplateShares: API.PaginatedOperationMethod<
   ListTemplateSharesInput,
   ListTemplateSharesOutput,
   ListTemplateSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTemplateSharesInput,
@@ -6494,7 +6493,7 @@ export const listWorkloads: API.PaginatedOperationMethod<
   ListWorkloadsInput,
   ListWorkloadsOutput,
   ListWorkloadsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadsInput,
@@ -6529,7 +6528,7 @@ export const listWorkloadShares: API.PaginatedOperationMethod<
   ListWorkloadSharesInput,
   ListWorkloadSharesOutput,
   ListWorkloadSharesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkloadSharesInput,
@@ -6564,7 +6563,7 @@ export const tagResource: API.OperationMethod<
   TagResourceInput,
   TagResourceOutput,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceInput,
   output: TagResourceOutput,
@@ -6591,7 +6590,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceInput,
   UntagResourceOutput,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceInput,
   output: UntagResourceOutput,
@@ -6616,7 +6615,7 @@ export const updateAnswer: API.OperationMethod<
   UpdateAnswerInput,
   UpdateAnswerOutput,
   UpdateAnswerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAnswerInput,
   output: UpdateAnswerOutput,
@@ -6647,7 +6646,7 @@ export const updateGlobalSettings: API.OperationMethod<
   UpdateGlobalSettingsInput,
   UpdateGlobalSettingsResponse,
   UpdateGlobalSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGlobalSettingsInput,
   output: UpdateGlobalSettingsResponse,
@@ -6678,7 +6677,7 @@ export const updateIntegration: API.OperationMethod<
   UpdateIntegrationInput,
   UpdateIntegrationResponse,
   UpdateIntegrationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIntegrationInput,
   output: UpdateIntegrationResponse,
@@ -6710,7 +6709,7 @@ export const updateLensReview: API.OperationMethod<
   UpdateLensReviewInput,
   UpdateLensReviewOutput,
   UpdateLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateLensReviewInput,
   output: UpdateLensReviewOutput,
@@ -6742,7 +6741,7 @@ export const updateProfile: API.OperationMethod<
   UpdateProfileInput,
   UpdateProfileOutput,
   UpdateProfileError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateProfileInput,
   output: UpdateProfileOutput,
@@ -6774,7 +6773,7 @@ export const updateReviewTemplate: API.OperationMethod<
   UpdateReviewTemplateInput,
   UpdateReviewTemplateOutput,
   UpdateReviewTemplateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReviewTemplateInput,
   output: UpdateReviewTemplateOutput,
@@ -6806,7 +6805,7 @@ export const updateReviewTemplateAnswer: API.OperationMethod<
   UpdateReviewTemplateAnswerInput,
   UpdateReviewTemplateAnswerOutput,
   UpdateReviewTemplateAnswerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReviewTemplateAnswerInput,
   output: UpdateReviewTemplateAnswerOutput,
@@ -6838,7 +6837,7 @@ export const updateReviewTemplateLensReview: API.OperationMethod<
   UpdateReviewTemplateLensReviewInput,
   UpdateReviewTemplateLensReviewOutput,
   UpdateReviewTemplateLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateReviewTemplateLensReviewInput,
   output: UpdateReviewTemplateLensReviewOutput,
@@ -6872,7 +6871,7 @@ export const updateShareInvitation: API.OperationMethod<
   UpdateShareInvitationInput,
   UpdateShareInvitationOutput,
   UpdateShareInvitationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateShareInvitationInput,
   output: UpdateShareInvitationOutput,
@@ -6904,7 +6903,7 @@ export const updateWorkload: API.OperationMethod<
   UpdateWorkloadInput,
   UpdateWorkloadOutput,
   UpdateWorkloadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkloadInput,
   output: UpdateWorkloadOutput,
@@ -6936,7 +6935,7 @@ export const updateWorkloadShare: API.OperationMethod<
   UpdateWorkloadShareInput,
   UpdateWorkloadShareOutput,
   UpdateWorkloadShareError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkloadShareInput,
   output: UpdateWorkloadShareOutput,
@@ -6969,7 +6968,7 @@ export const upgradeLensReview: API.OperationMethod<
   UpgradeLensReviewInput,
   UpgradeLensReviewResponse,
   UpgradeLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeLensReviewInput,
   output: UpgradeLensReviewResponse,
@@ -7003,7 +7002,7 @@ export const upgradeProfileVersion: API.OperationMethod<
   UpgradeProfileVersionInput,
   UpgradeProfileVersionResponse,
   UpgradeProfileVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeProfileVersionInput,
   output: UpgradeProfileVersionResponse,
@@ -7036,7 +7035,7 @@ export const upgradeReviewTemplateLensReview: API.OperationMethod<
   UpgradeReviewTemplateLensReviewInput,
   UpgradeReviewTemplateLensReviewResponse,
   UpgradeReviewTemplateLensReviewError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpgradeReviewTemplateLensReviewInput,
   output: UpgradeReviewTemplateLensReviewResponse,

--- a/packages/aws/src/services/wickr.ts
+++ b/packages/aws/src/services/wickr.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Wickr",
@@ -2551,7 +2550,7 @@ export const batchCreateUser: API.OperationMethod<
   BatchCreateUserRequest,
   BatchCreateUserResponse,
   BatchCreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchCreateUserRequest,
   output: BatchCreateUserResponse,
@@ -2585,7 +2584,7 @@ export const batchDeleteUser: API.OperationMethod<
   BatchDeleteUserRequest,
   BatchDeleteUserResponse,
   BatchDeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchDeleteUserRequest,
   output: BatchDeleteUserResponse,
@@ -2619,7 +2618,7 @@ export const batchLookupUserUname: API.OperationMethod<
   BatchLookupUserUnameRequest,
   BatchLookupUserUnameResponse,
   BatchLookupUserUnameError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchLookupUserUnameRequest,
   output: BatchLookupUserUnameResponse,
@@ -2653,7 +2652,7 @@ export const batchReinviteUser: API.OperationMethod<
   BatchReinviteUserRequest,
   BatchReinviteUserResponse,
   BatchReinviteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchReinviteUserRequest,
   output: BatchReinviteUserResponse,
@@ -2687,7 +2686,7 @@ export const batchResetDevicesForUser: API.OperationMethod<
   BatchResetDevicesForUserRequest,
   BatchResetDevicesForUserResponse,
   BatchResetDevicesForUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchResetDevicesForUserRequest,
   output: BatchResetDevicesForUserResponse,
@@ -2721,7 +2720,7 @@ export const batchToggleUserSuspendStatus: API.OperationMethod<
   BatchToggleUserSuspendStatusRequest,
   BatchToggleUserSuspendStatusResponse,
   BatchToggleUserSuspendStatusError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: BatchToggleUserSuspendStatusRequest,
   output: BatchToggleUserSuspendStatusResponse,
@@ -2755,7 +2754,7 @@ export const createBot: API.OperationMethod<
   CreateBotRequest,
   CreateBotResponse,
   CreateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBotRequest,
   output: CreateBotResponse,
@@ -2789,7 +2788,7 @@ export const createDataRetentionBot: API.OperationMethod<
   CreateDataRetentionBotRequest,
   CreateDataRetentionBotResponse,
   CreateDataRetentionBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataRetentionBotRequest,
   output: CreateDataRetentionBotResponse,
@@ -2823,7 +2822,7 @@ export const createDataRetentionBotChallenge: API.OperationMethod<
   CreateDataRetentionBotChallengeRequest,
   CreateDataRetentionBotChallengeResponse,
   CreateDataRetentionBotChallengeError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataRetentionBotChallengeRequest,
   output: CreateDataRetentionBotChallengeResponse,
@@ -2857,7 +2856,7 @@ export const createNetwork: API.OperationMethod<
   CreateNetworkRequest,
   CreateNetworkResponse,
   CreateNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkRequest,
   output: CreateNetworkResponse,
@@ -2891,7 +2890,7 @@ export const createSecurityGroup: API.OperationMethod<
   CreateSecurityGroupRequest,
   CreateSecurityGroupResponse,
   CreateSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSecurityGroupRequest,
   output: CreateSecurityGroupResponse,
@@ -2925,7 +2924,7 @@ export const deleteBot: API.OperationMethod<
   DeleteBotRequest,
   DeleteBotResponse,
   DeleteBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBotRequest,
   output: DeleteBotResponse,
@@ -2959,7 +2958,7 @@ export const deleteDataRetentionBot: API.OperationMethod<
   DeleteDataRetentionBotRequest,
   DeleteDataRetentionBotResponse,
   DeleteDataRetentionBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataRetentionBotRequest,
   output: DeleteDataRetentionBotResponse,
@@ -2993,7 +2992,7 @@ export const deleteNetwork: API.OperationMethod<
   DeleteNetworkRequest,
   DeleteNetworkResponse,
   DeleteNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkRequest,
   output: DeleteNetworkResponse,
@@ -3027,7 +3026,7 @@ export const deleteSecurityGroup: API.OperationMethod<
   DeleteSecurityGroupRequest,
   DeleteSecurityGroupResponse,
   DeleteSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSecurityGroupRequest,
   output: DeleteSecurityGroupResponse,
@@ -3061,7 +3060,7 @@ export const getBot: API.OperationMethod<
   GetBotRequest,
   GetBotResponse,
   GetBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotRequest,
   output: GetBotResponse,
@@ -3095,7 +3094,7 @@ export const getBotsCount: API.OperationMethod<
   GetBotsCountRequest,
   GetBotsCountResponse,
   GetBotsCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBotsCountRequest,
   output: GetBotsCountResponse,
@@ -3129,7 +3128,7 @@ export const getDataRetentionBot: API.OperationMethod<
   GetDataRetentionBotRequest,
   GetDataRetentionBotResponse,
   GetDataRetentionBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataRetentionBotRequest,
   output: GetDataRetentionBotResponse,
@@ -3163,7 +3162,7 @@ export const getGuestUserHistoryCount: API.OperationMethod<
   GetGuestUserHistoryCountRequest,
   GetGuestUserHistoryCountResponse,
   GetGuestUserHistoryCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGuestUserHistoryCountRequest,
   output: GetGuestUserHistoryCountResponse,
@@ -3197,7 +3196,7 @@ export const getNetwork: API.OperationMethod<
   GetNetworkRequest,
   GetNetworkResponse,
   GetNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkRequest,
   output: GetNetworkResponse,
@@ -3231,7 +3230,7 @@ export const getNetworkSettings: API.OperationMethod<
   GetNetworkSettingsRequest,
   GetNetworkSettingsResponse,
   GetNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkSettingsRequest,
   output: GetNetworkSettingsResponse,
@@ -3265,7 +3264,7 @@ export const getOidcInfo: API.OperationMethod<
   GetOidcInfoRequest,
   GetOidcInfoResponse,
   GetOidcInfoError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOidcInfoRequest,
   output: GetOidcInfoResponse,
@@ -3299,7 +3298,7 @@ export const getOpentdfConfig: API.OperationMethod<
   GetOpentdfConfigRequest,
   GetOpentdfConfigResponse,
   GetOpentdfConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetOpentdfConfigRequest,
   output: GetOpentdfConfigResponse,
@@ -3333,7 +3332,7 @@ export const getSecurityGroup: API.OperationMethod<
   GetSecurityGroupRequest,
   GetSecurityGroupResponse,
   GetSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSecurityGroupRequest,
   output: GetSecurityGroupResponse,
@@ -3367,7 +3366,7 @@ export const getUser: API.OperationMethod<
   GetUserRequest,
   GetUserResponse,
   GetUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserRequest,
   output: GetUserResponse,
@@ -3401,7 +3400,7 @@ export const getUsersCount: API.OperationMethod<
   GetUsersCountRequest,
   GetUsersCountResponse,
   GetUsersCountError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUsersCountRequest,
   output: GetUsersCountResponse,
@@ -3435,7 +3434,7 @@ export const listBlockedGuestUsers: API.PaginatedOperationMethod<
   ListBlockedGuestUsersRequest,
   ListBlockedGuestUsersResponse,
   ListBlockedGuestUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BlockedGuestUser
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBlockedGuestUsersRequest,
@@ -3476,7 +3475,7 @@ export const listBots: API.PaginatedOperationMethod<
   ListBotsRequest,
   ListBotsResponse,
   ListBotsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Bot
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBotsRequest,
@@ -3517,7 +3516,7 @@ export const listDevicesForUser: API.PaginatedOperationMethod<
   ListDevicesForUserRequest,
   ListDevicesForUserResponse,
   ListDevicesForUserError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   BasicDeviceObject
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesForUserRequest,
@@ -3558,7 +3557,7 @@ export const listGuestUsers: API.PaginatedOperationMethod<
   ListGuestUsersRequest,
   ListGuestUsersResponse,
   ListGuestUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GuestUser
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGuestUsersRequest,
@@ -3598,7 +3597,7 @@ export const listNetworks: API.PaginatedOperationMethod<
   ListNetworksRequest,
   ListNetworksResponse,
   ListNetworksError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Network
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworksRequest,
@@ -3638,7 +3637,7 @@ export const listSecurityGroups: API.PaginatedOperationMethod<
   ListSecurityGroupsRequest,
   ListSecurityGroupsResponse,
   ListSecurityGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SecurityGroup
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityGroupsRequest,
@@ -3679,7 +3678,7 @@ export const listSecurityGroupUsers: API.PaginatedOperationMethod<
   ListSecurityGroupUsersRequest,
   ListSecurityGroupUsersResponse,
   ListSecurityGroupUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSecurityGroupUsersRequest,
@@ -3720,7 +3719,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -3761,7 +3760,7 @@ export const registerOidcConfig: API.OperationMethod<
   RegisterOidcConfigRequest,
   RegisterOidcConfigResponse,
   RegisterOidcConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOidcConfigRequest,
   output: RegisterOidcConfigResponse,
@@ -3795,7 +3794,7 @@ export const registerOidcConfigTest: API.OperationMethod<
   RegisterOidcConfigTestRequest,
   RegisterOidcConfigTestResponse,
   RegisterOidcConfigTestError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOidcConfigTestRequest,
   output: RegisterOidcConfigTestResponse,
@@ -3829,7 +3828,7 @@ export const registerOpentdfConfig: API.OperationMethod<
   RegisterOpentdfConfigRequest,
   RegisterOpentdfConfigResponse,
   RegisterOpentdfConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterOpentdfConfigRequest,
   output: RegisterOpentdfConfigResponse,
@@ -3863,7 +3862,7 @@ export const updateBot: API.OperationMethod<
   UpdateBotRequest,
   UpdateBotResponse,
   UpdateBotError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBotRequest,
   output: UpdateBotResponse,
@@ -3897,7 +3896,7 @@ export const updateDataRetention: API.OperationMethod<
   UpdateDataRetentionRequest,
   UpdateDataRetentionResponse,
   UpdateDataRetentionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataRetentionRequest,
   output: UpdateDataRetentionResponse,
@@ -3931,7 +3930,7 @@ export const updateGuestUser: API.OperationMethod<
   UpdateGuestUserRequest,
   UpdateGuestUserResponse,
   UpdateGuestUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGuestUserRequest,
   output: UpdateGuestUserResponse,
@@ -3965,7 +3964,7 @@ export const updateNetwork: API.OperationMethod<
   UpdateNetworkRequest,
   UpdateNetworkResponse,
   UpdateNetworkError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkRequest,
   output: UpdateNetworkResponse,
@@ -3999,7 +3998,7 @@ export const updateNetworkSettings: API.OperationMethod<
   UpdateNetworkSettingsRequest,
   UpdateNetworkSettingsResponse,
   UpdateNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkSettingsRequest,
   output: UpdateNetworkSettingsResponse,
@@ -4033,7 +4032,7 @@ export const updateSecurityGroup: API.OperationMethod<
   UpdateSecurityGroupRequest,
   UpdateSecurityGroupResponse,
   UpdateSecurityGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSecurityGroupRequest,
   output: UpdateSecurityGroupResponse,
@@ -4069,7 +4068,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/wisdom.ts
+++ b/packages/aws/src/services/wisdom.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Wisdom",
@@ -2495,7 +2494,7 @@ export const createAssistant: API.OperationMethod<
   CreateAssistantRequest,
   CreateAssistantResponse,
   CreateAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssistantRequest,
   output: CreateAssistantResponse,
@@ -2526,7 +2525,7 @@ export const createAssistantAssociation: API.OperationMethod<
   CreateAssistantAssociationRequest,
   CreateAssistantAssociationResponse,
   CreateAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAssistantAssociationRequest,
   output: CreateAssistantAssociationResponse,
@@ -2557,7 +2556,7 @@ export const createContent: API.OperationMethod<
   CreateContentRequest,
   CreateContentResponse,
   CreateContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateContentRequest,
   output: CreateContentResponse,
@@ -2603,7 +2602,7 @@ export const createKnowledgeBase: API.OperationMethod<
   CreateKnowledgeBaseRequest,
   CreateKnowledgeBaseResponse,
   CreateKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateKnowledgeBaseRequest,
   output: CreateKnowledgeBaseResponse,
@@ -2632,7 +2631,7 @@ export const createQuickResponse: API.OperationMethod<
   CreateQuickResponseRequest,
   CreateQuickResponseResponse,
   CreateQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateQuickResponseRequest,
   output: CreateQuickResponseResponse,
@@ -2662,7 +2661,7 @@ export const createSession: API.OperationMethod<
   CreateSessionRequest,
   CreateSessionResponse,
   CreateSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionRequest,
   output: CreateSessionResponse,
@@ -2684,7 +2683,7 @@ export const deleteAssistant: API.OperationMethod<
   DeleteAssistantRequest,
   DeleteAssistantResponse,
   DeleteAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssistantRequest,
   output: DeleteAssistantResponse,
@@ -2710,7 +2709,7 @@ export const deleteAssistantAssociation: API.OperationMethod<
   DeleteAssistantAssociationRequest,
   DeleteAssistantAssociationResponse,
   DeleteAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAssistantAssociationRequest,
   output: DeleteAssistantAssociationResponse,
@@ -2736,7 +2735,7 @@ export const deleteContent: API.OperationMethod<
   DeleteContentRequest,
   DeleteContentResponse,
   DeleteContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteContentRequest,
   output: DeleteContentResponse,
@@ -2763,7 +2762,7 @@ export const deleteImportJob: API.OperationMethod<
   DeleteImportJobRequest,
   DeleteImportJobResponse,
   DeleteImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImportJobRequest,
   output: DeleteImportJobResponse,
@@ -2798,7 +2797,7 @@ export const deleteKnowledgeBase: API.OperationMethod<
   DeleteKnowledgeBaseRequest,
   DeleteKnowledgeBaseResponse,
   DeleteKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteKnowledgeBaseRequest,
   output: DeleteKnowledgeBaseResponse,
@@ -2825,7 +2824,7 @@ export const deleteQuickResponse: API.OperationMethod<
   DeleteQuickResponseRequest,
   DeleteQuickResponseResponse,
   DeleteQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteQuickResponseRequest,
   output: DeleteQuickResponseResponse,
@@ -2851,7 +2850,7 @@ export const getAssistant: API.OperationMethod<
   GetAssistantRequest,
   GetAssistantResponse,
   GetAssistantError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssistantRequest,
   output: GetAssistantResponse,
@@ -2877,7 +2876,7 @@ export const getAssistantAssociation: API.OperationMethod<
   GetAssistantAssociationRequest,
   GetAssistantAssociationResponse,
   GetAssistantAssociationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAssistantAssociationRequest,
   output: GetAssistantAssociationResponse,
@@ -2903,7 +2902,7 @@ export const getContent: API.OperationMethod<
   GetContentRequest,
   GetContentResponse,
   GetContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContentRequest,
   output: GetContentResponse,
@@ -2929,7 +2928,7 @@ export const getContentSummary: API.OperationMethod<
   GetContentSummaryRequest,
   GetContentSummaryResponse,
   GetContentSummaryError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetContentSummaryRequest,
   output: GetContentSummaryResponse,
@@ -2955,7 +2954,7 @@ export const getImportJob: API.OperationMethod<
   GetImportJobRequest,
   GetImportJobResponse,
   GetImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImportJobRequest,
   output: GetImportJobResponse,
@@ -2981,7 +2980,7 @@ export const getKnowledgeBase: API.OperationMethod<
   GetKnowledgeBaseRequest,
   GetKnowledgeBaseResponse,
   GetKnowledgeBaseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetKnowledgeBaseRequest,
   output: GetKnowledgeBaseResponse,
@@ -3007,7 +3006,7 @@ export const getQuickResponse: API.OperationMethod<
   GetQuickResponseRequest,
   GetQuickResponseResponse,
   GetQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetQuickResponseRequest,
   output: GetQuickResponseResponse,
@@ -3036,7 +3035,7 @@ export const getRecommendations: API.OperationMethod<
   GetRecommendationsRequest,
   GetRecommendationsResponse,
   GetRecommendationsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRecommendationsRequest,
   output: GetRecommendationsResponse,
@@ -3062,7 +3061,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -3088,7 +3087,7 @@ export const listAssistantAssociations: API.PaginatedOperationMethod<
   ListAssistantAssociationsRequest,
   ListAssistantAssociationsResponse,
   ListAssistantAssociationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssistantAssociationSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssistantAssociationsRequest,
@@ -3120,7 +3119,7 @@ export const listAssistants: API.PaginatedOperationMethod<
   ListAssistantsRequest,
   ListAssistantsResponse,
   ListAssistantsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AssistantSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAssistantsRequest,
@@ -3149,7 +3148,7 @@ export const listContents: API.PaginatedOperationMethod<
   ListContentsRequest,
   ListContentsResponse,
   ListContentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListContentsRequest,
@@ -3181,7 +3180,7 @@ export const listImportJobs: API.PaginatedOperationMethod<
   ListImportJobsRequest,
   ListImportJobsResponse,
   ListImportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ImportJobSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImportJobsRequest,
@@ -3209,7 +3208,7 @@ export const listKnowledgeBases: API.PaginatedOperationMethod<
   ListKnowledgeBasesRequest,
   ListKnowledgeBasesResponse,
   ListKnowledgeBasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   KnowledgeBaseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListKnowledgeBasesRequest,
@@ -3238,7 +3237,7 @@ export const listQuickResponses: API.PaginatedOperationMethod<
   ListQuickResponsesRequest,
   ListQuickResponsesResponse,
   ListQuickResponsesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuickResponseSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListQuickResponsesRequest,
@@ -3267,7 +3266,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -3291,7 +3290,7 @@ export const notifyRecommendationsReceived: API.OperationMethod<
   NotifyRecommendationsReceivedRequest,
   NotifyRecommendationsReceivedResponse,
   NotifyRecommendationsReceivedError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: NotifyRecommendationsReceivedRequest,
   output: NotifyRecommendationsReceivedResponse,
@@ -3319,7 +3318,7 @@ export const queryAssistant: API.PaginatedOperationMethod<
   QueryAssistantRequest,
   QueryAssistantResponse,
   QueryAssistantError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResultData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: QueryAssistantRequest,
@@ -3353,7 +3352,7 @@ export const removeKnowledgeBaseTemplateUri: API.OperationMethod<
   RemoveKnowledgeBaseTemplateUriRequest,
   RemoveKnowledgeBaseTemplateUriResponse,
   RemoveKnowledgeBaseTemplateUriError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveKnowledgeBaseTemplateUriRequest,
   output: RemoveKnowledgeBaseTemplateUriResponse,
@@ -3380,7 +3379,7 @@ export const searchContent: API.PaginatedOperationMethod<
   SearchContentRequest,
   SearchContentResponse,
   SearchContentError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ContentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchContentRequest,
@@ -3414,7 +3413,7 @@ export const searchQuickResponses: API.PaginatedOperationMethod<
   SearchQuickResponsesRequest,
   SearchQuickResponsesResponse,
   SearchQuickResponsesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   QuickResponseSearchResultData
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchQuickResponsesRequest,
@@ -3448,7 +3447,7 @@ export const searchSessions: API.PaginatedOperationMethod<
   SearchSessionsRequest,
   SearchSessionsResponse,
   SearchSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchSessionsRequest,
@@ -3484,7 +3483,7 @@ export const startContentUpload: API.OperationMethod<
   StartContentUploadRequest,
   StartContentUploadResponse,
   StartContentUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartContentUploadRequest,
   output: StartContentUploadResponse,
@@ -3515,7 +3514,7 @@ export const startImportJob: API.OperationMethod<
   StartImportJobRequest,
   StartImportJobResponse,
   StartImportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartImportJobRequest,
   output: StartImportJobResponse,
@@ -3542,7 +3541,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3560,7 +3559,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3583,7 +3582,7 @@ export const updateContent: API.OperationMethod<
   UpdateContentRequest,
   UpdateContentResponse,
   UpdateContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateContentRequest,
   output: UpdateContentResponse,
@@ -3614,7 +3613,7 @@ export const updateKnowledgeBaseTemplateUri: API.OperationMethod<
   UpdateKnowledgeBaseTemplateUriRequest,
   UpdateKnowledgeBaseTemplateUriResponse,
   UpdateKnowledgeBaseTemplateUriError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateKnowledgeBaseTemplateUriRequest,
   output: UpdateKnowledgeBaseTemplateUriResponse,
@@ -3642,7 +3641,7 @@ export const updateQuickResponse: API.OperationMethod<
   UpdateQuickResponseRequest,
   UpdateQuickResponseResponse,
   UpdateQuickResponseError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateQuickResponseRequest,
   output: UpdateQuickResponseResponse,

--- a/packages/aws/src/services/workdocs.ts
+++ b/packages/aws/src/services/workdocs.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const ns = T.XmlNamespace("https://aws.amazon.com/api/v1/");
 const svc = T.AwsApiService({
@@ -2855,7 +2854,7 @@ export const abortDocumentVersionUpload: API.OperationMethod<
   AbortDocumentVersionUploadRequest,
   AbortDocumentVersionUploadResponse,
   AbortDocumentVersionUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AbortDocumentVersionUploadRequest,
   output: AbortDocumentVersionUploadResponse,
@@ -2888,7 +2887,7 @@ export const activateUser: API.OperationMethod<
   ActivateUserRequest,
   ActivateUserResponse,
   ActivateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ActivateUserRequest,
   output: ActivateUserResponse,
@@ -2920,7 +2919,7 @@ export const addResourcePermissions: API.OperationMethod<
   AddResourcePermissionsRequest,
   AddResourcePermissionsResponse,
   AddResourcePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AddResourcePermissionsRequest,
   output: AddResourcePermissionsResponse,
@@ -2953,7 +2952,7 @@ export const createComment: API.OperationMethod<
   CreateCommentRequest,
   CreateCommentResponse,
   CreateCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCommentRequest,
   output: CreateCommentResponse,
@@ -2989,7 +2988,7 @@ export const createCustomMetadata: API.OperationMethod<
   CreateCustomMetadataRequest,
   CreateCustomMetadataResponse,
   CreateCustomMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateCustomMetadataRequest,
   output: CreateCustomMetadataResponse,
@@ -3026,7 +3025,7 @@ export const createFolder: API.OperationMethod<
   CreateFolderRequest,
   CreateFolderResponse,
   CreateFolderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateFolderRequest,
   output: CreateFolderResponse,
@@ -3063,7 +3062,7 @@ export const createLabels: API.OperationMethod<
   CreateLabelsRequest,
   CreateLabelsResponse,
   CreateLabelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateLabelsRequest,
   output: CreateLabelsResponse,
@@ -3097,7 +3096,7 @@ export const createNotificationSubscription: API.OperationMethod<
   CreateNotificationSubscriptionRequest,
   CreateNotificationSubscriptionResponse,
   CreateNotificationSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNotificationSubscriptionRequest,
   output: CreateNotificationSubscriptionResponse,
@@ -3127,7 +3126,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -3158,7 +3157,7 @@ export const deactivateUser: API.OperationMethod<
   DeactivateUserRequest,
   DeactivateUserResponse,
   DeactivateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeactivateUserRequest,
   output: DeactivateUserResponse,
@@ -3190,7 +3189,7 @@ export const deleteComment: API.OperationMethod<
   DeleteCommentRequest,
   DeleteCommentResponse,
   DeleteCommentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCommentRequest,
   output: DeleteCommentResponse,
@@ -3223,7 +3222,7 @@ export const deleteCustomMetadata: API.OperationMethod<
   DeleteCustomMetadataRequest,
   DeleteCustomMetadataResponse,
   DeleteCustomMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteCustomMetadataRequest,
   output: DeleteCustomMetadataResponse,
@@ -3258,7 +3257,7 @@ export const deleteDocument: API.OperationMethod<
   DeleteDocumentRequest,
   DeleteDocumentResponse,
   DeleteDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentRequest,
   output: DeleteDocumentResponse,
@@ -3295,7 +3294,7 @@ export const deleteDocumentVersion: API.OperationMethod<
   DeleteDocumentVersionRequest,
   DeleteDocumentVersionResponse,
   DeleteDocumentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDocumentVersionRequest,
   output: DeleteDocumentVersionResponse,
@@ -3332,7 +3331,7 @@ export const deleteFolder: API.OperationMethod<
   DeleteFolderRequest,
   DeleteFolderResponse,
   DeleteFolderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFolderRequest,
   output: DeleteFolderResponse,
@@ -3368,7 +3367,7 @@ export const deleteFolderContents: API.OperationMethod<
   DeleteFolderContentsRequest,
   DeleteFolderContentsResponse,
   DeleteFolderContentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteFolderContentsRequest,
   output: DeleteFolderContentsResponse,
@@ -3401,7 +3400,7 @@ export const deleteLabels: API.OperationMethod<
   DeleteLabelsRequest,
   DeleteLabelsResponse,
   DeleteLabelsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteLabelsRequest,
   output: DeleteLabelsResponse,
@@ -3431,7 +3430,7 @@ export const deleteNotificationSubscription: API.OperationMethod<
   DeleteNotificationSubscriptionRequest,
   DeleteNotificationSubscriptionResponse,
   DeleteNotificationSubscriptionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNotificationSubscriptionRequest,
   output: DeleteNotificationSubscriptionResponse,
@@ -3462,7 +3461,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -3492,7 +3491,7 @@ export const describeActivities: API.PaginatedOperationMethod<
   DescribeActivitiesRequest,
   DescribeActivitiesResponse,
   DescribeActivitiesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Activity
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeActivitiesRequest,
@@ -3530,7 +3529,7 @@ export const describeComments: API.PaginatedOperationMethod<
   DescribeCommentsRequest,
   DescribeCommentsResponse,
   DescribeCommentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Comment
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeCommentsRequest,
@@ -3573,7 +3572,7 @@ export const describeDocumentVersions: API.PaginatedOperationMethod<
   DescribeDocumentVersionsRequest,
   DescribeDocumentVersionsResponse,
   DescribeDocumentVersionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DocumentVersionMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeDocumentVersionsRequest,
@@ -3620,7 +3619,7 @@ export const describeFolderContents: API.PaginatedOperationMethod<
   DescribeFolderContentsRequest,
   DescribeFolderContentsResponse,
   DescribeFolderContentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeFolderContentsRequest,
@@ -3657,7 +3656,7 @@ export const describeGroups: API.PaginatedOperationMethod<
   DescribeGroupsRequest,
   DescribeGroupsResponse,
   DescribeGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeGroupsRequest,
@@ -3691,7 +3690,7 @@ export const describeNotificationSubscriptions: API.PaginatedOperationMethod<
   DescribeNotificationSubscriptionsRequest,
   DescribeNotificationSubscriptionsResponse,
   DescribeNotificationSubscriptionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Subscription
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeNotificationSubscriptionsRequest,
@@ -3726,7 +3725,7 @@ export const describeResourcePermissions: API.PaginatedOperationMethod<
   DescribeResourcePermissionsRequest,
   DescribeResourcePermissionsResponse,
   DescribeResourcePermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Principal
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeResourcePermissionsRequest,
@@ -3772,7 +3771,7 @@ export const describeRootFolders: API.PaginatedOperationMethod<
   DescribeRootFoldersRequest,
   DescribeRootFoldersResponse,
   DescribeRootFoldersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   FolderMetadata
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeRootFoldersRequest,
@@ -3816,7 +3815,7 @@ export const describeUsers: API.PaginatedOperationMethod<
   DescribeUsersRequest,
   DescribeUsersResponse,
   DescribeUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   User
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeUsersRequest,
@@ -3862,7 +3861,7 @@ export const getCurrentUser: API.OperationMethod<
   GetCurrentUserRequest,
   GetCurrentUserResponse,
   GetCurrentUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetCurrentUserRequest,
   output: GetCurrentUserResponse,
@@ -3894,7 +3893,7 @@ export const getDocument: API.OperationMethod<
   GetDocumentRequest,
   GetDocumentResponse,
   GetDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentRequest,
   output: GetDocumentResponse,
@@ -3932,7 +3931,7 @@ export const getDocumentPath: API.OperationMethod<
   GetDocumentPathRequest,
   GetDocumentPathResponse,
   GetDocumentPathError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentPathRequest,
   output: GetDocumentPathResponse,
@@ -3964,7 +3963,7 @@ export const getDocumentVersion: API.OperationMethod<
   GetDocumentVersionRequest,
   GetDocumentVersionResponse,
   GetDocumentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDocumentVersionRequest,
   output: GetDocumentVersionResponse,
@@ -3998,7 +3997,7 @@ export const getFolder: API.OperationMethod<
   GetFolderRequest,
   GetFolderResponse,
   GetFolderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFolderRequest,
   output: GetFolderResponse,
@@ -4036,7 +4035,7 @@ export const getFolderPath: API.OperationMethod<
   GetFolderPathRequest,
   GetFolderPathResponse,
   GetFolderPathError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetFolderPathRequest,
   output: GetFolderPathResponse,
@@ -4067,7 +4066,7 @@ export const getResources: API.OperationMethod<
   GetResourcesRequest,
   GetResourcesResponse,
   GetResourcesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetResourcesRequest,
   output: GetResourcesResponse,
@@ -4113,7 +4112,7 @@ export const initiateDocumentVersionUpload: API.OperationMethod<
   InitiateDocumentVersionUploadRequest,
   InitiateDocumentVersionUploadResponse,
   InitiateDocumentVersionUploadError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: InitiateDocumentVersionUploadRequest,
   output: InitiateDocumentVersionUploadResponse,
@@ -4151,7 +4150,7 @@ export const removeAllResourcePermissions: API.OperationMethod<
   RemoveAllResourcePermissionsRequest,
   RemoveAllResourcePermissionsResponse,
   RemoveAllResourcePermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveAllResourcePermissionsRequest,
   output: RemoveAllResourcePermissionsResponse,
@@ -4180,7 +4179,7 @@ export const removeResourcePermission: API.OperationMethod<
   RemoveResourcePermissionRequest,
   RemoveResourcePermissionResponse,
   RemoveResourcePermissionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RemoveResourcePermissionRequest,
   output: RemoveResourcePermissionResponse,
@@ -4212,7 +4211,7 @@ export const restoreDocumentVersions: API.OperationMethod<
   RestoreDocumentVersionsRequest,
   RestoreDocumentVersionsResponse,
   RestoreDocumentVersionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreDocumentVersionsRequest,
   output: RestoreDocumentVersionsResponse,
@@ -4244,7 +4243,7 @@ export const searchResources: API.PaginatedOperationMethod<
   SearchResourcesRequest,
   SearchResourcesResponse,
   SearchResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResponseItem
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: SearchResourcesRequest,
@@ -4286,7 +4285,7 @@ export const updateDocument: API.OperationMethod<
   UpdateDocumentRequest,
   UpdateDocumentResponse,
   UpdateDocumentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentRequest,
   output: UpdateDocumentResponse,
@@ -4328,7 +4327,7 @@ export const updateDocumentVersion: API.OperationMethod<
   UpdateDocumentVersionRequest,
   UpdateDocumentVersionResponse,
   UpdateDocumentVersionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDocumentVersionRequest,
   output: UpdateDocumentVersionResponse,
@@ -4367,7 +4366,7 @@ export const updateFolder: API.OperationMethod<
   UpdateFolderRequest,
   UpdateFolderResponse,
   UpdateFolderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateFolderRequest,
   output: UpdateFolderResponse,
@@ -4407,7 +4406,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/workmail.ts
+++ b/packages/aws/src/services/workmail.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "WorkMail",
@@ -3412,7 +3411,7 @@ export const associateDelegateToResource: API.OperationMethod<
   AssociateDelegateToResourceRequest,
   AssociateDelegateToResourceResponse,
   AssociateDelegateToResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDelegateToResourceRequest,
   output: AssociateDelegateToResourceResponse,
@@ -3446,7 +3445,7 @@ export const associateMemberToGroup: API.OperationMethod<
   AssociateMemberToGroupRequest,
   AssociateMemberToGroupResponse,
   AssociateMemberToGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateMemberToGroupRequest,
   output: AssociateMemberToGroupResponse,
@@ -3479,7 +3478,7 @@ export const assumeImpersonationRole: API.OperationMethod<
   AssumeImpersonationRoleRequest,
   AssumeImpersonationRoleResponse,
   AssumeImpersonationRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssumeImpersonationRoleRequest,
   output: AssumeImpersonationRoleResponse,
@@ -3510,7 +3509,7 @@ export const cancelMailboxExportJob: API.OperationMethod<
   CancelMailboxExportJobRequest,
   CancelMailboxExportJobResponse,
   CancelMailboxExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelMailboxExportJobRequest,
   output: CancelMailboxExportJobResponse,
@@ -3543,7 +3542,7 @@ export const createAlias: API.OperationMethod<
   CreateAliasRequest,
   CreateAliasResponse,
   CreateAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAliasRequest,
   output: CreateAliasResponse,
@@ -3577,7 +3576,7 @@ export const createAvailabilityConfiguration: API.OperationMethod<
   CreateAvailabilityConfigurationRequest,
   CreateAvailabilityConfigurationResponse,
   CreateAvailabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAvailabilityConfigurationRequest,
   output: CreateAvailabilityConfigurationResponse,
@@ -3610,7 +3609,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResponse,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResponse,
@@ -3639,7 +3638,7 @@ export const createIdentityCenterApplication: API.OperationMethod<
   CreateIdentityCenterApplicationRequest,
   CreateIdentityCenterApplicationResponse,
   CreateIdentityCenterApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentityCenterApplicationRequest,
   output: CreateIdentityCenterApplicationResponse,
@@ -3669,7 +3668,7 @@ export const createImpersonationRole: API.OperationMethod<
   CreateImpersonationRoleRequest,
   CreateImpersonationRoleResponse,
   CreateImpersonationRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateImpersonationRoleRequest,
   output: CreateImpersonationRoleResponse,
@@ -3699,7 +3698,7 @@ export const createMobileDeviceAccessRule: API.OperationMethod<
   CreateMobileDeviceAccessRuleRequest,
   CreateMobileDeviceAccessRuleResponse,
   CreateMobileDeviceAccessRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateMobileDeviceAccessRuleRequest,
   output: CreateMobileDeviceAccessRuleResponse,
@@ -3738,7 +3737,7 @@ export const createOrganization: API.OperationMethod<
   CreateOrganizationRequest,
   CreateOrganizationResponse,
   CreateOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateOrganizationRequest,
   output: CreateOrganizationResponse,
@@ -3771,7 +3770,7 @@ export const createResource: API.OperationMethod<
   CreateResourceRequest,
   CreateResourceResponse,
   CreateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateResourceRequest,
   output: CreateResourceResponse,
@@ -3808,7 +3807,7 @@ export const createUser: API.OperationMethod<
   CreateUserRequest,
   CreateUserResponse,
   CreateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserRequest,
   output: CreateUserResponse,
@@ -3841,7 +3840,7 @@ export const deleteAccessControlRule: API.OperationMethod<
   DeleteAccessControlRuleRequest,
   DeleteAccessControlRuleResponse,
   DeleteAccessControlRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessControlRuleRequest,
   output: DeleteAccessControlRuleResponse,
@@ -3866,7 +3865,7 @@ export const deleteAlias: API.OperationMethod<
   DeleteAliasRequest,
   DeleteAliasResponse,
   DeleteAliasError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAliasRequest,
   output: DeleteAliasResponse,
@@ -3893,7 +3892,7 @@ export const deleteAvailabilityConfiguration: API.OperationMethod<
   DeleteAvailabilityConfigurationRequest,
   DeleteAvailabilityConfigurationResponse,
   DeleteAvailabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAvailabilityConfigurationRequest,
   output: DeleteAvailabilityConfigurationResponse,
@@ -3915,7 +3914,7 @@ export const deleteEmailMonitoringConfiguration: API.OperationMethod<
   DeleteEmailMonitoringConfigurationRequest,
   DeleteEmailMonitoringConfigurationResponse,
   DeleteEmailMonitoringConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEmailMonitoringConfigurationRequest,
   output: DeleteEmailMonitoringConfigurationResponse,
@@ -3945,7 +3944,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResponse,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResponse,
@@ -3974,7 +3973,7 @@ export const deleteIdentityCenterApplication: API.OperationMethod<
   DeleteIdentityCenterApplicationRequest,
   DeleteIdentityCenterApplicationResponse,
   DeleteIdentityCenterApplicationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityCenterApplicationRequest,
   output: DeleteIdentityCenterApplicationResponse,
@@ -3996,7 +3995,7 @@ export const deleteIdentityProviderConfiguration: API.OperationMethod<
   DeleteIdentityProviderConfigurationRequest,
   DeleteIdentityProviderConfigurationResponse,
   DeleteIdentityProviderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityProviderConfigurationRequest,
   output: DeleteIdentityProviderConfigurationResponse,
@@ -4022,7 +4021,7 @@ export const deleteImpersonationRole: API.OperationMethod<
   DeleteImpersonationRoleRequest,
   DeleteImpersonationRoleResponse,
   DeleteImpersonationRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteImpersonationRoleRequest,
   output: DeleteImpersonationRoleResponse,
@@ -4050,7 +4049,7 @@ export const deleteMailboxPermissions: API.OperationMethod<
   DeleteMailboxPermissionsRequest,
   DeleteMailboxPermissionsResponse,
   DeleteMailboxPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMailboxPermissionsRequest,
   output: DeleteMailboxPermissionsResponse,
@@ -4081,7 +4080,7 @@ export const deleteMobileDeviceAccessOverride: API.OperationMethod<
   DeleteMobileDeviceAccessOverrideRequest,
   DeleteMobileDeviceAccessOverrideResponse,
   DeleteMobileDeviceAccessOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMobileDeviceAccessOverrideRequest,
   output: DeleteMobileDeviceAccessOverrideResponse,
@@ -4110,7 +4109,7 @@ export const deleteMobileDeviceAccessRule: API.OperationMethod<
   DeleteMobileDeviceAccessRuleRequest,
   DeleteMobileDeviceAccessRuleResponse,
   DeleteMobileDeviceAccessRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteMobileDeviceAccessRuleRequest,
   output: DeleteMobileDeviceAccessRuleResponse,
@@ -4136,7 +4135,7 @@ export const deleteOrganization: API.OperationMethod<
   DeleteOrganizationRequest,
   DeleteOrganizationResponse,
   DeleteOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteOrganizationRequest,
   output: DeleteOrganizationResponse,
@@ -4162,7 +4161,7 @@ export const deletePersonalAccessToken: API.OperationMethod<
   DeletePersonalAccessTokenRequest,
   DeletePersonalAccessTokenResponse,
   DeletePersonalAccessTokenError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePersonalAccessTokenRequest,
   output: DeletePersonalAccessTokenResponse,
@@ -4190,7 +4189,7 @@ export const deleteResource: API.OperationMethod<
   DeleteResourceRequest,
   DeleteResourceResponse,
   DeleteResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourceRequest,
   output: DeleteResourceResponse,
@@ -4218,7 +4217,7 @@ export const deleteRetentionPolicy: API.OperationMethod<
   DeleteRetentionPolicyRequest,
   DeleteRetentionPolicyResponse,
   DeleteRetentionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteRetentionPolicyRequest,
   output: DeleteRetentionPolicyResponse,
@@ -4253,7 +4252,7 @@ export const deleteUser: API.OperationMethod<
   DeleteUserRequest,
   DeleteUserResponse,
   DeleteUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserRequest,
   output: DeleteUserResponse,
@@ -4288,7 +4287,7 @@ export const deregisterFromWorkMail: API.OperationMethod<
   DeregisterFromWorkMailRequest,
   DeregisterFromWorkMailResponse,
   DeregisterFromWorkMailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterFromWorkMailRequest,
   output: DeregisterFromWorkMailResponse,
@@ -4319,7 +4318,7 @@ export const deregisterMailDomain: API.OperationMethod<
   DeregisterMailDomainRequest,
   DeregisterMailDomainResponse,
   DeregisterMailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterMailDomainRequest,
   output: DeregisterMailDomainResponse,
@@ -4348,7 +4347,7 @@ export const describeEmailMonitoringConfiguration: API.OperationMethod<
   DescribeEmailMonitoringConfigurationRequest,
   DescribeEmailMonitoringConfigurationResponse,
   DescribeEmailMonitoringConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEmailMonitoringConfigurationRequest,
   output: DescribeEmailMonitoringConfigurationResponse,
@@ -4376,7 +4375,7 @@ export const describeEntity: API.OperationMethod<
   DescribeEntityRequest,
   DescribeEntityResponse,
   DescribeEntityError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeEntityRequest,
   output: DescribeEntityResponse,
@@ -4404,7 +4403,7 @@ export const describeGroup: API.OperationMethod<
   DescribeGroupRequest,
   DescribeGroupResponse,
   DescribeGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeGroupRequest,
   output: DescribeGroupResponse,
@@ -4432,7 +4431,7 @@ export const describeIdentityProviderConfiguration: API.OperationMethod<
   DescribeIdentityProviderConfigurationRequest,
   DescribeIdentityProviderConfigurationResponse,
   DescribeIdentityProviderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIdentityProviderConfigurationRequest,
   output: DescribeIdentityProviderConfigurationResponse,
@@ -4458,7 +4457,7 @@ export const describeInboundDmarcSettings: API.OperationMethod<
   DescribeInboundDmarcSettingsRequest,
   DescribeInboundDmarcSettingsResponse,
   DescribeInboundDmarcSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeInboundDmarcSettingsRequest,
   output: DescribeInboundDmarcSettingsResponse,
@@ -4481,7 +4480,7 @@ export const describeMailboxExportJob: API.OperationMethod<
   DescribeMailboxExportJobRequest,
   DescribeMailboxExportJobResponse,
   DescribeMailboxExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeMailboxExportJobRequest,
   output: DescribeMailboxExportJobResponse,
@@ -4508,7 +4507,7 @@ export const describeOrganization: API.OperationMethod<
   DescribeOrganizationRequest,
   DescribeOrganizationResponse,
   DescribeOrganizationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeOrganizationRequest,
   output: DescribeOrganizationResponse,
@@ -4532,7 +4531,7 @@ export const describeResource: API.OperationMethod<
   DescribeResourceRequest,
   DescribeResourceResponse,
   DescribeResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeResourceRequest,
   output: DescribeResourceResponse,
@@ -4563,7 +4562,7 @@ export const describeUser: API.OperationMethod<
   DescribeUserRequest,
   DescribeUserResponse,
   DescribeUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeUserRequest,
   output: DescribeUserResponse,
@@ -4595,7 +4594,7 @@ export const disassociateDelegateFromResource: API.OperationMethod<
   DisassociateDelegateFromResourceRequest,
   DisassociateDelegateFromResourceResponse,
   DisassociateDelegateFromResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDelegateFromResourceRequest,
   output: DisassociateDelegateFromResourceResponse,
@@ -4629,7 +4628,7 @@ export const disassociateMemberFromGroup: API.OperationMethod<
   DisassociateMemberFromGroupRequest,
   DisassociateMemberFromGroupResponse,
   DisassociateMemberFromGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateMemberFromGroupRequest,
   output: DisassociateMemberFromGroupResponse,
@@ -4663,7 +4662,7 @@ export const getAccessControlEffect: API.OperationMethod<
   GetAccessControlEffectRequest,
   GetAccessControlEffectResponse,
   GetAccessControlEffectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessControlEffectRequest,
   output: GetAccessControlEffectResponse,
@@ -4692,7 +4691,7 @@ export const getDefaultRetentionPolicy: API.OperationMethod<
   GetDefaultRetentionPolicyRequest,
   GetDefaultRetentionPolicyResponse,
   GetDefaultRetentionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDefaultRetentionPolicyRequest,
   output: GetDefaultRetentionPolicyResponse,
@@ -4720,7 +4719,7 @@ export const getImpersonationRole: API.OperationMethod<
   GetImpersonationRoleRequest,
   GetImpersonationRoleResponse,
   GetImpersonationRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImpersonationRoleRequest,
   output: GetImpersonationRoleResponse,
@@ -4750,7 +4749,7 @@ export const getImpersonationRoleEffect: API.OperationMethod<
   GetImpersonationRoleEffectRequest,
   GetImpersonationRoleEffectResponse,
   GetImpersonationRoleEffectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetImpersonationRoleEffectRequest,
   output: GetImpersonationRoleEffectResponse,
@@ -4780,7 +4779,7 @@ export const getMailboxDetails: API.OperationMethod<
   GetMailboxDetailsRequest,
   GetMailboxDetailsResponse,
   GetMailboxDetailsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMailboxDetailsRequest,
   output: GetMailboxDetailsResponse,
@@ -4808,7 +4807,7 @@ export const getMailDomain: API.OperationMethod<
   GetMailDomainRequest,
   GetMailDomainResponse,
   GetMailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMailDomainRequest,
   output: GetMailDomainResponse,
@@ -4836,7 +4835,7 @@ export const getMobileDeviceAccessEffect: API.OperationMethod<
   GetMobileDeviceAccessEffectRequest,
   GetMobileDeviceAccessEffectResponse,
   GetMobileDeviceAccessEffectError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMobileDeviceAccessEffectRequest,
   output: GetMobileDeviceAccessEffectResponse,
@@ -4864,7 +4863,7 @@ export const getMobileDeviceAccessOverride: API.OperationMethod<
   GetMobileDeviceAccessOverrideRequest,
   GetMobileDeviceAccessOverrideResponse,
   GetMobileDeviceAccessOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetMobileDeviceAccessOverrideRequest,
   output: GetMobileDeviceAccessOverrideResponse,
@@ -4893,7 +4892,7 @@ export const getPersonalAccessTokenMetadata: API.OperationMethod<
   GetPersonalAccessTokenMetadataRequest,
   GetPersonalAccessTokenMetadataResponse,
   GetPersonalAccessTokenMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPersonalAccessTokenMetadataRequest,
   output: GetPersonalAccessTokenMetadataResponse,
@@ -4919,7 +4918,7 @@ export const listAccessControlRules: API.OperationMethod<
   ListAccessControlRulesRequest,
   ListAccessControlRulesResponse,
   ListAccessControlRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAccessControlRulesRequest,
   output: ListAccessControlRulesResponse,
@@ -4944,7 +4943,7 @@ export const listAliases: API.PaginatedOperationMethod<
   ListAliasesRequest,
   ListAliasesResponse,
   ListAliasesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAliasesRequest,
@@ -4978,7 +4977,7 @@ export const listAvailabilityConfigurations: API.PaginatedOperationMethod<
   ListAvailabilityConfigurationsRequest,
   ListAvailabilityConfigurationsResponse,
   ListAvailabilityConfigurationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AvailabilityConfiguration
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAvailabilityConfigurationsRequest,
@@ -5014,7 +5013,7 @@ export const listGroupMembers: API.PaginatedOperationMethod<
   ListGroupMembersRequest,
   ListGroupMembersResponse,
   ListGroupMembersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupMembersRequest,
@@ -5049,7 +5048,7 @@ export const listGroups: API.PaginatedOperationMethod<
   ListGroupsRequest,
   ListGroupsResponse,
   ListGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsRequest,
@@ -5084,7 +5083,7 @@ export const listGroupsForEntity: API.PaginatedOperationMethod<
   ListGroupsForEntityRequest,
   ListGroupsForEntityResponse,
   ListGroupsForEntityError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListGroupsForEntityRequest,
@@ -5118,7 +5117,7 @@ export const listImpersonationRoles: API.PaginatedOperationMethod<
   ListImpersonationRolesRequest,
   ListImpersonationRolesResponse,
   ListImpersonationRolesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListImpersonationRolesRequest,
@@ -5151,7 +5150,7 @@ export const listMailboxExportJobs: API.PaginatedOperationMethod<
   ListMailboxExportJobsRequest,
   ListMailboxExportJobsResponse,
   ListMailboxExportJobsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMailboxExportJobsRequest,
@@ -5185,7 +5184,7 @@ export const listMailboxPermissions: API.PaginatedOperationMethod<
   ListMailboxPermissionsRequest,
   ListMailboxPermissionsResponse,
   ListMailboxPermissionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMailboxPermissionsRequest,
@@ -5218,7 +5217,7 @@ export const listMailDomains: API.PaginatedOperationMethod<
   ListMailDomainsRequest,
   ListMailDomainsResponse,
   ListMailDomainsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMailDomainsRequest,
@@ -5251,7 +5250,7 @@ export const listMobileDeviceAccessOverrides: API.PaginatedOperationMethod<
   ListMobileDeviceAccessOverridesRequest,
   ListMobileDeviceAccessOverridesResponse,
   ListMobileDeviceAccessOverridesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListMobileDeviceAccessOverridesRequest,
@@ -5284,7 +5283,7 @@ export const listMobileDeviceAccessRules: API.OperationMethod<
   ListMobileDeviceAccessRulesRequest,
   ListMobileDeviceAccessRulesResponse,
   ListMobileDeviceAccessRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListMobileDeviceAccessRulesRequest,
   output: ListMobileDeviceAccessRulesResponse,
@@ -5306,7 +5305,7 @@ export const listOrganizations: API.PaginatedOperationMethod<
   ListOrganizationsRequest,
   ListOrganizationsResponse,
   ListOrganizationsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListOrganizationsRequest,
@@ -5336,7 +5335,7 @@ export const listPersonalAccessTokens: API.PaginatedOperationMethod<
   ListPersonalAccessTokensRequest,
   ListPersonalAccessTokensResponse,
   ListPersonalAccessTokensError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   PersonalAccessTokenSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPersonalAccessTokensRequest,
@@ -5375,7 +5374,7 @@ export const listResourceDelegates: API.PaginatedOperationMethod<
   ListResourceDelegatesRequest,
   ListResourceDelegatesResponse,
   ListResourceDelegatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourceDelegatesRequest,
@@ -5411,7 +5410,7 @@ export const listResources: API.PaginatedOperationMethod<
   ListResourcesRequest,
   ListResourcesResponse,
   ListResourcesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcesRequest,
@@ -5440,7 +5439,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5462,7 +5461,7 @@ export const listUsers: API.PaginatedOperationMethod<
   ListUsersRequest,
   ListUsersResponse,
   ListUsersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUsersRequest,
@@ -5500,7 +5499,7 @@ export const putAccessControlRule: API.OperationMethod<
   PutAccessControlRuleRequest,
   PutAccessControlRuleResponse,
   PutAccessControlRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutAccessControlRuleRequest,
   output: PutAccessControlRuleResponse,
@@ -5530,7 +5529,7 @@ export const putEmailMonitoringConfiguration: API.OperationMethod<
   PutEmailMonitoringConfigurationRequest,
   PutEmailMonitoringConfigurationResponse,
   PutEmailMonitoringConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEmailMonitoringConfigurationRequest,
   output: PutEmailMonitoringConfigurationResponse,
@@ -5559,7 +5558,7 @@ export const putIdentityProviderConfiguration: API.OperationMethod<
   PutIdentityProviderConfigurationRequest,
   PutIdentityProviderConfigurationResponse,
   PutIdentityProviderConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutIdentityProviderConfigurationRequest,
   output: PutIdentityProviderConfigurationResponse,
@@ -5585,7 +5584,7 @@ export const putInboundDmarcSettings: API.OperationMethod<
   PutInboundDmarcSettingsRequest,
   PutInboundDmarcSettingsResponse,
   PutInboundDmarcSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutInboundDmarcSettingsRequest,
   output: PutInboundDmarcSettingsResponse,
@@ -5610,7 +5609,7 @@ export const putMailboxPermissions: API.OperationMethod<
   PutMailboxPermissionsRequest,
   PutMailboxPermissionsResponse,
   PutMailboxPermissionsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMailboxPermissionsRequest,
   output: PutMailboxPermissionsResponse,
@@ -5640,7 +5639,7 @@ export const putMobileDeviceAccessOverride: API.OperationMethod<
   PutMobileDeviceAccessOverrideRequest,
   PutMobileDeviceAccessOverrideResponse,
   PutMobileDeviceAccessOverrideError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutMobileDeviceAccessOverrideRequest,
   output: PutMobileDeviceAccessOverrideResponse,
@@ -5669,7 +5668,7 @@ export const putRetentionPolicy: API.OperationMethod<
   PutRetentionPolicyRequest,
   PutRetentionPolicyResponse,
   PutRetentionPolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRetentionPolicyRequest,
   output: PutRetentionPolicyResponse,
@@ -5699,7 +5698,7 @@ export const registerMailDomain: API.OperationMethod<
   RegisterMailDomainRequest,
   RegisterMailDomainResponse,
   RegisterMailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterMailDomainRequest,
   output: RegisterMailDomainResponse,
@@ -5743,7 +5742,7 @@ export const registerToWorkMail: API.OperationMethod<
   RegisterToWorkMailRequest,
   RegisterToWorkMailResponse,
   RegisterToWorkMailError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterToWorkMailRequest,
   output: RegisterToWorkMailResponse,
@@ -5784,7 +5783,7 @@ export const resetPassword: API.OperationMethod<
   ResetPasswordRequest,
   ResetPasswordResponse,
   ResetPasswordError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ResetPasswordRequest,
   output: ResetPasswordResponse,
@@ -5821,7 +5820,7 @@ export const startMailboxExportJob: API.OperationMethod<
   StartMailboxExportJobRequest,
   StartMailboxExportJobResponse,
   StartMailboxExportJobError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartMailboxExportJobRequest,
   output: StartMailboxExportJobResponse,
@@ -5851,7 +5850,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5885,7 +5884,7 @@ export const testAvailabilityConfiguration: API.OperationMethod<
   TestAvailabilityConfigurationRequest,
   TestAvailabilityConfigurationResponse,
   TestAvailabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TestAvailabilityConfigurationRequest,
   output: TestAvailabilityConfigurationResponse,
@@ -5909,7 +5908,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5933,7 +5932,7 @@ export const updateAvailabilityConfiguration: API.OperationMethod<
   UpdateAvailabilityConfigurationRequest,
   UpdateAvailabilityConfigurationResponse,
   UpdateAvailabilityConfigurationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateAvailabilityConfigurationRequest,
   output: UpdateAvailabilityConfigurationResponse,
@@ -5962,7 +5961,7 @@ export const updateDefaultMailDomain: API.OperationMethod<
   UpdateDefaultMailDomainRequest,
   UpdateDefaultMailDomainResponse,
   UpdateDefaultMailDomainError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDefaultMailDomainRequest,
   output: UpdateDefaultMailDomainResponse,
@@ -5993,7 +5992,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResponse,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResponse,
@@ -6026,7 +6025,7 @@ export const updateImpersonationRole: API.OperationMethod<
   UpdateImpersonationRoleRequest,
   UpdateImpersonationRoleResponse,
   UpdateImpersonationRoleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateImpersonationRoleRequest,
   output: UpdateImpersonationRoleResponse,
@@ -6059,7 +6058,7 @@ export const updateMailboxQuota: API.OperationMethod<
   UpdateMailboxQuotaRequest,
   UpdateMailboxQuotaResponse,
   UpdateMailboxQuotaError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMailboxQuotaRequest,
   output: UpdateMailboxQuotaResponse,
@@ -6088,7 +6087,7 @@ export const updateMobileDeviceAccessRule: API.OperationMethod<
   UpdateMobileDeviceAccessRuleRequest,
   UpdateMobileDeviceAccessRuleResponse,
   UpdateMobileDeviceAccessRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateMobileDeviceAccessRuleRequest,
   output: UpdateMobileDeviceAccessRuleResponse,
@@ -6125,7 +6124,7 @@ export const updatePrimaryEmailAddress: API.OperationMethod<
   UpdatePrimaryEmailAddressRequest,
   UpdatePrimaryEmailAddressResponse,
   UpdatePrimaryEmailAddressError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePrimaryEmailAddressRequest,
   output: UpdatePrimaryEmailAddressResponse,
@@ -6170,7 +6169,7 @@ export const updateResource: API.OperationMethod<
   UpdateResourceRequest,
   UpdateResourceResponse,
   UpdateResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateResourceRequest,
   output: UpdateResourceResponse,
@@ -6212,7 +6211,7 @@ export const updateUser: API.OperationMethod<
   UpdateUserRequest,
   UpdateUserResponse,
   UpdateUserError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserRequest,
   output: UpdateUserResponse,

--- a/packages/aws/src/services/workmailmessageflow.ts
+++ b/packages/aws/src/services/workmailmessageflow.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({
   sdkId: "WorkMailMessageFlow",
   serviceShapeName: "GiraffeMessageInTransitService",
@@ -191,7 +190,7 @@ export const getRawMessageContent: API.OperationMethod<
   GetRawMessageContentRequest,
   GetRawMessageContentResponse,
   GetRawMessageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRawMessageContentRequest,
   output: GetRawMessageContentResponse,
@@ -224,7 +223,7 @@ export const putRawMessageContent: API.OperationMethod<
   PutRawMessageContentRequest,
   PutRawMessageContentResponse,
   PutRawMessageContentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutRawMessageContentRequest,
   output: PutRawMessageContentResponse,

--- a/packages/aws/src/services/workspaces-instances.ts
+++ b/packages/aws/src/services/workspaces-instances.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "Workspaces Instances",
@@ -1218,7 +1217,7 @@ export const associateVolume: API.OperationMethod<
   AssociateVolumeRequest,
   AssociateVolumeResponse,
   AssociateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateVolumeRequest,
   output: AssociateVolumeResponse,
@@ -1250,7 +1249,7 @@ export const createVolume: API.OperationMethod<
   CreateVolumeRequest,
   CreateVolumeResponse,
   CreateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateVolumeRequest,
   output: CreateVolumeResponse,
@@ -1282,7 +1281,7 @@ export const createWorkspaceInstance: API.OperationMethod<
   CreateWorkspaceInstanceRequest,
   CreateWorkspaceInstanceResponse,
   CreateWorkspaceInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceInstanceRequest,
   output: CreateWorkspaceInstanceResponse,
@@ -1314,7 +1313,7 @@ export const deleteVolume: API.OperationMethod<
   DeleteVolumeRequest,
   DeleteVolumeResponse,
   DeleteVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteVolumeRequest,
   output: DeleteVolumeResponse,
@@ -1348,7 +1347,7 @@ export const deleteWorkspaceInstance: API.OperationMethod<
   DeleteWorkspaceInstanceRequest,
   DeleteWorkspaceInstanceResponse,
   DeleteWorkspaceInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceInstanceRequest,
   output: DeleteWorkspaceInstanceResponse,
@@ -1380,7 +1379,7 @@ export const disassociateVolume: API.OperationMethod<
   DisassociateVolumeRequest,
   DisassociateVolumeResponse,
   DisassociateVolumeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateVolumeRequest,
   output: DisassociateVolumeResponse,
@@ -1411,7 +1410,7 @@ export const getWorkspaceInstance: API.OperationMethod<
   GetWorkspaceInstanceRequest,
   GetWorkspaceInstanceResponse,
   GetWorkspaceInstanceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetWorkspaceInstanceRequest,
   output: GetWorkspaceInstanceResponse,
@@ -1440,7 +1439,7 @@ export const listInstanceTypes: API.PaginatedOperationMethod<
   ListInstanceTypesRequest,
   ListInstanceTypesResponse,
   ListInstanceTypesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   InstanceTypeInfo
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListInstanceTypesRequest,
@@ -1475,7 +1474,7 @@ export const listRegions: API.PaginatedOperationMethod<
   ListRegionsRequest,
   ListRegionsResponse,
   ListRegionsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Region
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListRegionsRequest,
@@ -1511,7 +1510,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1540,7 +1539,7 @@ export const listWorkspaceInstances: API.PaginatedOperationMethod<
   ListWorkspaceInstancesRequest,
   ListWorkspaceInstancesResponse,
   ListWorkspaceInstancesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkspaceInstance
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListWorkspaceInstancesRequest,
@@ -1576,7 +1575,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1606,7 +1605,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,

--- a/packages/aws/src/services/workspaces-thin-client.ts
+++ b/packages/aws/src/services/workspaces-thin-client.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "WorkSpaces Thin Client",
@@ -1053,7 +1052,7 @@ export const createEnvironment: API.OperationMethod<
   CreateEnvironmentRequest,
   CreateEnvironmentResponse,
   CreateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateEnvironmentRequest,
   output: CreateEnvironmentResponse,
@@ -1087,7 +1086,7 @@ export const deleteDevice: API.OperationMethod<
   DeleteDeviceRequest,
   DeleteDeviceResponse,
   DeleteDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDeviceRequest,
   output: DeleteDeviceResponse,
@@ -1120,7 +1119,7 @@ export const deleteEnvironment: API.OperationMethod<
   DeleteEnvironmentRequest,
   DeleteEnvironmentResponse,
   DeleteEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteEnvironmentRequest,
   output: DeleteEnvironmentResponse,
@@ -1153,7 +1152,7 @@ export const deregisterDevice: API.OperationMethod<
   DeregisterDeviceRequest,
   DeregisterDeviceResponse,
   DeregisterDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterDeviceRequest,
   output: DeregisterDeviceResponse,
@@ -1185,7 +1184,7 @@ export const getDevice: API.OperationMethod<
   GetDeviceRequest,
   GetDeviceResponse,
   GetDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDeviceRequest,
   output: GetDeviceResponse,
@@ -1216,7 +1215,7 @@ export const getEnvironment: API.OperationMethod<
   GetEnvironmentRequest,
   GetEnvironmentResponse,
   GetEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEnvironmentRequest,
   output: GetEnvironmentResponse,
@@ -1247,7 +1246,7 @@ export const getSoftwareSet: API.OperationMethod<
   GetSoftwareSetRequest,
   GetSoftwareSetResponse,
   GetSoftwareSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSoftwareSetRequest,
   output: GetSoftwareSetResponse,
@@ -1277,7 +1276,7 @@ export const listDevices: API.PaginatedOperationMethod<
   ListDevicesRequest,
   ListDevicesResponse,
   ListDevicesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DeviceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDevicesRequest,
@@ -1313,7 +1312,7 @@ export const listEnvironments: API.PaginatedOperationMethod<
   ListEnvironmentsRequest,
   ListEnvironmentsResponse,
   ListEnvironmentsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   EnvironmentSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListEnvironmentsRequest,
@@ -1349,7 +1348,7 @@ export const listSoftwareSets: API.PaginatedOperationMethod<
   ListSoftwareSetsRequest,
   ListSoftwareSetsResponse,
   ListSoftwareSetsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SoftwareSetSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSoftwareSetsRequest,
@@ -1386,7 +1385,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -1418,7 +1417,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -1451,7 +1450,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -1483,7 +1482,7 @@ export const updateDevice: API.OperationMethod<
   UpdateDeviceRequest,
   UpdateDeviceResponse,
   UpdateDeviceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDeviceRequest,
   output: UpdateDeviceResponse,
@@ -1515,7 +1514,7 @@ export const updateEnvironment: API.OperationMethod<
   UpdateEnvironmentRequest,
   UpdateEnvironmentResponse,
   UpdateEnvironmentError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateEnvironmentRequest,
   output: UpdateEnvironmentResponse,
@@ -1547,7 +1546,7 @@ export const updateSoftwareSet: API.OperationMethod<
   UpdateSoftwareSetRequest,
   UpdateSoftwareSetResponse,
   UpdateSoftwareSetError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSoftwareSetRequest,
   output: UpdateSoftwareSetResponse,

--- a/packages/aws/src/services/workspaces-web.ts
+++ b/packages/aws/src/services/workspaces-web.ts
@@ -8,7 +8,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 import { SensitiveString } from "../sensitive.ts";
 const svc = T.AwsApiService({
   sdkId: "WorkSpaces Web",
@@ -3623,7 +3622,7 @@ export const associateBrowserSettings: API.OperationMethod<
   AssociateBrowserSettingsRequest,
   AssociateBrowserSettingsResponse,
   AssociateBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateBrowserSettingsRequest,
   output: AssociateBrowserSettingsResponse,
@@ -3655,7 +3654,7 @@ export const associateDataProtectionSettings: API.OperationMethod<
   AssociateDataProtectionSettingsRequest,
   AssociateDataProtectionSettingsResponse,
   AssociateDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateDataProtectionSettingsRequest,
   output: AssociateDataProtectionSettingsResponse,
@@ -3687,7 +3686,7 @@ export const associateIpAccessSettings: API.OperationMethod<
   AssociateIpAccessSettingsRequest,
   AssociateIpAccessSettingsResponse,
   AssociateIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIpAccessSettingsRequest,
   output: AssociateIpAccessSettingsResponse,
@@ -3719,7 +3718,7 @@ export const associateNetworkSettings: API.OperationMethod<
   AssociateNetworkSettingsRequest,
   AssociateNetworkSettingsResponse,
   AssociateNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateNetworkSettingsRequest,
   output: AssociateNetworkSettingsResponse,
@@ -3751,7 +3750,7 @@ export const associateSessionLogger: API.OperationMethod<
   AssociateSessionLoggerRequest,
   AssociateSessionLoggerResponse,
   AssociateSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateSessionLoggerRequest,
   output: AssociateSessionLoggerResponse,
@@ -3783,7 +3782,7 @@ export const associateTrustStore: API.OperationMethod<
   AssociateTrustStoreRequest,
   AssociateTrustStoreResponse,
   AssociateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateTrustStoreRequest,
   output: AssociateTrustStoreResponse,
@@ -3815,7 +3814,7 @@ export const associateUserAccessLoggingSettings: API.OperationMethod<
   AssociateUserAccessLoggingSettingsRequest,
   AssociateUserAccessLoggingSettingsResponse,
   AssociateUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateUserAccessLoggingSettingsRequest,
   output: AssociateUserAccessLoggingSettingsResponse,
@@ -3847,7 +3846,7 @@ export const associateUserSettings: API.OperationMethod<
   AssociateUserSettingsRequest,
   AssociateUserSettingsResponse,
   AssociateUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateUserSettingsRequest,
   output: AssociateUserSettingsResponse,
@@ -3880,7 +3879,7 @@ export const createBrowserSettings: API.OperationMethod<
   CreateBrowserSettingsRequest,
   CreateBrowserSettingsResponse,
   CreateBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateBrowserSettingsRequest,
   output: CreateBrowserSettingsResponse,
@@ -3914,7 +3913,7 @@ export const createDataProtectionSettings: API.OperationMethod<
   CreateDataProtectionSettingsRequest,
   CreateDataProtectionSettingsResponse,
   CreateDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateDataProtectionSettingsRequest,
   output: CreateDataProtectionSettingsResponse,
@@ -3948,7 +3947,7 @@ export const createIdentityProvider: API.OperationMethod<
   CreateIdentityProviderRequest,
   CreateIdentityProviderResponse,
   CreateIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIdentityProviderRequest,
   output: CreateIdentityProviderResponse,
@@ -3981,7 +3980,7 @@ export const createIpAccessSettings: API.OperationMethod<
   CreateIpAccessSettingsRequest,
   CreateIpAccessSettingsResponse,
   CreateIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpAccessSettingsRequest,
   output: CreateIpAccessSettingsResponse,
@@ -4013,7 +4012,7 @@ export const createNetworkSettings: API.OperationMethod<
   CreateNetworkSettingsRequest,
   CreateNetworkSettingsResponse,
   CreateNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateNetworkSettingsRequest,
   output: CreateNetworkSettingsResponse,
@@ -4046,7 +4045,7 @@ export const createPortal: API.OperationMethod<
   CreatePortalRequest,
   CreatePortalResponse,
   CreatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreatePortalRequest,
   output: CreatePortalResponse,
@@ -4079,7 +4078,7 @@ export const createSessionLogger: API.OperationMethod<
   CreateSessionLoggerRequest,
   CreateSessionLoggerResponse,
   CreateSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSessionLoggerRequest,
   output: CreateSessionLoggerResponse,
@@ -4111,7 +4110,7 @@ export const createTrustStore: API.OperationMethod<
   CreateTrustStoreRequest,
   CreateTrustStoreResponse,
   CreateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTrustStoreRequest,
   output: CreateTrustStoreResponse,
@@ -4143,7 +4142,7 @@ export const createUserAccessLoggingSettings: API.OperationMethod<
   CreateUserAccessLoggingSettingsRequest,
   CreateUserAccessLoggingSettingsResponse,
   CreateUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserAccessLoggingSettingsRequest,
   output: CreateUserAccessLoggingSettingsResponse,
@@ -4176,7 +4175,7 @@ export const createUserSettings: API.OperationMethod<
   CreateUserSettingsRequest,
   CreateUserSettingsResponse,
   CreateUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUserSettingsRequest,
   output: CreateUserSettingsResponse,
@@ -4208,7 +4207,7 @@ export const deleteBrowserSettings: API.OperationMethod<
   DeleteBrowserSettingsRequest,
   DeleteBrowserSettingsResponse,
   DeleteBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBrowserSettingsRequest,
   output: DeleteBrowserSettingsResponse,
@@ -4238,7 +4237,7 @@ export const deleteDataProtectionSettings: API.OperationMethod<
   DeleteDataProtectionSettingsRequest,
   DeleteDataProtectionSettingsResponse,
   DeleteDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteDataProtectionSettingsRequest,
   output: DeleteDataProtectionSettingsResponse,
@@ -4268,7 +4267,7 @@ export const deleteIdentityProvider: API.OperationMethod<
   DeleteIdentityProviderRequest,
   DeleteIdentityProviderResponse,
   DeleteIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIdentityProviderRequest,
   output: DeleteIdentityProviderResponse,
@@ -4298,7 +4297,7 @@ export const deleteIpAccessSettings: API.OperationMethod<
   DeleteIpAccessSettingsRequest,
   DeleteIpAccessSettingsResponse,
   DeleteIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpAccessSettingsRequest,
   output: DeleteIpAccessSettingsResponse,
@@ -4328,7 +4327,7 @@ export const deleteNetworkSettings: API.OperationMethod<
   DeleteNetworkSettingsRequest,
   DeleteNetworkSettingsResponse,
   DeleteNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteNetworkSettingsRequest,
   output: DeleteNetworkSettingsResponse,
@@ -4358,7 +4357,7 @@ export const deletePortal: API.OperationMethod<
   DeletePortalRequest,
   DeletePortalResponse,
   DeletePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeletePortalRequest,
   output: DeletePortalResponse,
@@ -4388,7 +4387,7 @@ export const deleteSessionLogger: API.OperationMethod<
   DeleteSessionLoggerRequest,
   DeleteSessionLoggerResponse,
   DeleteSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSessionLoggerRequest,
   output: DeleteSessionLoggerResponse,
@@ -4418,7 +4417,7 @@ export const deleteTrustStore: API.OperationMethod<
   DeleteTrustStoreRequest,
   DeleteTrustStoreResponse,
   DeleteTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTrustStoreRequest,
   output: DeleteTrustStoreResponse,
@@ -4448,7 +4447,7 @@ export const deleteUserAccessLoggingSettings: API.OperationMethod<
   DeleteUserAccessLoggingSettingsRequest,
   DeleteUserAccessLoggingSettingsResponse,
   DeleteUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserAccessLoggingSettingsRequest,
   output: DeleteUserAccessLoggingSettingsResponse,
@@ -4478,7 +4477,7 @@ export const deleteUserSettings: API.OperationMethod<
   DeleteUserSettingsRequest,
   DeleteUserSettingsResponse,
   DeleteUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteUserSettingsRequest,
   output: DeleteUserSettingsResponse,
@@ -4509,7 +4508,7 @@ export const disassociateBrowserSettings: API.OperationMethod<
   DisassociateBrowserSettingsRequest,
   DisassociateBrowserSettingsResponse,
   DisassociateBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateBrowserSettingsRequest,
   output: DisassociateBrowserSettingsResponse,
@@ -4541,7 +4540,7 @@ export const disassociateDataProtectionSettings: API.OperationMethod<
   DisassociateDataProtectionSettingsRequest,
   DisassociateDataProtectionSettingsResponse,
   DisassociateDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateDataProtectionSettingsRequest,
   output: DisassociateDataProtectionSettingsResponse,
@@ -4573,7 +4572,7 @@ export const disassociateIpAccessSettings: API.OperationMethod<
   DisassociateIpAccessSettingsRequest,
   DisassociateIpAccessSettingsResponse,
   DisassociateIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIpAccessSettingsRequest,
   output: DisassociateIpAccessSettingsResponse,
@@ -4605,7 +4604,7 @@ export const disassociateNetworkSettings: API.OperationMethod<
   DisassociateNetworkSettingsRequest,
   DisassociateNetworkSettingsResponse,
   DisassociateNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateNetworkSettingsRequest,
   output: DisassociateNetworkSettingsResponse,
@@ -4636,7 +4635,7 @@ export const disassociateSessionLogger: API.OperationMethod<
   DisassociateSessionLoggerRequest,
   DisassociateSessionLoggerResponse,
   DisassociateSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateSessionLoggerRequest,
   output: DisassociateSessionLoggerResponse,
@@ -4667,7 +4666,7 @@ export const disassociateTrustStore: API.OperationMethod<
   DisassociateTrustStoreRequest,
   DisassociateTrustStoreResponse,
   DisassociateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateTrustStoreRequest,
   output: DisassociateTrustStoreResponse,
@@ -4699,7 +4698,7 @@ export const disassociateUserAccessLoggingSettings: API.OperationMethod<
   DisassociateUserAccessLoggingSettingsRequest,
   DisassociateUserAccessLoggingSettingsResponse,
   DisassociateUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateUserAccessLoggingSettingsRequest,
   output: DisassociateUserAccessLoggingSettingsResponse,
@@ -4731,7 +4730,7 @@ export const disassociateUserSettings: API.OperationMethod<
   DisassociateUserSettingsRequest,
   DisassociateUserSettingsResponse,
   DisassociateUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateUserSettingsRequest,
   output: DisassociateUserSettingsResponse,
@@ -4762,7 +4761,7 @@ export const expireSession: API.OperationMethod<
   ExpireSessionRequest,
   ExpireSessionResponse,
   ExpireSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ExpireSessionRequest,
   output: ExpireSessionResponse,
@@ -4792,7 +4791,7 @@ export const getBrowserSettings: API.OperationMethod<
   GetBrowserSettingsRequest,
   GetBrowserSettingsResponse,
   GetBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetBrowserSettingsRequest,
   output: GetBrowserSettingsResponse,
@@ -4822,7 +4821,7 @@ export const getDataProtectionSettings: API.OperationMethod<
   GetDataProtectionSettingsRequest,
   GetDataProtectionSettingsResponse,
   GetDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetDataProtectionSettingsRequest,
   output: GetDataProtectionSettingsResponse,
@@ -4852,7 +4851,7 @@ export const getIdentityProvider: API.OperationMethod<
   GetIdentityProviderRequest,
   GetIdentityProviderResponse,
   GetIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIdentityProviderRequest,
   output: GetIdentityProviderResponse,
@@ -4882,7 +4881,7 @@ export const getIpAccessSettings: API.OperationMethod<
   GetIpAccessSettingsRequest,
   GetIpAccessSettingsResponse,
   GetIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIpAccessSettingsRequest,
   output: GetIpAccessSettingsResponse,
@@ -4912,7 +4911,7 @@ export const getNetworkSettings: API.OperationMethod<
   GetNetworkSettingsRequest,
   GetNetworkSettingsResponse,
   GetNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetNetworkSettingsRequest,
   output: GetNetworkSettingsResponse,
@@ -4942,7 +4941,7 @@ export const getPortal: API.OperationMethod<
   GetPortalRequest,
   GetPortalResponse,
   GetPortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortalRequest,
   output: GetPortalResponse,
@@ -4972,7 +4971,7 @@ export const getPortalServiceProviderMetadata: API.OperationMethod<
   GetPortalServiceProviderMetadataRequest,
   GetPortalServiceProviderMetadataResponse,
   GetPortalServiceProviderMetadataError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetPortalServiceProviderMetadataRequest,
   output: GetPortalServiceProviderMetadataResponse,
@@ -5002,7 +5001,7 @@ export const getSession: API.OperationMethod<
   GetSessionRequest,
   GetSessionResponse,
   GetSessionError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionRequest,
   output: GetSessionResponse,
@@ -5032,7 +5031,7 @@ export const getSessionLogger: API.OperationMethod<
   GetSessionLoggerRequest,
   GetSessionLoggerResponse,
   GetSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSessionLoggerRequest,
   output: GetSessionLoggerResponse,
@@ -5062,7 +5061,7 @@ export const getTrustStore: API.OperationMethod<
   GetTrustStoreRequest,
   GetTrustStoreResponse,
   GetTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustStoreRequest,
   output: GetTrustStoreResponse,
@@ -5092,7 +5091,7 @@ export const getTrustStoreCertificate: API.OperationMethod<
   GetTrustStoreCertificateRequest,
   GetTrustStoreCertificateResponse,
   GetTrustStoreCertificateError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTrustStoreCertificateRequest,
   output: GetTrustStoreCertificateResponse,
@@ -5122,7 +5121,7 @@ export const getUserAccessLoggingSettings: API.OperationMethod<
   GetUserAccessLoggingSettingsRequest,
   GetUserAccessLoggingSettingsResponse,
   GetUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserAccessLoggingSettingsRequest,
   output: GetUserAccessLoggingSettingsResponse,
@@ -5152,7 +5151,7 @@ export const getUserSettings: API.OperationMethod<
   GetUserSettingsRequest,
   GetUserSettingsResponse,
   GetUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetUserSettingsRequest,
   output: GetUserSettingsResponse,
@@ -5181,7 +5180,7 @@ export const listBrowserSettings: API.PaginatedOperationMethod<
   ListBrowserSettingsRequest,
   ListBrowserSettingsResponse,
   ListBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListBrowserSettingsRequest,
@@ -5215,7 +5214,7 @@ export const listDataProtectionSettings: API.PaginatedOperationMethod<
   ListDataProtectionSettingsRequest,
   ListDataProtectionSettingsResponse,
   ListDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   DataProtectionSettingsSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListDataProtectionSettingsRequest,
@@ -5250,7 +5249,7 @@ export const listIdentityProviders: API.PaginatedOperationMethod<
   ListIdentityProvidersRequest,
   ListIdentityProvidersResponse,
   ListIdentityProvidersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIdentityProvidersRequest,
@@ -5284,7 +5283,7 @@ export const listIpAccessSettings: API.PaginatedOperationMethod<
   ListIpAccessSettingsRequest,
   ListIpAccessSettingsResponse,
   ListIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListIpAccessSettingsRequest,
@@ -5318,7 +5317,7 @@ export const listNetworkSettings: API.PaginatedOperationMethod<
   ListNetworkSettingsRequest,
   ListNetworkSettingsResponse,
   ListNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListNetworkSettingsRequest,
@@ -5352,7 +5351,7 @@ export const listPortals: API.PaginatedOperationMethod<
   ListPortalsRequest,
   ListPortalsResponse,
   ListPortalsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListPortalsRequest,
@@ -5386,7 +5385,7 @@ export const listSessionLoggers: API.PaginatedOperationMethod<
   ListSessionLoggersRequest,
   ListSessionLoggersResponse,
   ListSessionLoggersError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionLoggerSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionLoggersRequest,
@@ -5422,7 +5421,7 @@ export const listSessions: API.PaginatedOperationMethod<
   ListSessionsRequest,
   ListSessionsResponse,
   ListSessionsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SessionSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListSessionsRequest,
@@ -5459,7 +5458,7 @@ export const listTagsForResource: API.OperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListTagsForResourceRequest,
   output: ListTagsForResourceResponse,
@@ -5489,7 +5488,7 @@ export const listTrustStoreCertificates: API.PaginatedOperationMethod<
   ListTrustStoreCertificatesRequest,
   ListTrustStoreCertificatesResponse,
   ListTrustStoreCertificatesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustStoreCertificatesRequest,
@@ -5524,7 +5523,7 @@ export const listTrustStores: API.PaginatedOperationMethod<
   ListTrustStoresRequest,
   ListTrustStoresResponse,
   ListTrustStoresError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTrustStoresRequest,
@@ -5558,7 +5557,7 @@ export const listUserAccessLoggingSettings: API.PaginatedOperationMethod<
   ListUserAccessLoggingSettingsRequest,
   ListUserAccessLoggingSettingsResponse,
   ListUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserAccessLoggingSettingsRequest,
@@ -5592,7 +5591,7 @@ export const listUserSettings: API.PaginatedOperationMethod<
   ListUserSettingsRequest,
   ListUserSettingsResponse,
   ListUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListUserSettingsRequest,
@@ -5628,7 +5627,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -5659,7 +5658,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -5689,7 +5688,7 @@ export const updateBrowserSettings: API.OperationMethod<
   UpdateBrowserSettingsRequest,
   UpdateBrowserSettingsResponse,
   UpdateBrowserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateBrowserSettingsRequest,
   output: UpdateBrowserSettingsResponse,
@@ -5719,7 +5718,7 @@ export const updateDataProtectionSettings: API.OperationMethod<
   UpdateDataProtectionSettingsRequest,
   UpdateDataProtectionSettingsResponse,
   UpdateDataProtectionSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateDataProtectionSettingsRequest,
   output: UpdateDataProtectionSettingsResponse,
@@ -5749,7 +5748,7 @@ export const updateIdentityProvider: API.OperationMethod<
   UpdateIdentityProviderRequest,
   UpdateIdentityProviderResponse,
   UpdateIdentityProviderError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIdentityProviderRequest,
   output: UpdateIdentityProviderResponse,
@@ -5779,7 +5778,7 @@ export const updateIpAccessSettings: API.OperationMethod<
   UpdateIpAccessSettingsRequest,
   UpdateIpAccessSettingsResponse,
   UpdateIpAccessSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIpAccessSettingsRequest,
   output: UpdateIpAccessSettingsResponse,
@@ -5809,7 +5808,7 @@ export const updateNetworkSettings: API.OperationMethod<
   UpdateNetworkSettingsRequest,
   UpdateNetworkSettingsResponse,
   UpdateNetworkSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateNetworkSettingsRequest,
   output: UpdateNetworkSettingsResponse,
@@ -5841,7 +5840,7 @@ export const updatePortal: API.OperationMethod<
   UpdatePortalRequest,
   UpdatePortalResponse,
   UpdatePortalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdatePortalRequest,
   output: UpdatePortalResponse,
@@ -5873,7 +5872,7 @@ export const updateSessionLogger: API.OperationMethod<
   UpdateSessionLoggerRequest,
   UpdateSessionLoggerResponse,
   UpdateSessionLoggerError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSessionLoggerRequest,
   output: UpdateSessionLoggerResponse,
@@ -5904,7 +5903,7 @@ export const updateTrustStore: API.OperationMethod<
   UpdateTrustStoreRequest,
   UpdateTrustStoreResponse,
   UpdateTrustStoreError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTrustStoreRequest,
   output: UpdateTrustStoreResponse,
@@ -5935,7 +5934,7 @@ export const updateUserAccessLoggingSettings: API.OperationMethod<
   UpdateUserAccessLoggingSettingsRequest,
   UpdateUserAccessLoggingSettingsResponse,
   UpdateUserAccessLoggingSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserAccessLoggingSettingsRequest,
   output: UpdateUserAccessLoggingSettingsResponse,
@@ -5965,7 +5964,7 @@ export const updateUserSettings: API.OperationMethod<
   UpdateUserSettingsRequest,
   UpdateUserSettingsResponse,
   UpdateUserSettingsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateUserSettingsRequest,
   output: UpdateUserSettingsResponse,

--- a/packages/aws/src/services/workspaces.ts
+++ b/packages/aws/src/services/workspaces.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region as Rgn } from "../region.ts";
 const ns = T.XmlNamespace("http://workspaces.amazonaws.com/api/v1");
 const svc = T.AwsApiService({
   sdkId: "WorkSpaces",
@@ -5310,7 +5309,7 @@ export const acceptAccountLinkInvitation: API.OperationMethod<
   AcceptAccountLinkInvitationRequest,
   AcceptAccountLinkInvitationResult,
   AcceptAccountLinkInvitationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AcceptAccountLinkInvitationRequest,
   output: AcceptAccountLinkInvitationResult,
@@ -5347,7 +5346,7 @@ export const associateConnectionAlias: API.OperationMethod<
   AssociateConnectionAliasRequest,
   AssociateConnectionAliasResult,
   AssociateConnectionAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateConnectionAliasRequest,
   output: AssociateConnectionAliasResult,
@@ -5379,7 +5378,7 @@ export const associateIpGroups: API.OperationMethod<
   AssociateIpGroupsRequest,
   AssociateIpGroupsResult,
   AssociateIpGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateIpGroupsRequest,
   output: AssociateIpGroupsResult,
@@ -5415,7 +5414,7 @@ export const associateWorkspaceApplication: API.OperationMethod<
   AssociateWorkspaceApplicationRequest,
   AssociateWorkspaceApplicationResult,
   AssociateWorkspaceApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AssociateWorkspaceApplicationRequest,
   output: AssociateWorkspaceApplicationResult,
@@ -5453,7 +5452,7 @@ export const authorizeIpRules: API.OperationMethod<
   AuthorizeIpRulesRequest,
   AuthorizeIpRulesResult,
   AuthorizeIpRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: AuthorizeIpRulesRequest,
   output: AuthorizeIpRulesResult,
@@ -5495,7 +5494,7 @@ export const copyWorkspaceImage: API.OperationMethod<
   CopyWorkspaceImageRequest,
   CopyWorkspaceImageResult,
   CopyWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CopyWorkspaceImageRequest,
   output: CopyWorkspaceImageResult,
@@ -5526,7 +5525,7 @@ export const createAccountLinkInvitation: API.OperationMethod<
   CreateAccountLinkInvitationRequest,
   CreateAccountLinkInvitationResult,
   CreateAccountLinkInvitationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccountLinkInvitationRequest,
   output: CreateAccountLinkInvitationResult,
@@ -5558,7 +5557,7 @@ export const createConnectClientAddIn: API.OperationMethod<
   CreateConnectClientAddInRequest,
   CreateConnectClientAddInResult,
   CreateConnectClientAddInError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectClientAddInRequest,
   output: CreateConnectClientAddInResult,
@@ -5591,7 +5590,7 @@ export const createConnectionAlias: API.OperationMethod<
   CreateConnectionAliasRequest,
   CreateConnectionAliasResult,
   CreateConnectionAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateConnectionAliasRequest,
   output: CreateConnectionAliasResult,
@@ -5632,7 +5631,7 @@ export const createIpGroup: API.OperationMethod<
   CreateIpGroupRequest,
   CreateIpGroupResult,
   CreateIpGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateIpGroupRequest,
   output: CreateIpGroupResult,
@@ -5662,7 +5661,7 @@ export const createStandbyWorkspaces: API.OperationMethod<
   CreateStandbyWorkspacesRequest,
   CreateStandbyWorkspacesResult,
   CreateStandbyWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateStandbyWorkspacesRequest,
   output: CreateStandbyWorkspacesResult,
@@ -5690,7 +5689,7 @@ export const createTags: API.OperationMethod<
   CreateTagsRequest,
   CreateTagsResult,
   CreateTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateTagsRequest,
   output: CreateTagsResult,
@@ -5735,7 +5734,7 @@ export const createUpdatedWorkspaceImage: API.OperationMethod<
   CreateUpdatedWorkspaceImageRequest,
   CreateUpdatedWorkspaceImageResult,
   CreateUpdatedWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateUpdatedWorkspaceImageRequest,
   output: CreateUpdatedWorkspaceImageResult,
@@ -5770,7 +5769,7 @@ export const createWorkspaceBundle: API.OperationMethod<
   CreateWorkspaceBundleRequest,
   CreateWorkspaceBundleResult,
   CreateWorkspaceBundleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceBundleRequest,
   output: CreateWorkspaceBundleResult,
@@ -5803,7 +5802,7 @@ export const createWorkspaceImage: API.OperationMethod<
   CreateWorkspaceImageRequest,
   CreateWorkspaceImageResult,
   CreateWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspaceImageRequest,
   output: CreateWorkspaceImageResult,
@@ -5850,7 +5849,7 @@ export const createWorkspaces: API.OperationMethod<
   CreateWorkspacesRequest,
   CreateWorkspacesResult,
   CreateWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspacesRequest,
   output: CreateWorkspacesResult,
@@ -5875,7 +5874,7 @@ export const createWorkspacesPool: API.OperationMethod<
   CreateWorkspacesPoolRequest,
   CreateWorkspacesPoolResult,
   CreateWorkspacesPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateWorkspacesPoolRequest,
   output: CreateWorkspacesPoolResult,
@@ -5906,7 +5905,7 @@ export const deleteAccountLinkInvitation: API.OperationMethod<
   DeleteAccountLinkInvitationRequest,
   DeleteAccountLinkInvitationResult,
   DeleteAccountLinkInvitationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccountLinkInvitationRequest,
   output: DeleteAccountLinkInvitationResult,
@@ -5940,7 +5939,7 @@ export const deleteClientBranding: API.OperationMethod<
   DeleteClientBrandingRequest,
   DeleteClientBrandingResult,
   DeleteClientBrandingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteClientBrandingRequest,
   output: DeleteClientBrandingResult,
@@ -5967,7 +5966,7 @@ export const deleteConnectClientAddIn: API.OperationMethod<
   DeleteConnectClientAddInRequest,
   DeleteConnectClientAddInResult,
   DeleteConnectClientAddInError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectClientAddInRequest,
   output: DeleteConnectClientAddInResult,
@@ -6008,7 +6007,7 @@ export const deleteConnectionAlias: API.OperationMethod<
   DeleteConnectionAliasRequest,
   DeleteConnectionAliasResult,
   DeleteConnectionAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteConnectionAliasRequest,
   output: DeleteConnectionAliasResult,
@@ -6040,7 +6039,7 @@ export const deleteIpGroup: API.OperationMethod<
   DeleteIpGroupRequest,
   DeleteIpGroupResult,
   DeleteIpGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteIpGroupRequest,
   output: DeleteIpGroupResult,
@@ -6066,7 +6065,7 @@ export const deleteTags: API.OperationMethod<
   DeleteTagsRequest,
   DeleteTagsResult,
   DeleteTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteTagsRequest,
   output: DeleteTagsResult,
@@ -6091,7 +6090,7 @@ export const deleteWorkspaceBundle: API.OperationMethod<
   DeleteWorkspaceBundleRequest,
   DeleteWorkspaceBundleResult,
   DeleteWorkspaceBundleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceBundleRequest,
   output: DeleteWorkspaceBundleResult,
@@ -6120,7 +6119,7 @@ export const deleteWorkspaceImage: API.OperationMethod<
   DeleteWorkspaceImageRequest,
   DeleteWorkspaceImageResult,
   DeleteWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteWorkspaceImageRequest,
   output: DeleteWorkspaceImageResult,
@@ -6149,7 +6148,7 @@ export const deployWorkspaceApplications: API.OperationMethod<
   DeployWorkspaceApplicationsRequest,
   DeployWorkspaceApplicationsResult,
   DeployWorkspaceApplicationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeployWorkspaceApplicationsRequest,
   output: DeployWorkspaceApplicationsResult,
@@ -6193,7 +6192,7 @@ export const deregisterWorkspaceDirectory: API.OperationMethod<
   DeregisterWorkspaceDirectoryRequest,
   DeregisterWorkspaceDirectoryResult,
   DeregisterWorkspaceDirectoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeregisterWorkspaceDirectoryRequest,
   output: DeregisterWorkspaceDirectoryResult,
@@ -6218,7 +6217,7 @@ export const describeAccount: API.OperationMethod<
   DescribeAccountRequest,
   DescribeAccountResult,
   DescribeAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountRequest,
   output: DescribeAccountResult,
@@ -6239,7 +6238,7 @@ export const describeAccountModifications: API.OperationMethod<
   DescribeAccountModificationsRequest,
   DescribeAccountModificationsResult,
   DescribeAccountModificationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeAccountModificationsRequest,
   output: DescribeAccountModificationsResult,
@@ -6262,7 +6261,7 @@ export const describeApplicationAssociations: API.PaginatedOperationMethod<
   DescribeApplicationAssociationsRequest,
   DescribeApplicationAssociationsResult,
   DescribeApplicationAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeApplicationAssociationsRequest,
@@ -6296,7 +6295,7 @@ export const describeApplications: API.PaginatedOperationMethod<
   DescribeApplicationsRequest,
   DescribeApplicationsResult,
   DescribeApplicationsError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeApplicationsRequest,
@@ -6330,7 +6329,7 @@ export const describeBundleAssociations: API.OperationMethod<
   DescribeBundleAssociationsRequest,
   DescribeBundleAssociationsResult,
   DescribeBundleAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeBundleAssociationsRequest,
   output: DescribeBundleAssociationsResult,
@@ -6363,7 +6362,7 @@ export const describeClientBranding: API.OperationMethod<
   DescribeClientBrandingRequest,
   DescribeClientBrandingResult,
   DescribeClientBrandingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClientBrandingRequest,
   output: DescribeClientBrandingResult,
@@ -6389,7 +6388,7 @@ export const describeClientProperties: API.OperationMethod<
   DescribeClientPropertiesRequest,
   DescribeClientPropertiesResult,
   DescribeClientPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeClientPropertiesRequest,
   output: DescribeClientPropertiesResult,
@@ -6415,7 +6414,7 @@ export const describeConnectClientAddIns: API.OperationMethod<
   DescribeConnectClientAddInsRequest,
   DescribeConnectClientAddInsResult,
   DescribeConnectClientAddInsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectClientAddInsRequest,
   output: DescribeConnectClientAddInsResult,
@@ -6443,7 +6442,7 @@ export const describeConnectionAliases: API.OperationMethod<
   DescribeConnectionAliasesRequest,
   DescribeConnectionAliasesResult,
   DescribeConnectionAliasesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionAliasesRequest,
   output: DescribeConnectionAliasesResult,
@@ -6473,7 +6472,7 @@ export const describeConnectionAliasPermissions: API.OperationMethod<
   DescribeConnectionAliasPermissionsRequest,
   DescribeConnectionAliasPermissionsResult,
   DescribeConnectionAliasPermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeConnectionAliasPermissionsRequest,
   output: DescribeConnectionAliasPermissionsResult,
@@ -6499,7 +6498,7 @@ export const describeCustomWorkspaceImageImport: API.OperationMethod<
   DescribeCustomWorkspaceImageImportRequest,
   DescribeCustomWorkspaceImageImportResult,
   DescribeCustomWorkspaceImageImportError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeCustomWorkspaceImageImportRequest,
   output: DescribeCustomWorkspaceImageImportResult,
@@ -6522,7 +6521,7 @@ export const describeImageAssociations: API.OperationMethod<
   DescribeImageAssociationsRequest,
   DescribeImageAssociationsResult,
   DescribeImageAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeImageAssociationsRequest,
   output: DescribeImageAssociationsResult,
@@ -6548,7 +6547,7 @@ export const describeIpGroups: API.OperationMethod<
   DescribeIpGroupsRequest,
   DescribeIpGroupsResult,
   DescribeIpGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeIpGroupsRequest,
   output: DescribeIpGroupsResult,
@@ -6566,7 +6565,7 @@ export const describeTags: API.OperationMethod<
   DescribeTagsRequest,
   DescribeTagsResult,
   DescribeTagsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeTagsRequest,
   output: DescribeTagsResult,
@@ -6589,7 +6588,7 @@ export const describeWorkspaceAssociations: API.OperationMethod<
   DescribeWorkspaceAssociationsRequest,
   DescribeWorkspaceAssociationsResult,
   DescribeWorkspaceAssociationsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceAssociationsRequest,
   output: DescribeWorkspaceAssociationsResult,
@@ -6616,7 +6615,7 @@ export const describeWorkspaceBundles: API.PaginatedOperationMethod<
   DescribeWorkspaceBundlesRequest,
   DescribeWorkspaceBundlesResult,
   DescribeWorkspaceBundlesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkspaceBundle
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeWorkspaceBundlesRequest,
@@ -6642,7 +6641,7 @@ export const describeWorkspaceDirectories: API.PaginatedOperationMethod<
   DescribeWorkspaceDirectoriesRequest,
   DescribeWorkspaceDirectoriesResult,
   DescribeWorkspaceDirectoriesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   WorkspaceDirectory
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeWorkspaceDirectoriesRequest,
@@ -6670,7 +6669,7 @@ export const describeWorkspaceImagePermissions: API.OperationMethod<
   DescribeWorkspaceImagePermissionsRequest,
   DescribeWorkspaceImagePermissionsResult,
   DescribeWorkspaceImagePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceImagePermissionsRequest,
   output: DescribeWorkspaceImagePermissionsResult,
@@ -6693,7 +6692,7 @@ export const describeWorkspaceImages: API.OperationMethod<
   DescribeWorkspaceImagesRequest,
   DescribeWorkspaceImagesResult,
   DescribeWorkspaceImagesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceImagesRequest,
   output: DescribeWorkspaceImagesResult,
@@ -6717,7 +6716,7 @@ export const describeWorkspaces: API.PaginatedOperationMethod<
   DescribeWorkspacesRequest,
   DescribeWorkspacesResult,
   DescribeWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Workspace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeWorkspacesRequest,
@@ -6744,7 +6743,7 @@ export const describeWorkspacesConnectionStatus: API.OperationMethod<
   DescribeWorkspacesConnectionStatusRequest,
   DescribeWorkspacesConnectionStatusResult,
   DescribeWorkspacesConnectionStatusError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspacesConnectionStatusRequest,
   output: DescribeWorkspacesConnectionStatusResult,
@@ -6766,7 +6765,7 @@ export const describeWorkspaceSnapshots: API.OperationMethod<
   DescribeWorkspaceSnapshotsRequest,
   DescribeWorkspaceSnapshotsResult,
   DescribeWorkspaceSnapshotsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspaceSnapshotsRequest,
   output: DescribeWorkspaceSnapshotsResult,
@@ -6792,7 +6791,7 @@ export const describeWorkspacesPools: API.OperationMethod<
   DescribeWorkspacesPoolsRequest,
   DescribeWorkspacesPoolsResult,
   DescribeWorkspacesPoolsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspacesPoolsRequest,
   output: DescribeWorkspacesPoolsResult,
@@ -6818,7 +6817,7 @@ export const describeWorkspacesPoolSessions: API.OperationMethod<
   DescribeWorkspacesPoolSessionsRequest,
   DescribeWorkspacesPoolSessionsResult,
   DescribeWorkspacesPoolSessionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DescribeWorkspacesPoolSessionsRequest,
   output: DescribeWorkspacesPoolSessionsResult,
@@ -6853,7 +6852,7 @@ export const disassociateConnectionAlias: API.OperationMethod<
   DisassociateConnectionAliasRequest,
   DisassociateConnectionAliasResult,
   DisassociateConnectionAliasError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateConnectionAliasRequest,
   output: DisassociateConnectionAliasResult,
@@ -6883,7 +6882,7 @@ export const disassociateIpGroups: API.OperationMethod<
   DisassociateIpGroupsRequest,
   DisassociateIpGroupsResult,
   DisassociateIpGroupsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateIpGroupsRequest,
   output: DisassociateIpGroupsResult,
@@ -6913,7 +6912,7 @@ export const disassociateWorkspaceApplication: API.OperationMethod<
   DisassociateWorkspaceApplicationRequest,
   DisassociateWorkspaceApplicationResult,
   DisassociateWorkspaceApplicationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DisassociateWorkspaceApplicationRequest,
   output: DisassociateWorkspaceApplicationResult,
@@ -6942,7 +6941,7 @@ export const getAccountLink: API.OperationMethod<
   GetAccountLinkRequest,
   GetAccountLinkResult,
   GetAccountLinkError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccountLinkRequest,
   output: GetAccountLinkResult,
@@ -6990,7 +6989,7 @@ export const importClientBranding: API.OperationMethod<
   ImportClientBrandingRequest,
   ImportClientBrandingResult,
   ImportClientBrandingError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportClientBrandingRequest,
   output: ImportClientBrandingResult,
@@ -7024,7 +7023,7 @@ export const importCustomWorkspaceImage: API.OperationMethod<
   ImportCustomWorkspaceImageRequest,
   ImportCustomWorkspaceImageResult,
   ImportCustomWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportCustomWorkspaceImageRequest,
   output: ImportCustomWorkspaceImageResult,
@@ -7060,7 +7059,7 @@ export const importWorkspaceImage: API.OperationMethod<
   ImportWorkspaceImageRequest,
   ImportWorkspaceImageResult,
   ImportWorkspaceImageError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ImportWorkspaceImageRequest,
   output: ImportWorkspaceImageResult,
@@ -7089,7 +7088,7 @@ export const listAccountLinks: API.PaginatedOperationMethod<
   ListAccountLinksRequest,
   ListAccountLinksResult,
   ListAccountLinksError,
-  Credentials | Rgn | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   AccountLink
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListAccountLinksRequest,
@@ -7126,7 +7125,7 @@ export const listAvailableManagementCidrRanges: API.OperationMethod<
   ListAvailableManagementCidrRangesRequest,
   ListAvailableManagementCidrRangesResult,
   ListAvailableManagementCidrRangesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListAvailableManagementCidrRangesRequest,
   output: ListAvailableManagementCidrRangesResult,
@@ -7163,7 +7162,7 @@ export const migrateWorkspace: API.OperationMethod<
   MigrateWorkspaceRequest,
   MigrateWorkspaceResult,
   MigrateWorkspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: MigrateWorkspaceRequest,
   output: MigrateWorkspaceResult,
@@ -7195,7 +7194,7 @@ export const modifyAccount: API.OperationMethod<
   ModifyAccountRequest,
   ModifyAccountResult,
   ModifyAccountError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyAccountRequest,
   output: ModifyAccountResult,
@@ -7225,7 +7224,7 @@ export const modifyCertificateBasedAuthProperties: API.OperationMethod<
   ModifyCertificateBasedAuthPropertiesRequest,
   ModifyCertificateBasedAuthPropertiesResult,
   ModifyCertificateBasedAuthPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyCertificateBasedAuthPropertiesRequest,
   output: ModifyCertificateBasedAuthPropertiesResult,
@@ -7253,7 +7252,7 @@ export const modifyClientProperties: API.OperationMethod<
   ModifyClientPropertiesRequest,
   ModifyClientPropertiesResult,
   ModifyClientPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyClientPropertiesRequest,
   output: ModifyClientPropertiesResult,
@@ -7281,7 +7280,7 @@ export const modifyEndpointEncryptionMode: API.OperationMethod<
   ModifyEndpointEncryptionModeRequest,
   ModifyEndpointEncryptionModeResponse,
   ModifyEndpointEncryptionModeError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyEndpointEncryptionModeRequest,
   output: ModifyEndpointEncryptionModeResponse,
@@ -7310,7 +7309,7 @@ export const modifySamlProperties: API.OperationMethod<
   ModifySamlPropertiesRequest,
   ModifySamlPropertiesResult,
   ModifySamlPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySamlPropertiesRequest,
   output: ModifySamlPropertiesResult,
@@ -7339,7 +7338,7 @@ export const modifySelfservicePermissions: API.OperationMethod<
   ModifySelfservicePermissionsRequest,
   ModifySelfservicePermissionsResult,
   ModifySelfservicePermissionsError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifySelfservicePermissionsRequest,
   output: ModifySelfservicePermissionsResult,
@@ -7367,7 +7366,7 @@ export const modifyStreamingProperties: API.OperationMethod<
   ModifyStreamingPropertiesRequest,
   ModifyStreamingPropertiesResult,
   ModifyStreamingPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyStreamingPropertiesRequest,
   output: ModifyStreamingPropertiesResult,
@@ -7398,7 +7397,7 @@ export const modifyWorkspaceAccessProperties: API.OperationMethod<
   ModifyWorkspaceAccessPropertiesRequest,
   ModifyWorkspaceAccessPropertiesResult,
   ModifyWorkspaceAccessPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyWorkspaceAccessPropertiesRequest,
   output: ModifyWorkspaceAccessPropertiesResult,
@@ -7427,7 +7426,7 @@ export const modifyWorkspaceCreationProperties: API.OperationMethod<
   ModifyWorkspaceCreationPropertiesRequest,
   ModifyWorkspaceCreationPropertiesResult,
   ModifyWorkspaceCreationPropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyWorkspaceCreationPropertiesRequest,
   output: ModifyWorkspaceCreationPropertiesResult,
@@ -7464,7 +7463,7 @@ export const modifyWorkspaceProperties: API.OperationMethod<
   ModifyWorkspacePropertiesRequest,
   ModifyWorkspacePropertiesResult,
   ModifyWorkspacePropertiesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyWorkspacePropertiesRequest,
   output: ModifyWorkspacePropertiesResult,
@@ -7501,7 +7500,7 @@ export const modifyWorkspaceState: API.OperationMethod<
   ModifyWorkspaceStateRequest,
   ModifyWorkspaceStateResult,
   ModifyWorkspaceStateError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ModifyWorkspaceStateRequest,
   output: ModifyWorkspaceStateResult,
@@ -7532,7 +7531,7 @@ export const rebootWorkspaces: API.OperationMethod<
   RebootWorkspacesRequest,
   RebootWorkspacesResult,
   RebootWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebootWorkspacesRequest,
   output: RebootWorkspacesResult,
@@ -7563,7 +7562,7 @@ export const rebuildWorkspaces: API.OperationMethod<
   RebuildWorkspacesRequest,
   RebuildWorkspacesResult,
   RebuildWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RebuildWorkspacesRequest,
   output: RebuildWorkspacesResult,
@@ -7595,7 +7594,7 @@ export const registerWorkspaceDirectory: API.OperationMethod<
   RegisterWorkspaceDirectoryRequest,
   RegisterWorkspaceDirectoryResult,
   RegisterWorkspaceDirectoryError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RegisterWorkspaceDirectoryRequest,
   output: RegisterWorkspaceDirectoryResult,
@@ -7629,7 +7628,7 @@ export const rejectAccountLinkInvitation: API.OperationMethod<
   RejectAccountLinkInvitationRequest,
   RejectAccountLinkInvitationResult,
   RejectAccountLinkInvitationError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RejectAccountLinkInvitationRequest,
   output: RejectAccountLinkInvitationResult,
@@ -7668,7 +7667,7 @@ export const restoreWorkspace: API.OperationMethod<
   RestoreWorkspaceRequest,
   RestoreWorkspaceResult,
   RestoreWorkspaceError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RestoreWorkspaceRequest,
   output: RestoreWorkspaceResult,
@@ -7696,7 +7695,7 @@ export const revokeIpRules: API.OperationMethod<
   RevokeIpRulesRequest,
   RevokeIpRulesResult,
   RevokeIpRulesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: RevokeIpRulesRequest,
   output: RevokeIpRulesResult,
@@ -7722,7 +7721,7 @@ export const startWorkspaces: API.OperationMethod<
   StartWorkspacesRequest,
   StartWorkspacesResult,
   StartWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkspacesRequest,
   output: StartWorkspacesResult,
@@ -7751,7 +7750,7 @@ export const startWorkspacesPool: API.OperationMethod<
   StartWorkspacesPoolRequest,
   StartWorkspacesPoolResult,
   StartWorkspacesPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartWorkspacesPoolRequest,
   output: StartWorkspacesPoolResult,
@@ -7781,7 +7780,7 @@ export const stopWorkspaces: API.OperationMethod<
   StopWorkspacesRequest,
   StopWorkspacesResult,
   StopWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopWorkspacesRequest,
   output: StopWorkspacesResult,
@@ -7808,7 +7807,7 @@ export const stopWorkspacesPool: API.OperationMethod<
   StopWorkspacesPoolRequest,
   StopWorkspacesPoolResult,
   StopWorkspacesPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StopWorkspacesPoolRequest,
   output: StopWorkspacesPoolResult,
@@ -7857,7 +7856,7 @@ export const terminateWorkspaces: API.OperationMethod<
   TerminateWorkspacesRequest,
   TerminateWorkspacesResult,
   TerminateWorkspacesError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateWorkspacesRequest,
   output: TerminateWorkspacesResult,
@@ -7881,7 +7880,7 @@ export const terminateWorkspacesPool: API.OperationMethod<
   TerminateWorkspacesPoolRequest,
   TerminateWorkspacesPoolResult,
   TerminateWorkspacesPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateWorkspacesPoolRequest,
   output: TerminateWorkspacesPoolResult,
@@ -7911,7 +7910,7 @@ export const terminateWorkspacesPoolSession: API.OperationMethod<
   TerminateWorkspacesPoolSessionRequest,
   TerminateWorkspacesPoolSessionResult,
   TerminateWorkspacesPoolSessionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TerminateWorkspacesPoolSessionRequest,
   output: TerminateWorkspacesPoolSessionResult,
@@ -7940,7 +7939,7 @@ export const updateConnectClientAddIn: API.OperationMethod<
   UpdateConnectClientAddInRequest,
   UpdateConnectClientAddInResult,
   UpdateConnectClientAddInError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectClientAddInRequest,
   output: UpdateConnectClientAddInResult,
@@ -7985,7 +7984,7 @@ export const updateConnectionAliasPermission: API.OperationMethod<
   UpdateConnectionAliasPermissionRequest,
   UpdateConnectionAliasPermissionResult,
   UpdateConnectionAliasPermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateConnectionAliasPermissionRequest,
   output: UpdateConnectionAliasPermissionResult,
@@ -8018,7 +8017,7 @@ export const updateRulesOfIpGroup: API.OperationMethod<
   UpdateRulesOfIpGroupRequest,
   UpdateRulesOfIpGroupResult,
   UpdateRulesOfIpGroupError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRulesOfIpGroupRequest,
   output: UpdateRulesOfIpGroupResult,
@@ -8054,7 +8053,7 @@ export const updateWorkspaceBundle: API.OperationMethod<
   UpdateWorkspaceBundleRequest,
   UpdateWorkspaceBundleResult,
   UpdateWorkspaceBundleError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceBundleRequest,
   output: UpdateWorkspaceBundleResult,
@@ -8104,7 +8103,7 @@ export const updateWorkspaceImagePermission: API.OperationMethod<
   UpdateWorkspaceImagePermissionRequest,
   UpdateWorkspaceImagePermissionResult,
   UpdateWorkspaceImagePermissionError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspaceImagePermissionRequest,
   output: UpdateWorkspaceImagePermissionResult,
@@ -8136,7 +8135,7 @@ export const updateWorkspacesPool: API.OperationMethod<
   UpdateWorkspacesPoolRequest,
   UpdateWorkspacesPoolResult,
   UpdateWorkspacesPoolError,
-  Credentials | Rgn | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateWorkspacesPoolRequest,
   output: UpdateWorkspacesPoolResult,

--- a/packages/aws/src/services/xray.ts
+++ b/packages/aws/src/services/xray.ts
@@ -7,7 +7,6 @@ import * as T from "../traits.ts";
 import * as C from "../category.ts";
 import type { Credentials } from "../credentials.ts";
 import type { CommonErrors } from "../errors.ts";
-import type { Region } from "../region.ts";
 const svc = T.AwsApiService({ sdkId: "XRay", serviceShapeName: "AWSXRay" });
 const auth = T.AwsAuthSigv4({ name: "xray" });
 const ver = T.ServiceVersion("2016-04-12");
@@ -2651,7 +2650,7 @@ export const batchGetTraces: API.PaginatedOperationMethod<
   BatchGetTracesRequest,
   BatchGetTracesResult,
   BatchGetTracesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Trace
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: BatchGetTracesRequest,
@@ -2679,7 +2678,7 @@ export const cancelTraceRetrieval: API.OperationMethod<
   CancelTraceRetrievalRequest,
   CancelTraceRetrievalResult,
   CancelTraceRetrievalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CancelTraceRetrievalRequest,
   output: CancelTraceRetrievalResult,
@@ -2705,7 +2704,7 @@ export const createGroup: API.OperationMethod<
   CreateGroupRequest,
   CreateGroupResult,
   CreateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateGroupRequest,
   output: CreateGroupResult,
@@ -2734,7 +2733,7 @@ export const createSamplingRule: API.OperationMethod<
   CreateSamplingRuleRequest,
   CreateSamplingRuleResult,
   CreateSamplingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateSamplingRuleRequest,
   output: CreateSamplingRuleResult,
@@ -2761,7 +2760,7 @@ export const deleteGroup: API.OperationMethod<
   DeleteGroupRequest,
   DeleteGroupResult,
   DeleteGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteGroupRequest,
   output: DeleteGroupResult,
@@ -2783,7 +2782,7 @@ export const deleteResourcePolicy: API.OperationMethod<
   DeleteResourcePolicyRequest,
   DeleteResourcePolicyResult,
   DeleteResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteResourcePolicyRequest,
   output: DeleteResourcePolicyResult,
@@ -2809,7 +2808,7 @@ export const deleteSamplingRule: API.OperationMethod<
   DeleteSamplingRuleRequest,
   DeleteSamplingRuleResult,
   DeleteSamplingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteSamplingRuleRequest,
   output: DeleteSamplingRuleResult,
@@ -2830,7 +2829,7 @@ export const getEncryptionConfig: API.OperationMethod<
   GetEncryptionConfigRequest,
   GetEncryptionConfigResult,
   GetEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetEncryptionConfigRequest,
   output: GetEncryptionConfigResult,
@@ -2852,7 +2851,7 @@ export const getGroup: API.OperationMethod<
   GetGroupRequest,
   GetGroupResult,
   GetGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetGroupRequest,
   output: GetGroupResult,
@@ -2873,7 +2872,7 @@ export const getGroups: API.PaginatedOperationMethod<
   GetGroupsRequest,
   GetGroupsResult,
   GetGroupsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   GroupSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetGroupsRequest,
@@ -2902,7 +2901,7 @@ export const getIndexingRules: API.OperationMethod<
   GetIndexingRulesRequest,
   GetIndexingRulesResult,
   GetIndexingRulesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetIndexingRulesRequest,
   output: GetIndexingRulesResult,
@@ -2925,7 +2924,7 @@ export const getInsight: API.OperationMethod<
   GetInsightRequest,
   GetInsightResult,
   GetInsightError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightRequest,
   output: GetInsightResult,
@@ -2948,7 +2947,7 @@ export const getInsightEvents: API.PaginatedOperationMethod<
   GetInsightEventsRequest,
   GetInsightEventsResult,
   GetInsightEventsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInsightEventsRequest,
@@ -2976,7 +2975,7 @@ export const getInsightImpactGraph: API.OperationMethod<
   GetInsightImpactGraphRequest,
   GetInsightImpactGraphResult,
   GetInsightImpactGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetInsightImpactGraphRequest,
   output: GetInsightImpactGraphResult,
@@ -2997,7 +2996,7 @@ export const getInsightSummaries: API.PaginatedOperationMethod<
   GetInsightSummariesRequest,
   GetInsightSummariesResult,
   GetInsightSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   unknown
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetInsightSummariesRequest,
@@ -3033,7 +3032,7 @@ export const getRetrievedTracesGraph: API.OperationMethod<
   GetRetrievedTracesGraphRequest,
   GetRetrievedTracesGraphResult,
   GetRetrievedTracesGraphError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRetrievedTracesGraphRequest,
   output: GetRetrievedTracesGraphResult,
@@ -3058,7 +3057,7 @@ export const getSamplingRules: API.PaginatedOperationMethod<
   GetSamplingRulesRequest,
   GetSamplingRulesResult,
   GetSamplingRulesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SamplingRuleRecord
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSamplingRulesRequest,
@@ -3085,7 +3084,7 @@ export const getSamplingStatisticSummaries: API.PaginatedOperationMethod<
   GetSamplingStatisticSummariesRequest,
   GetSamplingStatisticSummariesResult,
   GetSamplingStatisticSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   SamplingStatisticSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetSamplingStatisticSummariesRequest,
@@ -3112,7 +3111,7 @@ export const getSamplingTargets: API.OperationMethod<
   GetSamplingTargetsRequest,
   GetSamplingTargetsResult,
   GetSamplingTargetsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetSamplingTargetsRequest,
   output: GetSamplingTargetsResult,
@@ -3137,7 +3136,7 @@ export const getServiceGraph: API.PaginatedOperationMethod<
   GetServiceGraphRequest,
   GetServiceGraphResult,
   GetServiceGraphError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Service
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetServiceGraphRequest,
@@ -3165,7 +3164,7 @@ export const getTimeSeriesServiceStatistics: API.PaginatedOperationMethod<
   GetTimeSeriesServiceStatisticsRequest,
   GetTimeSeriesServiceStatisticsResult,
   GetTimeSeriesServiceStatisticsError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TimeSeriesServiceStatistics
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTimeSeriesServiceStatisticsRequest,
@@ -3192,7 +3191,7 @@ export const getTraceGraph: API.PaginatedOperationMethod<
   GetTraceGraphRequest,
   GetTraceGraphResult,
   GetTraceGraphError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Service
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTraceGraphRequest,
@@ -3219,7 +3218,7 @@ export const getTraceSegmentDestination: API.OperationMethod<
   GetTraceSegmentDestinationRequest,
   GetTraceSegmentDestinationResult,
   GetTraceSegmentDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: GetTraceSegmentDestinationRequest,
   output: GetTraceSegmentDestinationResult,
@@ -3257,7 +3256,7 @@ export const getTraceSummaries: API.PaginatedOperationMethod<
   GetTraceSummariesRequest,
   GetTraceSummariesResult,
   GetTraceSummariesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   TraceSummary
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: GetTraceSummariesRequest,
@@ -3284,7 +3283,7 @@ export const listResourcePolicies: API.PaginatedOperationMethod<
   ListResourcePoliciesRequest,
   ListResourcePoliciesResult,
   ListResourcePoliciesError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   ResourcePolicy
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListResourcePoliciesRequest,
@@ -3320,7 +3319,7 @@ export const listRetrievedTraces: API.OperationMethod<
   ListRetrievedTracesRequest,
   ListRetrievedTracesResult,
   ListRetrievedTracesError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: ListRetrievedTracesRequest,
   output: ListRetrievedTracesResult,
@@ -3346,7 +3345,7 @@ export const listTagsForResource: API.PaginatedOperationMethod<
   ListTagsForResourceRequest,
   ListTagsForResourceResponse,
   ListTagsForResourceError,
-  Credentials | Region | HttpClient.HttpClient,
+  Credentials | HttpClient.HttpClient,
   Tag
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: ListTagsForResourceRequest,
@@ -3377,7 +3376,7 @@ export const putEncryptionConfig: API.OperationMethod<
   PutEncryptionConfigRequest,
   PutEncryptionConfigResult,
   PutEncryptionConfigError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutEncryptionConfigRequest,
   output: PutEncryptionConfigResult,
@@ -3405,7 +3404,7 @@ export const putResourcePolicy: API.OperationMethod<
   PutResourcePolicyRequest,
   PutResourcePolicyResult,
   PutResourcePolicyError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutResourcePolicyRequest,
   output: PutResourcePolicyResult,
@@ -3433,7 +3432,7 @@ export const putTelemetryRecords: API.OperationMethod<
   PutTelemetryRecordsRequest,
   PutTelemetryRecordsResult,
   PutTelemetryRecordsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTelemetryRecordsRequest,
   output: PutTelemetryRecordsResult,
@@ -3505,7 +3504,7 @@ export const putTraceSegments: API.OperationMethod<
   PutTraceSegmentsRequest,
   PutTraceSegmentsResult,
   PutTraceSegmentsError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: PutTraceSegmentsRequest,
   output: PutTraceSegmentsResult,
@@ -3533,7 +3532,7 @@ export const startTraceRetrieval: API.OperationMethod<
   StartTraceRetrievalRequest,
   StartTraceRetrievalResult,
   StartTraceRetrievalError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: StartTraceRetrievalRequest,
   output: StartTraceRetrievalResult,
@@ -3560,7 +3559,7 @@ export const tagResource: API.OperationMethod<
   TagResourceRequest,
   TagResourceResponse,
   TagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: TagResourceRequest,
   output: TagResourceResponse,
@@ -3588,7 +3587,7 @@ export const untagResource: API.OperationMethod<
   UntagResourceRequest,
   UntagResourceResponse,
   UntagResourceError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UntagResourceRequest,
   output: UntagResourceResponse,
@@ -3614,7 +3613,7 @@ export const updateGroup: API.OperationMethod<
   UpdateGroupRequest,
   UpdateGroupResult,
   UpdateGroupError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateGroupRequest,
   output: UpdateGroupResult,
@@ -3638,7 +3637,7 @@ export const updateIndexingRule: API.OperationMethod<
   UpdateIndexingRuleRequest,
   UpdateIndexingRuleResult,
   UpdateIndexingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateIndexingRuleRequest,
   output: UpdateIndexingRuleResult,
@@ -3664,7 +3663,7 @@ export const updateSamplingRule: API.OperationMethod<
   UpdateSamplingRuleRequest,
   UpdateSamplingRuleResult,
   UpdateSamplingRuleError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateSamplingRuleRequest,
   output: UpdateSamplingRuleResult,
@@ -3685,7 +3684,7 @@ export const updateTraceSegmentDestination: API.OperationMethod<
   UpdateTraceSegmentDestinationRequest,
   UpdateTraceSegmentDestinationResult,
   UpdateTraceSegmentDestinationError,
-  Credentials | Region | HttpClient.HttpClient
+  Credentials | HttpClient.HttpClient
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateTraceSegmentDestinationRequest,
   output: UpdateTraceSegmentDestinationResult,

--- a/packages/aws/test/region.test.ts
+++ b/packages/aws/test/region.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Region from "../src/region.ts";
+
+/**
+ * `Region` is an override, not a requirement — generated operations don't
+ * list it in their context, so `resolve` has to answer for every combination
+ * of provided/absent service and set/unset environment.
+ *
+ * The environment is supplied through a ConfigProvider rather than by
+ * mutating `process.env`: the default provider doesn't re-read the
+ * environment per call, so env mutation leaks between cases.
+ */
+const withEnv = (env: Record<string, string>) =>
+  Effect.provideService(
+    ConfigProvider.ConfigProvider,
+    ConfigProvider.fromUnknown(env),
+  );
+
+describe("Region.resolve", () => {
+  it.effect("prefers a provided Region over the environment", () =>
+    Region.resolve.pipe(
+      Effect.provideService(Region.Region, Effect.succeed("eu-west-2")),
+      withEnv({ AWS_REGION: "us-east-1" }),
+      Effect.map((region) => {
+        expect(region).toBe("eu-west-2");
+      }),
+    ),
+  );
+
+  it.effect("falls back to AWS_REGION when nothing provides Region", () =>
+    Region.resolve.pipe(
+      withEnv({ AWS_REGION: "ap-southeast-2" }),
+      Effect.map((region) => {
+        expect(region).toBe("ap-southeast-2");
+      }),
+    ),
+  );
+
+  it.effect("falls back to AWS_DEFAULT_REGION when AWS_REGION is unset", () =>
+    Region.resolve.pipe(
+      withEnv({ AWS_DEFAULT_REGION: "sa-east-1" }),
+      Effect.map((region) => {
+        expect(region).toBe("sa-east-1");
+      }),
+    ),
+  );
+
+  it.effect(
+    "dies, rather than failing, with no region configured anywhere",
+    () =>
+      Region.resolve.pipe(
+        withEnv({}),
+        Effect.exit,
+        Effect.map((exit) => {
+          // A defect, not an error: keeping it out of the error channel is what
+          // lets every generated operation drop Region from its requirements.
+          expect(Exit.isFailure(exit)).toBe(true);
+          expect(String(exit)).toContain("No AWS region configured");
+        }),
+      ),
+  );
+});

--- a/packages/aws/test/region.test.ts
+++ b/packages/aws/test/region.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import * as Credentials from "../src/credentials.browser.ts";
 import * as Region from "../src/region.ts";
+import { listBuckets } from "../src/services/s3.ts";
 
 /**
- * `Region` is an override, not a requirement — generated operations don't
- * list it in their context, so `resolve` has to answer for every combination
- * of provided/absent service and set/unset environment.
+ * A credentials layer always establishes a region — see `ResolvedCredentials`
+ * — and `Region` is the optional override on top of it. These cover both
+ * halves: where credentials get their region from, and that an override wins.
  *
  * The environment is supplied through a ConfigProvider rather than by
- * mutating `process.env`: the default provider doesn't re-read the
- * environment per call, so env mutation leaks between cases.
+ * mutating `process.env`, because the default provider does not re-read the
+ * environment per call and mutation leaks between cases.
  */
 const withEnv = (env: Record<string, string>) =>
   Effect.provideService(
@@ -19,19 +22,9 @@ const withEnv = (env: Record<string, string>) =>
     ConfigProvider.fromUnknown(env),
   );
 
-describe("Region.resolve", () => {
-  it.effect("prefers a provided Region over the environment", () =>
-    Region.resolve.pipe(
-      Effect.provideService(Region.Region, Effect.succeed("eu-west-2")),
-      withEnv({ AWS_REGION: "us-east-1" }),
-      Effect.map((region) => {
-        expect(region).toBe("eu-west-2");
-      }),
-    ),
-  );
-
-  it.effect("falls back to AWS_REGION when nothing provides Region", () =>
-    Region.resolve.pipe(
+describe("credentials carry a region", () => {
+  it.effect("takes it from AWS_REGION", () =>
+    Credentials.regionFromEnv.pipe(
       withEnv({ AWS_REGION: "ap-southeast-2" }),
       Effect.map((region) => {
         expect(region).toBe("ap-southeast-2");
@@ -39,8 +32,8 @@ describe("Region.resolve", () => {
     ),
   );
 
-  it.effect("falls back to AWS_DEFAULT_REGION when AWS_REGION is unset", () =>
-    Region.resolve.pipe(
+  it.effect("falls back to AWS_DEFAULT_REGION", () =>
+    Credentials.regionFromEnv.pipe(
       withEnv({ AWS_DEFAULT_REGION: "sa-east-1" }),
       Effect.map((region) => {
         expect(region).toBe("sa-east-1");
@@ -48,18 +41,83 @@ describe("Region.resolve", () => {
     ),
   );
 
-  it.effect(
-    "dies, rather than failing, with no region configured anywhere",
-    () =>
-      Region.resolve.pipe(
-        withEnv({}),
-        Effect.exit,
-        Effect.map((exit) => {
-          // A defect, not an error: keeping it out of the error channel is what
-          // lets every generated operation drop Region from its requirements.
-          expect(Exit.isFailure(exit)).toBe(true);
-          expect(String(exit)).toContain("No AWS region configured");
-        }),
-      ),
+  it.effect("fails with MissingRegion when the environment is silent", () =>
+    Credentials.regionFromEnv.pipe(
+      withEnv({}),
+      Effect.flip,
+      Effect.map((error) => {
+        // A credential-resolution failure like any other, not a defect: the
+        // caller's fix is the same shape as for a missing access key.
+        expect(error._tag).toBe("Alchemy::AWS::MissingRegion");
+        expect(error.hints?.join(" ")).toContain("AWS_REGION");
+      }),
+    ),
   );
+
+  it.effect("prefers an explicit region over the environment", () =>
+    Effect.gen(function* () {
+      const resolved = yield* yield* Credentials.Credentials;
+      expect(resolved.region).toBe("eu-west-1");
+    }).pipe(
+      Effect.provide(
+        Credentials.fromCredentials(
+          { accessKeyId: "AKIA", secretAccessKey: "secret" },
+          "eu-west-1",
+        ),
+      ),
+      withEnv({ AWS_REGION: "us-east-1" }),
+    ),
+  );
+
+  it.effect("mock credentials carry one", () =>
+    Effect.gen(function* () {
+      const resolved = yield* yield* Credentials.Credentials;
+      expect(resolved.region).toBe("us-east-1");
+    }).pipe(Effect.provide(Credentials.mock)),
+  );
+});
+
+describe("Region overrides the credentials' region", () => {
+  /** Captures the signed URL without reaching the network. */
+  const capturing = (urls: string[]) =>
+    HttpClient.make((request) => {
+      urls.push(request.url);
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(
+            '<?xml version="1.0"?><ListAllMyBucketsResult><Buckets/></ListAllMyBucketsResult>',
+            { status: 200, headers: { "content-type": "application/xml" } },
+          ),
+        ),
+      );
+    });
+
+  it("uses the credentials' region when nothing overrides it", async () => {
+    const urls: string[] = [];
+    await Effect.runPromise(
+      listBuckets({}).pipe(
+        Effect.provideService(HttpClient.HttpClient, capturing(urls)),
+        Effect.provide(Credentials.mock),
+        Effect.asVoid,
+        Effect.orDie,
+      ),
+    );
+    expect(urls[0]).toContain("us-east-1");
+  });
+
+  it("uses a provided Region instead", async () => {
+    const urls: string[] = [];
+    await Effect.runPromise(
+      listBuckets({}).pipe(
+        Effect.provideService(HttpClient.HttpClient, capturing(urls)),
+        Effect.provide(Credentials.mock),
+        Effect.provide(Region.of("eu-west-2")),
+        Effect.asVoid,
+        Effect.orDie,
+      ),
+    );
+    expect(urls[0]).toContain("eu-west-2");
+    expect(urls[0]).not.toContain("us-east-1");
+  });
 });


### PR DESCRIPTION
Every generated operation required `Region`. A caller who had already told AWS which region to use — through `AWS_REGION`, or a profile that configures one — still had to state it a second time in code, where the two could then disagree.

**The credentials layer now carries the region.** Authenticating always establishes one, so `ResolvedCredentials` has a required `region` field, and `Region` is purely the optional override on top of it. Operations list `Credentials | HttpClient.HttpClient`; the protocol reads `Region` with `Effect.serviceOption` and uses `credentials.region` when nothing provides it.

```diff
- yield* listBuckets({}).pipe(
-   Effect.provide(Credentials.fromSSO("dev")),
-   Effect.provide(Region.of("us-west-2")),   // the profile already says this
- )
+ yield* listBuckets({}).pipe(
+   Effect.provide(Credentials.fromSSO("dev")),
+ )
+
+ // still available where a call needs a different region:
+ yield* listBuckets({}).pipe(
+   Effect.provide(Credentials.fromSSO("dev")),
+   Effect.provide(Region.of("eu-west-2")),
+ )
```

### Where each provider gets its region

| Provider | Region |
| --- | --- |
| `fromEnv`, `fromContainerMetadata`, `fromTokenFile`, `fromHttp` | `AWS_REGION`, then `AWS_DEFAULT_REGION` |
| `fromChain`, `fromIni`, `fromProcess` | the above, then the active profile's `region` in `~/.aws/config` |
| `fromSSO` | the profile's `region`, else its `sso_region` |
| `fromCredentials` | an explicit argument, else the environment |
| `mock` | `us-east-1` |

The profile is read through `@smithy/shared-ini-file-loader`, already a dependency — no new ones. The environment is consulted before the profile so `AWS_REGION` still overrides config without editing it, matching the AWS CLI.

Failing to resolve a region is `MissingRegion`, a new member of `CredentialsError`. It happens at the same moment, and has the same shape of fix, as any other credential-resolution failure — so it belongs in that channel rather than being a defect. Nothing dies.

### Verification

- `bun run typecheck:ci` clean, `bun run format:check` clean
- 7 tests in `packages/aws/test/region.test.ts`: where credentials get their region (env, `AWS_DEFAULT_REGION` fallback, explicit argument, `MissingRegion`, `mock`), plus override precedence end-to-end through a stub `HttpClient` asserting the region in the signed URL — one test proving the credentials' region is used, one proving `Region.of` beats it.
- The env is fed through a `ConfigProvider` rather than `process.env`, because the default provider doesn't re-read the environment per call and mutation leaked between cases.

The 425 regenerated service files are the emitter change only: `Region` dropped from the context type and the imports.
