### PR TITLE
fix(cloudflare/queues): regenerate for the effect-105 generator surface

### DIFF
--- a/packages/cloudflare/src/services/queues.ts
+++ b/packages/cloudflare/src/services/queues.ts
@@ -166,7 +166,7 @@ export class QueueInUseByEventNotification
 
 export class QueueInUseByWorkerBinding
   extends /*@__PURE__*/ T.applyErrorMatchers(
-    /*@__PURE__*/ S.TaggedErrorClass<QueueInUseByWorkerBinding>()(
+    /*@__PURE__*/ S.TaggedError<QueueInUseByWorkerBinding>()(
       "QueueInUseByWorkerBinding",
       {
         code: S.Number,


### PR DESCRIPTION
The #432 merge carried a `queues.ts` generated before the effect 4.0.0-beta.105 upgrade: `QueueInUseByWorkerBinding` used the removed `S.TaggedErrorClass` API, whose declaration emits as `any` — and an `any`-tagged error swallows sibling tags from consumers' `catchTag`/`Extract` narrowing. Regenerated with the current generator (`S.TaggedError`), no model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)