### PR TITLE
feat(aws): resolve endpoints by service

### DIFF
--- a/packages/aws/src/endpoint.ts
+++ b/packages/aws/src/endpoint.ts
@@ -27,3 +27,43 @@ export const fromEnv = () =>
 /** Override the endpoint for a scope, e.g. `Endpoint.of("http://localhost:4566")`. */
 export const of = (endpoint: string) =>
   Layer.succeed(Endpoint, Effect.succeed(endpoint));
+
+/**
+ * Resolves an endpoint for one AWS service, keyed by the service's SDK
+ * service ID exactly as it appears in the model's `aws.api#service` trait —
+ * e.g. `"S3"`, `"DynamoDB"`, `"SESv2"`, `"S3 Control"`. This is the
+ * identifier AWS's service-specific endpoint configuration
+ * (`AWS_ENDPOINT_URL_<SERVICE>`, the `services` sections of `~/.aws/config`)
+ * is derived from, and unlike the SigV4 signing name it never collides
+ * (SES and SESv2 both sign as `ses` but keep distinct SDK IDs).
+ *
+ * This is deliberately separate from {@link Endpoint}: providing
+ * `Endpoint` around an individual operation is an explicit override and must
+ * take precedence over a process-wide service policy.
+ */
+export interface ServiceEndpointResolver {
+  readonly resolve: (service: string) => string | undefined;
+}
+
+export class ServiceEndpoint extends Context.Service<
+  ServiceEndpoint,
+  ServiceEndpointResolver
+>()("AWS::ServiceEndpoint") {}
+
+/**
+ * Resolve the endpoint for one AWS service, keyed by its SDK service ID
+ * (see {@link ServiceEndpointResolver}). An explicit operation-scoped
+ * {@link Endpoint} wins, followed by the optional service resolver. Returning
+ * `undefined` lets the generated Smithy endpoint rules select AWS normally.
+ */
+export const resolve = Effect.fnUntraced(function* (service: string) {
+  const explicit = yield* yield* Effect.serviceOption(Endpoint).pipe(
+    Effect.map(Option.getOrElse(() => Effect.undefined)),
+  );
+  if (explicit !== undefined) return explicit;
+
+  const resolver = yield* Effect.serviceOption(ServiceEndpoint).pipe(
+    Effect.map(Option.getOrUndefined),
+  );
+  return resolver?.resolve(service);
+});

--- a/packages/aws/src/presign.ts
+++ b/packages/aws/src/presign.ts
@@ -1,6 +1,5 @@
 import { AwsV4Signer } from "aws4fetch";
 import * as Effect from "effect/Effect";
-import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 
 import * as Credentials from "./credentials.browser.ts";
