### PR TITLE
fix(cloudflare): unwrap single-type envelope wrappers in spec conversion

### DIFF
--- a/packages/cloudflare/.generated-specs/audit_logs.json
+++ b/packages/cloudflare/.generated-specs/audit_logs.json
@@ -163,12 +163,175 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.audit_logs#ListResultItemAction": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "A boolean that indicates if the action attempted was successful."
+          }
+        },
+        "type": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A short string that describes the action that was performed."
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultItemActorType": {
+      "type": "enum",
+      "members": {
+        "USER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "user"
+          }
+        },
+        "ADMIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "admin"
+          }
+        },
+        "CLOUDFLARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Cloudflare"
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultItemActor": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The ID of the actor that performed the action. If a user performed the action, this will be their User ID."
+          }
+        },
+        "email": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The email of the user that performed the action."
+          }
+        },
+        "ip": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The IP address of the request that performed the action."
+          }
+        },
+        "type": {
+          "target": "com.cloudflare.audit_logs#ListResultItemActorType",
+          "traits": {
+            "smithy.api#documentation": "The type of actor, whether a User, Cloudflare Admin, or an Automated System."
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultItemOwner": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier"
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultItemResource": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "An identifier for the resource that was affected by the action."
+          }
+        },
+        "type": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A short string that describes the resource that was affected by the action."
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultItem": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A string that uniquely identifies the audit log."
+          }
+        },
+        "action": {
+          "target": "com.cloudflare.audit_logs#ListResultItemAction"
+        },
+        "actor": {
+          "target": "com.cloudflare.audit_logs#ListResultItemActor"
+        },
+        "interface": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The source of the event."
+          }
+        },
+        "metadata": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "smithy.api#documentation": "An object which can lend more context to the action being logged. This is a flexible value and varies between different actions."
+          }
+        },
+        "newValue": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The new value of the resource that was modified."
+          }
+        },
+        "oldValue": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The value of the resource before it was modified."
+          }
+        },
+        "owner": {
+          "target": "com.cloudflare.audit_logs#ListResultItemOwner"
+        },
+        "resource": {
+          "target": "com.cloudflare.audit_logs#ListResultItemResource"
+        },
+        "when": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A UTC RFC3339 timestamp that specifies when the action being logged occured."
+          }
+        }
+      }
+    },
+    "com.cloudflare.audit_logs#ListResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.audit_logs#ListResultItem"
+      }
+    },
     "com.cloudflare.audit_logs#ListResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "result": {
+          "target": "com.cloudflare.audit_logs#ListResultList",
+          "traits": {
+            "com.cloudflare.protocols#envelopePayload": {},
+            "smithy.api#documentation": "The unwrapped `result` payload of the v4 response envelope."
+          }
+        }
+      },
       "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#output": {}
       }
     },
     "com.cloudflare.audit_logs#List": {

--- a/packages/cloudflare/.generated-specs/email_routing.json
+++ b/packages/cloudflare/.generated-specs/email_routing.json
@@ -1226,21 +1226,13 @@
         "smithy.api#input": {}
       }
     },
-    "com.cloudflare.email_routing#DnsDeleteResponse": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
-      }
-    },
     "com.cloudflare.email_routing#DnsDelete": {
       "type": "operation",
       "input": {
         "target": "com.cloudflare.email_routing#DnsDeleteRequest"
       },
       "output": {
-        "target": "com.cloudflare.email_routing#DnsDeleteResponse"
+        "target": "smithy.api#Unit"
       },
       "traits": {
         "smithy.api#http": {
@@ -1415,12 +1407,228 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.email_routing#DnsGetResponseErrorsItemMissingType": {
+      "type": "enum",
+      "members": {
+        "A": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "A"
+          }
+        },
+        "AAAA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AAAA"
+          }
+        },
+        "CNAME": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CNAME"
+          }
+        },
+        "HTTPS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "HTTPS"
+          }
+        },
+        "TXT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TXT"
+          }
+        },
+        "SRV": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SRV"
+          }
+        },
+        "LOC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOC"
+          }
+        },
+        "MX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MX"
+          }
+        },
+        "NS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NS"
+          }
+        },
+        "CERT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CERT"
+          }
+        },
+        "DNSKEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DNSKEY"
+          }
+        },
+        "DS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DS"
+          }
+        },
+        "NAPTR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NAPTR"
+          }
+        },
+        "SMIMEA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SMIMEA"
+          }
+        },
+        "SSHFP": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SSHFP"
+          }
+        },
+        "SVCB": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SVCB"
+          }
+        },
+        "TLSA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "TLSA"
+          }
+        },
+        "URI": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "URI"
+          }
+        }
+      }
+    },
+    "com.cloudflare.email_routing#DnsGetResponseErrorsItemMissing": {
+      "type": "structure",
+      "members": {
+        "content": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "DNS record content."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "DNS record name (or @ for the zone apex)."
+          }
+        },
+        "priority": {
+          "target": "smithy.api#Double",
+          "traits": {
+            "smithy.api#documentation": "Required for MX, SRV and URI records. Unused by other record types. Records with lower priorities are preferred."
+          }
+        },
+        "ttl": {
+          "target": "smithy.api#Double",
+          "traits": {
+            "smithy.api#documentation": "Time to live, in seconds, of the DNS record. Must be between 60 and 86400, or 1 for 'automatic'."
+          }
+        },
+        "type": {
+          "target": "com.cloudflare.email_routing#DnsGetResponseErrorsItemMissingType",
+          "traits": {
+            "smithy.api#documentation": "DNS record type."
+          }
+        }
+      }
+    },
+    "com.cloudflare.email_routing#DnsGetResponseErrorsItem": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "smithy.api#String"
+        },
+        "missing": {
+          "target": "com.cloudflare.email_routing#DnsGetResponseErrorsItemMissing",
+          "traits": {
+            "smithy.api#documentation": "List of records needed to enable an Email Routing zone."
+          }
+        }
+      }
+    },
+    "com.cloudflare.email_routing#DnsGetResponseErrorsList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.email_routing#DnsGetResponseErrorsItem"
+      }
+    },
+    "com.cloudflare.email_routing#DnsGetResponseRecordItem": {
+      "type": "structure",
+      "members": {
+        "content": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "DNS record content."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "DNS record name (or @ for the zone apex)."
+          }
+        },
+        "priority": {
+          "target": "smithy.api#Double",
+          "traits": {
+            "smithy.api#documentation": "Required for MX, SRV and URI records. Unused by other record types. Records with lower priorities are preferred."
+          }
+        },
+        "ttl": {
+          "target": "smithy.api#Double",
+          "traits": {
+            "smithy.api#documentation": "Time to live, in seconds, of the DNS record. Must be between 60 and 86400, or 1 for 'automatic'."
+          }
+        },
+        "type": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "DNS record type."
+          }
+        }
+      }
+    },
+    "com.cloudflare.email_routing#DnsGetResponseRecordList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.email_routing#DnsGetResponseRecordItem"
+      }
+    },
     "com.cloudflare.email_routing#DnsGetResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "errors": {
