### PR TITLE
fix(aws/cloudwatch): type UnsupportedOperation on describeInsightRules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ lib/
 *.tgz
 pnpm-lock.yaml
 .scripts-types/
+**/.turbo/

--- a/packages/aws/patches/cloudwatch.json
+++ b/packages/aws/patches/cloudwatch.json
@@ -1,10 +1,27 @@
 {
   "errorCategories": {
-    "ValidationException": ["BadRequestError"]
+    "ValidationException": [
+      "BadRequestError"
+    ]
   },
   "operations": {
     "describeAlarmContributors": {
-      "errors": ["ValidationException"]
+      "errors": [
+        "ValidationException"
+      ]
+    },
+    "describeInsightRules": {
+      "errors": [
+        "UnsupportedOperation"
+      ]
+    }
+  },
+  "errors": {
+    "UnsupportedOperation": {
+      "Message": {
+        "type": "string",
+        "optional": true
+      }
     }
   }
 }

--- a/packages/aws/src/services/cloudwatch.ts
+++ b/packages/aws/src/services/cloudwatch.ts
@@ -272,6 +272,11 @@ export class ResourceNotFoundException
       T.HttpError(404),
     ),
   ).pipe(C.withBadRequestError) {}
+export class UnsupportedOperation
+  extends /*@__PURE__*/ S.TaggedError<UnsupportedOperation>()(
+    "UnsupportedOperation",
+    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
+  ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedError<ValidationException>()(
     "ValidationException",
@@ -3716,7 +3721,10 @@ export const describeAnomalyDetectors: API.PaginatedOperationMethod<
   } as const,
 })) as any;
 
-export type DescribeInsightRulesError = InvalidNextToken | CommonErrors;
+export type DescribeInsightRulesError =
+  | InvalidNextToken
+  | UnsupportedOperation
+  | CommonErrors;
 /**
  * Returns a list of all the Contributor Insights rules in your account.
  *
@@ -3732,7 +3740,7 @@ export const describeInsightRules: API.PaginatedOperationMethod<
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInsightRulesInput,
   output: DescribeInsightRulesOutput,
-  errors: [InvalidNextToken],
+  errors: [InvalidNextToken, UnsupportedOperation],
   protocol: AwsProtocol,
   retry: Retry,
   operationName: "DescribeInsightRules",


### PR DESCRIPTION
Type `UnsupportedOperation` on cloudwatch's `describeInsightRules`.

Local emulators (floci/LocalStack) reject insight-rule APIs with the `UnsupportedOperation` wire code, which the generated union doesn't carry — alchemy's DynamoDB `Table` delete lifecycle catches it alongside `UnknownOperationException` when waiting out Contributor Insights rule cleanup, and the rc.4 regeneration left the tag untyped (`catchTag` fails to compile).

```json
// patches/cloudwatch.json
"errors": { "UnsupportedOperation": { "Message": { "type": "string", "optional": true } } },
"operations": { "describeInsightRules": { "errors": ["UnsupportedOperation"] } }
```

`src/services/cloudwatch.ts` regenerated (`bun scripts/generate.ts --resource cloudwatch` + oxfmt).

Consumed by alchemy-run/alchemy#1206, whose submodule pin references this branch's commit — merge without squashing (or ping so the pin gets updated to the rewritten SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
