### PR TITLE
fix(cloudflare): correct getCrawl's response schema

### DIFF
--- a/packages/cloudflare/patches/browser_rendering/getCrawlRecordShape.manual.json
+++ b/packages/cloudflare/patches/browser_rendering/getCrawlRecordShape.manual.json
@@ -1,0 +1,14 @@
+{
+  "description": "Docs bugs in getCrawl's response, both observed on the wire (reported in #331 by @k3dom, who had been running them as a `pnpm patch` in production). 1) `records[].metadata` is documented as required, but Cloudflare omits it for any record that hasn't completed — `queued`, `skipped`, `cancelled` — so polling a crawl that is still running fails to decode until every record finishes. 2) The response `cursor` is documented as a string but is returned as a number: the next record index for pagination, absent on the last page. (The REQUEST cursor is already correctly typed as a number upstream.)",
+  "patches": [
+    {
+      "op": "remove",
+      "path": "/shapes/com.cloudflare.browser_rendering#CrawlGetResponseRecordsItem/members/metadata/traits/smithy.api#required"
+    },
+    {
+      "op": "replace",
+      "path": "/shapes/com.cloudflare.browser_rendering#GetCrawlResponse/members/cursor/target",
+      "value": "smithy.api#Integer"
+    }
+  ]
+}

--- a/packages/cloudflare/src/services/browser_rendering.ts
+++ b/packages/cloudflare/src/services/browser_rendering.ts
@@ -4396,7 +4396,7 @@ export const CrawlGetResponseRecordsItemJsonMap = /*@__PURE__*/ S.Record(
 ) as any as S.Schema<CrawlGetResponseRecordsItemJsonMap>;
 
 export interface CrawlGetResponseRecordsItem {
-  metadata: CrawlGetResponseRecordsItemMetadata;
+  metadata?: CrawlGetResponseRecordsItemMetadata | null;
   /** Current status of the crawled URL. */
   status: CrawlGetResponseRecordsItemStatus;
   /** Crawled URL. */
@@ -4410,7 +4410,7 @@ export interface CrawlGetResponseRecordsItem {
 }
 export const CrawlGetResponseRecordsItem = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    metadata: CrawlGetResponseRecordsItemMetadata,
+    metadata: S.optional(S.NullOr(CrawlGetResponseRecordsItemMetadata)),
     status: CrawlGetResponseRecordsItemStatus,
     url: S.String,
     html: S.optional(S.NullOr(S.String)),
@@ -4443,7 +4443,7 @@ export interface GetCrawlResponse {
   /** Total current number of URLs in the crawl job. */
   total: number;
   /** Cursor for pagination. */
-  cursor?: string | null;
+  cursor?: number | null;
 }
 export const GetCrawlResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -4454,7 +4454,7 @@ export const GetCrawlResponse = /*@__PURE__*/ S.suspend(() =>
     skipped: S.Number,
     status: S.String,
     total: S.Number,
-    cursor: S.optional(S.NullOr(S.String)),
+    cursor: S.optional(S.NullOr(S.Number)),
   }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "GetCrawlResponse",


### PR DESCRIPTION
Reimplements #331 against the current generator. Original report and diagnosis by @k3dom, who had been running the equivalent fixes as a `pnpm patch` against the published package — so this is confirmed live behaviour, not inferred from docs.

Two documentation bugs in browser-rendering's `getCrawl` response:

1. **`records[].metadata` is documented as required**, but Cloudflare omits it for any record that hasn't completed — `queued`, `skipped`, `cancelled`. Polling a crawl that is still running therefore failed to decode with a `ParseError` until every record finished, which is precisely when you'd want to poll.
2. **The response `cursor` is documented as a string** but comes back as a number: the next record index for pagination, absent on the last page.

```diff
  export interface CrawlGetResponseRecordsItem {
-   metadata: CrawlGetResponseRecordsItemMetadata;
+   metadata?: CrawlGetResponseRecordsItemMetadata | null;
    status: CrawlGetResponseRecordsItemStatus;
    url: string;
```

```diff
  export interface GetCrawlResponse {
-   cursor?: string | null;
+   cursor?: number | null;
```

### Why a new PR rather than a rebase

#331 predates #390 and targets paths that no longer exist — `patches/browser-rendering/` (hyphen; it's `browser_rendering` now) and `specs/cloudflare/browser-rendering.openapi.yml`. The patch format changed too: patches are now RFC-6902 against the Smithy model rather than the `{"response": {"properties": …}}` shape. Nothing of the original diff applies, but the diagnosis is entirely k3dom's.

Also worth recording: the request-side `cursor` was already correct on main. The v1 rewrite fixed that half incidentally, so only the response half remained.

### Implementation note

The patch targets `GetCrawlResponse`, not `CrawlGetResponse`. The resource's own `getCrawl.json` renames that shape, and `*.manual.json` patches apply last — targeting the pre-rename name gets reported as a stale patch and silently skipped, which is how I caught it.

`bun run typecheck:ci` and `bun run format:check` are clean.