+          "target": "com.cloudflare.email_routing#DnsGetResponseErrorsList"
+        },
+        "record": {
+          "target": "com.cloudflare.email_routing#DnsGetResponseRecordList"
+        }
+      },
       "traits": {
         "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#documentation": "Unwrapped `result` payload of the Cloudflare v4 response envelope."
       }
     },
     "com.cloudflare.email_routing#DnsGet": {

--- a/packages/cloudflare/.generated-specs/logs.json
+++ b/packages/cloudflare/.generated-specs/logs.json
@@ -1590,12 +1590,115 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemObjectType": {
+      "type": "enum",
+      "members": {
+        "ACCOUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "account"
+          }
+        },
+        "ZONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zone"
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaPropertiesMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#Document"
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaRequiredList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaType": {
+      "type": "enum",
+      "members": {
+        "OBJECT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "object"
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchema": {
+      "type": "structure",
+      "members": {
+        "properties": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaPropertiesMap"
+        },
+        "required": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaRequiredList"
+        },
+        "type": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchemaType"
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItem": {
+      "type": "structure",
+      "members": {
+        "dataset": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Dataset type name (e.g. `http_requests`).",
+            "smithy.api#required": {}
+          }
+        },
+        "object_type": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemObjectType",
+          "traits": {
+            "smithy.api#documentation": "Whether this dataset type is account-scoped or zone-scoped.",
+            "smithy.api#required": {}
+          }
+        },
+        "schema": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItemSchema",
+          "traits": {
+            "smithy.api#documentation": "JSON Schema that describes the fields this dataset exposes.",
+            "smithy.api#required": {}
+          }
+        },
+        "timestamp_field": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The primary timestamp field name for this dataset.",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultItem"
+      }
+    },
     "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "result": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccountResultList",
+          "traits": {
+            "com.cloudflare.protocols#envelopePayload": {},
+            "smithy.api#documentation": "The unwrapped `result` payload of the v4 response envelope."
+          }
+        }
+      },
       "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#output": {}
       }
     },
     "com.cloudflare.logs#LogExplorerDatasetsAvailableListForAccount": {
@@ -1632,12 +1735,115 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemObjectType": {
+      "type": "enum",
+      "members": {
+        "ACCOUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "account"
+          }
+        },
+        "ZONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "zone"
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaPropertiesMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#Document"
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaRequiredList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaType": {
+      "type": "enum",
+      "members": {
+        "OBJECT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "object"
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchema": {
+      "type": "structure",
+      "members": {
+        "properties": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaPropertiesMap"
+        },
+        "required": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaRequiredList"
+        },
+        "type": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchemaType"
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItem": {
+      "type": "structure",
+      "members": {
+        "dataset": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Dataset type name (e.g. `http_requests`).",
+            "smithy.api#required": {}
+          }
+        },
+        "object_type": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemObjectType",
+          "traits": {
+            "smithy.api#documentation": "Whether this dataset type is account-scoped or zone-scoped.",
+            "smithy.api#required": {}
+          }
+        },
+        "schema": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItemSchema",
+          "traits": {
+            "smithy.api#documentation": "JSON Schema that describes the fields this dataset exposes.",
+            "smithy.api#required": {}
+          }
+        },
+        "timestamp_field": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The primary timestamp field name for this dataset.",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultItem"
+      }
+    },
     "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "result": {
+          "target": "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZoneResultList",
+          "traits": {
+            "com.cloudflare.protocols#envelopePayload": {},
+            "smithy.api#documentation": "The unwrapped `result` payload of the v4 response envelope."
+          }
+        }
+      },
       "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#output": {}
       }
     },
     "com.cloudflare.logs#LogExplorerDatasetsAvailableListForZone": {

--- a/packages/cloudflare/.generated-specs/memberships.json
+++ b/packages/cloudflare/.generated-specs/memberships.json
@@ -637,12 +637,238 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.memberships#ListResultItemAccountType": {
+      "type": "enum",
+      "members": {
+        "STANDARD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "standard"
+          }
+        },
+        "ENTERPRISE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "enterprise"
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemAccountManagedBy": {
+      "type": "structure",
+      "members": {
+        "parent_org_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "ID of the parent Organization, if one exists"
+          }
+        },
+        "parent_org_name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Name of the parent Organization, if one exists"
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemAccountSettings": {
+      "type": "structure",
+      "members": {
+        "abuse_contact_email": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Sets an abuse contact email to notify for abuse reports."
+          }
+        },
+        "enforce_twofactor": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Indicates whether membership in this account requires that"
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemAccount": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier",
+            "smithy.api#required": {}
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Account name",
+            "smithy.api#required": {}
+          }
+        },
+        "type": {
+          "target": "com.cloudflare.memberships#ListResultItemAccountType",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "created_on": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Timestamp for the creation of the account"
+          }
+        },
+        "managed_by": {
+          "target": "com.cloudflare.memberships#ListResultItemAccountManagedBy",
+          "traits": {
+            "smithy.api#documentation": "Parent container details"
+          }
+        },
+        "settings": {
+          "target": "com.cloudflare.memberships#ListResultItemAccountSettings",
+          "traits": {
+            "smithy.api#documentation": "Account settings"
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemPermissionsAnalytics": {
+      "type": "structure",
+      "members": {
+        "read": {
+          "target": "smithy.api#Boolean"
+        },
+        "write": {
+          "target": "smithy.api#Boolean"
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemPermissions": {
+      "type": "structure",
+      "members": {
+        "analytics": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "billing": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "cache_purge": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "dns": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "dns_records": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "lb": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "logs": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "organization": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "ssl": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "waf": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "zone_settings": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        },
+        "zones": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissionsAnalytics"
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemRolesList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "com.cloudflare.memberships#ListResultItemStatus": {
+      "type": "enum",
+      "members": {
+        "ACCEPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "accepted"
+          }
+        },
+        "PENDING": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "pending"
+          }
+        },
+        "REJECTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "rejected"
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultItem": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Membership identifier tag."
+          }
+        },
+        "account": {
+          "target": "com.cloudflare.memberships#ListResultItemAccount"
+        },
+        "api_access_enabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Enterprise only. Indicates whether or not API access is enabled specifically for this user on a given account."
+          }
+        },
+        "permissions": {
+          "target": "com.cloudflare.memberships#ListResultItemPermissions",
+          "traits": {
+            "smithy.api#documentation": "All access permissions for the user at the account."
+          }
+        },
+        "roles": {
+          "target": "com.cloudflare.memberships#ListResultItemRolesList",
+          "traits": {
+            "smithy.api#documentation": "List of role names the membership has for this account."
+          }
+        },
+        "status": {
+          "target": "com.cloudflare.memberships#ListResultItemStatus",
+          "traits": {
+            "smithy.api#documentation": "Status of this membership."
+          }
+        }
+      }
+    },
+    "com.cloudflare.memberships#ListResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.memberships#ListResultItem"
+      }
+    },
     "com.cloudflare.memberships#ListResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "result": {
