### PR TITLE
fix(aws): key the SSO role-credentials cache on account and role

### DIFF
--- a/packages/aws/src/auth.test.ts
+++ b/packages/aws/src/auth.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  makeAuthService,
+  ssoRoleCredentialsCacheName,
+  ssoTokenCacheName,
+} from "./auth.ts";
+
+const sha1 = (input: string) => createHash("sha1").update(input).digest("hex");
+
+const SESSION = "my-sso";
+const START_URL = "https://d-1234567890.awsapps.com/start";
+const SSO_REGION = "us-east-1";
+
+// The smithy ini loader reads `$HOME/.aws/config` from the real disk and
+// memoises the file contents per path, so each test gets a fresh HOME.
+const config = `
+[sso-session ${SESSION}]
+sso_start_url = ${START_URL}
+sso_region = ${SSO_REGION}
+sso_registration_scopes = sso:account:access
+
+[profile dev]
+sso_session = ${SESSION}
+sso_account_id = 111111111111
+sso_role_name = AdministratorAccess
+region = us-west-2
+
+[profile prod]
+sso_session = ${SESSION}
+sso_account_id = 222222222222
+sso_role_name = AdministratorAccess
+region = us-west-2
+
+[profile prod-readonly]
+sso_session = ${SESSION}
+sso_account_id = 222222222222
+sso_role_name = ReadOnlyAccess
+region = us-west-2
+`;
+
+const inOneHour = () => new Date(Date.now() + 60 * 60 * 1000);
+
+type Harness = ReturnType<typeof harness>;
+
+/**
+ * In-memory `~/.aws/sso/cache` plus a fake SSO portal. `portalCalls` records
+ * every `GetRoleCredentials` request as `account_id/role_name`.
+ */
+const harness = (home: string) => {
+  const cacheDir = join(home, ".aws", "sso", "cache");
+  const files = new Map<string, string>();
+  const portalCalls: string[] = [];
+
+  // `loadProfile` re-reads the config through the Effect FileSystem to
+  // resolve the `[sso-session]` section; the smithy loader reads the real
+  // file written in `beforeEach`.
+  files.set(join(home, ".aws", "config"), config);
+  files.set(
+    join(cacheDir, `${ssoTokenCacheName(SESSION)}.json`),
+    JSON.stringify({
+      accessToken: "token-for-session",
+      expiresAt: inOneHour().toISOString(),
+      region: SSO_REGION,
+      startUrl: START_URL,
+    }),
+  );
+
+  const notFound = (method: string, path: string) =>
+    PlatformError.systemError({
+      _tag: "NotFound",
+      module: "FileSystem",
+      method,
+      pathOrDescriptor: path,
+    });
+
+  const fs = FileSystem.layerNoop({
+    readFileString: (path) =>
+      files.has(path)
+        ? Effect.succeed(files.get(path)!)
+        : Effect.fail(notFound("readFileString", path)),
+    writeFileString: (path, data) =>
+      Effect.sync(() => {
+        files.set(path, data);
+      }),
+  });
+
+  const http = Layer.succeed(HttpClient.HttpClient)(
+    HttpClient.make((request, url) =>
+      Effect.sync(() => {
+        expect(url.hostname).toBe(`portal.sso.${SSO_REGION}.amazonaws.com`);
+        expect(url.pathname).toBe("/federation/credentials");
+        expect(request.headers["x-amz-sso_bearer_token"]).toBe(
+          "token-for-session",
+        );
+        const accountId = url.searchParams.get("account_id")!;
+        const roleName = url.searchParams.get("role_name")!;
+        portalCalls.push(`${accountId}/${roleName}`);
+        return HttpClientResponse.fromWeb(
+          request,
+          Response.json({
+            roleCredentials: {
+              accessKeyId: `AKIA-${accountId}-${roleName}`,
+              secretAccessKey: `secret-${accountId}-${roleName}`,
+              sessionToken: `session-${accountId}-${roleName}`,
+              expiration: inOneHour().getTime(),
+            },
+          }),
+        );
+      }),
+    ),
+  );
+
+  const layer = Layer.mergeAll(fs, http, Path.layer);
+
+  const load = (profile: string) =>
+    Effect.runPromise(
+      Effect.flatMap(makeAuthService(), (auth) =>
+        auth.loadProfileCredentials(profile),
+      ).pipe(Effect.provide(layer)),
+    );
+
+  const credsPath = (profile: {
+    sso_account_id: string;
+    sso_role_name: string;
+  }) =>
+    join(
+      cacheDir,
+      `${ssoRoleCredentialsCacheName({ sso_session: SESSION, ...profile })}.credentials.json`,
+    );
+
+  return { cacheDir, files, portalCalls, load, credsPath };
+};
+
+describe("SSO role credentials cache (#565)", () => {
+  let home: string;
+  let originalHome: string | undefined;
+  let h: Harness;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "distilled-aws-auth-"));
+    mkdirSync(join(home, ".aws"), { recursive: true });
+    writeFileSync(join(home, ".aws", "config"), config);
+    originalHome = process.env.HOME;
+    process.env.HOME = home;
+    h = harness(home);
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("two profiles sharing one sso_session each get their own account's keys", async () => {
+    const dev = await h.load("dev");
+    expect(Redacted.value(dev.accessKeyId)).toBe(
+      "AKIA-111111111111-AdministratorAccess",
+    );
+
+    const prod = await h.load("prod");
+    expect(Redacted.value(prod.accessKeyId)).toBe(
+      "AKIA-222222222222-AdministratorAccess",
+    );
+    expect(Redacted.value(prod.secretAccessKey)).toBe(
+      "secret-222222222222-AdministratorAccess",
+    );
+
+    expect(h.portalCalls).toEqual([
+      "111111111111/AdministratorAccess",
+      "222222222222/AdministratorAccess",
+    ]);
+
+    // One file per account+role, and neither is the session-only key.
+    const devPath = h.credsPath({
+      sso_account_id: "111111111111",
+      sso_role_name: "AdministratorAccess",
+    });
+    const prodPath = h.credsPath({
+      sso_account_id: "222222222222",
+      sso_role_name: "AdministratorAccess",
+    });
+    expect(devPath).not.toBe(prodPath);
+    expect(h.files.has(devPath)).toBe(true);
+    expect(h.files.has(prodPath)).toBe(true);
+    expect(
+      h.files.has(
+        join(h.cacheDir, `${ssoTokenCacheName(SESSION)}.credentials.json`),
+      ),
+    ).toBe(false);
+
+    expect(JSON.parse(h.files.get(prodPath)!)).toMatchObject({
+      accessKeyId: "AKIA-222222222222-AdministratorAccess",
+      sso_account_id: "222222222222",
+      sso_role_name: "AdministratorAccess",
+    });
+  });
+
+  test("same account, different role is a different cache entry", async () => {
+    await h.load("prod");
+    const readonly = await h.load("prod-readonly");
+    expect(Redacted.value(readonly.accessKeyId)).toBe(
+      "AKIA-222222222222-ReadOnlyAccess",
+    );
+    expect(h.portalCalls).toEqual([
+      "222222222222/AdministratorAccess",
+      "222222222222/ReadOnlyAccess",
+    ]);
+  });
+
+  test("cache hit for the same account+role makes no portal call", async () => {
+    const first = await h.load("dev");
+    const second = await h.load("dev");
+    expect(h.portalCalls).toEqual(["111111111111/AdministratorAccess"]);
+    expect(Redacted.value(second.accessKeyId)).toBe(
+      Redacted.value(first.accessKeyId),
+    );
+    expect(second.region).toBe("us-west-2");
+  });
+
+  test("expired cache entry is refetched", async () => {
+    await h.load("dev");
+    const path = h.credsPath({
+      sso_account_id: "111111111111",
+      sso_role_name: "AdministratorAccess",
+    });
+    const cached = JSON.parse(h.files.get(path)!);
+    h.files.set(
+      path,
+      JSON.stringify({
+        ...cached,
+        accessKeyId: "AKIA-stale",
+        expiry: Date.now() - 1000,
+      }),
+    );
+
+    const fresh = await h.load("dev");
+    expect(Redacted.value(fresh.accessKeyId)).toBe(
+      "AKIA-111111111111-AdministratorAccess",
+    );
+    expect(h.portalCalls).toEqual([
+      "111111111111/AdministratorAccess",
+      "111111111111/AdministratorAccess",
+    ]);
+    expect(JSON.parse(h.files.get(path)!).accessKeyId).toBe(
+      "AKIA-111111111111-AdministratorAccess",
+    );
+  });
+
+  test("a cached file naming a different account or role is not a hit", async () => {
+    const path = h.credsPath({
+      sso_account_id: "222222222222",
+      sso_role_name: "AdministratorAccess",
+    });
+    // Same filename, but the contents claim to be another account's keys.
+    h.files.set(
+      path,
+      JSON.stringify({
+        accessKeyId: "AKIA-wrong-account",
+        secretAccessKey: "secret-wrong-account",
+        sessionToken: "session-wrong-account",
+        expiry: inOneHour().getTime(),
+        sso_account_id: "111111111111",
+        sso_role_name: "AdministratorAccess",
+      }),
+    );
+
+    const prod = await h.load("prod");
+    expect(Redacted.value(prod.accessKeyId)).toBe(
+      "AKIA-222222222222-AdministratorAccess",
+    );
+    expect(h.portalCalls).toEqual(["222222222222/AdministratorAccess"]);
+    expect(JSON.parse(h.files.get(path)!).sso_account_id).toBe("222222222222");
+  });
+
+  test("a legacy session-keyed .credentials.json is never reused", async () => {
+    // The pre-#565 layout: role creds under the token's session-only key,
+    // without account/role fields. It must be ignored even if it were to
+    // land under the new filename.
+    const legacy = JSON.stringify({
+      accessKeyId: "AKIA-legacy",
+      secretAccessKey: "secret-legacy",
+      sessionToken: "session-legacy",
+      expiry: inOneHour().getTime(),
+    });
+    h.files.set(
+      join(h.cacheDir, `${ssoTokenCacheName(SESSION)}.credentials.json`),
+      legacy,
+    );
+    h.files.set(
+      h.credsPath({
+        sso_account_id: "222222222222",
+        sso_role_name: "AdministratorAccess",
+      }),
+      legacy,
+    );
+
+    const prod = await h.load("prod");
+    expect(Redacted.value(prod.accessKeyId)).toBe(
+      "AKIA-222222222222-AdministratorAccess",
+    );
+    expect(h.portalCalls).toEqual(["222222222222/AdministratorAccess"]);
+  });
+
+  test("token file stays keyed by session only", async () => {
+    expect(ssoTokenCacheName(SESSION)).toBe(sha1(SESSION));
+    expect(ssoTokenCacheName(START_URL)).toBe(sha1(START_URL));
+
+    // Both profiles read the same token file; no other token path is read.
+    const reads: string[] = [];
+    const inner = h.files;
+    const fs = FileSystem.layerNoop({
+      readFileString: (path) => {
+        reads.push(path);
+        return inner.has(path)
+          ? Effect.succeed(inner.get(path)!)
+          : Effect.fail(
+              PlatformError.systemError({
+                _tag: "NotFound",
+                module: "FileSystem",
+                method: "readFileString",
+                pathOrDescriptor: path,
+              }),
+            );
+      },
+      writeFileString: (path, data) =>
+        Effect.sync(() => {
+          inner.set(path, data);
+        }),
+    });
+    const http = Layer.succeed(HttpClient.HttpClient)(
+      HttpClient.make((request, url) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              roleCredentials: {
+                accessKeyId: `AKIA-${url.searchParams.get("account_id")}`,
+                secretAccessKey: "s",
+                sessionToken: "t",
+                expiration: inOneHour().getTime(),
+              },
+            }),
+          ),
+        ),
+      ),
+    );
+    const layer = Layer.mergeAll(fs, http, Path.layer);
+    for (const profile of ["dev", "prod"]) {
+      await Effect.runPromise(
+        Effect.flatMap(makeAuthService(), (auth) =>
+          auth.loadProfileCredentials(profile),
+        ).pipe(Effect.provide(layer)),
+      );
+    }
+
+    const tokenPath = join(h.cacheDir, `${ssoTokenCacheName(SESSION)}.json`);
+    const tokenReads = reads.filter(
+      (p) => p.startsWith(h.cacheDir) && !p.endsWith(".credentials.json"),
+    );
+    expect(tokenReads).toEqual([tokenPath, tokenPath]);
+  });
+
+  test("role cache key formula covers session, account and role", () => {
+    const base = {
+      sso_session: SESSION,
+      sso_account_id: "111111111111",
+      sso_role_name: "AdministratorAccess",
+    };
+    expect(ssoRoleCredentialsCacheName(base)).toBe(
+      sha1(`${SESSION}\n111111111111\nAdministratorAccess`),
+    );
+    expect(ssoRoleCredentialsCacheName(base)).not.toBe(
+      ssoRoleCredentialsCacheName({ ...base, sso_account_id: "222222222222" }),
+    );
+    expect(ssoRoleCredentialsCacheName(base)).not.toBe(
+      ssoRoleCredentialsCacheName({ ...base, sso_role_name: "ReadOnlyAccess" }),
+    );
+    expect(ssoRoleCredentialsCacheName(base)).not.toBe(
+      ssoTokenCacheName(SESSION),
+    );
+    // Legacy inline profiles key on the start URL, like the token does.
+    expect(
+      ssoRoleCredentialsCacheName({
+        ...base,
+        sso_session: undefined,
+        sso_start_url: START_URL,
+      }),
+    ).toBe(sha1(`${START_URL}\n111111111111\nAdministratorAccess`));
+  });
+});

