### PR TITLE
chore: ignore Turbo cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib/
 !.husky/pre-commit
 
 .cache
+.turbo/
 .tmp
 *.tgz
 pnpm-lock.yaml


### PR DESCRIPTION
Ignore `.turbo/` cache directories throughout the repository.

This prevents generated Turbo state from making shared submodule worktree checkouts appear dirty.