### PR TITLE
fix(core,aws): honor per-call context overrides in yield-first ops; parse X-Amz-Errortype

### DIFF
--- a/packages/aws/src/protocols/aws-json.ts
+++ b/packages/aws/src/protocols/aws-json.ts
@@ -179,10 +179,13 @@ function createAwsJsonProtocol(version: "1.0" | "1.1"): Protocol {
           }
         }
 
-        // Extract error code: check X-Amzn-Errortype header first, then body fields
+        // Extract error code: X-Amzn-Errortype first (Smithy), then the
+        // Coral X-Amz-Errortype spelling, then body fields.
         const rawErrorCode =
           response.headers["x-amzn-errortype"] ??
           response.headers["X-Amzn-Errortype"] ??
+          response.headers["x-amz-errortype"] ??
+          response.headers["X-Amz-Errortype"] ??
           extractJsonErrorCode(body);
 
         if (!rawErrorCode) {

--- a/packages/aws/src/protocols/rest-json.ts
+++ b/packages/aws/src/protocols/rest-json.ts
@@ -408,10 +408,13 @@ export const restJson1Protocol: Protocol = (
         }
       }
 
-      // Extract error code: check X-Amzn-Errortype header first, then body fields
+      // Extract error code: X-Amzn-Errortype first (Smithy restJson1), then
+      // the Coral X-Amz-Errortype spelling, then body fields.
       const rawErrorCode =
         response.headers["x-amzn-errortype"] ??
         response.headers["X-Amzn-Errortype"] ??
+        response.headers["x-amz-errortype"] ??
+        response.headers["X-Amz-Errortype"] ??
         extractJsonErrorCode(body);
 
       if (!rawErrorCode) {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -276,7 +276,11 @@ export function make<
 
   // Make the operation itself yieldable: `yield* operation` captures the
   // current context and returns a requirement-free call function (mirrors
-  // the distilled repo's OperationMethod).
+  // the distilled repo's OperationMethod). The captured context is a
+  // FALLBACK, not a snapshot: entries present on the calling fiber at call
+  // time win, so per-call overrides — e.g. providing `Endpoint` with a
+  // discovered data-plane address around one invocation — take effect
+  // instead of being shadowed by the context captured at yield time.
   const Proto = {
     [Symbol.iterator](this: any) {
       return new SingleShotGen(this.asEffect());
@@ -288,7 +292,9 @@ export function make<
       return Effect.map(
         Effect.context(),
         (context) => (input: unknown) =>
-          Effect.provideContext(fn(input), context),
+          Effect.updateContext(fn(input), (current: Context.Context<never>) =>
+            Context.merge(context, current),
+          ),
       );
     },
   };
@@ -432,11 +438,15 @@ export function makePaginated<
   // `yield* operation` runs through `make`'s Proto.asEffect, which builds a
   // fresh arrow and would drop `.pages` / `.items` (distilled #145). Override
   // it here — Proto's `[Symbol.iterator]`/`pipe` dispatch on `this`, so both
-  // pick this up. Only paginated operations pay for it.
+  // pick this up. Only paginated operations pay for it. Same fallback (not
+  // snapshot) semantics as Proto.asEffect: call-time fiber entries win over
+  // the captured context.
   fn.asEffect = () =>
     Effect.map(Effect.context(), (context) =>
       withStreams((input: unknown) =>
-        Effect.provideContext(fn(input), context),
+        Effect.updateContext(fn(input), (current: Context.Context<never>) =>
+          Context.merge(context, current),
+        ),
       ),
     );
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -292,7 +292,10 @@ export function make<
       return Effect.map(
         Effect.context(),
         (context) => (input: unknown) =>
-          Effect.updateContext(fn(input), (current: Context.Context<never>) =>
+          // `Context` is contravariant, so `Context<never>` is not assignable
+          // to the `Context<any>` updateContext expects — the widening cast is
+          // sound (the merge only ever adds entries).
+          Effect.updateContext(fn(input), (current): Context.Context<any> =>
             Context.merge(context, current),
           ),
       );
@@ -444,7 +447,8 @@ export function makePaginated<
   fn.asEffect = () =>
     Effect.map(Effect.context(), (context) =>
       withStreams((input: unknown) =>
-        Effect.updateContext(fn(input), (current: Context.Context<never>) =>
+        // Same contravariance widening as Proto.asEffect above.
+        Effect.updateContext(fn(input), (current): Context.Context<any> =>
           Context.merge(context, current),
         ),
       ),


### PR DESCRIPTION
Make yield-first operations honor per-call context overrides, and recognize the Coral `X-Amz-Errortype` header spelling.

### Yield-time context is a fallback, not a snapshot

`const op = yield* operation` captured the current context and re-provided it on every call with `Effect.provideContext`, which shadowed anything the calling fiber provided around a single invocation:

```ts
const op = yield* kinesisVideo.getMedia;
// the provided Endpoint was silently ignored — the Endpoint captured at
// yield time (e.g. Endpoint.fromEnv → undefined) won:
yield* op(input).pipe(
  Effect.provideService(Endpoint.Endpoint, Effect.succeed(discovered)),
);
```

Now the captured context is merged UNDER the calling fiber's context (`Effect.updateContext` + `Context.merge(captured, current)`), so call-time entries win and the capture only fills requirements the caller lacks. Applied to both `make` and `makePaginated`.

Note for consumers: a service provided only *around the yield* is now a fallback too — if the calling fiber has its own entry for that tag (e.g. a Lambda runtime's ambient `Region`), the caller's entry wins. Pin per call instead.

### `X-Amz-Errortype` header

aws-json 1.0/1.1 and restJson1 error-code extraction now also checks the Coral `X-Amz-Errortype` spelling before falling back to body fields.
