### PR TITLE
fix(fly-io): deploy-token response and base64 PetSem payloads

### DIFF
--- a/packages/fly-io/.generated-specs/machines.json
+++ b/packages/fly-io/.generated-specs/machines.json
@@ -1188,7 +1188,7 @@
         "smithy.api#input": {}
       }
     },
-    "com.flyio.machines#CreateAppResponse": {
+    "com.flyio.machines#CreateAppDeployTokenResponse": {
       "type": "structure",
       "members": {
         "token": {
@@ -1203,7 +1203,7 @@
         "target": "com.flyio.machines#CreateAppDeployTokenRequest"
       },
       "output": {
-        "target": "com.flyio.machines#CreateAppResponse"
+        "target": "com.flyio.machines#CreateAppDeployTokenResponse"
       },
       "errors": [
         {

--- a/packages/fly-io/.generated-specs/mpg.json
+++ b/packages/fly-io/.generated-specs/mpg.json
@@ -153,6 +153,9 @@
       },
       "errors": [
         {
+          "target": "com.flyio.mpg#Forbidden"
+        },
+        {
           "target": "com.flyio.mpg#NotFound"
         }
       ],
@@ -1450,19 +1453,6 @@
         "smithy.api#documentation": "Restore a cluster from a backup (creates a new cluster)"
       }
     },
-    "com.flyio.mpg#NotFound": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#error": "client",
-        "smithy.api#httpError": 404,
-        "com.distilled.openapi#errorMatchers": [
-          {
-            "status": 404
-          }
-        ]
-      }
-    },
     "com.flyio.mpg#Forbidden": {
       "type": "structure",
       "members": {},
@@ -1472,6 +1462,19 @@
         "com.distilled.openapi#errorMatchers": [
           {
             "status": 403
+          }
+        ]
+      }
+    },
+    "com.flyio.mpg#NotFound": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 404,
+        "com.distilled.openapi#errorMatchers": [
+          {
+            "status": 404
           }
         ]
       }

--- a/packages/fly-io/patches/machines/appDeployToken.patch.json
+++ b/packages/fly-io/patches/machines/appDeployToken.patch.json
@@ -1,0 +1,15 @@
+{
+  "description": "Give the deploy-token response its own schema name. `POST /apps` declares a 201 with no body, so codegen synthesizes an empty `CreateAppResponse` for `createApp` — which collides with, and erases, the real `CreateAppResponse` (`{ token }`) that `POST /apps/{app_name}/deploy_token` returns. Renaming the real schema keeps `createAppDeployToken`'s `token` on the generated output type.",
+  "patches": [
+    {
+      "op": "move",
+      "from": "/components/schemas/CreateAppResponse",
+      "path": "/components/schemas/CreateAppDeployTokenResponse"
+    },
+    {
+      "op": "replace",
+      "path": "/paths/~1apps~1{app_name}~1deploy_token/post/responses/200/content/application~1json/schema/$ref",
+      "value": "#/components/schemas/CreateAppDeployTokenResponse"
+    }
+  ]
+}

--- a/packages/fly-io/patches/machines/secretKeyCrypto.patch.json
+++ b/packages/fly-io/patches/machines/secretKeyCrypto.patch.json
@@ -1,0 +1,79 @@
+{
+  "description": "PetSem crypto payloads are base64 strings on the wire, not integer arrays. Fly's Machines API is Go, and Go's encoding/json marshals []byte as base64 \u2014 the spec generator only saw the []byte and wrote `array of integer`. Verified against a live Machine over /.fly/api: an integer array is rejected, base64 round-trips. Plaintext members are marked x-sensitive so they land in Redacted.",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "/components/schemas/DecryptSecretkeyRequest/properties/associated_data",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DecryptSecretkeyRequest/properties/ciphertext",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/DecryptSecretkeyResponse/properties/plaintext",
+      "value": {
+        "type": "string",
+        "x-sensitive": true
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/EncryptSecretkeyRequest/properties/associated_data",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/EncryptSecretkeyRequest/properties/plaintext",
+      "value": {
+        "type": "string",
+        "x-sensitive": true
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/EncryptSecretkeyResponse/properties/ciphertext",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SignSecretkeyRequest/properties/plaintext",
+      "value": {
+        "type": "string",
+        "x-sensitive": true
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/SignSecretkeyResponse/properties/signature",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/VerifySecretkeyRequest/properties/plaintext",
+      "value": {
+        "type": "string",
+        "x-sensitive": true
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/components/schemas/VerifySecretkeyRequest/properties/signature",
+      "value": {
+        "type": "string"
+      }
+    }
+  ]
+}

--- a/packages/fly-io/specs/mpg/openapi.json
+++ b/packages/fly-io/specs/mpg/openapi.json
@@ -28,6 +28,7 @@
               }
             }
           },
