### PR TITLE
chore: add an SDK request template, track the open requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/sdk-request.yml
+++ b/.github/ISSUE_TEMPLATE/sdk-request.yml
@@ -1,0 +1,80 @@
+name: SDK request
+description: Ask for an SDK for a provider distilled doesn't cover yet
+title: "Request: <provider>"
+labels: ["sdk-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every SDK here is generated from a machine-readable description of the
+        API. That makes the spec link the single thing that decides how much
+        work a request is: a published OpenAPI document means adding a spec
+        and a `scripts/generate.ts`, while an API with only prose docs means
+        transcribing the surface by hand first.
+
+        So please fill in the spec field honestly — "none published" is a
+        useful answer, a guess is not.
+
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      description: The service, as it's actually branded.
+      placeholder: Xata
+    validations:
+      required: true
+
+  - type: input
+    id: homepage
+    attributes:
+      label: Homepage
+      description: Link to the service itself.
+      placeholder: https://xata.io
+    validations:
+      required: true
+
+  - type: textarea
+    id: specs
+    attributes:
+      label: Specs
+      description: >-
+        Link to a machine-readable description of the API — OpenAPI/Swagger,
+        a Smithy model, a GraphQL schema, protobuf, or a JSON schema. If none
+        is published, link the API reference docs and say "no machine-readable
+        spec published".
+      placeholder: |
+        https://github.com/xataio/xata/tree/main/openapi
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Which part of the API?
+      description: >-
+        Optional, but it scopes the work a lot. Many providers split a control
+        plane (accounts, projects, provisioning) from a data plane (records,
+        queries, per-resource endpoints). Say which one you need, and name the
+        specific operations if you know them.
+      placeholder: |
+        Control plane — creating and deleting databases and branches.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What are you building?
+      description: >-
+        Optional. Helps prioritise, and sometimes reveals that an existing SDK
+        already covers it.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched open issues and PRs for an existing request for this provider.
+          required: true

--- a/todo.md
+++ b/todo.md
@@ -11,3 +11,19 @@
 - agents.md
 - license.md
 - extract cf docs mirror into its own submodule
+- requested sdks (name — source of the request)
+  - xata — distilled#354
+  - sentry — alchemy#1003 (review comment r3709110628)
+  - spacetimedb — alchemy#1044 (review comment r3710539021)
+  - docker — distilled#170
+  - meilisearch — distilled#377
+  - polar — distilled#373, distilled#236
+  - railway — distilled#340, distilled#226
+  - clerk — distilled#317
+  - resend — distilled#346
+  - turbopuffer — distilled#357
+  - better-auth — distilled#372
+  - unkey — distilled#323
+  - hostinger — distilled#338
+  - discord — distilled#276
+  - modrinth — distilled#287


### PR DESCRIPTION
Replaces the master-issue idea from earlier with something that scales: a form, plus the current requests recorded in `todo.md`.

## The template

Every SDK here is generated from a machine-readable description of the API, so **the spec link is what decides how much work a request is** — "add a spec and a `generate.ts`" versus "transcribe the surface by hand first". Requests arrive without it and then sit.

`.github/ISSUE_TEMPLATE/sdk-request.yml` requires provider, homepage and specs, and says plainly that *"no machine-readable spec published"* is a useful answer where a guess is not. Two optional fields carry the rest of the scoping:

- **which part of the API** — most providers split a control plane (accounts, projects, provisioning) from a data plane, and alchemy generally wants the former; naming it up front removes the largest unknown
- **what you're building** — helps prioritise, and occasionally reveals an existing SDK already covers it

It's the first template in the repo; there was no `ISSUE_TEMPLATE` directory.

## todo.md

Records the fifteen currently-open requests with the thread each came from, so they're tracked somewhere other than a search across issues and PRs. No `@` mentions.

## One thing to decide

The form sets `labels: ["sdk-request"]`, and that label doesn't exist in the repo yet. GitHub drops an unknown label **silently** rather than erroring, so either create it or drop the `labels:` line — say which and I'll adjust.
