### PR TITLE
fix(cloudflare/r2): type the object-plane missing-bucket / missing-key rejections

### DIFF
--- a/packages/cloudflare/patches/r2/_errors.json
+++ b/packages/cloudflare/patches/r2/_errors.json
@@ -399,6 +399,9 @@
               "message": {
                 "includes": "specified key does not exist"
               }
+            },
+            {
+              "code": 10007
             }
           ]
         }

--- a/packages/cloudflare/patches/r2/deleteBucketObject.json
+++ b/packages/cloudflare/patches/r2/deleteBucketObject.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align r2#BucketsObjectsDelete with distilled cloudflare/r2 deleteBucketObject",
+  "description": "Align r2#BucketsObjectsDelete with distilled cloudflare/r2 deleteBucketObject, and type the missing-bucket / missing-key rejections",
   "patches": [
     {
       "op": "move",
@@ -35,6 +35,18 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.r2#DeleteBucketObject/traits/smithy.api#http/uri",
       "value": "/accounts/{account_id}/r2/buckets/{bucket_name}/objects/{object_name}"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.r2#DeleteBucketObject/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.r2#NoSuchBucket"
+        },
+        {
+          "target": "com.cloudflare.r2#NoSuchKey"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/patches/r2/listBucketObjects.json
+++ b/packages/cloudflare/patches/r2/listBucketObjects.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align r2#BucketsObjectsList with distilled cloudflare/r2 listBucketObjects",
+  "description": "Align r2#BucketsObjectsList with distilled cloudflare/r2 listBucketObjects, and type the missing-bucket rejection",
   "patches": [
     {
       "op": "move",
@@ -36,6 +36,15 @@
         "items": "result",
         "pageSize": "perPage"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.r2#ListBucketObjects/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.r2#NoSuchBucket"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/patches/r2/uploadBucketObject.json
+++ b/packages/cloudflare/patches/r2/uploadBucketObject.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align r2#BucketsObjectsUpload with distilled cloudflare/r2 uploadBucketObject",
+  "description": "Align r2#BucketsObjectsUpload with distilled cloudflare/r2 uploadBucketObject, and type the missing-bucket rejection",
   "patches": [
     {
       "op": "move",
@@ -40,6 +40,15 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.r2#UploadBucketObject/traits/smithy.api#http/uri",
       "value": "/accounts/{account_id}/r2/buckets/{bucket_name}/objects/{object_name}"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.r2#UploadBucketObject/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.r2#NoSuchBucket"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -5522,7 +5522,7 @@ export const listBucketMetrics: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type ListBucketObjectsError = CloudflareOpError;
+export type ListBucketObjectsError = NoSuchBucket | CloudflareOpError;
 /** Lists objects in an R2 bucket. Returns object metadata including key, size, etag, last modified date, HTTP metadata, and custom metadata. For most workloads, we recommend using R2's [S3-compatible API](https://developers.cloudflare.com/r2/api/s3/api/) or a [Worker with an R2 binding](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/) instead. */
 export const listBucketObjects: API.PaginatedOperationMethod<
   ListBucketObjectsRequest,
@@ -5534,7 +5534,7 @@ export const listBucketObjects: API.PaginatedOperationMethod<
   () => ({
     input: ListBucketObjectsRequest,
     output: ListBucketObjectsResponse,
-    errors: [CloudflareRateLimited, CloudflareError],
+    errors: [NoSuchBucket, CloudflareRateLimited, CloudflareError],
     protocol: CloudflarePaginatedProtocol,
     retry: Retry.Retry,
     pagination: {

--- a/packages/cloudflare/src/services/r2.ts
+++ b/packages/cloudflare/src/services/r2.ts
@@ -191,7 +191,10 @@ export class NoSuchKey
       code: S.Number,
       message: S.String,
     }),
-    [{ status: 404, message: { includes: "specified key does not exist" } }],
+    [
+      { status: 404, message: { includes: "specified key does not exist" } },
+      { code: 10007 },
+    ],
   ) {}
 
 export class QueueNotFound
@@ -5190,7 +5193,10 @@ export const deleteBucketEventNotification: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type DeleteBucketObjectError = CloudflareOpError;
+export type DeleteBucketObjectError =
+  | NoSuchBucket
+  | NoSuchKey
+  | CloudflareOpError;
 /** Deletes an object from an R2 bucket. For most workloads, we recommend using R2's [S3-compatible API](https://developers.cloudflare.com/r2/api/s3/api/) or a [Worker with an R2 binding](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/) instead. */
 export const deleteBucketObject: API.OperationMethod<
   DeleteBucketObjectRequest,
@@ -5200,7 +5206,7 @@ export const deleteBucketObject: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteBucketObjectRequest,
   output: DeleteBucketObjectResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [NoSuchBucket, NoSuchKey, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));
@@ -5832,7 +5838,7 @@ export const updateBucketDomainCustom: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type UploadBucketObjectError = CloudflareOpError;
+export type UploadBucketObjectError = NoSuchBucket | CloudflareOpError;
 /** Uploads an object to an R2 bucket. The object body is provided as the request body. Returns metadata about the uploaded object. The maximum upload size for this endpoint is 300 MB. For most workloads, we recommend using R2's [S3-compatible API](https://developers.cloudflare.com/r2/api/s3/api/) or a [Worker with an R2 binding](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/) instead. */
 export const uploadBucketObject: API.OperationMethod<
   UploadBucketObjectRequest,
@@ -5842,7 +5848,7 @@ export const uploadBucketObject: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: UploadBucketObjectRequest,
   output: UploadBucketObjectResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [NoSuchBucket, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
Audit of every r2 operation's declared error union against the live API. Three operations reported missing resources through status-derived classes (`NotFound`, `UnknownCloudflareError`) instead of r2's typed tags:

| operation | condition | before | after |
| --- | --- | --- | --- |
| `listBucketObjects` | missing bucket | `NotFound` | `NoSuchBucket` |
| `uploadBucketObject` | missing bucket | `NotFound` | `NoSuchBucket` |
| `deleteBucketObject` | missing bucket | `NotFound` | `NoSuchBucket` |
| `deleteBucketObject` | missing key | `UnknownCloudflareError` | `NoSuchKey` |

`listBucketObjects`, `uploadBucketObject` and `deleteBucketObject` declared no errors at all. The missing-key case needed a matcher change too — `deleteBucketObject` reports code 10007 without the 404 status `NoSuchKey` matched on:

```diff
  "com.cloudflare.protocols#errorMatchers": [
-   { "status": 404, "message": { "includes": "specified key does not exist" } }
+   { "status": 404, "message": { "includes": "specified key does not exist" } },
+   { "code": 10007 }
  ]
```

Every mapping was probed against the live API before and after the patch — the codes are observed, not inferred.

Downstream, these are what let a caller emptying a bucket stay idempotent, and what lets an HTTP-API R2 client match the native binding's idempotent `delete` ([alchemy#1253](https://github.com/alchemy-run/alchemy/pull/1253)).

Not patched, but worth recording: the Super Slurper job operations (`getSuperSlurperJob`, `progressSuperSlurperJob`, `abortSuperSlurperJob`, `pauseSuperSlurperJob`, `resumeSuperSlurperJob`) answer an unknown job id with a **500**, which the retry policy correctly treats as transient — so the call burns its full retry budget before failing. Typing that would mean matching a generic 500, so it needs a Cloudflare-side fix rather than a matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
