### PR TITLE
fix(core): send a body on GET when the schema declares one

### DIFF
--- a/packages/core/src/protocol-http.ts
+++ b/packages/core/src/protocol-http.ts
@@ -616,9 +616,17 @@ export const buildRequest = ({
       request = request.pipe(HttpClientRequest.bodyJsonUnsafe(rawBody));
     }
   } else if (
-    !BODYLESS.has(http.method) &&
-    (Object.keys(body).length > 0 ||
-      (hasBodyMembers && http.method !== "DELETE"))
+    // A GET/HEAD sends a body only when body members actually carry values.
+    // Some APIs really do document GET-with-body: MongoDB Atlas's
+    // `…/lineItems:search` declares a `requestBody` on `get`, and AWS EFS's
+    // DescribeAccountPreferences takes `{ MaxResults, NextToken }` on a GET.
+    // Suppressing it outright dropped those members silently — the request
+    // succeeded, unfiltered, with nothing on the wire to show why.
+    //
+    // The `{}`-when-empty rule below stays limited to methods that expect a
+    // body, so a bodyless method with nothing set still sends nothing.
+    Object.keys(body).length > 0 ||
+    (hasBodyMembers && !BODYLESS.has(http.method) && http.method !== "DELETE")
   ) {
     // Send `{}` rather than no body when the schema declares body members —
     // some endpoints reject a missing JSON body outright.

--- a/packages/mongodb-atlas/test/wire-sanity.ts
+++ b/packages/mongodb-atlas/test/wire-sanity.ts
@@ -23,7 +23,11 @@ import * as Redacted from "effect/Redacted";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import * as MongodbAtlas from "../src/index.ts";
-import { getGroup, NotFound } from "../src/services/atlas.ts";
+import {
+  getGroup,
+  NotFound,
+  searchOrgInvoiceLineItems,
+} from "../src/services/atlas.ts";
 
 // ---------------------------------------------------------------------------
 // Stub credentials: fixed bearer token, default base URL
@@ -47,16 +51,22 @@ interface Captured {
   method: string;
   url: string;
   headers: Record<string, string>;
+  bodyText?: string;
 }
 
 const captured: Captured[] = [];
 let script: Array<(req: Captured) => Response> = [];
 
 const stubClient = HttpClient.make((request) => {
+  const rawBody = request.body as { _tag: string; body?: Uint8Array };
   const cap: Captured = {
     method: request.method,
     url: request.url,
     headers: { ...request.headers } as Record<string, string>,
+    bodyText:
+      rawBody._tag === "Uint8Array"
+        ? new TextDecoder().decode(rawBody.body)
+        : undefined,
   };
   captured.push(cap);
   const next = script.shift();
@@ -196,6 +206,32 @@ await Effect.runPromise(
         .errorCode === "TEAPOT",
       "errorCode carried from the envelope",
     );
+
+    // (d) A GET that documents a requestBody sends it. Atlas's
+    // `lineItems:search` declares `requestBody` on `get`, so filters/sort
+    // are body members; suppressing bodies on GET dropped them silently and
+    // the search came back unfiltered.
+    console.log("(d) GET with a documented request body");
+    script = [() => json({ results: [], totalCount: 0 })];
+    yield* provide(
+      searchOrgInvoiceLineItems({
+        orgId: "4f8e5f8f8f8f8f8f8f8f8f8f",
+        invoiceId: "5f8e5f8f8f8f8f8f8f8f8f8f",
+        sortField: "created",
+      }),
+    );
+    {
+      const req = captured.at(-1)!;
+      assert(req.method === "GET", `method GET (got ${req.method})`);
+      assert(
+        req.bodyText !== undefined,
+        "a body is sent on GET when the schema declares body members",
+      );
+      assert(
+        JSON.parse(req.bodyText!).sortField === "created",
+        `sortField reaches the body (got ${req.bodyText})`,
+      );
+    }
 
     console.log("\nAll wire-sanity checks passed.");
   }),


### PR DESCRIPTION
Follow-up to closing #335, which surfaced this.

`buildRequest` refused to attach a body to any GET or HEAD. Members bound to the body on such an operation were dropped without a trace — the request went out, the server answered, and nothing indicated that part of the input never left the process.

Some APIs genuinely document GET-with-body:

- **MongoDB Atlas** `…/invoices/{invoiceId}/lineItems:search` declares a `requestBody` on `get`. So `filters`, `sortField` and `sortOrder` are body members, and **every search ran unfiltered** — the worst kind of failure, because an unfiltered search still returns results.
- **AWS EFS** `DescribeAccountPreferences` is the same shape (`{ MaxResults, NextToken }` on a GET). It was unaffected only because the AWS package builds requests through its own serializer, which never had this restriction.

```diff
- } else if (
-   !BODYLESS.has(http.method) &&
-   (Object.keys(body).length > 0 || (hasBodyMembers && http.method !== "DELETE"))
- ) {
+ } else if (
+   Object.keys(body).length > 0 ||
+   (hasBodyMembers && !BODYLESS.has(http.method) && http.method !== "DELETE")
+ ) {
```

A bodyless method now sends a body when body members actually carry values. The `{}`-when-empty rule stays limited to methods that expect a body, so a GET with nothing set still sends nothing.

### Scope

I scanned all **13,117** GET/HEAD request schemas across every package. **Two** have body-bound members: the Atlas search above, and the AWS one that already worked. Nothing else changes behaviour.

### Verification

- New check **(d)** in the Atlas wire-sanity suite asserts the GET carries `{"sortField":"created"}`. Confirmed it **fails on the previous behaviour** — reverted the protocol change and watched it break, then restored it.
- The cloudflare, stripe, expo-eas and neon wire-sanity suites still pass.
- `bun run typecheck:ci` and `oxfmt --check` clean.

### Not fixed here

Atlas's spec gives that request body the media type `application/vnd.atlas.2024-08-05+json`, while we send `application/json`. The `Http` trait now carries `accept` but has no request-side counterpart. Worth a look if the endpoint turns out to be picky — it's a separate change.