+          "target": "com.cloudflare.memberships#ListResultList",
+          "traits": {
+            "com.cloudflare.protocols#envelopePayload": {},
+            "smithy.api#documentation": "The unwrapped `result` payload of the v4 response envelope."
+          }
+        }
+      },
       "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#output": {}
       }
     },
     "com.cloudflare.memberships#List": {

--- a/packages/cloudflare/.generated-specs/user.json
+++ b/packages/cloudflare/.generated-specs/user.json
@@ -576,12 +576,175 @@
         "smithy.api#input": {}
       }
     },
+    "com.cloudflare.user#AuditLogsListResultItemAction": {
+      "type": "structure",
+      "members": {
+        "result": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "A boolean that indicates if the action attempted was successful."
+          }
+        },
+        "type": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A short string that describes the action that was performed."
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultItemActorType": {
+      "type": "enum",
+      "members": {
+        "USER": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "user"
+          }
+        },
+        "ADMIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "admin"
+          }
+        },
+        "CLOUDFLARE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "Cloudflare"
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultItemActor": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The ID of the actor that performed the action. If a user performed the action, this will be their User ID."
+          }
+        },
+        "email": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The email of the user that performed the action."
+          }
+        },
+        "ip": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The IP address of the request that performed the action."
+          }
+        },
+        "type": {
+          "target": "com.cloudflare.user#AuditLogsListResultItemActorType",
+          "traits": {
+            "smithy.api#documentation": "The type of actor, whether a User, Cloudflare Admin, or an Automated System."
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultItemOwner": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier"
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultItemResource": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "An identifier for the resource that was affected by the action."
+          }
+        },
+        "type": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A short string that describes the resource that was affected by the action."
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultItem": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A string that uniquely identifies the audit log."
+          }
+        },
+        "action": {
+          "target": "com.cloudflare.user#AuditLogsListResultItemAction"
+        },
+        "actor": {
+          "target": "com.cloudflare.user#AuditLogsListResultItemActor"
+        },
+        "interface": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The source of the event."
+          }
+        },
+        "metadata": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "smithy.api#documentation": "An object which can lend more context to the action being logged. This is a flexible value and varies between different actions."
+          }
+        },
+        "newValue": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The new value of the resource that was modified."
+          }
+        },
+        "oldValue": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The value of the resource before it was modified."
+          }
+        },
+        "owner": {
+          "target": "com.cloudflare.user#AuditLogsListResultItemOwner"
+        },
+        "resource": {
+          "target": "com.cloudflare.user#AuditLogsListResultItemResource"
+        },
+        "when": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A UTC RFC3339 timestamp that specifies when the action being logged occured."
+          }
+        }
+      }
+    },
+    "com.cloudflare.user#AuditLogsListResultList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.user#AuditLogsListResultItem"
+      }
+    },
     "com.cloudflare.user#AuditLogsListResponse": {
       "type": "structure",
-      "members": {},
+      "members": {
+        "result": {
+          "target": "com.cloudflare.user#AuditLogsListResultList",
+          "traits": {
+            "com.cloudflare.protocols#envelopePayload": {},
+            "smithy.api#documentation": "The unwrapped `result` payload of the v4 response envelope."
+          }
+        }
+      },
       "traits": {
-        "smithy.api#output": {},
-        "smithy.api#documentation": "Raw response payload (operation does not use the standard v4 result envelope)."
+        "smithy.api#output": {}
       }
     },
     "com.cloudflare.user#AuditLogsList": {

--- a/packages/cloudflare/patches/email_routing/deleteDns.json
+++ b/packages/cloudflare/patches/email_routing/deleteDns.json
@@ -1,5 +1,5 @@
 {
-  "description": "Align email_routing#DnsDelete with distilled cloudflare/email-routing deleteDns",
+  "description": "Align email_routing#DnsDelete with distilled cloudflare/email-routing deleteDns. The response is the bare v4 envelope with no result payload (smithy.api#Unit output), so the generator synthesizes the empty DeleteDnsResponse from the op name.",
   "patches": [
     {
       "op": "move",
@@ -15,24 +15,6 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.email_routing#DeleteDns/input/target",
       "value": "com.cloudflare.email_routing#DeleteDnsRequest"
-    },
-    {
-      "op": "move",
-      "from": "/shapes/com.cloudflare.email_routing#DnsDeleteResponse",
-      "path": "/shapes/com.cloudflare.email_routing#DeleteDnsResponse"
-    },
-    {
-      "op": "replace",
-      "path": "/shapes/com.cloudflare.email_routing#DeleteDns/output/target",
-      "value": "com.cloudflare.email_routing#DeleteDnsResponse"
-    },
-    {
-      "op": "add",
-      "path": "/shapes/com.cloudflare.email_routing#DeleteDns/traits/smithy.api#paginated",
-      "value": {
-        "mode": "single",
-        "items": "result"
-      }
     }
   ]
 }

--- a/packages/cloudflare/scripts/spec-to-smithy.ts
+++ b/packages/cloudflare/scripts/spec-to-smithy.ts
@@ -1020,6 +1020,27 @@ const buildMembers = (
 
 const ENVELOPE_KEYS = new Set(["success", "errors", "messages", "result_info"]);
 
+/** A node whose children are the v4 envelope keys (success/errors/…). */
+const isEnvelopeWrapper = (node: FieldNode): boolean => {
+  const names = new Set(node.children.map((c) => c.name));
+  return names.has("success") && names.has("errors");
+};
+
+/**
+ * Some doc pages wrap the whole Returns section in named envelope types
+ * (`IAMCollectionMembershipResponse object { errors, messages, success,
+ * result, result_info }`) instead of listing the envelope keys as top-level
+ * bullets — sometimes as a union of several such wrappers (memberships
+ * documents plain and with-policies variants). Unwrap so the standard
+ * result handling sees `result`; a wrapper union unwraps its first arm,
+ * the common base every variant extends. Without this the operation
+ * generated an EMPTY response structure and the payload was undecodable.
+ */
+const unwrapEnvelopeReturns = (returns: FieldNode[]): FieldNode[] =>
+  returns.length > 0 && returns.every(isEnvelopeWrapper)
+    ? returns[0].children
+    : returns;
+
 // ============================================================================
 // Whole-body union flattening
 // ============================================================================
@@ -1292,7 +1313,8 @@ const buildOperation = (bag: Bag, opName: string, parsed: ParsedOp): string => {
 
   // ---- Output: the UNWRAPPED `result` payload ----
   let outputTarget: string = PRELUDE.Unit;
-  const resultNode = parsed.returns.find((n) => n.name === "result");
+  const returns = unwrapEnvelopeReturns(parsed.returns);
+  const resultNode = returns.find((n) => n.name === "result");
   if (resultNode) {
     const { core } = stripOptional(resultNode.typeStr);
     const fieldChildren = resultNode.children.filter((c) => !isArmChild(c));
@@ -1354,7 +1376,7 @@ const buildOperation = (bag: Bag, opName: string, parsed: ParsedOp): string => {
     }
   } else {
     // Non-standard envelope: keep any non-envelope top-level fields as output.
-    const rest = parsed.returns.filter((n) => !ENVELOPE_KEYS.has(n.name));
+    const rest = returns.filter((n) => !ENVELOPE_KEYS.has(n.name));
     if (rest.length) {
       const members = buildMembers(bag, rest, `${opName}Response`, "output");
       outputTarget = addShape(bag, `${opName}Response`, {
@@ -1680,7 +1702,7 @@ const command = Command.make(
       const protocolPath = path.join(outDir, "cloudflare.protocols.json");
       yield* fs.writeFileString(
         protocolPath,
-        JSON.stringify(buildProtocolModel(), null, 2),
+        `${JSON.stringify(buildProtocolModel(), null, 2)}\n`,
       );
 
       const suppressions = {
@@ -1698,7 +1720,7 @@ const command = Command.make(
           shapes: bag.shapes,
         };
         const fp = path.join(outDir, `${sanitizeNsSegment(top)}.json`);
-        yield* fs.writeFileString(fp, JSON.stringify(model, null, 2));
+        yield* fs.writeFileString(fp, `${JSON.stringify(model, null, 2)}\n`);
       }
 
       yield* Console.log(

--- a/packages/cloudflare/src/services/audit_logs.ts
+++ b/packages/cloudflare/src/services/audit_logs.ts
@@ -4,9 +4,11 @@ import * as API from "@distilled.cloud/core/api";
 import * as T from "../traits.ts";
 import {
   CloudflareProtocol,
+  CloudflarePaginatedProtocol,
   type CloudflareOpError,
   type CloudflareOpContext,
 } from "../protocol.ts";
+import { cloudflarePaginate, ResultInfo } from "../pagination.ts";
 import { CloudflareError, CloudflareRateLimited } from "../errors.ts";
 import * as Retry from "../retry.ts";
 
@@ -111,25 +113,147 @@ export const ListAuditLogsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListAuditLogsRequest",
 }) as any as S.Schema<ListAuditLogsRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
-export interface ListAuditLogsResponse {}
+export interface ListResultItemAction {
+  /** A boolean that indicates if the action attempted was successful. */
+  result?: boolean | null;
+  /** A short string that describes the action that was performed. */
+  type?: string | null;
+}
+export const ListResultItemAction = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    result: S.optional(S.NullOr(S.Boolean)),
+    type: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "ListResultItemAction",
+}) as any as S.Schema<ListResultItemAction>;
+
+export type ListResultItemActorType = "user" | "admin" | "Cloudflare";
+export const ListResultItemActorType = /*@__PURE__*/ S.String;
+
+export interface ListResultItemActor {
+  /** The ID of the actor that performed the action. If a user performed the action, this will be their User ID. */
+  id?: string | null;
+  /** The email of the user that performed the action. */
+  email?: string | null;
+  /** The IP address of the request that performed the action. */
+  ip?: string | null;
+  /** The type of actor, whether a User, Cloudflare Admin, or an Automated System. */
+  type?: ListResultItemActorType | null;
+}
+export const ListResultItemActor = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    email: S.optional(S.NullOr(S.String)),
+    ip: S.optional(S.NullOr(S.String)),
+    type: S.optional(S.NullOr(ListResultItemActorType)),
+  }),
+).annotate({
+  identifier: "ListResultItemActor",
+}) as any as S.Schema<ListResultItemActor>;
+
+export interface ListResultItemOwner {
+  /** Identifier */
+  id?: string | null;
+}
+export const ListResultItemOwner = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "ListResultItemOwner",
+}) as any as S.Schema<ListResultItemOwner>;
+
+export interface ListResultItemResource {
+  /** An identifier for the resource that was affected by the action. */
+  id?: string | null;
+  /** A short string that describes the resource that was affected by the action. */
+  type?: string | null;
+}
+export const ListResultItemResource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    type: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "ListResultItemResource",
+}) as any as S.Schema<ListResultItemResource>;
+
+export interface ListResultItem {
+  /** A string that uniquely identifies the audit log. */
+  id?: string | null;
+  action?: ListResultItemAction | null;
+  actor?: ListResultItemActor | null;
+  /** The source of the event. */
+  interface?: string | null;
+  /** An object which can lend more context to the action being logged. This is a flexible value and varies between different actions. */
+  metadata?: unknown | null;
+  /** The new value of the resource that was modified. */
+  newValue?: string | null;
+  /** The value of the resource before it was modified. */
+  oldValue?: string | null;
+  owner?: ListResultItemOwner | null;
+  resource?: ListResultItemResource | null;
+  /** A UTC RFC3339 timestamp that specifies when the action being logged occured. */
+  when?: string | null;
+}
+export const ListResultItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    action: S.optional(S.NullOr(ListResultItemAction)),
+    actor: S.optional(S.NullOr(ListResultItemActor)),
+    interface: S.optional(S.NullOr(S.String)),
+    metadata: S.optional(S.NullOr(S.Unknown)),
+    newValue: S.optional(S.NullOr(S.String)),
+    oldValue: S.optional(S.NullOr(S.String)),
+    owner: S.optional(S.NullOr(ListResultItemOwner)),
+    resource: S.optional(S.NullOr(ListResultItemResource)),
+    when: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({ identifier: "ListResultItem" }) as any as S.Schema<ListResultItem>;
+
+export type ListResultList = Array<ListResultItem>;
+export const ListResultList = /*@__PURE__*/ S.Array(
+  ListResultItem,
+) as any as S.Schema<ListResultList>;
+
+export interface ListAuditLogsResponse {
+  /** The unwrapped `result` payload of the v4 response envelope. */
+  result: ListResultList;
+  /** Pagination info from the envelope's `result_info`. */
+  resultInfo?: ResultInfo | null;
+}
 export const ListAuditLogsResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+  S.Struct({
+    result: ListResultList.pipe(T.EnvelopePayload()),
+    resultInfo: S.optional(S.NullOr(ResultInfo).pipe(T.ResultInfo())),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "ListAuditLogsResponse",
 }) as any as S.Schema<ListAuditLogsResponse>;
 
 export type ListAuditLogsError = CloudflareOpError;
 /** Gets a list of audit logs for an account. Can be filtered by who made the change, on which zone, and the timeframe of the change. */
