### PR TITLE
fix(cloudflare/r2): type the non-empty bucket rejection on deleteBucket

### DIFF
--- a/packages/cloudflare/patches/r2/_errors.json
+++ b/packages/cloudflare/patches/r2/_errors.json
@@ -26,6 +26,32 @@
     },
     {
       "op": "add",
+      "path": "/shapes/com.cloudflare.r2#BucketNotEmpty",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": {
+            "target": "smithy.api#Integer"
+          },
+          "message": {
+            "target": "smithy.api#String"
+          }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [
+            {
+              "status": 409,
+              "message": {
+                "includes": "is not empty"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
       "path": "/shapes/com.cloudflare.r2#BucketNotFound",
       "value": {
         "type": "structure",

--- a/packages/cloudflare/patches/r2/deleteBucket.json
+++ b/packages/cloudflare/patches/r2/deleteBucket.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align r2#BucketsDelete with distilled cloudflare/r2 deleteBucket",
+  "description": "Align r2#BucketsDelete with distilled cloudflare/r2 deleteBucket, and type the non-empty-bucket rejection",
   "patches": [
     {
       "op": "move",
@@ -32,6 +32,9 @@
       "value": [
         {
           "target": "com.cloudflare.r2#NoSuchBucket"
+        },
+        {
+          "target": "com.cloudflare.r2#BucketNotEmpty"
         },
         {
           "target": "com.cloudflare.r2#InvalidRoute"

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -35,6 +35,15 @@ export class BucketAlreadyExists
     [{ code: 10004 }],
   ) {}
 
+export class BucketNotEmpty
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<BucketNotEmpty>()("BucketNotEmpty", {
+      code: S.Number,
+      message: S.String,
+    }),
+    [{ status: 409, message: { includes: "is not empty" } }],
+  ) {}
+
 export class BucketNotFound
   extends /*@__PURE__*/ T.applyErrorMatchers(
     /*@__PURE__*/ S.TaggedError<BucketNotFound>()("BucketNotFound", {
@@ -5088,6 +5097,7 @@ export const createTemporaryCredential: API.OperationMethod<
 
 export type DeleteBucketError =
   | NoSuchBucket
+  | BucketNotEmpty
   | InvalidRoute
   | NoRoute
   | CloudflareOpError;
@@ -5102,6 +5112,7 @@ export const deleteBucket: API.OperationMethod<
   output: DeleteBucketResponse,
   errors: [
     NoSuchBucket,
+    BucketNotEmpty,
     InvalidRoute,
     NoRoute,
     CloudflareRateLimited,


### PR DESCRIPTION
`deleteBucket` on a bucket that still has objects returns 409 with `The bucket you tried to delete (<name>) is not empty (account <id>).`, which had no matcher and fell through to the status-derived `Conflict` class.

```ts
// before: Conflict (status-derived, not in the typed union)
// after:
r2.deleteBucket({ accountId, bucketName }).pipe(
  Effect.catchTag("BucketNotEmpty", () => ...),
)
```

Matcher is status + message — R2 does not return a Cloudflare error code on this rejection (verified live against the API).

Needed by [alchemy#1248](https://github.com/alchemy-run/alchemy/issues/1248), where R2's refusal to delete a non-empty bucket becomes the data-protection default instead of alchemy emptying the bucket first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
