### PR TITLE
chore(ci): restore release changelog and Discord notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  ALCHEMY_REPO: alchemy-run/distilled
+
 jobs:
   build:
     name: Build and pack
@@ -84,13 +87,17 @@ jobs:
         name: Commit and tag
         env:
           VERSION: ${{ steps.release.outputs.version }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           TAG="v${VERSION}"
           git config user.email "alchemy-version-bot[bot]@users.noreply.github.com"
           git config user.name "alchemy-version-bot[bot]"
+          if [[ "$CHANNEL" != "tag" ]]; then bun scripts/release/release-notes.ts "$TAG"; fi
           mapfile -t PACKAGE_JSONS < <(jq -r '.[] | "\(.)/package.json"' release-package-dirs.json)
           git add "${PACKAGE_JSONS[@]}" pnpm-lock.yaml
+          if [[ "$CHANNEL" != "tag" ]]; then git add CHANGELOG.md; fi
           if ! git diff --cached --quiet; then git commit -m "chore(release): ${VERSION}"; fi
           if ! git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1; then git tag -a "$TAG" -m "Release ${TAG}"; fi
           git push origin HEAD
@@ -144,7 +151,17 @@ jobs:
         run: bash scripts/release/publish.sh
 
       - name: Create GitHub release
+        if: needs.build.outputs.channel != 'tag'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.build.outputs.version }}
-        run: gh release view "v${VERSION}" >/dev/null 2>&1 || gh release create "v${VERSION}" --verify-tag --generate-notes --title "v${VERSION}"
+          CHANNEL: ${{ needs.build.outputs.channel }}
+        run: bun scripts/release/github-release.ts "v${VERSION}" "$CHANNEL"
+
+      - name: Notify Discord
+        if: needs.build.outputs.channel != 'tag'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANNEL: ${{ needs.build.outputs.channel }}
+        run: bun scripts/release/discord-notify.ts "v${VERSION}" "$CHANNEL"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "typescript": "catalog:build",
     "husky": "catalog:tooling",
     "oxfmt": "catalog:tooling",
-    "oxlint": "catalog:tooling"
+    "oxlint": "catalog:tooling",
+    "changelogithub": "^13.16.1"
   },
   "packageManager": "pnpm@11.21.0",
   "devEngines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/node':
         specifier: catalog:tooling
         version: 26.2.0
+      changelogithub:
+        specifier: ^13.16.1
+        version: 13.16.1
       husky:
         specifier: catalog:tooling
         version: 9.1.7
@@ -979,6 +982,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@smithy/core@3.32.0':
     resolution: {integrity: sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==}
     engines: {node: '>=18.0.0'}