+          "403": { "description": "Forbidden" },
           "404": { "description": "Organization not found" }
         }
       },

--- a/packages/fly-io/src/services/machines.ts
+++ b/packages/fly-io/src/services/machines.ts
@@ -624,6 +624,17 @@ export const CreateAppDeployTokenRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "CreateAppDeployTokenRequest",
 }) as any as S.Schema<CreateAppDeployTokenRequest>;
 
+export interface CreateAppDeployTokenResponse {
+  token?: string;
+}
+export const CreateAppDeployTokenResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    token: S.optional(S.String),
+  }),
+).annotate({
+  identifier: "CreateAppDeployTokenResponse",
+}) as any as S.Schema<CreateAppDeployTokenResponse>;
+
 export interface CreateAppIPAssignmentRequest {
   /** Fly App Name */
   app_name: string;
@@ -4738,12 +4749,12 @@ export type CreateAppDeployTokenError =
 /** Create App deploy token */
 export const createAppDeployToken: API.OperationMethod<
   CreateAppDeployTokenRequest,
-  CreateAppResponse,
+  CreateAppDeployTokenResponse,
   CreateAppDeployTokenError,
   FlyIoOpContext
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateAppDeployTokenRequest,
-  output: CreateAppResponse,
+  output: CreateAppDeployTokenResponse,
   errors: [BadRequest, Forbidden, NotFound],
   protocol: FlyIoProtocol,
   retry: Retry.Retry,

--- a/packages/fly-io/src/services/mpg.ts
+++ b/packages/fly-io/src/services/mpg.ts
@@ -1082,7 +1082,7 @@ export const listBackups: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type ListClustersError = NotFound | FlyIoOpError;
+export type ListClustersError = Forbidden | NotFound | FlyIoOpError;
 /** List MPG v2 clusters in an organization */
 export const listClusters: API.OperationMethod<
   ListClustersRequest,
@@ -1092,7 +1092,7 @@ export const listClusters: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: ListClustersRequest,
   output: ListClustersResponse,
-  errors: [NotFound],
+  errors: [Forbidden, NotFound],
   protocol: FlyApiProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
Two fly-io schema bugs surfaced by alchemy's Fly provider, plus a missing typed error.

### `createAppDeployToken` lost its `token`

`POST /apps` declares a 201 with no body, so codegen synthesizes an empty `CreateAppResponse` for `createApp` — which collides with, and erases, the real `CreateAppResponse` returned by `POST /apps/{app_name}/deploy_token`. Renaming the real schema breaks the collision:

```diff lang="typescript"
 export const createAppDeployToken: API.OperationMethod<
   CreateAppDeployTokenRequest,
-  CreateAppResponse,
+  CreateAppDeployTokenResponse,
```

### PetSem payloads are base64, not integer arrays

The Machines API is Go, and `encoding/json` marshals `[]byte` as base64 — the spec generator only saw the `[]byte` and wrote `array of integer`. `.generated-specs/machines.json` already carried that correction as a hand-edit, so any `bun scripts/convert.ts` reverted it. Encoded as a patch instead:

```ts
// encrypt / decrypt / sign / verify
plaintext?: string   // was: Array<number>
ciphertext?: string
signature?: string
associated_data?: string
```

### `listClusters` 403

`GET /organizations/{org_slug}/postgresv2` returns 403 for tokens without org scope; the sibling POST already declared it.

```diff lang="typescript"
-export type ListClustersError = NotFound | FlyIoOpError;
+export type ListClustersError = Forbidden | NotFound | FlyIoOpError;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