-export const listAuditLogs: API.OperationMethod<
+export const listAuditLogs: API.PaginatedOperationMethod<
   ListAuditLogsRequest,
   ListAuditLogsResponse,
   ListAuditLogsError,
-  CloudflareOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: ListAuditLogsRequest,
-  output: ListAuditLogsResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
-  protocol: CloudflareProtocol,
-  retry: Retry.Retry,
-}));
+  CloudflareOpContext,
+  ListResultItem
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListAuditLogsRequest,
+    output: ListAuditLogsResponse,
+    errors: [CloudflareRateLimited, CloudflareError],
+    protocol: CloudflarePaginatedProtocol,
+    retry: Retry.Retry,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "resultInfo.page",
+      items: "result",
+      pageSize: "perPage",
+    } as const,
+  }),
+  cloudflarePaginate,
+) as any;

--- a/packages/cloudflare/src/services/email_routing.ts
+++ b/packages/cloudflare/src/services/email_routing.ts
@@ -532,7 +532,6 @@ export const DeleteDnsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "DeleteDnsRequest",
 }) as any as S.Schema<DeleteDnsRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
 export interface DeleteDnsResponse {}
 export const DeleteDnsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
@@ -866,10 +865,109 @@ export const GetDnsRequest = /*@__PURE__*/ S.suspend(() =>
     .pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({ identifier: "GetDnsRequest" }) as any as S.Schema<GetDnsRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
-export interface GetDnsResponse {}
+export type DnsGetResponseErrorsItemMissingType =
+  | "A"
+  | "AAAA"
+  | "CNAME"
+  | "HTTPS"
+  | "TXT"
+  | "SRV"
+  | "LOC"
+  | "MX"
+  | "NS"
+  | "CERT"
+  | "DNSKEY"
+  | "DS"
+  | "NAPTR"
+  | "SMIMEA"
+  | "SSHFP"
+  | "SVCB"
+  | "TLSA"
+  | "URI";
+export const DnsGetResponseErrorsItemMissingType = /*@__PURE__*/ S.String;
+
+export interface DnsGetResponseErrorsItemMissing {
+  /** DNS record content. */
+  content?: string | null;
+  /** DNS record name (or @ for the zone apex). */
+  name?: string | null;
+  /** Required for MX, SRV and URI records. Unused by other record types. Records with lower priorities are preferred. */
+  priority?: number | null;
+  /** Time to live, in seconds, of the DNS record. Must be between 60 and 86400, or 1 for 'automatic'. */
+  ttl?: number | null;
+  /** DNS record type. */
+  type?: DnsGetResponseErrorsItemMissingType | null;
+}
+export const DnsGetResponseErrorsItemMissing = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    content: S.optional(S.NullOr(S.String)),
+    name: S.optional(S.NullOr(S.String)),
+    priority: S.optional(S.NullOr(S.Number)),
+    ttl: S.optional(S.NullOr(S.Number)),
+    type: S.optional(S.NullOr(DnsGetResponseErrorsItemMissingType)),
+  }),
+).annotate({
+  identifier: "DnsGetResponseErrorsItemMissing",
+}) as any as S.Schema<DnsGetResponseErrorsItemMissing>;
+
+export interface DnsGetResponseErrorsItem {
+  code?: string | null;
+  /** List of records needed to enable an Email Routing zone. */
+  missing?: DnsGetResponseErrorsItemMissing | null;
+}
+export const DnsGetResponseErrorsItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    code: S.optional(S.NullOr(S.String)),
+    missing: S.optional(S.NullOr(DnsGetResponseErrorsItemMissing)),
+  }),
+).annotate({
+  identifier: "DnsGetResponseErrorsItem",
+}) as any as S.Schema<DnsGetResponseErrorsItem>;
+
+export type DnsGetResponseErrorsList = Array<DnsGetResponseErrorsItem>;
+export const DnsGetResponseErrorsList = /*@__PURE__*/ S.Array(
+  DnsGetResponseErrorsItem,
+) as any as S.Schema<DnsGetResponseErrorsList>;
+
+export interface DnsGetResponseRecordItem {
+  /** DNS record content. */
+  content?: string | null;
+  /** DNS record name (or @ for the zone apex). */
+  name?: string | null;
+  /** Required for MX, SRV and URI records. Unused by other record types. Records with lower priorities are preferred. */
+  priority?: number | null;
+  /** Time to live, in seconds, of the DNS record. Must be between 60 and 86400, or 1 for 'automatic'. */
+  ttl?: number | null;
+  /** DNS record type. */
+  type?: string | null;
+}
+export const DnsGetResponseRecordItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    content: S.optional(S.NullOr(S.String)),
+    name: S.optional(S.NullOr(S.String)),
+    priority: S.optional(S.NullOr(S.Number)),
+    ttl: S.optional(S.NullOr(S.Number)),
+    type: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "DnsGetResponseRecordItem",
+}) as any as S.Schema<DnsGetResponseRecordItem>;
+
+export type DnsGetResponseRecordList = Array<DnsGetResponseRecordItem>;
+export const DnsGetResponseRecordList = /*@__PURE__*/ S.Array(
+  DnsGetResponseRecordItem,
+) as any as S.Schema<DnsGetResponseRecordList>;
+
+/** Unwrapped `result` payload of the Cloudflare v4 response envelope. */
+export interface GetDnsResponse {
+  errors?: DnsGetResponseErrorsList | null;
+  record?: DnsGetResponseRecordList | null;
+}
 export const GetDnsResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+  S.Struct({
+    errors: S.optional(S.NullOr(DnsGetResponseErrorsList)),
+    record: S.optional(S.NullOr(DnsGetResponseRecordList)),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({ identifier: "GetDnsResponse" }) as any as S.Schema<GetDnsResponse>;
 
 export interface GetEmailRoutingRequest {

--- a/packages/cloudflare/src/services/logs.ts
+++ b/packages/cloudflare/src/services/logs.ts
@@ -600,10 +600,98 @@ export const ListLogExplorerDatasetAvailablesForAccountRequest =
     identifier: "ListLogExplorerDatasetAvailablesForAccountRequest",
   }) as any as S.Schema<ListLogExplorerDatasetAvailablesForAccountRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
-export interface ListLogExplorerDatasetAvailablesResponse {}
+export type LogExplorerDatasetsAvailableListResultItemObjectType =
+  | "account"
+  | "zone";
+export const LogExplorerDatasetsAvailableListResultItemObjectType =
+  /*@__PURE__*/ S.String;
+
+export type LogExplorerDatasetsAvailableListResultItemSchemaPropertiesMap = {
+  [key: string]: unknown | undefined;
+};
+export const LogExplorerDatasetsAvailableListResultItemSchemaPropertiesMap =
+  /*@__PURE__*/ S.Record(
+    S.String,
+    S.Unknown,
+  ) as any as S.Schema<LogExplorerDatasetsAvailableListResultItemSchemaPropertiesMap>;
+
+export type LogExplorerDatasetsAvailableListResultItemSchemaRequiredList =
+  Array<string>;
+export const LogExplorerDatasetsAvailableListResultItemSchemaRequiredList =
+  /*@__PURE__*/ S.Array(
+    S.String,
+  ) as any as S.Schema<LogExplorerDatasetsAvailableListResultItemSchemaRequiredList>;
+
+export type LogExplorerDatasetsAvailableListResultItemSchemaType = "object";
+export const LogExplorerDatasetsAvailableListResultItemSchemaType =
+  /*@__PURE__*/ S.String;
+
+export interface LogExplorerDatasetsAvailableListResultItemSchema {
+  properties?: LogExplorerDatasetsAvailableListResultItemSchemaPropertiesMap | null;
+  required?: LogExplorerDatasetsAvailableListResultItemSchemaRequiredList | null;
+  type?: LogExplorerDatasetsAvailableListResultItemSchemaType | null;
+}
+export const LogExplorerDatasetsAvailableListResultItemSchema =
+  /*@__PURE__*/ S.suspend(() =>
+    S.Struct({
+      properties: S.optional(
+        S.NullOr(LogExplorerDatasetsAvailableListResultItemSchemaPropertiesMap),
+      ),
+      required: S.optional(
+        S.NullOr(LogExplorerDatasetsAvailableListResultItemSchemaRequiredList),
+      ),
+      type: S.optional(
+        S.NullOr(LogExplorerDatasetsAvailableListResultItemSchemaType),
+      ),
+    }),
+  ).annotate({
+    identifier: "LogExplorerDatasetsAvailableListResultItemSchema",
+  }) as any as S.Schema<LogExplorerDatasetsAvailableListResultItemSchema>;
+
+export interface LogExplorerDatasetsAvailableListResultItem {
+  /** Dataset type name (e.g. `http_requests`). */
+  dataset: string;
+  /** Whether this dataset type is account-scoped or zone-scoped. */
+  objectType: LogExplorerDatasetsAvailableListResultItemObjectType;
+  /** JSON Schema that describes the fields this dataset exposes. */
+  schema: LogExplorerDatasetsAvailableListResultItemSchema;
+  /** The primary timestamp field name for this dataset. */
+  timestampField: string;
+}
+export const LogExplorerDatasetsAvailableListResultItem =
+  /*@__PURE__*/ S.suspend(() =>
+    S.Struct({
+      dataset: S.String,
+      objectType: LogExplorerDatasetsAvailableListResultItemObjectType.pipe(
+        T.Body("object_type"),
+      ),
+      schema: LogExplorerDatasetsAvailableListResultItemSchema,
+      timestampField: S.String.pipe(T.Body("timestamp_field")),
+    }),
+  ).annotate({
+    identifier: "LogExplorerDatasetsAvailableListResultItem",
+  }) as any as S.Schema<LogExplorerDatasetsAvailableListResultItem>;
+
+export type LogExplorerDatasetsAvailableListResultList =
+  Array<LogExplorerDatasetsAvailableListResultItem>;
+export const LogExplorerDatasetsAvailableListResultList = /*@__PURE__*/ S.Array(
+  LogExplorerDatasetsAvailableListResultItem,
+) as any as S.Schema<LogExplorerDatasetsAvailableListResultList>;
+
+export interface ListLogExplorerDatasetAvailablesResponse {
+  /** The unwrapped `result` payload of the v4 response envelope. */
+  result: LogExplorerDatasetsAvailableListResultList;
+  /** Pagination info from the envelope's `result_info`. */
+  resultInfo?: ResultInfo | null;
+}
 export const ListLogExplorerDatasetAvailablesResponse = /*@__PURE__*/ S.suspend(
-  () => S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+  () =>
+    S.Struct({
+      result: LogExplorerDatasetsAvailableListResultList.pipe(
+        T.EnvelopePayload(),
+      ),
+      resultInfo: S.optional(S.NullOr(ResultInfo).pipe(T.ResultInfo())),
+    }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "ListLogExplorerDatasetAvailablesResponse",
 }) as any as S.Schema<ListLogExplorerDatasetAvailablesResponse>;
@@ -1151,33 +1239,43 @@ export const getReceivedField: API.OperationMethod<
 
 export type ListLogExplorerDatasetAvailablesForAccountError = CloudflareOpError;
 /** Returns all dataset types that this account or zone can create. Each entry includes the dataset schema and timestamp field. The schema shows all possible fields for a dataset. However, not all fields may be available for your account or zone. When creating or updating a dataset, only fields available to your account or zone can be enabled. If you request a field that is not available, you will receive an error. */
-export const listLogExplorerDatasetAvailablesForAccount: API.OperationMethod<
+export const listLogExplorerDatasetAvailablesForAccount: API.PaginatedOperationMethod<
   ListLogExplorerDatasetAvailablesForAccountRequest,
   ListLogExplorerDatasetAvailablesResponse,
   ListLogExplorerDatasetAvailablesForAccountError,
-  CloudflareOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: ListLogExplorerDatasetAvailablesForAccountRequest,
-  output: ListLogExplorerDatasetAvailablesResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
-  protocol: CloudflareProtocol,
-  retry: Retry.Retry,
-}));
+  CloudflareOpContext,
+  LogExplorerDatasetsAvailableListResultItem
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListLogExplorerDatasetAvailablesForAccountRequest,
+    output: ListLogExplorerDatasetAvailablesResponse,
+    errors: [CloudflareRateLimited, CloudflareError],
+    protocol: CloudflarePaginatedProtocol,
+    retry: Retry.Retry,
+    pagination: { mode: "single", items: "result" } as const,
+  }),
+  cloudflarePaginate,
+) as any;
 
 export type ListLogExplorerDatasetAvailablesForZoneError = CloudflareOpError;
 /** Returns all dataset types that this account or zone can create. Each entry includes the dataset schema and timestamp field. The schema shows all possible fields for a dataset. However, not all fields may be available for your account or zone. When creating or updating a dataset, only fields available to your account or zone can be enabled. If you request a field that is not available, you will receive an error. */
