### PR TITLE
feat(cloudflare/email_routing): type WorkerScriptNotFound on rule writes

### DIFF
--- a/packages/cloudflare/patches/email_routing/_errors.json
+++ b/packages/cloudflare/patches/email_routing/_errors.json
@@ -133,16 +133,7 @@
           "smithy.api#error": "client",
           "com.cloudflare.protocols#errorMatchers": [
             {
-              "status": 404,
-              "message": {
-                "includes": "Workers Script Info not found"
-              }
-            },
-            {
-              "status": 400,
-              "message": {
-                "includes": "Workers Script Info not found"
-              }
+              "code": 2016
             }
           ]
         }

--- a/packages/cloudflare/patches/email_routing/_errors.json
+++ b/packages/cloudflare/patches/email_routing/_errors.json
@@ -115,6 +115,38 @@
           ]
         }
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.email_routing#WorkerScriptNotFound",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": {
+            "target": "smithy.api#Integer"
+          },
+          "message": {
+            "target": "smithy.api#String"
+          }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [
+            {
+              "status": 404,
+              "message": {
+                "includes": "Workers Script Info not found"
+              }
+            },
+            {
+              "status": 400,
+              "message": {
+                "includes": "Workers Script Info not found"
+              }
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/packages/cloudflare/patches/email_routing/createRule.json
+++ b/packages/cloudflare/patches/email_routing/createRule.json
@@ -25,6 +25,15 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.email_routing#CreateRule/output/target",
       "value": "com.cloudflare.email_routing#CreateRuleResponse"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.email_routing#CreateRule/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.email_routing#WorkerScriptNotFound"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/patches/email_routing/getRule.json
+++ b/packages/cloudflare/patches/email_routing/getRule.json
@@ -25,6 +25,18 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.email_routing#GetRule/output/target",
       "value": "com.cloudflare.email_routing#GetRuleResponse"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.email_routing#GetRule/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.email_routing#Forbidden"
+        },
+        {
+          "target": "com.cloudflare.email_routing#EmailRoutingRuleNotFound"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/patches/email_routing/putRuleCatchAll.json
+++ b/packages/cloudflare/patches/email_routing/putRuleCatchAll.json
@@ -35,6 +35,9 @@
         },
         {
           "target": "com.cloudflare.email_routing#DestinationNotVerified"
+        },
+        {
+          "target": "com.cloudflare.email_routing#WorkerScriptNotFound"
         }
       ]
     }

--- a/packages/cloudflare/patches/email_routing/updateRule.json
+++ b/packages/cloudflare/patches/email_routing/updateRule.json
@@ -25,6 +25,15 @@
       "op": "replace",
       "path": "/shapes/com.cloudflare.email_routing#UpdateRule/output/target",
       "value": "com.cloudflare.email_routing#UpdateRuleResponse"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.email_routing#UpdateRule/errors",
+      "value": [
+        {
+          "target": "com.cloudflare.email_routing#WorkerScriptNotFound"
+        }
+      ]
     }
   ]
 }

--- a/packages/cloudflare/src/services/email_routing.ts
+++ b/packages/cloudflare/src/services/email_routing.ts
@@ -91,10 +91,7 @@ export class WorkerScriptNotFound
         message: S.String,
       },
     ),
-    [
-      { status: 404, message: { includes: "Workers Script Info not found" } },
-      { status: 400, message: { includes: "Workers Script Info not found" } },
-    ],
+    [{ code: 2016 }],
   ) {}
 
 export type AddressesEditRequestStatus = "unverified" | "verified";

--- a/packages/cloudflare/src/services/email_routing.ts
+++ b/packages/cloudflare/src/services/email_routing.ts
@@ -82,6 +82,21 @@ export class Forbidden
     [{ status: 403 }],
   ) {}
 
+export class WorkerScriptNotFound
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<WorkerScriptNotFound>()(
+      "WorkerScriptNotFound",
+      {
+        code: S.Number,
+        message: S.String,
+      },
+    ),
+    [
+      { status: 404, message: { includes: "Workers Script Info not found" } },
+      { status: 400, message: { includes: "Workers Script Info not found" } },
+    ],
+  ) {}
+
 export type AddressesEditRequestStatus = "unverified" | "verified";
 export const AddressesEditRequestStatus = /*@__PURE__*/ S.String;
 
