### PR TITLE
fix(aws): isolate SSO credentials by account and role

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -96,6 +96,7 @@
     "build": "tsc -b",
     "fmt": "oxfmt --write src",
     "lint": "oxlint --fix src",
+    "test": "bun test test",
     "check": "tsc && oxlint src && oxfmt --check src",
     "generate": "bun run scripts/generate.ts",
     "specs:fetch": "git submodule update --force --init --recursive --depth=1 specs/api-models-aws && git -C specs/api-models-aws checkout -- .",

--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -38,6 +38,15 @@ const EXPIRE_WINDOW_MS = 5 * 60 * 1000;
 
 const REFRESH_MESSAGE = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
 
+export const getSsoCredentialCacheName = (
+  session: string,
+  account: string,
+  role: string,
+) =>
+  createHash("sha1")
+    .update(JSON.stringify([session, account, role]))
+    .digest("hex");
+
 export const Default = Effect.serviceOption(Auth).pipe(
   Effect.map(Option.getOrUndefined),
   Effect.flatMap((c) => (c ? Effect.succeed(c) : makeAuthService())),
@@ -162,15 +171,25 @@ export const makeAuthService = () =>
 
       // Both SSO formats cache the access token under sha1 of the cache key: the
       // `sso_session` name (modern) or the `sso_start_url` (legacy inline format).
+      // Role credentials need a separate identity because one SSO session can
+      // authorize multiple account/role pairs.
       const ssoCacheKey = profile.sso_session ?? profile.sso_start_url;
       if (ssoCacheKey) {
-        const hasher = createHash("sha1");
-        const cacheName = hasher.update(ssoCacheKey).digest("hex");
-        const ssoTokenFilepath = path.join(cachePath, `${cacheName}.json`);
+        const tokenCacheName = createHash("sha1")
+          .update(ssoCacheKey)
+          .digest("hex");
+        const credentialCacheName = getSsoCredentialCacheName(
+          ssoCacheKey,
+          profile.sso_account_id!,
+          profile.sso_role_name!,
+        );
+        const ssoTokenFilepath = path.join(cachePath, `${tokenCacheName}.json`);
         const cachedCredsFilePath = path.join(
           cachePath,
-          `${cacheName}.credentials.json`,
+          `${credentialCacheName}.credentials.json`,
         );
+
+        // The old session-only credentials file is intentionally ignored.
 
         // `Effect.try` so a `JSON.parse` throw on an empty/partial file
         // (a brief race window when another process is rewriting the

--- a/packages/aws/test/sso-credential-cache.test.ts
+++ b/packages/aws/test/sso-credential-cache.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { getSsoCredentialCacheName } from "../src/auth.ts";
+
+test("SSO credential cache includes account and role", () => {
+  const first = getSsoCredentialCacheName(
+    "shared-session",
+    "111111111111",
+    "RoleA",
+  );
+
+  expect(first).not.toBe(
+    getSsoCredentialCacheName("shared-session", "222222222222", "RoleA"),
+  );
+  expect(first).not.toBe(
+    getSsoCredentialCacheName("shared-session", "111111111111", "RoleB"),
+  );
+  expect(first).not.toBe(
+    createHash("sha1").update("shared-session").digest("hex"),
+  );
+});


### PR DESCRIPTION
## What was happening

When switching between AWS SSO profiles (e.g. CLI for local development!), the profiles can share the same SSO session while pointing at completely different accounts and roles. Distilled used only that shared session to cache the temporary AWS credentials, so jumping between profiles could reuse credentials from the previous account.

## Before

One SSO session meant one credentials cache file, even across different accounts and roles.

## After

The SSO login token stays shared, but temporary credentials are cached per session, account, and role. Small change, and switching profiles no longer carries credentials across accounts.