-export const listLogExplorerDatasetAvailablesForZone: API.OperationMethod<
+export const listLogExplorerDatasetAvailablesForZone: API.PaginatedOperationMethod<
   ListLogExplorerDatasetAvailablesForZoneRequest,
   ListLogExplorerDatasetAvailablesResponse,
   ListLogExplorerDatasetAvailablesForZoneError,
-  CloudflareOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: ListLogExplorerDatasetAvailablesForZoneRequest,
-  output: ListLogExplorerDatasetAvailablesResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
-  protocol: CloudflareProtocol,
-  retry: Retry.Retry,
-}));
+  CloudflareOpContext,
+  LogExplorerDatasetsAvailableListResultItem
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListLogExplorerDatasetAvailablesForZoneRequest,
+    output: ListLogExplorerDatasetAvailablesResponse,
+    errors: [CloudflareRateLimited, CloudflareError],
+    protocol: CloudflarePaginatedProtocol,
+    retry: Retry.Retry,
+    pagination: { mode: "single", items: "result" } as const,
+  }),
+  cloudflarePaginate,
+) as any;
 
 export type ListLogExplorerDatasetsForAccountError = CloudflareOpError;
 /** Returns all Log Explorer datasets configured for the account or zone. Pass `include_zones=true` to also include zone-level datasets that belong to this account or zone. List responses omit the `fields` property; use the single-dataset endpoint to retrieve field configuration. */

