### PR TITLE
fix(cloudflare/workers): type WorkerHasNoVersions on getScript

### DIFF
--- a/packages/cloudflare/patches/workers/getScript.json
+++ b/packages/cloudflare/patches/workers/getScript.json
@@ -77,6 +77,9 @@
         },
         {
           "target": "com.cloudflare.workers#InvalidRoute"
+        },
+        {
+          "target": "com.cloudflare.workers#WorkerHasNoVersions"
         }
       ]
     }

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -35563,7 +35563,11 @@ export const getRoute: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type GetScriptError = WorkerNotFound | InvalidRoute | CloudflareOpError;
+export type GetScriptError =
+  | WorkerNotFound
+  | InvalidRoute
+  | WorkerHasNoVersions
+  | CloudflareOpError;
 /** Fetch raw script content for your worker. Note this is the original script content, not JSON encoded. */
 export const getScript: API.OperationMethod<
   GetScriptRequest,
@@ -35576,6 +35580,7 @@ export const getScript: API.OperationMethod<
   errors: [
     WorkerNotFound,
     InvalidRoute,
+    WorkerHasNoVersions,
     CloudflareRateLimited,
     CloudflareError,
   ],


### PR DESCRIPTION
getScript on a just-deleted worker can briefly 404 with "This Worker has no versions, which means this Worker has no content or versioned settings." before the 10007 not-found lands, surfacing as an out-of-union NotFound.

```diff
-export type GetScriptError = WorkerNotFound | InvalidRoute | CloudflareOpError;
+export type GetScriptError = WorkerNotFound | InvalidRoute | WorkerHasNoVersions | CloudflareOpError;
```

The `WorkerHasNoVersions` shape already existed (typed for getScriptScriptAndVersionSetting); this attaches it to GetScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)