--- a/packages/aws/src/auth.ts
+++ b/packages/aws/src/auth.ts
@@ -38,6 +38,51 @@ const EXPIRE_WINDOW_MS = 5 * 60 * 1000;
 
 const REFRESH_MESSAGE = `To refresh this SSO session run 'aws sso login' with the corresponding profile.`;
 
+/**
+ * Shape of `~/.aws/sso/cache/<key>.credentials.json`, the cached role
+ * credentials minted from an SSO token. `sso_account_id` / `sso_role_name`
+ * record which role the keys belong to; a file that does not name the
+ * profile's account and role is not a cache hit.
+ */
+export interface CachedSsoRoleCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  /** Epoch milliseconds, as returned by the SSO portal. */
+  expiry: number;
+  sso_account_id: string;
+  sso_role_name: string;
+}
+
+const sha1 = (input: string) => createHash("sha1").update(input).digest("hex");
+
+/**
+ * Cache file name (without extension) of the SSO access token: sha1 of the
+ * `sso_session` name (modern) or the `sso_start_url` (legacy inline format).
+ * Matches the AWS CLI, so one `aws sso login` serves every profile in the
+ * session.
+ */
+export const ssoTokenCacheName = (ssoCacheKey: string) => sha1(ssoCacheKey);
+
+/**
+ * Cache file name (without extension) of the role credentials for a profile:
+ * sha1 of `<sso_session | sso_start_url>\n<sso_account_id>\n<sso_role_name>`.
+ * The token is per session; the role credentials are per account + role.
+ */
+export const ssoRoleCredentialsCacheName = (
+  profile: Pick<
+    AwsProfileConfig,
+    "sso_session" | "sso_start_url" | "sso_account_id" | "sso_role_name"
+  >,
+) =>
+  sha1(
+    [
+      profile.sso_session ?? profile.sso_start_url ?? "",
+      profile.sso_account_id ?? "",
+      profile.sso_role_name ?? "",
+    ].join("\n"),
+  );
+
 export const Default = Effect.serviceOption(Auth).pipe(
   Effect.map(Option.getOrUndefined),
   Effect.flatMap((c) => (c ? Effect.succeed(c) : makeAuthService())),
@@ -138,7 +183,8 @@ export const makeAuthService = () =>
               )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
           });
         }
