### PR TITLE
fix(cloudflare/zero-trust): type Forbidden on getAccessApplicationForAccount

### DIFF
--- a/packages/cloudflare/patches/zero_trust/getAccessApplicationForAccount.json
+++ b/packages/cloudflare/patches/zero_trust/getAccessApplicationForAccount.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align zero_trust#AccessApplicationsGetForAccount with distilled cloudflare/zero-trust getAccessApplicationForAccount",
+  "description": "Align getAccessApplicationForAccount rename and type Forbidden (403) — Cloudflare returns 403 as transient token back-pressure",
   "patches": [
     {
       "op": "move",
@@ -25,6 +25,15 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.zero_trust#GetAccessApplicationForAccount/output/target",
       "value": "com.cloudflare.zero_trust#GetAccessApplicationForAccountResponse"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.zero_trust#GetAccessApplicationForAccount/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.zero_trust#Forbidden"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/src/services/zero_trust.ts
+++ b/packages/cloudflare/src/services/zero_trust.ts
@@ -202324,7 +202324,7 @@ export const getAccessApplicationCaForZone: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type GetAccessApplicationForAccountError = CloudflareOpError;
+export type GetAccessApplicationForAccountError = Forbidden | CloudflareOpError;
 /** Fetches information about an Access application. */
 export const getAccessApplicationForAccount: API.OperationMethod<
   GetAccessApplicationForAccountRequest,
@@ -202334,7 +202334,7 @@ export const getAccessApplicationForAccount: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessApplicationForAccountRequest,
   output: GetAccessApplicationResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [Forbidden, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
Type `Forbidden` (HTTP 403) on `getAccessApplicationForAccount` so alchemy can retry transient token back-pressure without falling into `UnknownCloudflareError`.

```ts
export type GetAccessApplicationForAccountError = Forbidden | CloudflareOpError;
```
