### PR TITLE
fix(release): ship lib from the packages that never published

### DIFF
--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
+    "lib",
     "src"
   ],
   "exports": {


### PR DESCRIPTION
Eight packages had `"files": ["src"]`, so their tarballs would have contained **no compiled output at all** — while their `exports` point straight at it:

```json
"types":   "./lib/index.d.ts",
"bun":     "./src/index.ts",
"worker":  "./src/index.ts",
"default": "./lib/index.js"
```

`npm pack --dry-run` on cloudflare, before this change:

```
cloudflare tarball —  lib files: 0   src files: 129
```

The published package would have worked under **Bun**, which resolves the `bun` condition to `src`, and been broken for every other consumer: no runtime entry at `./lib/index.js`, and no type declarations at `./lib/index.d.ts` either. Since Bun is what this repo develops and tests with, nothing local would have caught it.

## Affected

axiom, azure, cloudflare, coinbase, kubernetes, neon, planetscale, stripe.

That's the same set that was missing `repository` in #422, and for the same reason: **these were `private: true` through the whole v0 line**, so no part of their publish surface was ever exercised. Removing `private` to make them publishable didn't make them correct — it just moved the failure to publish time. #422 caught the half that npm's provenance check rejects loudly; this is the half that would have published successfully and been broken on install.

## After

```
cloudflare tarball now — lib: 516   src: 129
```

Verified all 20 packages now include `lib` in `files`.

## Still worth a look, separately

Eleven packages have no `module` field where the ones that shipped in v0 do (axiom, azure, cloudflare, coinbase, core, gcp, kubernetes, neon, planetscale, stripe, typesense). With `exports` present, modern resolvers ignore `module` entirely, so it isn't release-blocking — but it's the same "never published, never audited" pattern and worth deciding on deliberately rather than leaving inconsistent.