-        return profile;
+        // Every field in `ssoFields` was just checked to be present.
+        return profile as SsoProfileConfig;
       }
 
       return yield* new ProfileNotFound({
@@ -164,12 +210,19 @@ export const makeAuthService = () =>
       // `sso_session` name (modern) or the `sso_start_url` (legacy inline format).
       const ssoCacheKey = profile.sso_session ?? profile.sso_start_url;
       if (ssoCacheKey) {
-        const hasher = createHash("sha1");
-        const cacheName = hasher.update(ssoCacheKey).digest("hex");
-        const ssoTokenFilepath = path.join(cachePath, `${cacheName}.json`);
+        const ssoTokenFilepath = path.join(
+          cachePath,
+          `${ssoTokenCacheName(ssoCacheKey)}.json`,
+        );
+        // The token is one login per session, but the role credentials it
+        // mints are per `sso_account_id` + `sso_role_name`. Several profiles
+        // normally share one `[sso-session]`, so the credentials file must
+        // be keyed on the account and role too — keyed on the session alone,
+        // every profile in the session read whichever account's keys were
+        // fetched first (#565).
         const cachedCredsFilePath = path.join(
           cachePath,
-          `${cacheName}.credentials.json`,
+          `${ssoRoleCredentialsCacheName(profile)}.credentials.json`,
         );
 
         // `Effect.try` so a `JSON.parse` throw on an empty/partial file
@@ -180,12 +233,11 @@ export const makeAuthService = () =>
         const cachedCreds = yield* fs.readFileString(cachedCredsFilePath).pipe(
           Effect.flatMap((text) =>
             Effect.try({
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              try: (): any => JSON.parse(text),
+              try: (): Partial<CachedSsoRoleCredentials> => JSON.parse(text),
               catch: (cause) => cause,
             }),
           ),
-          Effect.catch(() => Effect.void),
+          Effect.catch(() => Effect.succeed(undefined)),
         );
 
         const isExpired = (expiry: number | string | undefined) => {
@@ -195,7 +247,22 @@ export const makeAuthService = () =>
           );
         };
 
-        if (cachedCreds && !isExpired(cachedCreds.expiry)) {
+        // A hit must name the account and role being resolved. Files
+        // written before the key included them carry neither, so they are
+        // never reused for a different account.
+        const isCacheHit = (
+          creds: Partial<CachedSsoRoleCredentials> | undefined,
+        ): creds is CachedSsoRoleCredentials =>
+          creds !== undefined &&
+          creds !== null &&
+          typeof creds.accessKeyId === "string" &&
+          typeof creds.secretAccessKey === "string" &&
+          typeof creds.expiry === "number" &&
+          creds.sso_account_id === profile.sso_account_id &&
+          creds.sso_role_name === profile.sso_role_name &&
+          !isExpired(creds.expiry);
+
+        if (isCacheHit(cachedCreds)) {
           return {
             accessKeyId: Redacted.make(cachedCreds.accessKeyId),
             secretAccessKey: Redacted.make(cachedCreds.secretAccessKey),
@@ -281,7 +348,9 @@ export const makeAuthService = () =>
             secretAccessKey: credentials.secretAccessKey,
             sessionToken: credentials.sessionToken,
             expiry: credentials.expiration,
-          }),
+            sso_account_id: profile.sso_account_id,
+            sso_role_name: profile.sso_role_name,
+          } satisfies CachedSsoRoleCredentials),
         );
 
         return {


### PR DESCRIPTION
Fixes #565

## Problem

`loadProfileCredentials` in `packages/aws/src/auth.ts` cached SSO **role** credentials at `~/.aws/sso/cache/<sha1(sso_session)>.credentials.json`. The key was the `sso_session` name alone (or `sso_start_url` for legacy inline profiles), and a cache hit only checked expiry.

Profiles that share one `[sso-session]` — the normal Identity Center layout: several accounts, one login — therefore shared one credentials file. Whichever profile resolved first won; every other profile silently received that account's keys until expiry. That 403s (wrong-account `HeadBucket`) or, worse, succeeds against the **wrong AWS account**.

## Fix

Hand-written `packages/aws/src/auth.ts` only; no generated code touched.

- **Token cache unchanged.** `<sha1(sso_session | sso_start_url)>.json` is one login per session and matches the AWS CLI. No new `aws sso login` is needed.
- **Role-credentials cache is now per account + role.** File name:
  ```
  sha1(`${sso_session ?? sso_start_url}\n${sso_account_id}\n${sso_role_name}`) + ".credentials.json"
  ```
  exposed as `ssoRoleCredentialsCacheName(profile)` next to `ssoTokenCacheName(key)`.
- **The file records `sso_account_id` and `sso_role_name`,** and a read is only a hit when both match the profile being resolved (plus the existing expiry check). A leftover file from the old layout carries neither, so it is never treated as a valid role cache.
- `loadProfile` returns `SsoProfileConfig` for SSO profiles (the required fields were already validated there), and the cached `expiry` is typed as the epoch milliseconds the portal returns.

## Tests

`packages/aws/src/auth.test.ts` (bun:test, mocked `FileSystem` + fake SSO portal `HttpClient`, temp `$HOME` for the ini loader — no live AWS, no credentials):

1. Two profiles on one `sso_session`, different `sso_account_id` → each gets its own keys; the second does not return the first's cached pair.
2. Same account, different role → separate cache entry.
3. Cache hit for the same account + role → no extra portal call.
4. Expired entry → refetched and rewritten.
5. File under the right name but naming a different account/role → not a hit.
6. Legacy session-only `.credentials.json` (no account/role fields) → never reused.
7. Token file is still read from the session-keyed path for both profiles.
8. Cache-key formula: distinct per account, per role, and from the token key; legacy start-URL profiles key on the start URL.

Against the pre-fix `auth.ts`, 6 of the 8 tests fail.

```sh
cd packages/aws && bun test src/auth.test.ts
```

Also ran `pnpm exec tsc -b --noCheck false packages/aws` (clean), `oxlint`, `oxfmt --check`.
