### PR TITLE
fix(packages): effect is a peer, platform-bun is dev-only

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/aws": {
       "name": "@distilled.cloud/aws",
-      "version": "0.29.1",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@aws-crypto/crc32": "catalog:",
         "@aws-crypto/util": "catalog:",
@@ -46,59 +46,67 @@
     },
     "packages/axiom": {
       "name": "@distilled.cloud/axiom",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/azure": {
       "name": "@distilled.cloud/azure",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/cloudflare": {
       "name": "@distilled.cloud/cloudflare",
-      "version": "0.0.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/coinbase": {
       "name": "@distilled.cloud/coinbase",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core": {
       "name": "@distilled.cloud/core",
-      "version": "0.0.0",
+      "version": "1.0.0-rc.1",
       "devDependencies": {
         "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
@@ -111,184 +119,212 @@
     },
     "packages/expo-eas": {
       "name": "@distilled.cloud/expo-eas",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/fly-io": {
       "name": "@distilled.cloud/fly-io",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/gcp": {
       "name": "@distilled.cloud/gcp",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/kubernetes": {
       "name": "@distilled.cloud/kubernetes",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/mongodb-atlas": {
       "name": "@distilled.cloud/mongodb-atlas",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/neon": {
       "name": "@distilled.cloud/neon",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/planetscale": {
       "name": "@distilled.cloud/planetscale",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/posthog": {
       "name": "@distilled.cloud/posthog",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/prisma-postgres": {
       "name": "@distilled.cloud/prisma-postgres",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/stripe": {
       "name": "@distilled.cloud/stripe",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/supabase": {
       "name": "@distilled.cloud/supabase",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/turso": {
       "name": "@distilled.cloud/turso",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/typesense": {
       "name": "@distilled.cloud/typesense",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/workos": {
       "name": "@distilled.cloud/workos",
-      "version": "0.31.0",
+      "version": "1.0.0-rc.1",
       "dependencies": {
         "@distilled.cloud/core": "workspace:*",
-        "@effect/platform-bun": "catalog:",
-        "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/platform-bun": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
   },

--- a/packages/axiom/package.json
+++ b/packages/axiom/package.json
@@ -77,12 +77,14 @@
     "specs:update": "git -C specs/docs fetch && git -C specs/docs checkout main && git -C specs/docs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/azure/package.json
+++ b/packages/azure/package.json
@@ -65,12 +65,14 @@
     "specs:update": "git -C specs/azure-rest-api-specs fetch && git -C specs/azure-rest-api-specs checkout main && git -C specs/azure-rest-api-specs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -507,12 +507,14 @@
     "typecheck:strict": "tsc -p tsconfig.strict.json"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -65,12 +65,14 @@
     "specs:update": "git -C specs/cdp-sdk fetch && git -C specs/cdp-sdk checkout main && git -C specs/cdp-sdk pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/expo-eas/package.json
+++ b/packages/expo-eas/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/eas-cli fetch && git -C specs/eas-cli checkout main && git -C specs/eas-cli pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/fly-io/package.json
+++ b/packages/fly-io/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/distilled-spec-fly-io fetch && git -C specs/distilled-spec-fly-io checkout main && git -C specs/distilled-spec-fly-io pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/gcp/package.json
+++ b/packages/gcp/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/distilled-spec-gcp fetch && git -C specs/distilled-spec-gcp checkout main && git -C specs/distilled-spec-gcp pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -83,12 +83,14 @@
     "specs:update": "git -C specs/kubernetes fetch && git -C specs/kubernetes checkout master && git -C specs/kubernetes pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/mongodb-atlas/package.json
+++ b/packages/mongodb-atlas/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/distilled-spec-mongodb-atlas fetch && git -C specs/distilled-spec-mongodb-atlas checkout main && git -C specs/distilled-spec-mongodb-atlas pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -71,12 +71,14 @@
     "specs:update": "git -C specs/distilled-spec-neon fetch && git -C specs/distilled-spec-neon checkout main && git -C specs/distilled-spec-neon pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/planetscale/package.json
+++ b/packages/planetscale/package.json
@@ -83,12 +83,14 @@
     "specs:update": "git -C specs/distilled-spec-planetscale fetch && git -C specs/distilled-spec-planetscale checkout main && git -C specs/distilled-spec-planetscale pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -72,12 +72,14 @@
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/distilled-spec-posthog"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/prisma-postgres/package.json
+++ b/packages/prisma-postgres/package.json
@@ -74,12 +74,14 @@
     "specs:update": "git -C specs/distilled-spec-prisma-postgres fetch && git -C specs/distilled-spec-prisma-postgres checkout main && git -C specs/distilled-spec-prisma-postgres pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -77,12 +77,14 @@
     "specs:update": "git -C specs/stripe-openapi fetch && git -C specs/stripe-openapi checkout master && git -C specs/stripe-openapi pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/distilled-spec-supabase fetch && git -C specs/distilled-spec-supabase checkout main && git -C specs/distilled-spec-supabase pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/turso/package.json
+++ b/packages/turso/package.json
@@ -73,12 +73,14 @@
     "specs:update": "git -C specs/turso-docs fetch && git -C specs/turso-docs checkout main && git -C specs/turso-docs pull"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -59,12 +59,14 @@
     "typecheck:strict": "tsc -p tsconfig.strict.json"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -59,12 +59,14 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@distilled.cloud/core": "workspace:*",
-    "@effect/platform-bun": "catalog:",
-    "effect": "catalog:"
+    "@distilled.cloud/core": "workspace:*"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@effect/platform-bun": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }


### PR DESCRIPTION
The release warning for cloudflare — *"+22 more dependencies"* — is two mistakes repeated across **18 of the 20 packages**. `core` and `aws` already do it the way this makes uniform.

## `effect` belongs in peerDependencies

Two copies of effect in one process break Context tag identity: services resolve by tag, and a tag from a nested copy doesn't match the consumer's. The consumer has to own the single copy.

`core` and `aws` already declare `effect` as a peer. The other eighteen listed it as a runtime dependency, so an install could easily end up with a second effect underneath the SDK.

## `@effect/platform-bun` isn't used at runtime at all

It appears in **no `src/` file of any package**. The only importers are dev-time codegen scripts — cloudflare's `download-api-docs.ts` and `spec-to-smithy.ts`.

As a `dependency` it pulled nine transitive packages into every consumer's install:

```
multipasta, @effect/platform-node-shared, ws, @parcel/watcher,
detect-libc, is-glob, is-extglob, node-addon-api, picomatch
```

That's most of the +22. Moved to `devDependencies`.

## Why now

Both were invisible while these packages were `private: true` through the v0 line — nothing about their published surface was ever exercised. Same root cause as #422 (missing `repository`) and #423 (missing `lib` in `files`).

`bun install` and `bun run typecheck:ci` both clean.
