### PR TITLE
chore(docs): update pnpm commands

### DIFF
--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -23,7 +23,7 @@ The submodule is therefore **sparse-checked-out to the one file we consume**.
 ### Fetching it
 
 ```bash
-bun run specs:fetch
+pnpm specs:fetch
 ```
 
 Run this from `packages/github`. It initialises the submodule, narrows it to
@@ -34,7 +34,7 @@ the single description file, and leaves ~13 MB on disk.
 Sparse-checkout config lives in **local git config**, not in the repository,
 so it does not travel with a clone. Two consequences:
 
-- A fresh **`bun run specs:sync` at the repo root** — which does a plain
+- A fresh **`pnpm specs:sync` at the repo root** — which does a plain
   `git submodule update --init --recursive` across every package — expands
   this submodule to the full 6.7 GB. It is not wrong, just very expensive.
 - `specs:fetch` itself checks out *before* it narrows, so it also passes


### PR DESCRIPTION
## Summary

- update GitHub SDK developer commands to use pnpm
- keep Bun-specific runtime usage unchanged

## Validation

- `git diff --check`