### PR TITLE
fix(railway): type service pre-deploy commands

### DIFF
--- a/packages/railway/.generated-specs/railway.json
+++ b/packages/railway/.generated-specs/railway.json
@@ -22075,7 +22075,7 @@
           }
         },
         "preDeployCommand": {
-          "target": "smithy.api#Document",
+          "target": "com.railway.api#StringList",
           "traits": {
             "smithy.api#required": {},
             "com.railway.graphql#nullable": {}

--- a/packages/railway/patches/railway/serviceInstance.preDeployCommand.json
+++ b/packages/railway/patches/railway/serviceInstance.preDeployCommand.json
@@ -1,0 +1,10 @@
+{
+  "description": "Type serviceInstance.preDeployCommand as the string list returned by Railway's JSON scalar.",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "/shapes/com.railway.api#ServiceInstanceResponse/members/preDeployCommand/target",
+      "value": "com.railway.api#StringList"
+    }
+  ]
+}

--- a/packages/railway/src/services/railway.ts
+++ b/packages/railway/src/services/railway.ts
@@ -16412,7 +16412,7 @@ export interface ServiceInstanceResponse {
   nixpacksPlan: unknown | null;
   numReplicas: number | null;
   overlapSeconds: number | null;
-  preDeployCommand: unknown | null;
+  preDeployCommand: StringList | null;
   railpackInfo: unknown | null;
   railwayConfigFile: string | null;
   region: string | null;
@@ -16451,7 +16451,7 @@ export const ServiceInstanceResponse = /*@__PURE__*/ S.suspend(() =>
     nixpacksPlan: S.NullOr(S.Unknown),
     numReplicas: S.NullOr(S.Number),
     overlapSeconds: S.NullOr(S.Number),
-    preDeployCommand: S.NullOr(S.Unknown),
+    preDeployCommand: S.NullOr(StringList),
     railpackInfo: S.NullOr(S.Unknown),
     railwayConfigFile: S.NullOr(S.String),
     region: S.NullOr(S.String),


### PR DESCRIPTION
Type Railway service-instance `preDeployCommand` responses as `StringList` instead of `Document`.

The GraphQL schema exposes this response field as `JSON`, while the matching update input and runtime value are string lists. The Smithy patch keeps regeneration authoritative and lets Alchemy reconcile the setting without casts.

Unblocks alchemy-run/alchemy#1437.