--- a/packages/cloudflare/src/services/memberships.ts
+++ b/packages/cloudflare/src/services/memberships.ts
@@ -4,9 +4,11 @@ import * as API from "@distilled.cloud/core/api";
 import * as T from "../traits.ts";
 import {
   CloudflareProtocol,
+  CloudflarePaginatedProtocol,
   type CloudflareOpError,
   type CloudflareOpContext,
 } from "../protocol.ts";
+import { cloudflarePaginate, ResultInfo } from "../pagination.ts";
 import { CloudflareError, CloudflareRateLimited } from "../errors.ts";
 import * as Retry from "../retry.ts";
 
@@ -448,10 +450,101 @@ export const ListMembershipsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListMembershipsRequest",
 }) as any as S.Schema<ListMembershipsRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
-export interface ListMembershipsResponse {}
+export type ListResultItemAccountType = "standard" | "enterprise";
+export const ListResultItemAccountType = /*@__PURE__*/ S.String;
+
+export type ListResultItemAccountManagedBy = GetResponseAccountManagedBy;
+export const ListResultItemAccountManagedBy = GetResponseAccountManagedBy;
+
+export type ListResultItemAccountSettings = GetResponseAccountSettings;
+export const ListResultItemAccountSettings = GetResponseAccountSettings;
+
+export interface ListResultItemAccount {
+  /** Identifier */
+  id: string;
+  /** Account name */
+  name: string;
+  type: ListResultItemAccountType;
+  /** Timestamp for the creation of the account */
+  createdOn?: string | null;
+  /** Parent container details */
+  managedBy?: GetResponseAccountManagedBy | null;
+  /** Account settings */
+  settings?: GetResponseAccountSettings | null;
+}
+export const ListResultItemAccount = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.String,
+    name: S.String,
+    type: ListResultItemAccountType,
+    createdOn: S.optional(S.NullOr(S.String).pipe(T.Body("created_on"))),
+    managedBy: S.optional(
+      S.NullOr(GetResponseAccountManagedBy).pipe(T.Body("managed_by")),
+    ),
+    settings: S.optional(S.NullOr(GetResponseAccountSettings)),
+  }),
+).annotate({
+  identifier: "ListResultItemAccount",
+}) as any as S.Schema<ListResultItemAccount>;
+
+export type ListResultItemPermissionsAnalytics =
+  GetResponsePermissionsAnalytics;
+export const ListResultItemPermissionsAnalytics =
+  GetResponsePermissionsAnalytics;
+
+export type ListResultItemPermissions = GetResponsePermissions;
+export const ListResultItemPermissions = GetResponsePermissions;
+
+export type ListResultItemRolesList = Array<string>;
+export const ListResultItemRolesList = /*@__PURE__*/ S.Array(
+  S.String,
+) as any as S.Schema<ListResultItemRolesList>;
+
+export type ListResultItemStatus = "accepted" | "pending" | "rejected";
+export const ListResultItemStatus = /*@__PURE__*/ S.String;
+
+export interface ListResultItem {
+  /** Membership identifier tag. */
+  id?: string | null;
+  account?: ListResultItemAccount | null;
+  /** Enterprise only. Indicates whether or not API access is enabled specifically for this user on a given account. */
+  apiAccessEnabled?: boolean | null;
+  /** All access permissions for the user at the account. */
+  permissions?: GetResponsePermissions | null;
+  /** List of role names the membership has for this account. */
+  roles?: ListResultItemRolesList | null;
+  /** Status of this membership. */
+  status?: ListResultItemStatus | null;
+}
+export const ListResultItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    account: S.optional(S.NullOr(ListResultItemAccount)),
+    apiAccessEnabled: S.optional(
+      S.NullOr(S.Boolean).pipe(T.Body("api_access_enabled")),
+    ),
+    permissions: S.optional(S.NullOr(GetResponsePermissions)),
+    roles: S.optional(S.NullOr(ListResultItemRolesList)),
+    status: S.optional(S.NullOr(ListResultItemStatus)),
+  }),
+).annotate({ identifier: "ListResultItem" }) as any as S.Schema<ListResultItem>;
+
+export type ListResultList = Array<ListResultItem>;
+export const ListResultList = /*@__PURE__*/ S.Array(
+  ListResultItem,
+) as any as S.Schema<ListResultList>;
+
+export interface ListMembershipsResponse {
+  /** The unwrapped `result` payload of the v4 response envelope. */
+  result: ListResultList;
+  /** Pagination info from the envelope's `result_info`. */
+  resultInfo?: ResultInfo | null;
+}
 export const ListMembershipsResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+  S.Struct({
+    result: ListResultList.pipe(T.EnvelopePayload()),
+    resultInfo: S.optional(S.NullOr(ResultInfo).pipe(T.ResultInfo())),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "ListMembershipsResponse",
 }) as any as S.Schema<ListMembershipsResponse>;