@@ -1155,17 +1165,106 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  c12@1.11.2:
+    resolution: {integrity: sha512-oBs8a4uvSDO9dm8b7OCFW7+dgtVrwmwnrVXYzLm43ta7ep2jCn/0MhoUFygIWtxhyy6+/MG7/agvpY0U1Iemew==}
+    peerDependencies:
+      magicast: ^0.3.4
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  changelogen@0.5.7:
+    resolution: {integrity: sha512-cTZXBcJMl3pudE40WENOakXkcVtrbBpbkmSkM20NdRiUqa4+VYRdXdEsgQ0BNQ6JBE2YymTNWtPKVF7UCTN5+g==}
+    hasBin: true
+
+  changelogithub@13.16.1:
+    resolution: {integrity: sha512-h4etOmEM/wtqBWKPbnHoqv2C8moRCCEGTckwwWpvRgr/t1tY0MbyjQbZKy1ETQ7gn1UTQMJkCSRQ4KxiQ+HfSQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-gitmoji@0.1.5:
+    resolution: {integrity: sha512-4wqOafJdk2tqZC++cjcbGcaJ13BZ3kwldf06PTiAQRAB76Z1KJwZNL1SaRZMi2w1FM9RYTgZ6QErS8NUl/GBmQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1175,12 +1274,45 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   effect@4.0.0-rc.110:
     resolution: {integrity: sha512-ega6FTJ8CS2of7tHZiADvgyJyV999Q6tZ9juE56V81O0jw6flRwydaPNtyfvP2a5LL9PZrse8A1jnNUD5sWVHg==}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   fast-check@4.9.0:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
@@ -1193,13 +1325,136 @@ packages:
     resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
+  giget@1.2.5:
+    resolution: {integrity: sha512-r1ekGw/Bgpi3HLV3h1MRBIlSAdHoIMklpaQ3OQLFcRw9PwAj2rqigvIbg+dBUI51OxVI2jsEtDywDBjSiuf7Ug==}
+    hasBin: true
+
+  giget@3.3.1:
+    resolution: {integrity: sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
 
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-unsafe@2.0.0:
     resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
 
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
@@ -1208,9 +1463,38 @@ packages:
   msgpackr@2.0.5:
     resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
+  nypm@0.5.4:
+    resolution: {integrity: sha512-X0SNNrZiGU8/e/zAB7sCTtdxWTMSIO73q+xuKgglm2Yvzwlo8UoC5FNySQFCvl84uPaeADkqHUZUkWy4aH4xOA==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  ohash@1.1.6:
+    resolution: {integrity: sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==}
+
+  ohash@2.0.12:
+    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   oxfmt@0.63.0:
     resolution: {integrity: sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw==}
@@ -1238,22 +1522,122 @@ packages:
       vite-plus:
         optional: true
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   path-expression-matcher@1.6.2:
     resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
+    engines: {node: '>= 20.19.0'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strnum@2.4.1:
     resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1263,8 +1647,20 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
@@ -1278,9 +1674,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
     engines: {node: '>=16.0.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -1608,6 +2020,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.78.0':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@smithy/core@3.32.0':
     dependencies:
       '@smithy/types': 4.17.0
@@ -1739,26 +2155,182 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  acorn@8.18.0: {}
+
+  ansis@4.3.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
   anynum@1.0.1: {}
 
   aws4fetch@1.0.20: {}
 
+  binary-extensions@2.3.0: {}
+
   bowser@2.14.1: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   bun-types@1.3.14:
     dependencies:
       '@types/node': 26.2.0
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  c12@1.11.2:
+    dependencies:
+      chokidar: 3.6.0
+      confbox: 0.1.8
+      defu: 6.1.7
+      dotenv: 16.6.1
+      giget: 1.2.5
+      jiti: 1.21.7
+      mlly: 1.8.2
+      ohash: 1.1.6
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.3.1
+      rc9: 2.1.2
+
+  c12@3.3.4:
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.1
+      giget: 3.3.1
+      jiti: 2.7.0
+      ohash: 2.0.12
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+
+  cac@6.7.14: {}
+
+  changelogen@0.5.7:
+    dependencies:
+      c12: 1.11.2
+      colorette: 2.0.20
+      consola: 3.4.2
+      convert-gitmoji: 0.1.5
+      mri: 1.2.0
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      open: 10.2.0
+      pathe: 1.1.2
+      pkg-types: 1.3.1
+      scule: 1.3.0
+      semver: 7.8.5
+      std-env: 3.10.0
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - magicast
+
+  changelogithub@13.16.1:
+    dependencies:
+      ansis: 4.3.1
+      c12: 3.3.4
+      cac: 6.7.14
+      changelogen: 0.5.7
+      convert-gitmoji: 0.1.5
+      execa: 9.6.1
+      ofetch: 1.5.1
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - magicast
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.1.1
+
+  chownr@2.0.0: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  colorette@2.0.20: {}
+
+  confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
+
+  convert-gitmoji@0.1.5: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   dedent@1.7.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  defu@6.1.7: {}
+
+  destr@2.0.5: {}
 
   detect-libc@2.1.2:
     optional: true
+
+  dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   effect@4.0.0-rc.110:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
       msgpackr: 2.0.5
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
+
+  exsolve@1.1.1: {}
 
   fast-check@4.9.0:
     dependencies:
@@ -1778,9 +2350,107 @@ snapshots:
       strnum: 2.4.1
       xml-naming: 0.3.0
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
+  giget@1.2.5:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.5.4
+      pathe: 2.0.3
+      tar: 6.2.1
+
+  giget@3.3.1: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
 
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-unsafe@2.0.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  jiti@1.21.7: {}
+
+  jiti@2.7.0: {}
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp@1.0.4: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  mri@1.2.0: {}
 
   msgpackr-extract@3.0.4:
     dependencies:
@@ -1798,10 +2468,45 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
+  node-fetch-native@1.6.7: {}
+
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
     optional: true
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
+  nypm@0.5.4:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      tinyexec: 0.3.2
+      ufo: 1.6.4
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
+  ohash@1.1.6: {}
+
+  ohash@2.0.12: {}
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   oxfmt@0.63.0:
     dependencies:
@@ -1849,17 +2554,103 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.78.0
       '@oxlint/binding-win32-x64-msvc': 1.78.0
 
+  parse-ms@4.0.0: {}
+
   path-expression-matcher@1.6.2: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
+
+  pathe@1.1.2: {}
 
   pathe@2.0.3: {}
 
+  perfect-debounce@1.0.0: {}
+
+  perfect-debounce@2.1.0: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.1.1
+      pathe: 2.0.3
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   pure-rand@8.4.2: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@5.1.1: {}
+
+  run-applescript@7.1.0: {}
+
+  scule@1.3.0: {}
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  std-env@3.10.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strnum@2.4.1:
     dependencies:
       anynum: 1.0.1
 
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tinypool@2.1.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   tslib@2.8.1: {}
 
@@ -1886,8 +2677,26 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
+  ufo@1.6.4: {}
+
   undici-types@8.3.0: {}
+
+  unicorn-magic@0.3.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   ws@8.21.3: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   xml-naming@0.3.0: {}
+
+  yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
+
+  yoctocolors@2.2.0: {}

--- a/scripts/release/changelog.ts
+++ b/scripts/release/changelog.ts
@@ -1,0 +1,92 @@
+/**
+ * changelogithub's `generate()`, minus the 1 MB ceiling.
+ *
+ * Upstream reads the commit range with `execSync`, whose default `maxBuffer`
+ * is 1 MB. `git log … --name-status` prints every changed path of every
+ * commit in the range, so a release spanning a large diff blows past that and
+ * the process is killed:
+ *
+ *   error: spawnSync /bin/sh ENOBUFS (stdout or stderr buffer reached
+ *   maxBuffer size limit)
+ *
+ * It is not a pathological case — one repo-wide refactor in the range is
+ * enough, and the release then fails at the tagging step having already
+ * bumped versions.
+ *
+ * `generate()` is `getGitDiff → parseCommits → resolveAuthors → markdown`,
+ * and changelogithub exports every piece except the first. So this reads the
+ * log itself, streaming, and hands the result to the same parser — no
+ * reimplementation of the changelog format, and no fork.
+ */
+import type { ChangelogOptions, Commit } from "changelogithub";
+import {
+  generateMarkdown,
+  parseCommits,
+  resolveAuthors,
+  resolveConfig,
+} from "changelogithub";
+
+interface RawGitCommit {
+  message: string;
+  body: string;
+  shortHash: string;
+  author: { name: string; email: string };
+}
+
+/**
+ * The same command and parsing as changelogen's `getGitDiff`, read through a
+ * pipe instead of a fixed buffer. Kept byte-compatible with upstream: the
+ * `----` record separator and `|`-delimited header are what `parseCommits`
+ * expects.
+ */
+export const getGitDiff = async (
+  from: string | undefined,
+  to = "HEAD",
+): Promise<RawGitCommit[]> => {
+  const proc = Bun.spawn(
+    [
+      "git",
+      "--no-pager",
+      "log",
+      `${from ? `${from}...` : ""}${to}`,
+      "--pretty=----%n%s|%h|%an|%ae%n%b",
+      "--name-status",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const [raw, err, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git log ${from ?? ""}...${to} failed: ${err.trim()}`);
+  }
+  return raw
+    .trim()
+    .split("----\n")
+    .splice(1)
+    .map((line) => {
+      const [firstLine, ..._body] = line.split("\n");
+      const [message, shortHash, authorName, authorEmail] = (
+        firstLine ?? ""
+      ).split("|");
+      return {
+        message: message ?? "",
+        shortHash: shortHash ?? "",
+        author: { name: authorName ?? "", email: authorEmail ?? "" },
+        body: _body.join("\n"),
+      };
+    });
+};
+
+/** Drop-in for changelogithub's `generate`. */
+export const generate = async (options: ChangelogOptions) => {
+  const config = await resolveConfig(options);
+  const commits: Commit[] = parseCommits(
+    (await getGitDiff(config.from, config.to)) as never,
+    config,
+  );
+  if (config.contributors) await resolveAuthors(commits, config);
+  return { config, commits, md: generateMarkdown(commits, config) };
+};

--- a/scripts/release/config.ts
+++ b/scripts/release/config.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared config for the release scripts. Read from env vars set by the
+ * reusable workflow so the same scripts work for every consumer.
+ *
+ * ALCHEMY_PUBLISHABLE_DIRS   JSON array of package dirs (relative to repo root)
+ * ALCHEMY_PUBLISHABLE_NAMES  JSON array of npm names (parallel to dirs)
+ * ALCHEMY_CURRENT_VERSION    Anchor for prerelease bumps (e.g. "2.0.0")
+ * ALCHEMY_REPO               `<owner>/<repo>` for changelog/release-note URLs
+ * GITHUB_OUTPUT              GitHub Actions output file (used by output())
+ */
+import { appendFileSync } from "node:fs";
+
+export type Package = {
+  dir: string;
+  name: string;
+  project: string;
+  install: string;
+  runner: string;
+  artifact: string;
+};
+
+export type PrPackagePlan = {
+  packages: Package[];
+  publishable_names: string[];
+  tags: string[];
+  dependency_tag: string;
+  short: string;
+  install_host: string;
+};
+
+export function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+export function required(name: string): string {
+  const v = process.env[name];
+  if (!v || !v.trim()) {
+    fail(`Required env var ${name} is unset or empty`);
+  }
+  return v.trim();
+}
+
+export function output(name: string, value: unknown): void {
+  const encoded = typeof value === "string" ? value : JSON.stringify(value);
+  appendFileSync(required("GITHUB_OUTPUT"), `${name}=${encoded}\n`);
+}
+
+export function jsonArray<T>(name: string, value: string): T[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (e) {
+    fail(`${name} is not valid JSON: ${(e as Error).message}`);
+  }
+  if (!Array.isArray(parsed)) {
+    fail(`${name} must be a JSON array`);
+  }
+  return parsed as T[];
+}
+
+function parseJsonArray(name: string, value: string): string[] {
+  const parsed = jsonArray<unknown>(name, value);
+  if (!parsed.every((x) => typeof x === "string" && x.trim().length > 0)) {
+    fail(`${name} must be a JSON array of non-empty strings`);
+  }
+  return parsed as string[];
+}
+
+export function publishableDirs(): string[] {
+  return parseJsonArray(
+    "ALCHEMY_PUBLISHABLE_DIRS",
+    required("ALCHEMY_PUBLISHABLE_DIRS"),
+  );
+}
+
+export function publishableNames(): string[] {
+  return parseJsonArray(
+    "ALCHEMY_PUBLISHABLE_NAMES",
+    required("ALCHEMY_PUBLISHABLE_NAMES"),
+  );
+}
+
+export function currentVersion(): string {
+  const v = required("ALCHEMY_CURRENT_VERSION");
+  if (!/^\d+\.\d+\.\d+$/.test(v)) {
+    console.error(`ALCHEMY_CURRENT_VERSION must be x.y.z (got: ${v})`);
+    process.exit(1);
+  }
+  return v;
+}
+
+export function repo(): string {
+  const r = required("ALCHEMY_REPO");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(r)) {
+    console.error(`ALCHEMY_REPO must be <owner>/<repo> (got: ${r})`);
+    process.exit(1);
+  }
+  return r;
+}

--- a/scripts/release/discord-body.ts
+++ b/scripts/release/discord-body.ts
@@ -1,0 +1,56 @@
+/**
+ * Transform a CHANGELOG.md entry body (written for GitHub Releases, which
+ * render HTML) into text suitable for a Discord embed description.
+ *
+ * Discord renders neither HTML entities nor the `<samp>` tag, and only
+ * honors `#`, `##`, and `###` headings. The CHANGELOG entries produced by
+ * `render.ts` / `changelogithub` use:
+ *
+ *   - `&nbsp;` sequences to visually indent `###`/`#####` headings and
+ *     author/PR separators (`&nbsp;-&nbsp;`)
+ *   - `<samp>(hash)</samp>` to render commit-hash links in small caps
+ *   - A trailing `#####` "View changes on GitHub" line
+ *
+ * This converts those into plain-text / markdown equivalents.
+ */
+export function toDiscordBody(rawBody: string): string {
+  return (
+    rawBody
+      .replace(/&nbsp;/g, " ")
+      .replace(/<\/?samp>/g, "`")
+      // Collapse the long indent that the GitHub-flavored headings use.
+      .replace(/^(#{1,6})\s+/gm, "$1 ")
+      // Discord only renders #, ##, ### as headings; drop deeper levels so
+      // lines like "##### View changes on GitHub" become plain text.
+      .replace(/^#{4,6}\s+/gm, "")
+      // Strip any other stray HTML tags just in case.
+      .replace(/<\/?[a-z][^>]*>/gi, "")
+  );
+}
+
+/**
+ * Extract the body for a single `## <tag>` entry out of a CHANGELOG.md
+ * string. Stops at the `---` separator that `release-notes.ts` inserts
+ * between entries, or at the next `## ` heading if the separator is
+ * missing. Returns `undefined` if the tag isn't present.
+ */
+export function extractTagBody(
+  changelog: string,
+  tag: string,
+): string | undefined {
+  const heading = `## ${tag}\n`;
+  const start = changelog.indexOf(heading);
+  if (start === -1) return undefined;
+  const after = changelog.slice(start + heading.length);
+  const sepIdx = after.indexOf("\n---\n");
+  const nextHeadingIdx = after.indexOf("\n## ");
+  const end =
+    sepIdx === -1
+      ? nextHeadingIdx === -1
+        ? after.length
+        : nextHeadingIdx
+      : nextHeadingIdx === -1
+        ? sepIdx
+        : Math.min(sepIdx, nextHeadingIdx);
+  return after.slice(0, end).trim();
+}

--- a/scripts/release/discord-notify.ts
+++ b/scripts/release/discord-notify.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * Post a release announcement to Discord as a single embed. The body is
+ * read verbatim from the CHANGELOG.md entry the release-notes step just
+ * wrote, so Discord matches the GitHub Release copy exactly.
+ *
+ * The webhook posts under `<RepoName> Releases` (e.g. "Alchemy-Effect
+ * Releases", "Distilled Releases"). The embed title uses the first
+ * hyphen-segment of the repo name as the project prefix
+ * (alchemy-effect → "Alchemy", distilled → "Distilled") and omits the
+ * channel suffix for stable `release` channel so you don't get
+ * "...(release) released" doubling up.
+ *
+ *   alchemy-effect + beta → Alchemy v2.0.0-beta.42 (beta) released
+ *   distilled + release  → Distilled v0.21.3 released
+ *
+ * Reads DISCORD_WEBHOOK from the environment. Silently no-ops if unset.
+ *
+ * Usage: bun discord-notify.ts <tag> <release|beta|alpha|tag>
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to link to.
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { repo } from "./config.ts";
+import { extractTagBody, toDiscordBody } from "./discord-body.ts";
+
+const EMBED_DESCRIPTION_LIMIT = 4096;
+
+const tag = process.argv[2];
+const channel = process.argv[3];
+if (!tag || !channel) {
+  console.error("Usage: bun discord-notify.ts <tag> <channel>");
+  process.exit(1);
+}
+
+const webhook = process.env.DISCORD_WEBHOOK;
+if (!webhook) {
+  console.log("DISCORD_WEBHOOK not set, skipping Discord notification");
+  process.exit(0);
+}
+
+const REPO = repo();
+const repoSlug = REPO.split("/")[1]!;
+const capitalize = (s: string) =>
+  s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+// "alchemy-effect" -> "Alchemy-Effect"
+const fullRepoName = repoSlug.split("-").map(capitalize).join("-");
+// "alchemy-effect" -> "Alchemy"
+const projectName = capitalize(repoSlug.split("-")[0]!);
+const botName = `${fullRepoName} Releases`;
+const titleChannel = channel === "release" ? "" : ` (${channel})`;
+const title = `${projectName} ${tag}${titleChannel} released`;
+
+const changelogPath = join(process.cwd(), "CHANGELOG.md");
+const changelog = await readFile(changelogPath, "utf-8");
+const rawBody = extractTagBody(changelog, tag);
+if (rawBody === undefined) {
+  console.error(`CHANGELOG.md has no entry for ${tag}`);
+  process.exit(1);
+}
+
+const body = toDiscordBody(rawBody);
+
+const releaseUrl = `https://github.com/${REPO}/releases/tag/${tag}`;
+const footer = `\n\n[Full release notes →](${releaseUrl})`;
+// Discord embed descriptions cap at 4096 chars. If the rendered body
+// plus the footer would overflow, truncate the body to fit and prepend
+// a notice line so the reader knows there's more on GitHub. We cut at
+// the last newline before the budget so we never slice mid-bullet, then
+// fall back to a hard slice if no newline lands in range.
+const truncationNotice =
+  "_Release notes truncated — see the full changelog on GitHub._\n\n";
+let description = `${body}${footer}`;
+if (description.length > EMBED_DESCRIPTION_LIMIT) {
+  const budget =
+    EMBED_DESCRIPTION_LIMIT - footer.length - truncationNotice.length;
+  let cut = body.lastIndexOf("\n", budget);
+  if (cut < budget / 2) cut = budget; // no convenient newline — hard cut
+  const truncated = body.slice(0, cut).trimEnd();
+  description = `${truncationNotice}${truncated}${footer}`;
+  console.log(
+    `Changelog body (${body.length} chars) exceeded Discord limit; truncated to ${truncated.length} chars and linked to GitHub for the full notes.`,
+  );
+}
+
+const res = await fetch(webhook, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    username: botName,
+    embeds: [
+      {
+        title,
+        url: releaseUrl,
+        description,
+      },
+    ],
+    allowed_mentions: { parse: [] },
+  }),
+});
+
+if (!res.ok) {
+  console.error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  process.exit(1);
+}
+console.log(`Posted Discord release notification for ${tag}`);

--- a/scripts/release/github-release.ts
+++ b/scripts/release/github-release.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+/**
+ * Create a GitHub release for a tag, with channel-aware prerelease/latest flags.
+ *
+ * GitHub's API does not allow a release to be both `prerelease=true` and
+ * `latest=true`. To show an alpha/beta as "Latest" when no stable release
+ * exists yet, we publish it with `prerelease=false` — a masquerade. This
+ * script compensates on the next release: if the currently-latest release
+ * has a pre-release-style tag and prerelease=false, we flip it back to
+ * `prerelease=true` before publishing the new one. That keeps the latest
+ * badge where the user wants it without leaving stale "stable" markers on
+ * alpha/beta tags.
+ *
+ * Channel → flags on the new release:
+ *   release        prerelease=false, latest=true
+ *   beta|alpha|rc  if any true-stable release exists: prerelease=true, latest=false
+ *                  else:                              prerelease=false, latest=true (masquerade)
+ *   tag            prerelease=true, latest=false (always)
+ *
+ * Usage: bun github-release.ts <tag> <release|beta|alpha|tag>
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to query commit history from.
+ */
+import { $ } from "bun";
+import { generate } from "./changelog.ts";
+import { repo } from "./config.ts";
+
+type Channel = "release" | "beta" | "alpha" | "rc" | "tag";
+const CHANNELS: readonly Channel[] = ["release", "beta", "alpha", "rc", "tag"];
+
+function isStableTag(tag: string): boolean {
+  return /^v?\d+\.\d+\.\d+$/.test(tag);
+}
+
+const tag = process.argv[2];
+const channel = process.argv[3] as Channel | undefined;
+if (!tag || !channel || !CHANNELS.includes(channel)) {
+  console.error(
+    "Usage: bun github-release.ts <tag> <release|beta|alpha|rc|tag>",
+  );
+  process.exit(1);
+}
+
+const view = await $`gh release view ${tag}`.nothrow().quiet();
+if (view.exitCode === 0) {
+  console.log(`Release ${tag} already exists on GitHub, skipping`);
+  process.exit(0);
+}
+
+let prerelease: boolean;
+let latest: boolean;
+if (channel === "release") {
+  prerelease = false;
+  latest = true;
+} else if (channel === "tag") {
+  prerelease = true;
+  latest = false;
+} else {
+  const list = await $`gh release list --limit 500 --json tagName,isPrerelease`
+    .nothrow()
+    .quiet();
+  let hasStable = false;
+  if (list.exitCode === 0) {
+    const raw = list.stdout.toString().trim();
+    const releases = raw
+      ? (JSON.parse(raw) as Array<{ tagName: string; isPrerelease: boolean }>)
+      : [];
+    hasStable = releases.some((r) => isStableTag(r.tagName) && !r.isPrerelease);
+  }
+  if (hasStable) {
+    prerelease = true;
+    latest = false;
+  } else {
+    prerelease = false;
+    latest = true;
+    console.log(
+      "No true-stable release exists; publishing this prerelease with prerelease=false so it can be marked latest.",
+    );
+  }
+}
+
+if (latest) {
+  const cur = await $`gh release view --latest --json tagName,isPrerelease`
+    .nothrow()
+    .quiet();
+  if (cur.exitCode === 0) {
+    const raw = cur.stdout.toString().trim();
+    if (raw) {
+      const current = JSON.parse(raw) as {
+        tagName: string;
+        isPrerelease: boolean;
+      };
+      if (
+        current.tagName !== tag &&
+        !isStableTag(current.tagName) &&
+        !current.isPrerelease
+      ) {
+        console.log(
+          `Demoting previous masquerading latest ${current.tagName}: prerelease=false → true`,
+        );
+        await $`gh release edit ${current.tagName} --prerelease=true --latest=false`;
+      }
+    }
+  }
+}
+
+const prev = await $`git describe --tags --abbrev=0 ${`${tag}^`}`
+  .nothrow()
+  .quiet();
+const from = prev.exitCode === 0 ? prev.stdout.toString().trim() : undefined;
+
+console.log(
+  `Generating release notes for ${tag}${from ? ` from ${from}` : ""}`,
+);
+const { md } = await generate({
+  from,
+  to: tag,
+  emoji: true,
+  contributors: true,
+  repo: repo(),
+});
+
+const args = [
+  "release",
+  "create",
+  tag,
+  "--title",
+  tag,
+  "--notes",
+  md,
+  `--latest=${latest ? "true" : "false"}`,
+];
+if (prerelease) args.push("--prerelease");
+
+await $`gh ${args}`;

--- a/scripts/release/release-notes.ts
+++ b/scripts/release/release-notes.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+/**
+ * Prepend release notes for a tag to CHANGELOG.md. Idempotent: if the tag
+ * already appears as a heading in CHANGELOG.md, does nothing.
+ *
+ * Usage: bun release-notes.ts v2.0.0-beta.13
+ *
+ * Reads ALCHEMY_REPO for the GitHub repo to query commits/authors from.
+ */
+import { $ } from "bun";
+import { generate } from "./changelog.ts";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { repo } from "./config.ts";
+import { renderMarkdown } from "./render.ts";
+
+const tag = process.argv[2];
+if (!tag) {
+  console.error("Usage: bun release-notes.ts <tag>");
+  process.exit(1);
+}
+
+const changelogPath = join(process.cwd(), "CHANGELOG.md");
+const existing = await readFile(changelogPath, "utf-8").catch((e) => {
+  if ((e as NodeJS.ErrnoException).code === "ENOENT") return "";
+  throw e;
+});
+if (existing.includes(`## ${tag}\n`)) {
+  console.log(`${tag} already in CHANGELOG.md, skipping`);
+  process.exit(0);
+}
+
+const tagExists =
+  (await $`git rev-parse --verify ${`refs/tags/${tag}`}`.nothrow().quiet())
+    .exitCode === 0;
+const toRev = tagExists ? tag : "HEAD";
+
+console.log(`Generating release notes for ${tag} (using ${toRev})`);
+const { commits, config } = await generate({
+  to: toRev,
+  emoji: true,
+  contributors: true,
+  repo: repo(),
+});
+
+const md = renderMarkdown(commits, config);
+
+await writeFile(changelogPath, `## ${tag}\n\n${md}\n\n---\n\n${existing}`);

--- a/scripts/release/render.ts
+++ b/scripts/release/render.ts
@@ -1,0 +1,239 @@
+/**
+ * Custom markdown renderer for changelogithub-parsed commits.
+ *
+ * Mirrors the output of changelogithub's built-in generator but groups
+ * conventional-commit scopes hierarchically by splitting on `/`. For
+ * example commits like `fix(aws/lambda): ...`, `fix(aws/s3): ...` and
+ * `fix(aws): ...` render as nested categories under a shared `**aws**`
+ * top-level scope rather than as three unrelated flat groups.
+ *
+ * Line-level formatting (authors, PR/issue links, `<samp>` hash tags,
+ * `&nbsp;` spacing) is kept byte-compatible with changelogithub so output
+ * for single-segment scopes is identical to the upstream renderer.
+ */
+import type { ChangelogOptions, Commit } from "changelogithub";
+
+export type RenderConfig = Required<
+  Pick<
+    ChangelogOptions,
+    | "titles"
+    | "types"
+    | "capitalize"
+    | "emoji"
+    | "baseUrl"
+    | "repo"
+    | "from"
+    | "to"
+  >
+> & {
+  scopeMap?: Record<string, string>;
+};
+
+const emojisRE =
+  /([\u2700-\u27BF\uE000-\uF8FF\u2011-\u26FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|\uD83E[\uDD10-\uDDFF])/g;
+
+export function renderMarkdown(
+  commits: Commit[],
+  config: RenderConfig,
+): string {
+  const lines: string[] = [];
+  const [breaking, rest] = partition(commits, (c) => c.isBreaking);
+
+  if (config.titles?.breakingChanges) {
+    lines.push(
+      ...renderSection(breaking, config.titles.breakingChanges, config),
+    );
+  }
+
+  const byType = groupBy(rest, (c) => c.type);
+  for (const type of Object.keys(config.types)) {
+    const items = byType[type] || [];
+    lines.push(...renderSection(items, config.types[type].title, config));
+  }
+
+  if (!lines.length) lines.push("*No significant changes*");
+
+  const url = `https://${config.baseUrl}/${config.repo}/compare/${config.from}...${config.to}`;
+  lines.push(
+    "",
+    `##### &nbsp;&nbsp;&nbsp;&nbsp;[View changes on GitHub](${url})`,
+  );
+
+  return lines.join("\n").trim();
+}
+
+interface Node {
+  commits: Commit[];
+  children: Record<string, Node>;
+}
+
+function makeNode(): Node {
+  return { commits: [], children: {} };
+}
+
+function renderSection(
+  commits: Commit[],
+  sectionName: string,
+  config: RenderConfig,
+): string[] {
+  if (!commits.length) return [];
+  const out: string[] = ["", formatTitle(sectionName, config), ""];
+
+  // Build a tree keyed by the `/`-separated scope segments. Commits attach
+  // to the deepest node that matches their scope exactly.
+  const root = makeNode();
+  for (const commit of commits) {
+    const scope = (commit.scope ?? "").trim();
+    const mapped = config.scopeMap?.[scope] ?? scope;
+    const segments = mapped
+      ? mapped
+          .split("/")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+    let node = root;
+    for (const seg of segments) {
+      node.children[seg] ??= makeNode();
+      node = node.children[seg];
+    }
+    node.commits.push(commit);
+  }
+
+  out.push(...renderNode(root, 0, config));
+  return out;
+}
+
+function renderNode(node: Node, depth: number, config: RenderConfig): string[] {
+  const lines: string[] = [];
+  const pad = "  ".repeat(depth);
+
+  // Reverse to match changelogithub's ordering: commits come out of git log
+  // newest-first, and the upstream renderer flips them so the oldest entry
+  // in the range appears at the top of each bucket.
+  for (const commit of [...node.commits].reverse()) {
+    lines.push(`${pad}- ${formatLine(commit, config)}`);
+  }
+
+  const childNames = Object.keys(node.children).sort();
+
+  // Match changelogithub's `group: true` default: within a given level, if
+  // ANY sibling scope has more than a single inline-able commit (either
+  // multiple commits or further sub-scopes), force every sibling to render
+  // with a header. This keeps visual alignment consistent and is what the
+  // existing CHANGELOG.md entries already use, so it avoids regressing
+  // historical release-notes style.
+  const forceHeaders = childNames.some((name) => {
+    const child = node.children[name];
+    return countCommits(child) > 1 || Object.keys(child.children).length > 0;
+  });
+
+  for (const name of childNames) {
+    const child = node.children[name];
+    const label = `**${name}**`;
+
+    const childCommitCount = countCommits(child);
+    const hasGrandchildren = Object.keys(child.children).length > 0;
+
+    // Collapse inline only when NO sibling wants a header and this child is
+    // a single-commit leaf. Otherwise emit the header + nested bullets.
+    if (!forceHeaders && childCommitCount === 1 && !hasGrandchildren) {
+      const [commit] = child.commits;
+      lines.push(`${pad}- ${label}: ${formatLine(commit, config)}`);
+      continue;
+    }
+
+    lines.push(`${pad}- ${label}:`);
+    lines.push(...renderNode(child, depth + 1, config));
+  }
+
+  return lines;
+}
+
+function countCommits(node: Node): number {
+  let n = node.commits.length;
+  for (const child of Object.values(node.children)) n += countCommits(child);
+  return n;
+}
+
+function formatTitle(name: string, config: RenderConfig): string {
+  if (!config.emoji) name = name.replace(emojisRE, "");
+  return `### &nbsp;&nbsp;&nbsp;${name.trim()}`;
+}
+
+function formatLine(commit: Commit, config: RenderConfig): string {
+  const prRefs = formatReferences(commit.references, config, "issues");
+  const hashRefs = formatReferences(commit.references, config, "hash");
+  const authorNames = [
+    ...new Set(
+      (commit.resolvedAuthors ?? []).map((a) =>
+        a.login ? `@${a.login}` : `**${a.name}**`,
+      ),
+    ),
+  ];
+  const authors = joinWithAnd(authorNames).trim();
+  const authorStr = authors ? `by ${authors}` : "";
+  let refs = [authorStr, prRefs, hashRefs]
+    .filter((s) => s && s.trim())
+    .join(" ");
+  if (refs) refs = `&nbsp;-&nbsp; ${refs}`;
+  const description = config.capitalize
+    ? capitalize(commit.description)
+    : commit.description;
+  return [description, refs].filter((s) => s && s.trim()).join(" ");
+}
+
+function formatReferences(
+  references: Commit["references"],
+  config: RenderConfig,
+  kind: "issues" | "hash",
+): string {
+  const baseUrl = config.baseUrl;
+  const repo = config.repo;
+  const refs = references
+    .filter((r) =>
+      kind === "issues"
+        ? r.type === "issue" || r.type === "pull-request"
+        : r.type === "hash",
+    )
+    .map((ref) => {
+      if (!repo) return ref.value;
+      if (ref.type === "pull-request" || ref.type === "issue") {
+        return `https://${baseUrl}/${repo}/issues/${ref.value.slice(1)}`;
+      }
+      return `[<samp>(${ref.value.slice(0, 5)})</samp>](https://${baseUrl}/${repo}/commit/${ref.value})`;
+    });
+  const joined = joinWithAnd(refs).trim();
+  if (kind === "issues") return joined ? `in ${joined}` : "";
+  return joined;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function joinWithAnd(
+  array: string[],
+  glue = ", ",
+  finalGlue = " and ",
+): string {
+  if (!array || array.length === 0) return "";
+  if (array.length === 1) return array[0];
+  if (array.length === 2) return array.join(finalGlue);
+  return `${array.slice(0, -1).join(glue)}${finalGlue}${array.slice(-1)}`;
+}
+
+function partition<T>(items: T[], pred: (item: T) => boolean): [T[], T[]] {
+  const yes: T[] = [];
+  const no: T[] = [];
+  for (const item of items) (pred(item) ? yes : no).push(item);
+  return [yes, no];
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const item of items) {
+    const k = key(item);
+    (out[k] ??= []).push(item);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- restore the release scripts from the shared `alchemy-run/actions` workflow used before the pnpm migration
- generate and commit the established hierarchical `CHANGELOG.md` entry before tagging
- create GitHub releases with the restored channel-aware release generator
- post the generated changelog entry to Discord through `DISCORD_WEBHOOK_URL`
- adapt the scripts to the current Distilled repository, pnpm workspace, token environment, and formatter
- retain full-depth checkouts for both changelog and GitHub release generation

## Validation

- `vp install --frozen-lockfile --ignore-scripts`
- formatter and linter checks over the workflow and restored scripts
- local changelog-generation smoke test over 15 commits
- local extraction and Discord markdown conversion against `v1.0.0-rc.4`
- GitHub release idempotency check against `v1.0.0-rc.4`
- notifier no-webhook path exits cleanly