### PR TITLE
fix(aws): make UnsupportedOperation a common error instead of a cloudwatch patch

### DIFF
--- a/packages/aws/patches/cloudwatch.json
+++ b/packages/aws/patches/cloudwatch.json
@@ -5,17 +5,6 @@
   "operations": {
     "describeAlarmContributors": {
       "errors": ["ValidationException"]
-    },
-    "describeInsightRules": {
-      "errors": ["UnsupportedOperation"]
-    }
-  },
-  "errors": {
-    "UnsupportedOperation": {
-      "Message": {
-        "type": "string",
-        "optional": true
-      }
     }
   }
 }

--- a/packages/aws/patches/cloudwatch.json
+++ b/packages/aws/patches/cloudwatch.json
@@ -1,19 +1,13 @@
 {
   "errorCategories": {
-    "ValidationException": [
-      "BadRequestError"
-    ]
+    "ValidationException": ["BadRequestError"]
   },
   "operations": {
     "describeAlarmContributors": {
-      "errors": [
-        "ValidationException"
-      ]
+      "errors": ["ValidationException"]
     },
     "describeInsightRules": {
-      "errors": [
-        "UnsupportedOperation"
-      ]
+      "errors": ["UnsupportedOperation"]
     }
   },
   "errors": {

--- a/packages/aws/src/errors.ts
+++ b/packages/aws/src/errors.ts
@@ -94,6 +94,11 @@ export class UnknownOperationException extends S.TaggedError<UnknownOperationExc
   { message: ErrorMessage },
 ).pipe(Category.withBadRequestError) {}
 
+export class UnsupportedOperation extends S.TaggedError<UnsupportedOperation>()(
+  "UnsupportedOperation",
+  { message: ErrorMessage },
+).pipe(Category.withBadRequestError) {}
+
 export class ValidationError extends S.TaggedError<ValidationError>()(
   "ValidationError",
   { message: ErrorMessage },
@@ -204,6 +209,7 @@ export const COMMON_ERRORS = [
   ThrottlingException,
   UnknownOperationException,
   UnrecognizedClientException,
+  UnsupportedOperation,
   ValidationError,
   ValidationException,
 ] as const;
@@ -224,6 +230,7 @@ export type CommonAwsError =
   | ThrottlingException
   | UnrecognizedClientException
   | UnknownOperationException
+  | UnsupportedOperation
   | ValidationError
   | ValidationException
   | OperationAborted;

--- a/packages/aws/src/services/cloudwatch.ts
+++ b/packages/aws/src/services/cloudwatch.ts
@@ -272,11 +272,6 @@ export class ResourceNotFoundException
       T.HttpError(404),
     ),
   ).pipe(C.withBadRequestError) {}
-export class UnsupportedOperation
-  extends /*@__PURE__*/ S.TaggedError<UnsupportedOperation>()(
-    "UnsupportedOperation",
-    { message: S.optional(S.String).pipe(T.ErrorMessage()) },
-  ) {}
 export class ValidationException
   extends /*@__PURE__*/ S.TaggedError<ValidationException>()(
     "ValidationException",
@@ -3721,10 +3716,7 @@ export const describeAnomalyDetectors: API.PaginatedOperationMethod<
   } as const,
 })) as any;
 
-export type DescribeInsightRulesError =
-  | InvalidNextToken
-  | UnsupportedOperation
-  | CommonErrors;
+export type DescribeInsightRulesError = InvalidNextToken | CommonErrors;
 /**
  * Returns a list of all the Contributor Insights rules in your account.
  *
@@ -3740,7 +3732,7 @@ export const describeInsightRules: API.PaginatedOperationMethod<
 > = /*@__PURE__*/ API.makePaginated(() => ({
   input: DescribeInsightRulesInput,
   output: DescribeInsightRulesOutput,
-  errors: [InvalidNextToken, UnsupportedOperation],
+  errors: [InvalidNextToken],
   protocol: AwsProtocol,
   retry: Retry,
   operationName: "DescribeInsightRules",


### PR DESCRIPTION
Supersedes the approach from #450: instead of patching `UnsupportedOperation` onto cloudwatch's `describeInsightRules` via `patches/cloudwatch.json`, add it to `COMMON_ERRORS`/`CommonAwsError` in `src/errors.ts` so it is typed and decodable on **every** operation.

Local emulators (floci/LocalStack) reject unsupported APIs with this wire code regardless of service, so it belongs alongside `UnknownOperationException` as a common error rather than in per-service spec patches.

- Reverts the #450 patch entries; `src/services/cloudwatch.ts` regenerated back to its pre-patch state
- `DescribeInsightRulesError = InvalidNextToken | CommonErrors` still includes `UnsupportedOperation`, so alchemy-run/alchemy#1206's `catchTag("UnsupportedOperation")` keeps compiling
- Service-specific `UnsupportedOperation` schemas (ec2, cloudtrail, ...) still take decode precedence over the common one
- Also includes the original commit formatting `patches/cloudwatch.json` (the #450 patch was not run through oxfmt, breaking `format:check` on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
