### PR TITLE
docs(cloudflare/workers): document PutScriptAssetsConfig members

### DIFF
--- a/packages/cloudflare/patches/workers/putScript.manual.json
+++ b/packages/cloudflare/patches/workers/putScript.manual.json
@@ -249,22 +249,37 @@
         "type": "structure",
         "members": {
           "html_handling": {
-            "target": "com.cloudflare.workers#PutScriptAssetsConfigHtmlHandling"
+            "target": "com.cloudflare.workers#PutScriptAssetsConfigHtmlHandling",
+            "traits": {
+              "smithy.api#documentation": "Determines the redirects and rewrites of requests for HTML content."
+            }
           },
           "not_found_handling": {
-            "target": "com.cloudflare.workers#PutScriptAssetsConfigNotFoundHandling"
+            "target": "com.cloudflare.workers#PutScriptAssetsConfigNotFoundHandling",
+            "traits": {
+              "smithy.api#documentation": "Determines the response when a request does not match a static asset, and there is no Worker script."
+            }
           },
           "run_worker_first": {
-            "target": "com.cloudflare.workers#PutScriptAssetsConfigRunWorkerFirst"
+            "target": "com.cloudflare.workers#PutScriptAssetsConfigRunWorkerFirst",
+            "traits": {
+              "smithy.api#documentation": "Controls whether the Worker runs ahead of the static-asset layer. Defaults to false: a request matching an asset is served directly and never invokes the Worker. `true` routes every request through the Worker first (serve files yourself via the `ASSETS` binding). A list of path rules routes only matching paths worker-first: glob (*) and negative (!) rules are supported, rules must start with '/' or '!/', at least one non-negative rule must be provided, and negative rules take precedence."
+            }
           },
           "serve_directly": {
             "target": "smithy.api#Boolean"
           },
           "_headers": {
-            "target": "smithy.api#String"
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Raw contents of a `_headers` file — header rules applied by the asset layer."
+            }
           },
           "_redirects": {
-            "target": "smithy.api#String"
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Raw contents of a `_redirects` file — redirect rules applied by the asset layer."
+            }
           }
         }
       }

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -8627,11 +8627,16 @@ export const PutScriptAssetsConfigRunWorkerFirst = /*@__PURE__*/ S.Unknown.pipe(
 );
 
 export interface PutScriptAssetsConfig {
+  /** Determines the redirects and rewrites of requests for HTML content. */
   htmlHandling?: PutScriptAssetsConfigHtmlHandling | (string & {});
+  /** Determines the response when a request does not match a static asset, and there is no Worker script. */
   notFoundHandling?: PutScriptAssetsConfigNotFoundHandling | (string & {});
+  /** Controls whether the Worker runs ahead of the static-asset layer. Defaults to false: a request matching an asset is served directly and never invokes the Worker. `true` routes every request through the Worker first (serve files yourself via the `ASSETS` binding). A list of path rules routes only matching paths worker-first: glob (*) and negative (!) rules are supported, rules must start with '/' or '!/', at least one non-negative rule must be provided, and negative rules take precedence. */
   runWorkerFirst?: PutScriptAssetsConfigRunWorkerFirst;
   serveDirectly?: boolean;
+  /** Raw contents of a `_headers` file — header rules applied by the asset layer. */
   headers?: string;
+  /** Raw contents of a `_redirects` file — redirect rules applied by the asset layer. */
   redirects?: string;
 }
 export const PutScriptAssetsConfig = /*@__PURE__*/ S.suspend(() =>


### PR DESCRIPTION
The manual `putScript` spec defined `PutScriptAssetsConfig` with no documentation traits, so consumers extending it (alchemy's `AssetsProps`) get no hover docs on any member — notably `run_worker_first`, whose boolean/path-rule union is easy to misuse.

```ts
/** Controls whether the Worker runs ahead of the static-asset layer. Defaults to false: a request matching an asset is served directly and never invokes the Worker. `true` routes every request through the Worker first (serve files yourself via the `ASSETS` binding). A list of path rules routes only matching paths worker-first: glob (*) and negative (!) rules are supported, ... */
runWorkerFirst?: PutScriptAssetsConfigRunWorkerFirst;
```

- `run_worker_first` — full semantics (default, boolean, selective path rules; rule syntax mirrors the upstream Beta shapes' description)
- `html_handling` / `not_found_handling` — copied verbatim from the upstream spec descriptions on the Beta shapes
- `_headers` / `_redirects` — raw config-file contents

Workers service regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
