### PR TITLE
fix(release): give every package a repository field

### DIFF
--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/axiom",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/axiom"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/azure",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/azure"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/cloudflare",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/cloudflare"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/coinbase",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/coinbase"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/core",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/core"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/kubernetes",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/kubernetes"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/neon",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/neon"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/planetscale",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/planetscale"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/stripe",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/stripe"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@distilled.cloud/typesense",
   "version": "1.0.0-rc.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alchemy-run/distilled",
+    "directory": "packages/typesense"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
The `1.0.0-rc.1` publish was rejected by npm:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@distilled.cloud%2fcore
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/alchemy-run/distilled" from provenance
```

## Cause

Publishing with provenance requires `repository.url` in package.json to match the repository the build ran in. **Ten of the twenty packages had no `repository` field at all**: axiom, azure, cloudflare, coinbase, core, kubernetes, neon, planetscale, stripe, typesense.

The other ten already had one — those are the packages that shipped in the v0 line, which is why this never surfaced before. The ten without it are the ones that were `private: true` until the v1 release prep.

`core` is wave 1, so its failure skipped every other package. **Nothing was published at `1.0.0-rc.1`.**

## Fix

Adds the field to the ten, matching the shape the other ten already use, including `directory` so npm links source correctly from a monorepo:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/alchemy-run/distilled",
  "directory": "packages/core"
},
```

Verified all twenty parse and carry the right url and their own directory.

## Re-running the release

Worth knowing before dispatching: the failed run got further than it looks. `chore(release): 1.0.0-rc.1` is committed on main, package.json versions are already `1.0.0-rc.1`, and the tag `v1.0.0-rc.1` exists — only the npm publish and the GitHub release didn't happen.

So a plain `version: rc` re-run computes the next candidate from **npm**, sees nothing published, and lands on `rc.1` again — against a tag that already exists. Worth watching that step, or forcing `-f version=rc.1` deliberately.