@@ -720,18 +813,29 @@ export const getMembership: API.OperationMethod<
 
 export type ListMembershipsError = CloudflareOpError;
 /** List memberships of accounts the user can access. */
-export const listMemberships: API.OperationMethod<
+export const listMemberships: API.PaginatedOperationMethod<
   ListMembershipsRequest,
   ListMembershipsResponse,
   ListMembershipsError,
-  CloudflareOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: ListMembershipsRequest,
-  output: ListMembershipsResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
-  protocol: CloudflareProtocol,
-  retry: Retry.Retry,
-}));
+  CloudflareOpContext,
+  ListResultItem
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListMembershipsRequest,
+    output: ListMembershipsResponse,
+    errors: [CloudflareRateLimited, CloudflareError],
+    protocol: CloudflarePaginatedProtocol,
+    retry: Retry.Retry,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "resultInfo.page",
+      items: "result",
+      pageSize: "perPage",
+    } as const,
+  }),
+  cloudflarePaginate,
+) as any;
 
 export type PutMembershipError = CloudflareOpError;
 /** Accept or reject this account invitation. */

--- a/packages/cloudflare/src/services/user.ts
+++ b/packages/cloudflare/src/services/user.ts
@@ -1328,10 +1328,123 @@ export const ListAuditLogsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListAuditLogsRequest",
 }) as any as S.Schema<ListAuditLogsRequest>;
 