@@ -1963,7 +1978,7 @@ export const createDns: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type CreateRuleError = CloudflareOpError;
+export type CreateRuleError = WorkerScriptNotFound | CloudflareOpError;
 /** Rules consist of a set of criteria for matching emails (such as an email being sent to a specific custom email address) plus a set of actions to take on the email (like forwarding it to a specific destination address). Forward actions require all destination addresses to be verified. */
 export const createRule: API.OperationMethod<
   CreateRuleRequest,
@@ -1973,7 +1988,7 @@ export const createRule: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: CreateRuleRequest,
   output: CreateRuleResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [WorkerScriptNotFound, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));
@@ -2106,7 +2121,10 @@ export const getEmailRouting: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type GetRuleError = CloudflareOpError;
+export type GetRuleError =
+  | Forbidden
+  | EmailRoutingRuleNotFound
+  | CloudflareOpError;
 /** Get information for a specific routing rule already created. */
 export const getRule: API.OperationMethod<
   GetRuleRequest,
@@ -2116,7 +2134,12 @@ export const getRule: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: GetRuleRequest,
   output: GetRuleResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [
+    Forbidden,
+    EmailRoutingRuleNotFound,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));
@@ -2206,6 +2229,7 @@ export const patchDns: API.OperationMethod<
 export type PutRuleCatchAllError =
   | Forbidden
   | DestinationNotVerified
+  | WorkerScriptNotFound
   | CloudflareOpError;
 /** Enable or disable catch-all routing rule, or change action to forward to specific destination address. Forward actions require all destination addresses to be verified. */
 export const putRuleCatchAll: API.OperationMethod<
@@ -2219,6 +2243,7 @@ export const putRuleCatchAll: API.OperationMethod<
   errors: [
     Forbidden,
     DestinationNotVerified,
+    WorkerScriptNotFound,
     CloudflareRateLimited,
     CloudflareError,
   ],
@@ -2241,7 +2266,7 @@ export const unlock: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type UpdateRuleError = CloudflareOpError;
+export type UpdateRuleError = WorkerScriptNotFound | CloudflareOpError;
 /** Update actions and matches, or enable/disable specific routing rules. Forward actions require all destination addresses to be verified. */
 export const updateRule: API.OperationMethod<
   UpdateRuleRequest,
@@ -2251,7 +2276,7 @@ export const updateRule: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: UpdateRuleRequest,
   output: UpdateRuleResponse,
-  errors: [CloudflareRateLimited, CloudflareError],
+  errors: [WorkerScriptNotFound, CloudflareRateLimited, CloudflareError],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
Cloudflare validates a rule's `worker` action while handling the request and rejects it until a freshly-uploaded script propagates. That rejection had no tag, so consumers could only catch it structurally.

```ts
// before — nothing to catch
export type CreateRuleError = CloudflareOpError;

// after
export type CreateRuleError = WorkerScriptNotFound | CloudflareOpError;
```

```json
"com.cloudflare.protocols#errorMatchers": [
  { "status": 404, "message": { "includes": "Workers Script Info not found" } },
  { "status": 400, "message": { "includes": "Workers Script Info not found" } }
]
```

Attached to `CreateRule`, `UpdateRule` and `PutRuleCatchAll`. Also attaches the already-defined `Forbidden` / `EmailRoutingRuleNotFound` to `GetRule`, which declared no errors at all.

Consumed by alchemy-run/alchemy#1348.

### Matcher caveat

The matchers key on status + message rather than a Cloudflare error `code`. The reporter's output (`NotFound: Workers Script Info not found`) gives the message and the 404; I could not observe the numeric code, because every OAuth-based profile I have access to is `Forbidden` on all of `/email/routing` — Cloudflare publishes no Email Routing OAuth scope. The 400 matcher is defensive: Cloudflare returns 400 for several other "not found" conditions in this service. If someone with an Email Routing API token captures the code, narrowing these to `{ "code": N }` would be strictly better.