@@ -157,9 +156,7 @@ export const presignS3Url: (
   Credentials.Credentials | Region.Region
 > = Effect.fnUntraced(function* (options: PresignS3UrlOptions) {
   const region = options.region ?? (yield* yield* Region.Region);
-  const customEndpoint = yield* yield* Effect.serviceOption(
-    Endpoint.Endpoint,
-  ).pipe(Effect.map(Option.getOrElse(() => Effect.undefined)));
+  const customEndpoint = yield* Endpoint.resolve("S3");
 
   const encodedKey = options.key.split("/").map(encodeURIComponent).join("/");
   const url = new URL(

--- a/packages/aws/src/protocol.ts
+++ b/packages/aws/src/protocol.ts
@@ -170,9 +170,9 @@ const encode = ({
     let resolvedRequest = request;
     let signingRegion = region; // Default to context region
     let signingServiceName = serviceName; // Default to service name from sigv4 trait
-    const customEndpoint = yield* yield* Effect.serviceOption(
-      Endpoint.Endpoint,
-    ).pipe(Effect.map(Option.getOrElse(() => Effect.undefined)));
+    // Keyed by SDK service ID; the signing name is only a fallback for a
+    // model missing the aws.api#service trait.
+    const customEndpoint = yield* Endpoint.resolve(serviceSdkId ?? serviceName);
 
     if (customEndpoint) {
       // User provided a custom endpoint - use it directly

--- a/packages/aws/test/endpoint.test.ts
+++ b/packages/aws/test/endpoint.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+import * as Credentials from "../src/credentials.browser.ts";
+import * as Endpoint from "../src/endpoint.ts";
+import * as Presign from "../src/presign.ts";
+import * as Region from "../src/region.ts";
+import * as SESv2 from "../src/services/sesv2.ts";
+
+describe("service endpoint resolution", () => {
+  /**
+   * Routes a couple of services at dedicated addresses and everything else
+   * at a catch-all — the shape a local emulator or a private endpoint fleet
+   * takes. Keys are SDK service IDs verbatim (`aws.api#service` sdkId), so
+   * SES and SESv2 stay independently routable even though both sign as
+   * `ses`.
+   */
+  const perService: Record<string, string> = {
+    SESv2: "http://service-a.test:4600",
+    DynamoDB: "http://service-b.test:8000",
+  };
+  const catchAll = "http://catch-all.test:4566";
+
+  const endpoints = {
+    resolve: (service: string) => perService[service] ?? catchAll,
+  } satisfies Endpoint.ServiceEndpointResolver;
+
+  it("routes every service through the resolver", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        for (const [service, endpoint] of Object.entries(perService)) {
+          expect(yield* Endpoint.resolve(service)).toBe(endpoint);
+        }
+        // SES (v1) is NOT routed with SESv2: the key is the SDK service ID,
+        // not the shared `ses` signing name.
+        for (const service of ["SES", "S3", "not-routed-anywhere"]) {
+          expect(yield* Endpoint.resolve(service)).toBe(catchAll);
+        }
+      }).pipe(Effect.provideService(Endpoint.ServiceEndpoint, endpoints)),
+    );
+  });
+
+  it("keeps an explicit operation endpoint authoritative", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        expect(yield* Endpoint.resolve("SESv2")).toBe("http://operation.test");
+        expect(yield* Endpoint.resolve("SQS")).toBe("http://operation.test");
+      }).pipe(
+        Effect.provideService(Endpoint.ServiceEndpoint, endpoints),
+        Effect.provideService(
+          Endpoint.Endpoint,
+          Effect.succeed("http://operation.test"),
+        ),
+      ),
+    );
+  });
+
+  it("falls back to the resolver when the override resolves undefined", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        expect(yield* Endpoint.resolve("SESv2")).toBe(
+          "http://service-a.test:4600",
+        );
+      }).pipe(
+        Effect.provideService(Endpoint.ServiceEndpoint, endpoints),
+        Effect.provideService(Endpoint.Endpoint, Effect.succeed(undefined)),
+      ),
+    );
+  });
+
+  it("leaves cloud endpoint selection available without a resolver", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        expect(yield* Endpoint.resolve("SESv2")).toBeUndefined();
+      }),
+    );
+  });
+
+  it("routes generated operations by SDK service ID", async () => {
+    let requested: URL | undefined;
+    const client = HttpClient.make((request, url) => {
+      requested = url;
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+    });
+
+    await Effect.runPromise(
+      SESv2.getAccount({}).pipe(
+        Effect.provideService(Endpoint.ServiceEndpoint, {
+          resolve: (service) =>
+            service === "SESv2" ? "http://ses-local.test:4600" : undefined,
+        }),
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.provide(Credentials.mock),
+      ),
+    );
+
+    expect(requested?.origin).toBe("http://ses-local.test:4600");
+  });
+
+  it("falls through to generated endpoint rules", async () => {
+    let requested: URL | undefined;
+    const client = HttpClient.make((request, url) => {
+      requested = url;
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("{}", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+    });
+
+    await Effect.runPromise(
+      SESv2.getAccount({}).pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.provide(Credentials.mock),
+      ),
+    );
+
+    expect(requested?.origin).toBe("https://email.us-east-1.amazonaws.com");
+  });
+
+  it("uses the S3 service endpoint when presigning", async () => {
+    const url = await Effect.runPromise(
+      Presign.presignS3Url({
+        bucket: "uploads",
+        key: "reports/quarter 1.csv",
+        region: "us-east-1",
+        datetime: "20260824T000000Z",
+      }).pipe(
+        Effect.provideService(Endpoint.ServiceEndpoint, {
+          resolve: (service) =>
+            service === "S3" ? "http://s3-local.test:9000" : undefined,
+        }),
+        Effect.provide(Credentials.mock),
+        Effect.provide(Region.of("us-east-1")),
+      ),
+    );
+
+    const presigned = new URL(url);
+    expect(presigned.origin).toBe("http://s3-local.test:9000");
+    expect(presigned.pathname).toBe("/uploads/reports/quarter%201.csv");
+    expect(presigned.searchParams.get("X-Amz-Credential")).toContain(
+      "/s3/aws4_request",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Route individual AWS SDK services to distinct endpoints while preserving the existing operation-scoped `Endpoint` override and generated Smithy endpoint fallback.

## API

```ts
Effect.provideService(Endpoint.ServiceEndpoint, {
  resolve: (service) =>
    service === "S3" ? "http://127.0.0.1:9000" : undefined,
});
```

The resolver receives the model's SDK service ID, so services that share a SigV4 name, such as `SES` and `SESv2`, remain independently routable.

## Resolution order

| Priority | Source | Behavior |
| --- | --- | --- |
| 1 | `Endpoint` | Explicit operation-scoped override |
| 2 | `ServiceEndpoint` | Service-specific resolver |
| 3 | Smithy rules / default | Existing AWS endpoint selection |

The same resolution path is used by generated operations and S3 presigning.

## Validation

- `mise exec bun@1.3.13 -- bun test packages/aws/test/endpoint.test.ts` — 7 passing tests
- `oxfmt --check` on the four changed files
