### PR TITLE
feat(aws): Endpoint.fromEnv — resolve the AWS_ENDPOINT_URL override

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -48,6 +48,12 @@
       "browser": "./lib/credentials.browser.js",
       "default": "./lib/credentials.js"
     },
+    "./Endpoint": {
+      "types": "./lib/endpoint.d.ts",
+      "bun": "./src/endpoint.ts",
+      "worker": "./src/endpoint.ts",
+      "default": "./lib/endpoint.js"
+    },
     "./Errors": {
       "types": "./lib/errors.d.ts",
       "bun": "./src/errors.ts",

--- a/packages/aws/patches/cloudwatch.json
+++ b/packages/aws/patches/cloudwatch.json
@@ -1,19 +1,13 @@
 {
   "errorCategories": {
-    "ValidationException": [
-      "BadRequestError"
-    ]
+    "ValidationException": ["BadRequestError"]
   },
   "operations": {
     "describeAlarmContributors": {
-      "errors": [
-        "ValidationException"
-      ]
+      "errors": ["ValidationException"]
     },
     "describeInsightRules": {
-      "errors": [
-        "UnsupportedOperation"
-      ]
+      "errors": ["UnsupportedOperation"]
     }
   },
   "errors": {

--- a/packages/aws/src/endpoint.ts
+++ b/packages/aws/src/endpoint.ts
@@ -1,7 +1,29 @@
+import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 
 export class Endpoint extends Context.Service<
   Endpoint,
   Effect.Effect<string | undefined>
 >()("AWS::Endpoint") {}
+
+/**
+ * `AWS_ENDPOINT_URL` — the LocalStack-standard endpoint override that local
+ * emulators (floci, LocalStack) inject into runtime environments (e.g.
+ * Lambda containers). Resolves `undefined` when unset, so the SDK's
+ * default endpoint resolver runs.
+ */
+export const fromEnvironment = Config.string("AWS_ENDPOINT_URL").pipe(
+  Config.option,
+  Effect.map(Option.getOrUndefined),
+);
+
+/** Override the endpoint with whatever the environment names, if anything. */
+export const fromEnv = () =>
+  Layer.succeed(Endpoint, fromEnvironment.pipe(Effect.orDie));
+
+/** Override the endpoint for a scope, e.g. `Endpoint.of("http://localhost:4566")`. */
+export const of = (endpoint: string) =>
+  Layer.succeed(Endpoint, Effect.succeed(endpoint));


### PR DESCRIPTION
Resolve the LocalStack-standard `AWS_ENDPOINT_URL` endpoint override from the environment, mirroring `Region.fromEnv`, and expose the `./Endpoint` subpath export.

```ts
// packages/aws/src/endpoint.ts
export const fromEnvironment = Config.string("AWS_ENDPOINT_URL").pipe(
  Config.option,
  Effect.map(Option.getOrUndefined),
);
export const fromEnv = () =>
  Layer.succeed(Endpoint, fromEnvironment.pipe(Effect.orDie));
export const of = (endpoint: string) =>
  Layer.succeed(Endpoint, Effect.succeed(endpoint));
```

Local emulators (floci, LocalStack) inject `AWS_ENDPOINT_URL` into runtime environments (Lambda/ECS containers). Without an Endpoint layer built from it, a runtime with dummy emulator credentials silently calls REAL AWS (`UnrecognizedClientException` / `InvalidAccessKeyId`). Resolves `undefined` when unset, so nothing changes outside emulated environments.

Consumed by alchemy's Lambda and ECS container entrypoints in alchemy-run/alchemy#1210, whose submodule pin references this branch's commit — merge without squashing (or ping so the pin gets updated to the rewritten SHA).
