### PR TITLE
ci: bump the actions pin to pick up the changelog fix

### DIFF
--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   pr-package:
-    uses: alchemy-run/actions/.github/workflows/pr-package.yml@1d7f45962cfe2bbc365ffbf32f3cb27c64ca423c # main
+    uses: alchemy-run/actions/.github/workflows/pr-package.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
     with:
       install-host: pkg.distilled.cloud
       # Every package's build pulls in the core project reference; the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
   release:
     needs: typecheck
-    uses: alchemy-run/actions/.github/workflows/release.yml@1d7f45962cfe2bbc365ffbf32f3cb27c64ca423c # main
+    uses: alchemy-run/actions/.github/workflows/release.yml@45c20065c654cb378d02a707427405a1ad9ac3f3 # main
     with:
       version: ${{ inputs.version }}
       force-latest: ${{ inputs.force-latest }}


### PR DESCRIPTION
Picks up alchemy-run/actions#4, which fixes the release failure.

The last release died at **Commit bump + changelog, tag, push** ([run](https://github.com/alchemy-run/distilled/actions/runs/31022313414/job/92362764333)):

```
error: spawnSync /bin/sh ENOBUFS (stdout or stderr buffer reached maxBuffer size limit)
spawnargs: [ "-c", "git --no-pager log \"v0.30.3...HEAD\" --pretty=... --name-status" ]
```

changelogithub reads the commit range with `execSync`, whose default `maxBuffer` is 1 MB. `--name-status` prints every changed path of every commit, and the `v0.30.3...HEAD` range — which spans the v1 rewrite — is **1.29 MB**. Barely over, so it would have failed on the next release regardless. It also fails *after* versions are bumped and *before* the tag is pushed, which is why the run left things half-done.

## What this bump includes

Both workflows move `1d7f459` → `45c2006`, so alongside the fix it also brings in:

- **alchemy-run/actions#2** — pr-package publishes complete same-commit dependency graphs
- **alchemy-run/actions#3** — reusable workflows self-pin their scripts

`pr-package.yml` moves too, to keep the two workflows on one revision — and #2 is a pr-package fix, so it wants the newer pin anyway.

## Verification

Against the exact range that failed, in this repo: the new path parses 21 commits / 1,290,520 bytes; the old path reproduces `ENOBUFS` on identical input.

Nothing here can be tested until it's on `main` — the release workflow is `workflow_dispatch` only, and reusable-workflow pins resolve from the default branch. So the real check is the next `gh workflow run release.yml` after this merges.