-/** Raw response payload (operation does not use the standard v4 result envelope). */
-export interface ListAuditLogsResponse {}
+export interface AuditLogsListResultItemAction {
+  /** A boolean that indicates if the action attempted was successful. */
+  result?: boolean | null;
+  /** A short string that describes the action that was performed. */
+  type?: string | null;
+}
+export const AuditLogsListResultItemAction = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    result: S.optional(S.NullOr(S.Boolean)),
+    type: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "AuditLogsListResultItemAction",
+}) as any as S.Schema<AuditLogsListResultItemAction>;
+
+export type AuditLogsListResultItemActorType = "user" | "admin" | "Cloudflare";
+export const AuditLogsListResultItemActorType = /*@__PURE__*/ S.String;
+
+export interface AuditLogsListResultItemActor {
+  /** The ID of the actor that performed the action. If a user performed the action, this will be their User ID. */
+  id?: string | null;
+  /** The email of the user that performed the action. */
+  email?: string | null;
+  /** The IP address of the request that performed the action. */
+  ip?: string | null;
+  /** The type of actor, whether a User, Cloudflare Admin, or an Automated System. */
+  type?: AuditLogsListResultItemActorType | null;
+}
+export const AuditLogsListResultItemActor = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    email: S.optional(S.NullOr(S.String)),
+    ip: S.optional(S.NullOr(S.String)),
+    type: S.optional(S.NullOr(AuditLogsListResultItemActorType)),
+  }),
+).annotate({
+  identifier: "AuditLogsListResultItemActor",
+}) as any as S.Schema<AuditLogsListResultItemActor>;
+
+export interface AuditLogsListResultItemOwner {
+  /** Identifier */
+  id?: string | null;
+}
+export const AuditLogsListResultItemOwner = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "AuditLogsListResultItemOwner",
+}) as any as S.Schema<AuditLogsListResultItemOwner>;
+
+export interface AuditLogsListResultItemResource {
+  /** An identifier for the resource that was affected by the action. */
+  id?: string | null;
+  /** A short string that describes the resource that was affected by the action. */
+  type?: string | null;
+}
+export const AuditLogsListResultItemResource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    type: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "AuditLogsListResultItemResource",
+}) as any as S.Schema<AuditLogsListResultItemResource>;
+
+export interface AuditLogsListResultItem {
+  /** A string that uniquely identifies the audit log. */
+  id?: string | null;
+  action?: AuditLogsListResultItemAction | null;
+  actor?: AuditLogsListResultItemActor | null;
+  /** The source of the event. */
+  interface?: string | null;
+  /** An object which can lend more context to the action being logged. This is a flexible value and varies between different actions. */
+  metadata?: unknown | null;
+  /** The new value of the resource that was modified. */
+  newValue?: string | null;
+  /** The value of the resource before it was modified. */
+  oldValue?: string | null;
+  owner?: AuditLogsListResultItemOwner | null;
+  resource?: AuditLogsListResultItemResource | null;
+  /** A UTC RFC3339 timestamp that specifies when the action being logged occured. */
+  when?: string | null;
+}
+export const AuditLogsListResultItem = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.optional(S.NullOr(S.String)),
+    action: S.optional(S.NullOr(AuditLogsListResultItemAction)),
+    actor: S.optional(S.NullOr(AuditLogsListResultItemActor)),
+    interface: S.optional(S.NullOr(S.String)),
+    metadata: S.optional(S.NullOr(S.Unknown)),
+    newValue: S.optional(S.NullOr(S.String)),
+    oldValue: S.optional(S.NullOr(S.String)),
+    owner: S.optional(S.NullOr(AuditLogsListResultItemOwner)),
+    resource: S.optional(S.NullOr(AuditLogsListResultItemResource)),
+    when: S.optional(S.NullOr(S.String)),
+  }),
+).annotate({
+  identifier: "AuditLogsListResultItem",
+}) as any as S.Schema<AuditLogsListResultItem>;
+
+export type AuditLogsListResultList = Array<AuditLogsListResultItem>;
+export const AuditLogsListResultList = /*@__PURE__*/ S.Array(
+  AuditLogsListResultItem,
+) as any as S.Schema<AuditLogsListResultList>;
+
+export interface ListAuditLogsResponse {
+  /** The unwrapped `result` payload of the v4 response envelope. */
+  result: AuditLogsListResultList;
+  /** Pagination info from the envelope's `result_info`. */
+  resultInfo?: ResultInfo | null;
+}
 export const ListAuditLogsResponse = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+  S.Struct({
+    result: AuditLogsListResultList.pipe(T.EnvelopePayload()),
+    resultInfo: S.optional(S.NullOr(ResultInfo).pipe(T.ResultInfo())),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "ListAuditLogsResponse",
 }) as any as S.Schema<ListAuditLogsResponse>;
@@ -2913,18 +3026,29 @@ export const getUser: API.OperationMethod<
 
 export type ListAuditLogsError = CloudflareOpError;
 /** Gets a list of audit logs for a user account. Can be filtered by who made the change, on which zone, and the timeframe of the change. */
-export const listAuditLogs: API.OperationMethod<
+export const listAuditLogs: API.PaginatedOperationMethod<
   ListAuditLogsRequest,
   ListAuditLogsResponse,
   ListAuditLogsError,
-  CloudflareOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: ListAuditLogsRequest,
-  output: ListAuditLogsResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
-  protocol: CloudflareProtocol,
-  retry: Retry.Retry,
-}));
+  CloudflareOpContext,
+  AuditLogsListResultItem
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListAuditLogsRequest,
+    output: ListAuditLogsResponse,
+    errors: [CloudflareRateLimited, CloudflareError],
+    protocol: CloudflarePaginatedProtocol,
+    retry: Retry.Retry,
+    pagination: {
+      mode: "page",
+      inputToken: "page",
+      outputToken: "resultInfo.page",
+      items: "result",
+      pageSize: "perPage",
+    } as const,
+  }),
+  cloudflarePaginate,
+) as any;
 
 export type ListBillingHistoriesError = CloudflareOpError;
 /** Accesses your billing history object. */


### PR DESCRIPTION
The Cloudflare spec converter only recognizes the v4 envelope when its keys are top-level bullets under `### Returns`. Some doc pages wrap the whole section in a named envelope type — sometimes a union of several:

```md
### Returns

- `IAMCollectionMembershipResponse object { errors, messages, success, 2 more }`
- `IAMCollectionMembershipResponseWithPolicies object { errors, messages, success, 2 more }`
```

With no top-level `result` node, the operation generated an EMPTY response structure and the payload was undecodable:

```ts
/** Raw response payload (operation does not use the standard v4 result envelope). */
export interface ListMembershipsResponse {}
```

`unwrapEnvelopeReturns` now unwraps such wrappers before the result handling (first arm for unions — the common base every variant extends). Re-converting all specs, five services gain real response models that were previously empty:

- `memberships` — `listMemberships`, the only way to list a user-scoped OAuth token's accounts (`GET /accounts` returns an empty list for those tokens); used by the alchemy CLI's account picker
- `user`, `audit_logs` — audit log listings
- `logs` — log explorer available datasets
- `email_routing` — DNS settings read

Also in this change:

- `email_routing/deleteDns.json` no longer renames the response shape: that op's Returns is the bare envelope with no payload, so its output is now `smithy.api#Unit` and the generator synthesizes the empty `DeleteDnsResponse` from the op name — the exported surface is unchanged.
- The spec writer emits a trailing newline, matching the committed `.generated-specs` format (re-conversion previously churned all 121 files by one byte).

Verified against the live API: the regenerated `listMemberships` client decodes the requesting user's memberships (id, status, account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
