### PR TITLE
fix(cloudflare/zero-trust): type Access application not-found and destination conflict

### DIFF
--- a/packages/cloudflare/patches/zero_trust/_errors.json
+++ b/packages/cloudflare/patches/zero_trust/_errors.json
@@ -225,6 +225,57 @@
     },
     {
       "op": "add",
+      "path": "/shapes/com.cloudflare.zero_trust#AccessApplicationNotFound",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": {
+            "target": "smithy.api#Integer"
+          },
+          "message": {
+            "target": "smithy.api#String"
+          }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [
+            {
+              "status": 404,
+              "message": {
+                "includes": "unknown_application"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.zero_trust#AccessDestinationConflict",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": {
+            "target": "smithy.api#Integer"
+          },
+          "message": {
+            "target": "smithy.api#String"
+          }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [
+            {
+              "message": {
+                "includes": "destination belongs to another application"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
       "path": "/shapes/com.cloudflare.zero_trust#AccessTagNotFound",
       "value": {
         "type": "structure",

--- a/packages/cloudflare/patches/zero_trust/createAccessApplicationForAccount.json
+++ b/packages/cloudflare/patches/zero_trust/createAccessApplicationForAccount.json
@@ -32,6 +32,9 @@
       "value": [
         {
           "target": "com.cloudflare.zero_trust#AccessReferenceNotFound"
+        },
+        {
+          "target": "com.cloudflare.zero_trust#AccessDestinationConflict"
         }
       ]
     }

--- a/packages/cloudflare/patches/zero_trust/deleteAccessApplicationForAccount.json
+++ b/packages/cloudflare/patches/zero_trust/deleteAccessApplicationForAccount.json
@@ -25,6 +25,15 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.zero_trust#DeleteAccessApplicationForAccount/output/target",
       "value": "com.cloudflare.zero_trust#DeleteAccessApplicationForAccountResponse"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.zero_trust#DeleteAccessApplicationForAccount/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.zero_trust#AccessApplicationNotFound"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/patches/zero_trust/getAccessApplicationForAccount.json
+++ b/packages/cloudflare/patches/zero_trust/getAccessApplicationForAccount.json
@@ -32,6 +32,9 @@
       "value": [
         {
           "target": "com.cloudflare.zero_trust#Forbidden"
+        },
+        {
+          "target": "com.cloudflare.zero_trust#AccessApplicationNotFound"
         }
       ]
     }

--- a/packages/cloudflare/src/services/zero_trust.ts
+++ b/packages/cloudflare/src/services/zero_trust.ts
@@ -576,6 +576,18 @@ const KEY_DICTIONARY: Record<string, string | ReadonlyArray<string>> = {
   workerId: "worker_id",
 };
 
+export class AccessApplicationNotFound
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<AccessApplicationNotFound>()(
+      "AccessApplicationNotFound",
+      {
+        code: S.Number,
+        message: S.String,
+      },
+    ),
+    [{ status: 404, message: { includes: "unknown_application" } }],
+  ) {}
+
 export class AccessBookmarkNotFound
   extends /*@__PURE__*/ T.applyErrorMatchers(
     /*@__PURE__*/ S.TaggedError<AccessBookmarkNotFound>()(
@@ -639,6 +651,18 @@ export class AccessCustomPagesNotEntitled
         message: { includes: "does not have permission for custom pages" },
       },
     ],
+  ) {}
+
+export class AccessDestinationConflict
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<AccessDestinationConflict>()(
+      "AccessDestinationConflict",
+      {
+        code: S.Number,
+        message: S.String,
+      },
+    ),
+    [{ message: { includes: "destination belongs to another application" } }],
   ) {}
 
 export class AccessGroupNotFound
@@ -168481,6 +168505,7 @@ export const createAccessApplicationCaForZone: API.OperationMethod<
 
 export type CreateAccessApplicationForAccountError =
   | AccessReferenceNotFound
+  | AccessDestinationConflict
   | CloudflareOpError;
 /** Adds a new application to Access. */
 export const createAccessApplicationForAccount: API.OperationMethod<
@@ -168491,7 +168516,12 @@ export const createAccessApplicationForAccount: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAccessApplicationForAccountRequest,
   output: CreateAccessApplicationResponse,
-  errors: [AccessReferenceNotFound, CloudflareRateLimited, CloudflareError],
+  errors: [
+    AccessReferenceNotFound,
+    AccessDestinationConflict,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));
@@ -169667,7 +169697,9 @@ export const deleteAccessApplicationCaForZone: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type DeleteAccessApplicationForAccountError = CloudflareOpError;
+export type DeleteAccessApplicationForAccountError =
+  | AccessApplicationNotFound
+  | CloudflareOpError;
 /** Deletes an application from Access. */
 export const deleteAccessApplicationForAccount: API.OperationMethod<
   DeleteAccessApplicationForAccountRequest,
@@ -169677,7 +169709,7 @@ export const deleteAccessApplicationForAccount: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteAccessApplicationForAccountRequest,
   output: DeleteAccessApplicationResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [AccessApplicationNotFound, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));
@@ -170878,7 +170910,10 @@ export const getAccessApplicationCaForZone: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type GetAccessApplicationForAccountError = Forbidden | CloudflareOpError;
+export type GetAccessApplicationForAccountError =
+  | Forbidden
+  | AccessApplicationNotFound
+  | CloudflareOpError;
 /** Fetches information about an Access application. */
 export const getAccessApplicationForAccount: API.OperationMethod<
   GetAccessApplicationForAccountRequest,
@@ -170888,7 +170923,12 @@ export const getAccessApplicationForAccount: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: GetAccessApplicationForAccountRequest,
   output: GetAccessApplicationResponse,
-  errors: [Forbidden, CloudflareRateLimited, CloudflareError],
+  errors: [
+    Forbidden,
+    AccessApplicationNotFound,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
Type GET/DELETE 404 `unknown_application` as `AccessApplicationNotFound` and a duplicate worker-destination create as `AccessDestinationConflict`.

These tags showed up while adding Access applications that target Workers by identity ([docs](https://developers.cloudflare.com/workers/configuration/cloudflare-access/), [launch post](https://blog.cloudflare.com/workers-protected-by-access/)). Alchemy handles them with `catchTag`; this repo is the only place the union can grow — alchemy CI does not regenerate distilled.

```ts
Effect.catchTag("AccessApplicationNotFound", () => Effect.void)
Effect.catchTag("AccessDestinationConflict", () => /* reject the duplicate */)
```

Companion: [alchemy-run/alchemy#1227](https://github.com/alchemy-run/alchemy/pull/1227) (draft until this merges and that PR retargets the submodule pin).
