### PR TITLE
bench: rolldown bundle suite for AWS + Cloudflare (tree-shake + bundle time)

### DIFF
--- a/benches/bundle/README.md
+++ b/benches/bundle/README.md
@@ -1,1 +1,153 @@
-owned by bench-bundle@alchemy
+# benches/bundle — rolldown bundle bench
+
+Measures what a consumer pays for a Distilled SDK when bundling with
+**rolldown 1.2.5** the way Alchemy does: bundle time, output bytes (raw and
+gzip), and tree-shake quality. Measurements only — nothing here fails CI.
+
+```sh
+pnpm bench:bundle                    # from the repo root
+bun benches/bundle/run.ts            # same thing
+bun benches/bundle/run.ts --only aws-s3-deep,cf-workers-deep --runs 5
+bun benches/bundle/run.ts --all-variants --keep     # keep .out/<fixture>/<variant>/index.js
+```
+
+Flags: `--runs N` (builds per fixture, default 3), `--only a,b`,
+`--variants bun,bun+nopure,bun+nominify`, `--all-variants`, `--keep`
+(leave bundles in `.out/`), `--json` (append a compact JSON line).
+
+Output: markdown to stdout, plus `.out/report.md` and `.out/results.json`
+(per-module composition and per-service analysis). `.out/` is gitignored.
+
+## What is measured
+
+| column       | meaning                                                                                         |
+| ------------ | ----------------------------------------------------------------------------------------------- |
+| cold         | first `rolldown()` + `write()` in a fresh `bun` process (native binding load, resolver caches)  |
+| warm         | median of the remaining runs in the same process                                                 |
+| bytes / gzip | the single ESM entry chunk, minified                                                             |
+| modules      | modules in the chunk's graph                                                                     |
+| tree-shake   | ✅ / leaked markers, and `retained/total` operations of each service the fixture imports         |
+
+Tree-shake checks grep the minified bundle for string literals that survive
+minification: AWS `operationName: "X"` and Cloudflare route `uri: "/…"`. Each
+fixture lists what must be present (the op it calls) and what must be absent
+(other ops of the same service, other services, the other provider).
+
+The composition section counts rolldown's *rendered* module sizes (after
+tree-shaking, before minification) and, for each `packages/*/src/services/*.ts`
+module, splits the retained top-level bindings into endpoint rules, error
+classes, schemas and operations, flagging bindings that are **unreferenced**
+(kept only because rolldown could not prove the initializer pure).
+
+## How this mirrors Alchemy
+
+Settings are re-declared in `src/options.ts` (Alchemy is not a dependency):
+
+- `resolve.conditionNames = ["bun", "module", "default"]` — Alchemy's
+  `BUN_CONDITION_NAMES`; never `import`/`require`. This resolves
+  `@distilled.cloud/*` to the workspace **`src/*.ts`** (the `bun` export
+  condition), the same files an Alchemy worker sees via `"bun": "./src/…"`.
+  `NODE_CONDITION_NAMES` and the Cloudflare Worker set (`workerd, worker,
+  module, browser, production`) are available as variants; they resolve to the
+  same distilled sources.
+- `platform: "node"`, `treeshake: true`, `transform.define
+  {"globalThis.__ALCHEMY_RUNTIME__": "true"}`, `optimization.inlineConst
+  {mode: "smart", pass: 3}` — from `Bundle.build`.
+- Output: `format: "esm"`, `minify: true`, `keepNames: true`,
+  `strictExecutionOrder: true`, `sourcemap: "hidden"` — from
+  `Cloudflare/Workers/Sources/Rolldown.ts`. `+nominify` uses `"dce-only"`
+  (Alchemy's Lambda default).
+- **PURE annotator**: `src/pure-plugin.ts` is a dependency-free port of
+  Alchemy's `Bundle/PurePlugin.ts` (`alchemy:annotate-pure`) with the same
+  rules — `/*#__PURE__*/` on top-level bound calls in `effect`, `@effect/*`,
+  `alchemy`, `@alchemy.run/*`, `@distilled.cloud/*`; discarded-result calls
+  and `moduleSideEffects: false` only for packages declaring
+  `"sideEffects": false | []` (all distilled packages do). Differences:
+  picomatch replaced by a `name` / `@scope/*` matcher; no cross-build anchor
+  cache. The `+nopure` variant disables it so the report shows what it buys.
+
+Not mirrored: Alchemy's `@alchemy.run/cloudflare-runtime/rolldown` plugin
+(nodejs_compat shims, virtual entries), `rawPlugin`, and the bundle analyzer.
+None of them affect how distilled modules shake.
+
+## Fixtures (`fixtures/`)
+
+| fixture              | imports                                                                    |
+| -------------------- | -------------------------------------------------------------------------- |
+| `aws-s3-deep`        | `@distilled.cloud/aws/s3` + `/Credentials`; calls `getObject`              |
+| `aws-barrel`         | `@distilled.cloud/aws` root barrel (+ `/s3`); same call                    |
+| `aws-services-index` | `@distilled.cloud/aws/index` — all ~430 services as namespaces; `S3.getObject` |
+| `cf-workers-deep`    | `@distilled.cloud/cloudflare/workers` + `/Credentials`; `listScripts.items` |
+| `cf-barrel`          | `@distilled.cloud/cloudflare` root barrel (`Services.workers`); same call  |
+| `combined-worker`    | S3 `getObject` + Workers `listScripts` — an Alchemy-worker-shaped entry    |
+
+Each entry provides real layers (`Credentials.fromCredentials` /
+`fromApiToken`, `FetchHttpClient.layer`) and exports a `fetch` handler that
+runs the effect, so the operation is a live root for rolldown.
+
+## Adding a fixture
+
+1. Add `fixtures/<name>.ts` with a `default export` that references the
+   operation(s).
+2. Register it in `src/fixtures.ts` with `expect` / `forbid` markers and the
+   `services` whose op counts to report.
+
+## First results (2026-09-09, rolldown 1.2.5, bun 1.3.13, repo @ c7b11bc6b)
+
+| fixture            | variant    |    cold |    warm |    bytes |     gzip | modules | tree-shake                                    |
+| ------------------ | ---------- | ------: | ------: | -------: | -------: | ------: | --------------------------------------------- |
+| aws-s3-deep        | bun        |  ~320ms |  ~320ms | 410.7 KB | 118.4 KB |     222 | ✅ s3: 1/112 ops                              |
+| aws-s3-deep        | bun+nopure |  ~150ms |  ~150ms | 412.3 KB | 118.9 KB |     222 | ✅ s3: 1/112 ops                              |
+| aws-barrel         | bun        |  ~320ms |  ~310ms | 410.7 KB | 118.7 KB |     222 | ✅ s3: 1/112 ops                              |
+| aws-services-index | bun        | ~4200ms | ~4500ms | 410.7 KB | 118.4 KB |     222 | ✅ s3: 1/112 ops                              |
+| cf-workers-deep    | bun        |  ~300ms |  ~290ms | 222.2 KB |  61.7 KB |     106 | ✅ workers: 1/74 ops                          |
+| cf-workers-deep    | bun+nopure |  ~120ms |  ~120ms | 225.2 KB |  62.6 KB |     106 | ✅ workers: 1/74 ops                          |
+| cf-barrel          | bun        | ~1600ms | ~1550ms | 222.2 KB |  61.7 KB |     106 | ✅ workers: 1/74 ops                          |
+| combined-worker    | bun        |  ~450ms |  ~410ms | 464.8 KB | 129.7 KB |     234 | ✅ s3: 1/112 ops · workers: 1/74 ops          |
+
+Timings are one laptop run; treat ±30% as noise. Bytes are stable.
+
+### Findings
+
+1. **Service-level shaking works.** No operation from an un-imported service
+   and no other operation of the imported service survives in any fixture
+   (`operationName` / route `uri` literals: exactly 1 per used op).
+2. **Barrels cost bundle time, not bytes.** `@distilled.cloud/aws/index`
+   (all ~430 services) and `@distilled.cloud/cloudflare` (`Services.*`,
+   ~120 services) produce byte-identical output to the deep import, but
+   rolldown must parse and PURE-annotate every service module: 4.2 s vs
+   0.3 s (AWS), 1.6 s vs 0.3 s (Cloudflare). The `aws` root barrel
+   (`Auth`, `Credentials`, … namespaces, no services) is free.
+3. **The PURE annotator buys ~0.5–1.5% bytes and costs ~2× bundle time**
+   on these fixtures (410.7 vs 412.3 KB; 222.2 vs 225.2 KB) — the generated
+   services are already `/*@__PURE__*/`-annotated at the top level, so the
+   plugin mostly helps `effect`'s own `dist/`. Its cost is parsing every
+   matched module with oxc in JS (~180 modules → +170 ms; ~620 modules →
+   +4 s for the AWS index barrel).
+4. **What survives inside a service module is not the operations** — it is
+   two generated shapes rolldown cannot prove pure, plus S3's endpoint
+   resolver:
+   - `packages/aws/src/services/s3.ts` (92 KB rendered, ~42 KB minified):
+     **75%** is the `EndpointResolver` rules function (needed by the op —
+     not a shake failure, but the largest single cost of using S3), **8.9 KB**
+     is 49 error classes of which **39 are unreferenced**
+     (`class X extends /*@__PURE__*/ S.TaggedError()(…).pipe(C.withY) {}` —
+     the annotation sits on the inner call, the outer `.pipe(...)` in class
+     heritage is not annotated, so the class is kept), and 12 unreferenced
+     list/union schemas (`S.Array(Inner.pipe(T.XmlName(…)).annotate(…))`).
+   - `packages/cloudflare/src/services/workers.ts` (65.5 KB rendered, ~27 KB
+     minified): **141 of 170 retained bindings (46.6 KB rendered, ≈19 KB
+     minified, ~70% of the module) are unreferenced.** 106 are
+     `/*@__PURE__*/ S.Unknown.pipe(T.UnionCases([...]))` schemas — the outer
+     `.pipe` is annotated but the inner `T.UnionCases(...)` argument is not,
+     and rolldown treats an unannotated call argument as a side effect. 35
+     are error classes of the same
+     `class X extends /*@__PURE__*/ T.applyErrorMatchers(/*@__PURE__*/ S.TaggedError()(…)) {}`
+     shape. Verified with a micro-fixture: annotating the inner
+     `UnionCases(...)` call, and hoisting the class heritage expression into a
+     `/*@__PURE__*/ const` that the class extends, both shake to zero.
+5. **Where the bytes go overall** (S3 fixture, rendered): `effect` 50%,
+   `@distilled.cloud/aws` 22% (of which s3.ts 92 KB, protocol/rules-engine/
+   client the rest), `@smithy/*` + `@aws-sdk/credential-providers` chain ~10%,
+   `fast-xml-parser` 6%. The Cloudflare fixture is `effect` 78%,
+   `@distilled.cloud/cloudflare` 15%, `@distilled.cloud/core` 7%.

--- a/benches/bundle/README.md
+++ b/benches/bundle/README.md
@@ -143,7 +143,12 @@ Timings are one laptop run; treat ±30% as noise. Bytes are stable.
      minified, ~70% of the module) are unreferenced.** 106 are
      `/*@__PURE__*/ S.Unknown.pipe(T.UnionCases([...]))` schemas — the outer
      `.pipe` is annotated but the inner `T.UnionCases(...)` argument is not,
-     and rolldown treats an unannotated call argument as a side effect. 35
+     and rolldown treats an unannotated call argument as a side effect. The
+     opaque `Unknown.pipe(UnionCases(keySets))` form itself is intentional
+     for Cloudflare object unions; the missing inner annotation is the
+     shake bug. Of the 107 such schemas in `workers.ts`, 44 have only empty
+     key-sets (`UnionCases([[], []])` — scalar/array unions such as
+     `boolean | string[]`, where the annotation carries no information). 35
      are error classes of the same
      `class X extends /*@__PURE__*/ T.applyErrorMatchers(/*@__PURE__*/ S.TaggedError()(…)) {}`
      shape. Verified with a micro-fixture: annotating the inner

--- a/benches/bundle/README.md
+++ b/benches/bundle/README.md
@@ -11,10 +11,11 @@ bun benches/bundle/run.ts --only aws-s3-deep,cf-workers-deep --runs 5
 bun benches/bundle/run.ts --all-variants --keep     # keep .out/<fixture>/<variant>/index.js
 ```
 
-Flags: `--runs N` (builds per fixture, default 3), `--only a,b`,
-`--variants bun,bun+nopure,bun+nominify`, `--all-variants`, `--keep`
-(leave bundles in `.out/`), `--json` (append a compact JSON line),
-`--out <file>` (write the slim committed artifact; see `results/README.md`).
+Flags: `--runs N` (builds per fixture; default `$BENCH_RUNS`, then 3),
+`--only a,b`, `--variants bun,bun+nopure,bun+nominify`, `--all-variants`,
+`--keep` (leave bundles in `.out/`), `--json` (print the slim artifact JSON
+to stdout instead of the markdown, for piping), `--out <file>` (write the
+slim committed artifact; see `results/README.md`).
 `pnpm --filter @distilled.cloud/bench-bundle record` refreshes
 `results/latest.json`, which the website reads at build time.
 

--- a/benches/bundle/README.md
+++ b/benches/bundle/README.md
@@ -13,7 +13,10 @@ bun benches/bundle/run.ts --all-variants --keep     # keep .out/<fixture>/<varia
 
 Flags: `--runs N` (builds per fixture, default 3), `--only a,b`,
 `--variants bun,bun+nopure,bun+nominify`, `--all-variants`, `--keep`
-(leave bundles in `.out/`), `--json` (append a compact JSON line).
+(leave bundles in `.out/`), `--json` (append a compact JSON line),
+`--out <file>` (write the slim committed artifact; see `results/README.md`).
+`pnpm --filter @distilled.cloud/bench-bundle record` refreshes
+`results/latest.json`, which the website reads at build time.
 
 Output: markdown to stdout, plus `.out/report.md` and `.out/results.json`
 (per-module composition and per-service analysis). `.out/` is gitignored.

--- a/benches/bundle/fixtures/aws-barrel.ts
+++ b/benches/bundle/fixtures/aws-barrel.ts
@@ -1,0 +1,27 @@
+// AWS barrel import: the package root re-exports every hand-written module
+// (Auth, Credentials, Endpoint, …) as namespaces. Same S3 call as
+// `aws-s3-deep.ts`, but Credentials come through the barrel.
+import * as AWS from "@distilled.cloud/aws";
+import * as s3 from "@distilled.cloud/aws/s3";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  AWS.Credentials.fromCredentials(
+    { accessKeyId: "AKIA_BENCH", secretAccessKey: "bench" },
+    "us-east-1",
+  ),
+  FetchHttpClient.layer,
+);
+
+const program = s3
+  .getObject({ Bucket: "bench-bucket", Key: "bench-key" })
+  .pipe(Effect.provide(layer));
+
+export default {
+  fetch: () =>
+    Effect.runPromise(program).then(
+      (out) => new Response(String(out.ContentLength ?? 0)),
+    ),
+};

--- a/benches/bundle/fixtures/aws-s3-deep.ts
+++ b/benches/bundle/fixtures/aws-s3-deep.ts
@@ -1,0 +1,25 @@
+// AWS deep import: one service, one operation.
+import * as Credentials from "@distilled.cloud/aws/Credentials";
+import * as s3 from "@distilled.cloud/aws/s3";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  Credentials.fromCredentials(
+    { accessKeyId: "AKIA_BENCH", secretAccessKey: "bench" },
+    "us-east-1",
+  ),
+  FetchHttpClient.layer,
+);
+
+const program = s3
+  .getObject({ Bucket: "bench-bucket", Key: "bench-key" })
+  .pipe(Effect.provide(layer));
+
+export default {
+  fetch: () =>
+    Effect.runPromise(program).then(
+      (out) => new Response(String(out.ContentLength ?? 0)),
+    ),
+};

--- a/benches/bundle/fixtures/aws-services-index.ts
+++ b/benches/bundle/fixtures/aws-services-index.ts
@@ -1,0 +1,29 @@
+// AWS "everything" barrel: `@distilled.cloud/aws/index` resolves through the
+// `./*` export to `src/services/index.ts`, which re-exports all ~430 service
+// modules as namespaces. Still only S3 GetObject is used — this measures how
+// much of the other services survives tree-shaking.
+import * as Credentials from "@distilled.cloud/aws/Credentials";
+import * as AWS from "@distilled.cloud/aws/index";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  Credentials.fromCredentials(
+    { accessKeyId: "AKIA_BENCH", secretAccessKey: "bench" },
+    "us-east-1",
+  ),
+  FetchHttpClient.layer,
+);
+
+const program = AWS.S3.getObject({
+  Bucket: "bench-bucket",
+  Key: "bench-key",
+}).pipe(Effect.provide(layer));
+
+export default {
+  fetch: () =>
+    Effect.runPromise(program).then(
+      (out) => new Response(String(out.ContentLength ?? 0)),
+    ),
+};

--- a/benches/bundle/fixtures/cf-barrel.ts
+++ b/benches/bundle/fixtures/cf-barrel.ts
@@ -1,0 +1,21 @@
+// Cloudflare barrel import: `@distilled.cloud/cloudflare` re-exports
+// credentials, errors, protocol and `Services` (all ~120 service modules as
+// namespaces). Same listScripts call as `cf-workers-deep.ts`.
+import * as CF from "@distilled.cloud/cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  CF.fromApiToken({ apiToken: "bench-token" }),
+  FetchHttpClient.layer,
+);
+
+const program = CF.Services.workers.listScripts
+  .items({ accountId: "bench-account" })
+  .pipe(Stream.runCount, Effect.provide(layer));
+
+export default {
+  fetch: () => Effect.runPromise(program).then((n) => new Response(String(n))),
+};

--- a/benches/bundle/fixtures/cf-workers-deep.ts
+++ b/benches/bundle/fixtures/cf-workers-deep.ts
@@ -1,0 +1,20 @@
+// Cloudflare deep import: one service, one (paginated) operation.
+import * as Credentials from "@distilled.cloud/cloudflare/Credentials";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  Credentials.fromApiToken({ apiToken: "bench-token" }),
+  FetchHttpClient.layer,
+);
+
+const program = workers.listScripts
+  .items({ accountId: "bench-account" })
+  .pipe(Stream.runCount, Effect.provide(layer));
+
+export default {
+  fetch: () => Effect.runPromise(program).then((n) => new Response(String(n))),
+};

--- a/benches/bundle/fixtures/combined-worker.ts
+++ b/benches/bundle/fixtures/combined-worker.ts
@@ -1,0 +1,35 @@
+// "Alchemy worker-shaped" entry: two deep imports across providers —
+// S3 GetObject + Cloudflare Workers listScripts.
+import * as AwsCredentials from "@distilled.cloud/aws/Credentials";
+import * as s3 from "@distilled.cloud/aws/s3";
+import * as CfCredentials from "@distilled.cloud/cloudflare/Credentials";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+
+const layer = Layer.mergeAll(
+  AwsCredentials.fromCredentials(
+    { accessKeyId: "AKIA_BENCH", secretAccessKey: "bench" },
+    "us-east-1",
+  ),
+  CfCredentials.fromApiToken({ apiToken: "bench-token" }),
+  FetchHttpClient.layer,
+);
+
+const program = Effect.gen(function* () {
+  const object = yield* s3.getObject({
+    Bucket: "bench-bucket",
+    Key: "bench-key",
+  });
+  const scripts = yield* workers.listScripts
+    .items({ accountId: "bench-account" })
+    .pipe(Stream.runCount);
+  return { size: object.ContentLength ?? 0, scripts };
+}).pipe(Effect.provide(layer));
+
+export default {
+  fetch: () =>
+    Effect.runPromise(program).then((out) => new Response(JSON.stringify(out))),
+};

--- a/benches/bundle/package.json
+++ b/benches/bundle/package.json
@@ -6,7 +6,7 @@
   "description": "Rolldown bundle-size / tree-shake / bundle-time measurements for Distilled SDKs, using Alchemy's bundler settings.",
   "scripts": {
     "bench": "bun run.ts",
-    "record": "bun run.ts --runs 3 --out results/latest.json",
+    "record": "bun run.ts --out results/latest.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/benches/bundle/package.json
+++ b/benches/bundle/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@distilled.cloud/bench-bundle",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Rolldown bundle-size / tree-shake / bundle-time measurements for Distilled SDKs, using Alchemy's bundler settings.",
+  "scripts": {
+    "bench": "bun run.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@distilled.cloud/aws": "workspace:*",
+    "@distilled.cloud/cloudflare": "workspace:*",
+    "@distilled.cloud/core": "workspace:*",
+    "effect": "catalog:effect"
+  },
+  "devDependencies": {
+    "@oxc-project/types": "^0.146.0",
+    "@types/bun": "catalog:tooling",
+    "@types/node": "catalog:tooling",
+    "rolldown": "catalog:bench",
+    "typescript": "catalog:build"
+  }
+}

--- a/benches/bundle/package.json
+++ b/benches/bundle/package.json
@@ -6,6 +6,7 @@
   "description": "Rolldown bundle-size / tree-shake / bundle-time measurements for Distilled SDKs, using Alchemy's bundler settings.",
   "scripts": {
     "bench": "bun run.ts",
+    "record": "bun run.ts --runs 3 --out results/latest.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/benches/bundle/results/README.md
+++ b/benches/bundle/results/README.md
@@ -1,0 +1,47 @@
+# benches/bundle/results
+
+`latest.json` is the committed, slim form of the last full bench run. The
+website (`website/scripts/build.ts`) reads it at build time to render
+`/bench`; if the file is missing that section is omitted.
+
+Refresh it from the repo root:
+
+```sh
+pnpm --filter @distilled.cloud/bench-bundle record
+# same as: pnpm bench:bundle -- --runs 3 --out benches/bundle/results/latest.json
+```
+
+Then commit the file. Timings are from one dev box (±30 % on ms); bytes are
+deterministic for a given commit and rolldown version.
+
+Shape (`schema: 1`):
+
+```json
+{
+  "schema": 1,
+  "generatedAt": "ISO-8601",
+  "commit": "short sha",
+  "host": { "platform": "linux-x64", "cpu": "…", "cores": 16, "memoryGb": 62 },
+  "rolldown": "1.2.5",
+  "bun": "1.3.13",
+  "runs": 3,
+  "rows": [
+    {
+      "fixture": "aws-s3-deep",
+      "variant": "bun",
+      "description": "…",
+      "coldMs": 320,
+      "warmMs": 310,
+      "bytes": 420542,
+      "gzipBytes": 121287,
+      "moduleCount": 222,
+      "opsRetained": [{ "service": "aws/s3", "retained": 1, "total": 112 }],
+      "leaks": 0
+    }
+  ]
+}
+```
+
+`leaks` = number of failed tree-shake expectations (missing used-op literal
++ present forbidden literals); 0 is clean. `warmMs` is `null` when
+`--runs 1`.

--- a/benches/bundle/results/README.md
+++ b/benches/bundle/results/README.md
@@ -8,7 +8,8 @@ Refresh it from the repo root:
 
 ```sh
 pnpm --filter @distilled.cloud/bench-bundle record
-# same as: pnpm bench:bundle -- --runs 3 --out benches/bundle/results/latest.json
+# same as: pnpm bench:bundle -- --out benches/bundle/results/latest.json
+# runs per fixture: --runs N, else $BENCH_RUNS, else 3 (CI can set BENCH_RUNS=1)
 ```
 
 Then commit the file. Timings are from one dev box (±30 % on ms); bytes are
@@ -21,7 +22,7 @@ Shape (`schema: 1`):
   "schema": 1,
   "generatedAt": "ISO-8601",
   "commit": "short sha",
-  "host": { "platform": "linux-x64", "cpu": "…", "cores": 16, "memoryGb": 62 },
+  "host": { "platform": "linux-x64", "cpu": "…", "cores": 16, "memoryGb": 31 },
   "rolldown": "1.2.5",
   "bun": "1.3.13",
   "runs": 3,

--- a/benches/bundle/results/latest.json
+++ b/benches/bundle/results/latest.json
@@ -1,0 +1,165 @@
+{
+  "schema": 1,
+  "generatedAt": "2026-09-09T17:56:30.307Z",
+  "commit": "adc438102",
+  "host": {
+    "platform": "linux-x64",
+    "cpu": "Intel(R) Core(TM) Ultra X7 358H",
+    "cores": 16,
+    "memoryGb": 31
+  },
+  "rolldown": "1.2.5",
+  "bun": "1.3.13",
+  "runs": 3,
+  "rows": [
+    {
+      "fixture": "aws-s3-deep",
+      "variant": "bun",
+      "description": "`@distilled.cloud/aws/s3` + `/Credentials`, one op (GetObject)",
+      "coldMs": 355,
+      "warmMs": 308,
+      "bytes": 420542,
+      "gzipBytes": 121287,
+      "moduleCount": 222,
+      "opsRetained": [
+        {
+          "service": "aws/s3",
+          "retained": 1,
+          "total": 112
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "aws-s3-deep",
+      "variant": "bun+nopure",
+      "description": "`@distilled.cloud/aws/s3` + `/Credentials`, one op (GetObject)",
+      "coldMs": 191,
+      "warmMs": 166,
+      "bytes": 422208,
+      "gzipBytes": 121723,
+      "moduleCount": 222,
+      "opsRetained": [
+        {
+          "service": "aws/s3",
+          "retained": 1,
+          "total": 112
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "aws-barrel",
+      "variant": "bun",
+      "description": "`@distilled.cloud/aws` root barrel (+ `/s3` deep) — same op",
+      "coldMs": 317,
+      "warmMs": 295,
+      "bytes": 420511,
+      "gzipBytes": 121592,
+      "moduleCount": 222,
+      "opsRetained": [
+        {
+          "service": "aws/s3",
+          "retained": 1,
+          "total": 112
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "aws-services-index",
+      "variant": "bun",
+      "description": "`@distilled.cloud/aws/index` — all ~430 services as namespaces, only S3.getObject used",
+      "coldMs": 5420,
+      "warmMs": 4387,
+      "bytes": 420563,
+      "gzipBytes": 121290,
+      "moduleCount": 222,
+      "opsRetained": [
+        {
+          "service": "aws/s3",
+          "retained": 1,
+          "total": 112
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "cf-workers-deep",
+      "variant": "bun",
+      "description": "`@distilled.cloud/cloudflare/workers` + `/Credentials`, one paginated op (listScripts)",
+      "coldMs": 322,
+      "warmMs": 259,
+      "bytes": 227513,
+      "gzipBytes": 63209,
+      "moduleCount": 106,
+      "opsRetained": [
+        {
+          "service": "cloudflare/workers",
+          "retained": 1,
+          "total": 74
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "cf-workers-deep",
+      "variant": "bun+nopure",
+      "description": "`@distilled.cloud/cloudflare/workers` + `/Credentials`, one paginated op (listScripts)",
+      "coldMs": 116,
+      "warmMs": 109,
+      "bytes": 230580,
+      "gzipBytes": 64075,
+      "moduleCount": 106,
+      "opsRetained": [
+        {
+          "service": "cloudflare/workers",
+          "retained": 1,
+          "total": 74
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "cf-barrel",
+      "variant": "bun",
+      "description": "`@distilled.cloud/cloudflare` root barrel (Services.* — ~120 services), same op",
+      "coldMs": 1560,
+      "warmMs": 1446,
+      "bytes": 227495,
+      "gzipBytes": 63203,
+      "moduleCount": 106,
+      "opsRetained": [
+        {
+          "service": "cloudflare/workers",
+          "retained": 1,
+          "total": 74
+        }
+      ],
+      "leaks": 0
+    },
+    {
+      "fixture": "combined-worker",
+      "variant": "bun",
+      "description": "alchemy-worker-shaped: s3.getObject + workers.listScripts (two deep imports)",
+      "coldMs": 416,
+      "warmMs": 378,
+      "bytes": 475917,
+      "gzipBytes": 132804,
+      "moduleCount": 234,
+      "opsRetained": [
+        {
+          "service": "aws/s3",
+          "retained": 1,
+          "total": 112
+        },
+        {
+          "service": "cloudflare/workers",
+          "retained": 1,
+          "total": 74
+        }
+      ],
+      "leaks": 0
+    }
+  ]
+}

--- a/benches/bundle/run.ts
+++ b/benches/bundle/run.ts
@@ -1,0 +1,377 @@
+/**
+ * Rolldown bundle benchmark for Distilled SDKs.
+ *
+ *   bun benches/bundle/run.ts [--runs N] [--only name,…] [--variants a,b]
+ *                             [--all-variants] [--json] [--keep]
+ *
+ * Each fixture × variant is built in a fresh `bun` process (cold = first
+ * build in that process, warm = median of the remaining `--runs`). Prints a
+ * markdown report and writes `.out/report.md` + `.out/results.json`.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { BuildRequest, BuildResult } from "./src/build.ts";
+import { fixtures, type Fixture, type ServiceRef } from "./src/fixtures.ts";
+import { variantId, type BuildVariant } from "./src/options.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const outRoot = path.join(here, ".out");
+
+// --- CLI --------------------------------------------------------------------
+const args = process.argv.slice(2);
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? undefined : (args[i + 1] ?? "");
+};
+const has = (name: string) => args.includes(`--${name}`);
+
+const runs = Number(flag("runs") ?? 3);
+const only = flag("only")?.split(",").filter(Boolean);
+const keep = has("keep");
+
+/**
+ * Default variant matrix. `bun` = Alchemy's `BUN_CONDITION_NAMES` with the
+ * PURE annotator and full minify (Worker settings). The no-PURE variant is
+ * run on the two deep fixtures so the report shows what the annotator buys.
+ */
+const BUN: BuildVariant = { conditions: "bun", pure: true, minify: true };
+const BUN_NOPURE: BuildVariant = {
+  conditions: "bun",
+  pure: false,
+  minify: true,
+};
+const BUN_NOMINIFY: BuildVariant = {
+  conditions: "bun",
+  pure: true,
+  minify: false,
+};
+const ALL_VARIANTS = {
+  bun: BUN,
+  "bun+nopure": BUN_NOPURE,
+  "bun+nominify": BUN_NOMINIFY,
+};
+
+const defaultVariants = (f: Fixture): BuildVariant[] =>
+  f.name === "aws-s3-deep" || f.name === "cf-workers-deep"
+    ? [BUN, BUN_NOPURE]
+    : [BUN];
+
+const variantsFor = (f: Fixture): BuildVariant[] => {
+  const requested = flag("variants")?.split(",").filter(Boolean);
+  if (has("all-variants")) return Object.values(ALL_VARIANTS);
+  if (requested) {
+    return requested.map((v) => {
+      const found = ALL_VARIANTS[v as keyof typeof ALL_VARIANTS];
+      if (!found)
+        throw new Error(
+          `unknown variant ${v}; known: ${Object.keys(ALL_VARIANTS)}`,
+        );
+      return found;
+    });
+  }
+  return defaultVariants(f);
+};
+
+// --- helpers ----------------------------------------------------------------
+const kb = (n: number) => `${(n / 1024).toFixed(1)} KB`;
+const ms = (n: number) => `${n.toFixed(0)} ms`;
+const median = (xs: number[]) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s.length === 0 ? Number.NaN : s[Math.floor(s.length / 2)]!;
+};
+
+const OP_MARKER: Record<ServiceRef["pkg"], RegExp> = {
+  aws: /operationName:\s*[`"']/g,
+  cloudflare: /uri:\s*[`"']\/(?:accounts|zones)\/\{/g,
+};
+const count = (text: string, re: RegExp) => text.match(re)?.length ?? 0;
+
+async function serviceOpTotal(ref: ServiceRef): Promise<number> {
+  const file = path.join(
+    repoRoot,
+    "packages",
+    ref.pkg,
+    "src/services",
+    ref.file,
+  );
+  return count(await fs.readFile(file, "utf8"), OP_MARKER[ref.pkg]);
+}
+
+/** Group rendered module sizes by owning package (workspace or node_modules). */
+function composition(
+  result: BuildResult,
+): Array<{ pkg: string; bytes: number; modules: number }> {
+  const groups = new Map<string, { bytes: number; modules: number }>();
+  for (const m of result.modules) {
+    const id = m.id.replace(/\\/g, "/");
+    let pkg: string;
+    const nm = id.lastIndexOf("/node_modules/");
+    if (nm !== -1) {
+      const parts = id.slice(nm + "/node_modules/".length).split("/");
+      pkg = parts[0]!.startsWith("@") ? `${parts[0]}/${parts[1]}` : parts[0]!;
+    } else {
+      const ws = id.match(/\/packages\/([^/]+)\//);
+      pkg = ws
+        ? `@distilled.cloud/${ws[1]}`
+        : id.includes("/benches/bundle/")
+          ? "(entry)"
+          : id;
+    }
+    const g = groups.get(pkg) ?? { bytes: 0, modules: 0 };
+    g.bytes += m.renderedLength;
+    g.modules += 1;
+    groups.set(pkg, g);
+  }
+  return [...groups.entries()]
+    .map(([pkg, g]) => ({ pkg, ...g }))
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+interface Row {
+  fixture: Fixture;
+  variant: BuildVariant;
+  result: BuildResult;
+  expectMissing: string[];
+  forbidPresent: string[];
+  opsRetained: Array<{ service: string; retained: number; total: number }>;
+  composition: ReturnType<typeof composition>;
+}
+
+async function runOne(fixture: Fixture, variant: BuildVariant): Promise<Row> {
+  const id = variantId(variant);
+  const req: BuildRequest = {
+    entry: path.join(here, fixture.entry),
+    cwd: here,
+    outDir: path.join(outRoot, fixture.name, id),
+    variant,
+    runs,
+  };
+  const proc = Bun.spawn(
+    ["bun", path.join(here, "src/build.ts"), JSON.stringify(req)],
+    {
+      cwd: here,
+      stdout: "pipe",
+      stderr: "inherit",
+    },
+  );
+  const stdout = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  if (code !== 0)
+    throw new Error(`${fixture.name}/${id}: build process exited ${code}`);
+  const result = JSON.parse(stdout) as BuildResult;
+
+  const bundle = await fs.readFile(result.outputFile, "utf8");
+  const expectMissing = fixture.expect
+    .filter((m) => !m.pattern.test(bundle))
+    .map((m) => m.label);
+  const forbidPresent = fixture.forbid
+    .filter((m) => m.pattern.test(bundle))
+    .map((m) => m.label);
+  const opsRetained = await Promise.all(
+    fixture.services.map(async (s) => ({
+      service: `${s.pkg}/${s.file.replace(/\.ts$/, "")}`,
+      retained: count(bundle, OP_MARKER[s.pkg]),
+      total: await serviceOpTotal(s),
+    })),
+  );
+  return {
+    fixture,
+    variant,
+    result,
+    expectMissing,
+    forbidPresent,
+    opsRetained,
+    composition: composition(result),
+  };
+}
+
+// --- report -----------------------------------------------------------------
+function shakeNotes(row: Row): string {
+  const notes: string[] = [];
+  if (row.expectMissing.length)
+    notes.push(`❌ missing: ${row.expectMissing.join(", ")}`);
+  if (row.forbidPresent.length)
+    notes.push(`⚠️ leaked: ${row.forbidPresent.join("; ")}`);
+  for (const o of row.opsRetained)
+    notes.push(`${o.service}: ${o.retained}/${o.total} ops`);
+  if (!row.expectMissing.length && !row.forbidPresent.length)
+    notes.unshift("✅");
+  return notes.join(" · ");
+}
+
+function report(rows: Row[], rolldownVersion: string): string {
+  const lines: string[] = [];
+  lines.push(`# Distilled rolldown bundle bench`);
+  lines.push("");
+  lines.push(
+    `rolldown ${rolldownVersion} · bun ${Bun.version} · runs/fixture: ${runs} (cold = 1st build in a fresh process, warm = median of the rest) · conditions \`bun,module,default\` (resolves \`packages/*/src\`) · PURE annotator on unless \`+nopure\` · minify on unless \`+nominify\``,
+  );
+  lines.push("");
+  lines.push(
+    "| fixture | variant | cold | warm | bytes | gzip | modules | tree-shake |",
+  );
+  lines.push("|---|---|---:|---:|---:|---:|---:|---|");
+  for (const r of rows) {
+    const [cold, ...rest] = r.result.timesMs;
+    lines.push(
+      `| ${r.fixture.name} | ${variantId(r.variant)} | ${ms(cold!)} | ${rest.length ? ms(median(rest)) : "–"} | ${kb(r.result.bytes)} | ${kb(r.result.gzipBytes)} | ${r.result.moduleCount} | ${shakeNotes(r)} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Fixtures");
+  lines.push("");
+  for (const f of fixtures)
+    lines.push(`- **${f.name}** (\`${f.entry}\`): ${f.description}`);
+  lines.push("");
+  lines.push(
+    "## Composition (rendered bytes per package, post-treeshake / pre-minify)",
+  );
+  lines.push("");
+  for (const r of rows) {
+    const top = r.composition.slice(0, 8);
+    const total = r.composition.reduce((n, c) => n + c.bytes, 0);
+    lines.push(`### ${r.fixture.name} / ${variantId(r.variant)}`);
+    lines.push("");
+    lines.push(
+      `${kb(total)} rendered → ${kb(r.result.bytes)} written (×${(r.result.bytes / total).toFixed(2)}; scale rendered numbers below by this for a minified estimate). PURE plugin: ${r.result.pure.annotations} annotations in ${r.result.pure.annotatedModules}/${r.result.pure.matchedModules} matched modules, ${r.result.pure.sideEffectFreeModules} marked side-effect free.`,
+    );
+    lines.push("");
+    lines.push("| package | rendered | share | modules |");
+    lines.push("|---|---:|---:|---:|");
+    for (const c of top) {
+      lines.push(
+        `| ${c.pkg} | ${kb(c.bytes)} | ${((100 * c.bytes) / total).toFixed(1)}% | ${c.modules} |`,
+      );
+    }
+    for (const svc of r.result.services) {
+      lines.push("");
+      lines.push(
+        `**\`${path.relative(repoRoot, svc.id)}\`** — ${kb(svc.renderedBytes)} rendered, ${svc.decls} top-level bindings retained; ${svc.unreferenced} of them (${kb(svc.unreferencedBytes)}) are unreferenced — kept only because rolldown could not prove the initializer pure:`,
+      );
+      lines.push("");
+      lines.push(
+        "| kind | bytes | share | retained | unreferenced | unreferenced bytes |",
+      );
+      lines.push("|---|---:|---:|---:|---:|---:|");
+      const kinds = Object.keys(svc.bytesByKind) as Array<
+        keyof typeof svc.bytesByKind
+      >;
+      for (const k of kinds.sort(
+        (a, b) => svc.bytesByKind[b] - svc.bytesByKind[a],
+      )) {
+        if (svc.countByKind[k] === 0) continue;
+        lines.push(
+          `| ${k} | ${kb(svc.bytesByKind[k])} | ${((100 * svc.bytesByKind[k]) / svc.renderedBytes).toFixed(1)}% | ${svc.countByKind[k]} | ${svc.unreferencedByKind[k]} | ${kb(svc.unreferencedBytesByKind[k])} |`,
+        );
+      }
+      if (svc.largestUnreferenced.length) {
+        lines.push("");
+        lines.push(
+          `Largest unreferenced: ${svc.largestUnreferenced
+            .slice(0, 6)
+            .map((d) => `\`${d.name}\` (${d.bytes} B, ${d.kind})`)
+            .join(", ")}`,
+        );
+      }
+    }
+    if (r.result.warnings.length) {
+      lines.push("");
+      lines.push(
+        `Warnings (${r.result.warnings.length}): ${r.result.warnings.slice(0, 3).join(" | ")}`,
+      );
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// --- main -------------------------------------------------------------------
+const selected = fixtures.filter((f) => !only || only.includes(f.name));
+if (selected.length === 0) {
+  console.error(
+    `no fixtures match --only ${only}; known: ${fixtures.map((f) => f.name).join(",")}`,
+  );
+  process.exit(2);
+}
+
+const rolldownVersion = (
+  JSON.parse(
+    await fs.readFile(
+      path.join(here, "node_modules/rolldown/package.json"),
+      "utf8",
+    ),
+  ) as {
+    version: string;
+  }
+).version;
+
+const rows: Row[] = [];
+const t0 = performance.now();
+for (const fixture of selected) {
+  for (const variant of variantsFor(fixture)) {
+    process.stderr.write(`▶ ${fixture.name} [${variantId(variant)}] …`);
+    const row = await runOne(fixture, variant);
+    process.stderr.write(
+      ` cold ${ms(row.result.timesMs[0]!)} · ${kb(row.result.bytes)} · gzip ${kb(row.result.gzipBytes)}\n`,
+    );
+    rows.push(row);
+  }
+}
+const wall = performance.now() - t0;
+
+const md = report(rows, rolldownVersion);
+await fs.mkdir(outRoot, { recursive: true });
+await fs.writeFile(path.join(outRoot, "report.md"), md);
+await fs.writeFile(
+  path.join(outRoot, "results.json"),
+  JSON.stringify(
+    {
+      rolldown: rolldownVersion,
+      bun: Bun.version,
+      runs,
+      wallMs: wall,
+      rows: rows.map((r) => ({
+        fixture: r.fixture.name,
+        variant: variantId(r.variant),
+        timesMs: r.result.timesMs,
+        bytes: r.result.bytes,
+        gzipBytes: r.result.gzipBytes,
+        moduleCount: r.result.moduleCount,
+        pure: r.result.pure,
+        expectMissing: r.expectMissing,
+        forbidPresent: r.forbidPresent,
+        opsRetained: r.opsRetained,
+        composition: r.composition,
+        warnings: r.result.warnings,
+      })),
+    },
+    null,
+    2,
+  ),
+);
+if (!keep) {
+  for (const r of rows) {
+    await fs.rm(path.dirname(r.result.outputFile), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+console.log(md);
+console.log(
+  `\n_total wall time ${(wall / 1000).toFixed(1)} s · report: ${path.relative(process.cwd(), path.join(outRoot, "report.md"))}_`,
+);
+if (has("json"))
+  console.log(
+    JSON.stringify(
+      rows.map((r) => ({
+        fixture: r.fixture.name,
+        variant: variantId(r.variant),
+        bytes: r.result.bytes,
+        gzip: r.result.gzipBytes,
+        timesMs: r.result.timesMs,
+      })),
+    ),
+  );

--- a/benches/bundle/run.ts
+++ b/benches/bundle/run.ts
@@ -3,12 +3,16 @@
  *
  *   bun benches/bundle/run.ts [--runs N] [--only name,…] [--variants a,b]
  *                             [--all-variants] [--json] [--keep]
+ *                             [--out results/latest.json]
  *
  * Each fixture × variant is built in a fresh `bun` process (cold = first
  * build in that process, warm = median of the remaining `--runs`). Prints a
  * markdown report and writes `.out/report.md` + `.out/results.json`.
+ * `--out` additionally writes the slim, committed-artifact shape
+ * (`schema: 1`) that the website reads; see `results/README.md`.
  */
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { BuildRequest, BuildResult } from "./src/build.ts";
@@ -30,6 +34,7 @@ const has = (name: string) => args.includes(`--${name}`);
 const runs = Number(flag("runs") ?? 3);
 const only = flag("only")?.split(",").filter(Boolean);
 const keep = has("keep");
+const outFile = flag("out");
 
 /**
  * Default variant matrix. `bun` = Alchemy's `BUN_CONDITION_NAMES` with the
@@ -287,6 +292,52 @@ function report(rows: Row[], rolldownVersion: string): string {
   return lines.join("\n");
 }
 
+/**
+ * Committed-artifact shape (`--out`). Contract agreed with the website:
+ * schema 1, headline numbers only; `leaks` is the count of tree-shake
+ * expectations that failed (0 = clean).
+ */
+function slimResults(rows: Row[], rolldownVersion: string) {
+  return {
+    schema: 1,
+    generatedAt: new Date().toISOString(),
+    commit: gitShortSha(),
+    host: {
+      platform: `${os.platform()}-${os.arch()}`,
+      cpu: os.cpus()[0]?.model ?? null,
+      cores: os.cpus().length,
+      memoryGb: Math.round(os.totalmem() / 1024 ** 3),
+    },
+    rolldown: rolldownVersion,
+    bun: Bun.version,
+    runs,
+    rows: rows.map((r) => {
+      const [cold, ...rest] = r.result.timesMs;
+      return {
+        fixture: r.fixture.name,
+        variant: variantId(r.variant),
+        description: r.fixture.description,
+        coldMs: Math.round(cold!),
+        warmMs: rest.length ? Math.round(median(rest)) : null,
+        bytes: r.result.bytes,
+        gzipBytes: r.result.gzipBytes,
+        moduleCount: r.result.moduleCount,
+        opsRetained: r.opsRetained,
+        leaks: r.forbidPresent.length + r.expectMissing.length,
+      };
+    }),
+  };
+}
+
+function gitShortSha(): string | null {
+  const proc = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  return proc.exitCode === 0 ? proc.stdout.toString().trim() : null;
+}
+
 // --- main -------------------------------------------------------------------
 const selected = fixtures.filter((f) => !only || only.includes(f.name));
 if (selected.length === 0) {
@@ -351,6 +402,15 @@ await fs.writeFile(
     2,
   ),
 );
+if (outFile !== undefined) {
+  const target = path.resolve(process.cwd(), outFile);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(
+    target,
+    `${JSON.stringify(slimResults(rows, rolldownVersion), null, 2)}\n`,
+  );
+  process.stderr.write(`wrote ${path.relative(process.cwd(), target)}\n`);
+}
 if (!keep) {
   for (const r of rows) {
     await fs.rm(path.dirname(r.result.outputFile), {

--- a/benches/bundle/run.ts
+++ b/benches/bundle/run.ts
@@ -9,7 +9,9 @@
  * build in that process, warm = median of the remaining `--runs`). Prints a
  * markdown report and writes `.out/report.md` + `.out/results.json`.
  * `--out` additionally writes the slim, committed-artifact shape
- * (`schema: 1`) that the website reads; see `results/README.md`.
+ * (`schema: 1`) that the website reads; see `results/README.md`. `--json`
+ * prints that same shape to stdout instead of the markdown. `--runs`
+ * defaults to `$BENCH_RUNS`, then 3.
  */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -31,7 +33,7 @@ const flag = (name: string): string | undefined => {
 };
 const has = (name: string) => args.includes(`--${name}`);
 
-const runs = Number(flag("runs") ?? 3);
+const runs = Number(flag("runs") ?? process.env.BENCH_RUNS ?? 3);
 const only = flag("only")?.split(",").filter(Boolean);
 const keep = has("keep");
 const outFile = flag("out");
@@ -419,19 +421,12 @@ if (!keep) {
     });
   }
 }
-console.log(md);
-console.log(
-  `\n_total wall time ${(wall / 1000).toFixed(1)} s · report: ${path.relative(process.cwd(), path.join(outRoot, "report.md"))}_`,
-);
-if (has("json"))
+if (has("json")) {
+  // Machine-readable only: the slim artifact shape on stdout, nothing else.
+  console.log(JSON.stringify(slimResults(rows, rolldownVersion)));
+} else {
+  console.log(md);
   console.log(
-    JSON.stringify(
-      rows.map((r) => ({
-        fixture: r.fixture.name,
-        variant: variantId(r.variant),
-        bytes: r.result.bytes,
-        gzip: r.result.gzipBytes,
-        timesMs: r.result.timesMs,
-      })),
-    ),
+    `\n_total wall time ${(wall / 1000).toFixed(1)} s · report: ${path.relative(process.cwd(), path.join(outRoot, "report.md"))}_`,
   );
+}

--- a/benches/bundle/src/analyze.ts
+++ b/benches/bundle/src/analyze.ts
@@ -1,0 +1,155 @@
+/**
+ * Heuristic breakdown of what survives tree-shaking inside one rendered
+ * module (`OutputChunk.modules[id].code`, which rolldown renders after
+ * tree-shaking and before minification).
+ *
+ * Top-level bindings are located by line shape. With
+ * `strictExecutionOrder: true` rolldown hoists `var a, b, …;` and emits
+ * `\t\tName = …` assignments inside an `init_*` wrapper; without it the
+ * lines are `const Name = …`. Both are matched. A binding is "unreferenced"
+ * when its name never appears in the module outside its own declaration —
+ * nor in any other module's rendered code — i.e. tree-shaking kept it
+ * only because its initializer was not proven side-effect free.
+ */
+export interface RetainedDecl {
+  readonly name: string;
+  readonly bytes: number;
+  readonly kind: DeclKind;
+  readonly unreferenced: boolean;
+  /** First ~100 chars of the initializer, for the report. */
+  readonly head: string;
+}
+
+export type DeclKind =
+  | "endpoint-rules"
+  | "error-class"
+  | "operation"
+  | "schema"
+  | "other";
+
+export interface ModuleAnalysis {
+  readonly id: string;
+  readonly renderedBytes: number;
+  readonly decls: number;
+  readonly unreferenced: number;
+  readonly bytesByKind: Record<DeclKind, number>;
+  readonly countByKind: Record<DeclKind, number>;
+  readonly unreferencedByKind: Record<DeclKind, number>;
+  readonly unreferencedBytesByKind: Record<DeclKind, number>;
+  readonly unreferencedBytes: number;
+  /** Largest retained declarations (any kind). */
+  readonly largest: RetainedDecl[];
+  /** Largest unreferenced declarations (pure tree-shake misses). */
+  readonly largestUnreferenced: RetainedDecl[];
+}
+
+const DECL_RE =
+  /^(\s*)(?:export\s+)?(?:(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*=\s/;
+
+const classify = (name: string, head: string): DeclKind => {
+  if (/\bEndpointResolver\(/.test(head) || name === "rules")
+    return "endpoint-rules";
+  if (/^class\s|=\s*class\s/.test(head) || /\bclass extends\b/.test(head))
+    return "error-class";
+  if (/\b(?:make|makePaginated)\(/.test(head)) return "operation";
+  if (
+    /\b(?:suspend|Struct|Array\$?\d*|Union|String\$?\d*|Number\$?\d*|Boolean\$?\d*|Literals?|Record|optional|EventStream|Date\$?\d*|Blob\$?\d*|Unknown|Any)\b/.test(
+      head,
+    )
+  )
+    return "schema";
+  return "other";
+};
+
+const zero = (): Record<DeclKind, number> => ({
+  "endpoint-rules": 0,
+  "error-class": 0,
+  operation: 0,
+  schema: 0,
+  other: 0,
+});
+
+export function analyzeModule(
+  id: string,
+  code: string,
+  /** Rendered code of every other module in the chunk (cross-module refs). */
+  others = "",
+  top = 8,
+): ModuleAnalysis {
+  const lines = code.split("\n");
+  // Module-level bindings all sit at one indentation depth: `const X =` at
+  // column 0, or `\t\tX =` inside rolldown's `init_*` wrapper. Nested
+  // bindings (e.g. inside the endpoint resolver function) are deeper and
+  // must not be counted as separate declarations.
+  let depth: string | null = null;
+  const hoisted = /^var\s/m.test(code);
+  for (const line of lines) {
+    const m = DECL_RE.exec(line);
+    if (m && (hoisted ? m[1]!.length > 0 : m[1]!.length === 0)) {
+      depth = m[1]!;
+      break;
+    }
+  }
+  const starts: Array<{ line: number; name: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = DECL_RE.exec(lines[i]!);
+    if (m && m[1] === depth) starts.push({ line: i, name: m[2]! });
+  }
+  const segments = starts.map((s, i) => {
+    const end = i + 1 < starts.length ? starts[i + 1]!.line : lines.length;
+    const text = lines.slice(s.line, end).join("\n");
+    return { name: s.name, text };
+  });
+
+  const decls: RetainedDecl[] = [];
+  for (const seg of segments) {
+    const re = new RegExp(
+      `(?<![\\w$])${seg.name.replace(/\$/g, "\\$")}(?![\\w$])`,
+      "g",
+    );
+    const total = code.match(re)?.length ?? 0;
+    // Hits inside its own segment + 1 for the hoisted `var …` list (if any).
+    const own = (seg.text.match(re)?.length ?? 0) + (hoisted ? 1 : 0);
+    const head = seg.text
+      .replace(/^\s*(?:export\s+)?(?:(?:const|let|var)\s+)?[\w$]+\s*=\s*/, "")
+      .slice(0, 100)
+      .replace(/\s+/g, " ");
+    decls.push({
+      name: seg.name,
+      bytes: Buffer.byteLength(seg.text) + 1,
+      kind: classify(seg.name, head),
+      unreferenced: total <= own && !re.test(others),
+      head,
+    });
+  }
+
+  const bytesByKind = zero();
+  const countByKind = zero();
+  const unreferencedByKind = zero();
+  const unreferencedBytesByKind = zero();
+  for (const d of decls) {
+    bytesByKind[d.kind] += d.bytes;
+    countByKind[d.kind] += 1;
+    if (d.unreferenced) {
+      unreferencedByKind[d.kind] += 1;
+      unreferencedBytesByKind[d.kind] += d.bytes;
+    }
+  }
+  const bySize = [...decls].sort((a, b) => b.bytes - a.bytes);
+  return {
+    id,
+    renderedBytes: Buffer.byteLength(code),
+    decls: decls.length,
+    unreferenced: decls.filter((d) => d.unreferenced).length,
+    bytesByKind,
+    countByKind,
+    unreferencedByKind,
+    unreferencedBytesByKind,
+    unreferencedBytes: decls.reduce(
+      (n, d) => n + (d.unreferenced ? d.bytes : 0),
+      0,
+    ),
+    largest: bySize.slice(0, top),
+    largestUnreferenced: bySize.filter((d) => d.unreferenced).slice(0, top),
+  };
+}

--- a/benches/bundle/src/build.ts
+++ b/benches/bundle/src/build.ts
@@ -1,0 +1,131 @@
+/**
+ * One fixture × one variant, built `runs` times in this process. Spawned by
+ * `run.ts` as a fresh `bun` process per fixture so the first build is a true
+ * cold start (native binding load, resolver caches, plugin package cache);
+ * later builds in the same process are the warm number.
+ *
+ * Usage: `bun src/build.ts '<BuildRequest json>'` — prints `BuildResult` JSON.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { gzipSync } from "node:zlib";
+import { rolldown } from "rolldown";
+import { analyzeModule, type ModuleAnalysis } from "./analyze.ts";
+import { inputOptions, outputOptions, type BuildVariant } from "./options.ts";
+import type { PurePluginStats } from "./pure-plugin.ts";
+
+export interface BuildRequest {
+  readonly entry: string;
+  readonly cwd: string;
+  readonly outDir: string;
+  readonly variant: BuildVariant;
+  readonly runs: number;
+}
+
+export interface ModuleShare {
+  readonly id: string;
+  readonly renderedLength: number;
+  readonly renderedExports: number;
+}
+
+export interface BuildResult {
+  readonly timesMs: number[];
+  readonly bytes: number;
+  readonly gzipBytes: number;
+  readonly moduleCount: number;
+  readonly outputFile: string;
+  readonly pure: PurePluginStats;
+  /** Per-module rendered (post-treeshake, pre-minify) sizes. */
+  readonly modules: ModuleShare[];
+  /** What survived inside the distilled service modules. */
+  readonly services: ModuleAnalysis[];
+  readonly warnings: string[];
+}
+
+const SERVICE_MODULE_RE =
+  /\/packages\/[^/]+\/src\/services\/(?!index\.ts$)[^/]+\.ts$/;
+
+const emptyStats = (): PurePluginStats => ({
+  matchedModules: 0,
+  annotatedModules: 0,
+  annotations: 0,
+  sideEffectFreeModules: 0,
+});
+
+export async function buildOnce(req: BuildRequest) {
+  const stats = emptyStats();
+  const warnings: string[] = [];
+  const t0 = performance.now();
+  const bundle = await rolldown({
+    ...inputOptions(req.entry, req.cwd, req.variant, stats),
+    onLog(level, log) {
+      if (level === "warn") warnings.push(String(log.message ?? log));
+    },
+  });
+  const out = await bundle.write(outputOptions(req.outDir, req.variant));
+  await bundle.close();
+  const ms = performance.now() - t0;
+  const chunk = out.output.find((o) => o.type === "chunk" && o.isEntry);
+  if (!chunk || chunk.type !== "chunk") throw new Error("no entry chunk");
+  return { ms, chunk, stats, warnings };
+}
+
+export async function build(req: BuildRequest): Promise<BuildResult> {
+  await fs.rm(req.outDir, { recursive: true, force: true });
+  await fs.mkdir(req.outDir, { recursive: true });
+  const timesMs: number[] = [];
+  let last: Awaited<ReturnType<typeof buildOnce>> | undefined;
+  for (let i = 0; i < Math.max(1, req.runs); i++) {
+    last = await buildOnce(req);
+    timesMs.push(last.ms);
+  }
+  const { chunk, stats, warnings } = last!;
+  const code = chunk.code;
+  const modules = Object.entries(chunk.modules)
+    .map(([id, m]) => ({
+      id,
+      renderedLength: m.renderedLength,
+      renderedExports: m.renderedExports.length,
+    }))
+    .filter((m) => m.renderedLength > 0)
+    .sort((a, b) => b.renderedLength - a.renderedLength);
+  const rendered = Object.entries(chunk.modules).filter(
+    ([, m]) => m.renderedLength > 0 && m.code,
+  );
+  const services = rendered
+    .filter(([id]) => SERVICE_MODULE_RE.test(id))
+    .map(([id, m]) =>
+      analyzeModule(
+        id,
+        m.code!,
+        rendered
+          .filter(([other]) => other !== id)
+          .map(([, o]) => o.code!)
+          .join("\n"),
+      ),
+    );
+  return {
+    timesMs,
+    bytes: Buffer.byteLength(code),
+    gzipBytes: gzipSync(code).byteLength,
+    moduleCount: chunk.moduleIds.length,
+    outputFile: path.join(req.outDir, chunk.fileName),
+    pure: stats,
+    modules,
+    services,
+    warnings,
+  };
+}
+
+if (import.meta.main) {
+  const req = JSON.parse(process.argv[2] ?? "{}") as BuildRequest;
+  build(req).then(
+    (res) => {
+      process.stdout.write(JSON.stringify(res));
+    },
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/benches/bundle/src/fixtures.ts
+++ b/benches/bundle/src/fixtures.ts
@@ -1,0 +1,149 @@
+/**
+ * Fixture registry. Every fixture is an entry file under `fixtures/` plus
+ * the tree-shake expectations checked against the bundle text.
+ *
+ * Markers are regexes over string literals (operation names / route URIs)
+ * rather than identifiers so they survive `minify: true` (whitespace and
+ * identifier mangling) unchanged.
+ */
+export interface ShakeMarker {
+  /** Human label shown in the report. */
+  readonly label: string;
+  /** Pattern searched in the output chunk. */
+  readonly pattern: RegExp;
+}
+
+export interface Fixture {
+  readonly name: string;
+  readonly entry: string;
+  readonly description: string;
+  /** Must be present — proves the used operation survived. */
+  readonly expect: ReadonlyArray<ShakeMarker>;
+  /** Must be absent — services / operations the entry never references. */
+  readonly forbid: ReadonlyArray<ShakeMarker>;
+  /**
+   * Service source files whose operations are counted (`operationName: "`
+   * for AWS, `uri: "` for Cloudflare) to report "ops retained / ops total".
+   */
+  readonly services: ReadonlyArray<ServiceRef>;
+}
+
+export interface ServiceRef {
+  readonly pkg: "aws" | "cloudflare";
+  readonly file: string;
+}
+
+// --- markers ----------------------------------------------------------------
+const s3GetObject: ShakeMarker = {
+  label: "s3.GetObject",
+  pattern: /operationName:\s*[`"']GetObject[`"']/,
+};
+const s3PutObject: ShakeMarker = {
+  label: "s3.PutObject (unused op, same service)",
+  pattern: /operationName:\s*[`"']PutObject[`"']/,
+};
+const s3ListBuckets: ShakeMarker = {
+  label: "s3.ListBuckets (unused op, same service)",
+  pattern: /operationName:\s*[`"']ListBuckets[`"']/,
+};
+const ddbPutItem: ShakeMarker = {
+  label: "dynamodb.PutItem",
+  pattern: /operationName:\s*[`"']PutItem[`"']/,
+};
+const lambdaInvoke: ShakeMarker = {
+  label: "lambda.Invoke",
+  pattern: /operationName:\s*[`"']Invoke[`"']/,
+};
+const cfListScripts: ShakeMarker = {
+  label: "workers.listScripts",
+  pattern: /["'`]\/accounts\/\{account_id\}\/workers\/scripts["'`]/,
+};
+const cfScriptSecrets: ShakeMarker = {
+  label: "workers.listScriptSecrets (unused op, same service)",
+  pattern: /\/workers\/scripts\/\{script_name\}\/secrets/,
+};
+const cfKv: ShakeMarker = {
+  label: "kv.*",
+  pattern: /\/storage\/kv\/namespaces/,
+};
+const cfD1: ShakeMarker = {
+  label: "d1.*",
+  pattern: /\/d1\/database/,
+};
+
+const awsS3: ServiceRef = { pkg: "aws", file: "s3.ts" };
+const cfWorkers: ServiceRef = { pkg: "cloudflare", file: "workers.ts" };
+
+const awsForbid = [
+  s3PutObject,
+  s3ListBuckets,
+  ddbPutItem,
+  lambdaInvoke,
+  cfKv,
+  cfD1,
+];
+const cfForbid = [cfScriptSecrets, cfKv, cfD1, ddbPutItem, lambdaInvoke];
+
+export const fixtures: ReadonlyArray<Fixture> = [
+  {
+    name: "aws-s3-deep",
+    entry: "fixtures/aws-s3-deep.ts",
+    description:
+      "`@distilled.cloud/aws/s3` + `/Credentials`, one op (GetObject)",
+    expect: [s3GetObject],
+    forbid: [...awsForbid, cfListScripts],
+    services: [awsS3],
+  },
+  {
+    name: "aws-barrel",
+    entry: "fixtures/aws-barrel.ts",
+    description: "`@distilled.cloud/aws` root barrel (+ `/s3` deep) — same op",
+    expect: [s3GetObject],
+    forbid: [...awsForbid, cfListScripts],
+    services: [awsS3],
+  },
+  {
+    name: "aws-services-index",
+    entry: "fixtures/aws-services-index.ts",
+    description:
+      "`@distilled.cloud/aws/index` — all ~430 services as namespaces, only S3.getObject used",
+    expect: [s3GetObject],
+    forbid: [...awsForbid, cfListScripts],
+    services: [awsS3],
+  },
+  {
+    name: "cf-workers-deep",
+    entry: "fixtures/cf-workers-deep.ts",
+    description:
+      "`@distilled.cloud/cloudflare/workers` + `/Credentials`, one paginated op (listScripts)",
+    expect: [cfListScripts],
+    forbid: [...cfForbid, s3GetObject],
+    services: [cfWorkers],
+  },
+  {
+    name: "cf-barrel",
+    entry: "fixtures/cf-barrel.ts",
+    description:
+      "`@distilled.cloud/cloudflare` root barrel (Services.* — ~120 services), same op",
+    expect: [cfListScripts],
+    forbid: [...cfForbid, s3GetObject],
+    services: [cfWorkers],
+  },
+  {
+    name: "combined-worker",
+    entry: "fixtures/combined-worker.ts",
+    description:
+      "alchemy-worker-shaped: s3.getObject + workers.listScripts (two deep imports)",
+    expect: [s3GetObject, cfListScripts],
+    forbid: [
+      s3PutObject,
+      s3ListBuckets,
+      ddbPutItem,
+      lambdaInvoke,
+      cfScriptSecrets,
+      cfKv,
+      cfD1,
+    ],
+    services: [awsS3, cfWorkers],
+  },
+];

--- a/benches/bundle/src/options.ts
+++ b/benches/bundle/src/options.ts
@@ -1,0 +1,92 @@
+/**
+ * Rolldown options mirroring what Alchemy's bundler applies
+ * (`packages/alchemy/src/Bundle/Bundle.ts` + the Worker/Lambda callers).
+ * Values are re-declared here rather than imported so the bench does not
+ * depend on `alchemy`.
+ */
+import type { InputOptions, OutputOptions, Plugin } from "rolldown";
+import { purePlugin, type PurePluginStats } from "./pure-plugin.ts";
+
+/** `Bundle.BUN_CONDITION_NAMES` — never `import` / `require`. */
+export const BUN_CONDITION_NAMES: readonly string[] = [
+  "bun",
+  "module",
+  "default",
+];
+/** `Bundle.NODE_CONDITION_NAMES`. */
+export const NODE_CONDITION_NAMES: readonly string[] = [
+  "node",
+  "module",
+  "default",
+];
+/** `@alchemy.run/cloudflare-runtime/rolldown` `DEFAULT_RESOLVE_CONDITION_NAMES` + production. */
+export const WORKER_CONDITION_NAMES: readonly string[] = [
+  "workerd",
+  "worker",
+  "module",
+  "browser",
+  "production",
+];
+
+export type ConditionSet = "bun" | "node" | "worker";
+
+export const conditionNames = (set: ConditionSet): readonly string[] =>
+  set === "bun"
+    ? BUN_CONDITION_NAMES
+    : set === "node"
+      ? NODE_CONDITION_NAMES
+      : WORKER_CONDITION_NAMES;
+
+export interface BuildVariant {
+  /** Which `resolve.conditionNames` set to use. */
+  readonly conditions: ConditionSet;
+  /** Run the PURE annotator (Alchemy default: on). */
+  readonly pure: boolean;
+  /** `output.minify` — Alchemy Workers: `true`; Lambda: `false` → "dce-only". */
+  readonly minify: boolean;
+}
+
+export const variantId = (v: BuildVariant): string =>
+  `${v.conditions}${v.pure ? "" : "+nopure"}${v.minify ? "" : "+nominify"}`;
+
+export const inputOptions = (
+  entry: string,
+  cwd: string,
+  variant: BuildVariant,
+  stats: PurePluginStats,
+): InputOptions => {
+  const plugins: Plugin[] = [];
+  if (variant.pure) plugins.push(purePlugin({ stats }));
+  return {
+    input: entry,
+    cwd,
+    // Alchemy Lambda bundles use `platform: "node"`; Workers use "neutral" +
+    // the cloudflare-runtime plugin's nodejs_compat shims. `node` keeps
+    // `node:*` imports external without extra plugins.
+    platform: "node",
+    resolve: { conditionNames: [...conditionNames(variant.conditions)] },
+    plugins,
+    // `Bundle.ALCHEMY_DEFINE`
+    transform: { define: { "globalThis.__ALCHEMY_RUNTIME__": "true" } },
+    // `Bundle.build` default optimisation.
+    optimization: { inlineConst: { mode: "smart", pass: 3 } },
+    treeshake: true,
+    checks: { unresolvedImport: false, ineffectiveDynamicImport: false },
+    logLevel: "silent",
+  };
+};
+
+export const outputOptions = (
+  dir: string,
+  variant: BuildVariant,
+): OutputOptions => ({
+  format: "esm",
+  dir,
+  entryFileNames: "index.js",
+  codeSplitting: false,
+  // Worker bundle settings (`Cloudflare/Workers/Sources/Rolldown.ts`).
+  sourcemap: "hidden",
+  minify: variant.minify ? true : "dce-only",
+  keepNames: true,
+  strictExecutionOrder: true,
+});

--- a/benches/bundle/src/pure-plugin.ts
+++ b/benches/bundle/src/pure-plugin.ts
@@ -1,0 +1,358 @@
+/**
+ * Minimal port of Alchemy's `packages/alchemy/src/Bundle/PurePlugin.ts`
+ * (`alchemy:annotate-pure`), kept dependency-free so the bench does not
+ * depend on `alchemy`.
+ *
+ * Behaviour that matters for the numbers and is reproduced 1:1:
+ * - only modules owned by a package matching {@link DEFAULT_PURE_PACKAGES}
+ *   are touched (package name comes from the nearest `package.json`, so
+ *   workspace-linked `packages/<pkg>/src/**` sources are matched, not only
+ *   `node_modules/<pkg>/**`);
+ * - every top-level call / `new` whose result is BOUND (variable
+ *   initializer, export, assignment RHS) gets `/*#__PURE__*\/`;
+ * - top-level calls whose result is DISCARDED (bare expression statements)
+ *   are annotated only when the package declares `sideEffects: false | []`;
+ * - modules of such side-effect-free packages are also returned with
+ *   `moduleSideEffects: false`, except entry modules.
+ *
+ * Differences from Alchemy's plugin: package globs are matched with a tiny
+ * `name` / `@scope/*` matcher instead of picomatch, and there is no
+ * process-wide anchors cache (each bench build is a fresh process anyway;
+ * the warm run measures rolldown, not the plugin cache).
+ */
+import type {
+  CallExpression,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  Expression,
+  ExpressionStatement,
+  NewExpression,
+  Program,
+  Statement,
+  VariableDeclaration,
+} from "@oxc-project/types";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { InputOptions, Plugin } from "rolldown";
+import { RolldownMagicString } from "rolldown";
+import { parseAst } from "rolldown/parseAst";
+
+/** Same list as Alchemy's `DEFAULT_PURE_PACKAGES`. */
+export const DEFAULT_PURE_PACKAGES: ReadonlyArray<string> = [
+  "effect",
+  "@effect/*",
+  "alchemy",
+  "@alchemy.run/*",
+  "@distilled.cloud/*",
+];
+
+const PURE_COMMENT = "/*#__PURE__*/ ";
+const SUPPORTED_FILE_RE = /\.(?:m?[jt]sx?|cjs|cts)$/;
+
+export interface PurePluginStats {
+  /** Modules the plugin looked at (matched a configured package). */
+  matchedModules: number;
+  /** Modules that received at least one annotation. */
+  annotatedModules: number;
+  /** Total `/*#__PURE__*\/` comments inserted. */
+  annotations: number;
+  /** Modules returned with `moduleSideEffects: false`. */
+  sideEffectFreeModules: number;
+}
+
+export interface PurePluginOptions {
+  readonly packages?: ReadonlyArray<string>;
+  readonly markSideEffectFree?: boolean;
+  /** Receives per-build counters; useful for the report. */
+  readonly stats?: PurePluginStats;
+}
+
+const matcher = (patterns: ReadonlyArray<string>) => {
+  const exact = new Set<string>();
+  const scopes = new Set<string>();
+  for (const p of patterns) {
+    if (p.endsWith("/*")) scopes.add(p.slice(0, -2));
+    else exact.add(p);
+  }
+  return (name: string): boolean => {
+    if (exact.has(name)) return true;
+    const slash = name.indexOf("/");
+    return slash > 0 && scopes.has(name.slice(0, slash));
+  };
+};
+
+export const purePlugin = (options: PurePluginOptions = {}): Plugin => {
+  const isMatch = matcher(options.packages ?? DEFAULT_PURE_PACKAGES);
+  const markSideEffectFreeOpt = options.markSideEffectFree ?? true;
+  const stats = options.stats;
+  const pkgInfoCache = new Map<string, PackageInfo | null>();
+  const entryPaths = new Set<string>();
+
+  return {
+    name: "bench:annotate-pure",
+    options(opts) {
+      for (const input of inputFilePaths(opts)) entryPaths.add(input);
+      return null;
+    },
+    transform: {
+      filter: { id: SUPPORTED_FILE_RE },
+      async handler(code, id, meta) {
+        const cleanId = stripIdSuffix(id);
+        const info = await resolvePackageInfo(
+          path.dirname(cleanId),
+          pkgInfoCache,
+        );
+        const name = info?.name ?? packageNameFromId(cleanId);
+        if (name === null || !isMatch(name)) return null;
+        if (stats) stats.matchedModules++;
+
+        const isEntry = entryPaths.has(cleanId);
+        const sideEffectFreePkg = isSideEffectFree(info?.sideEffects);
+        const markSideEffectFree =
+          markSideEffectFreeOpt && !isEntry && sideEffectFreePkg;
+        if (stats && markSideEffectFree) stats.sideEffectFreeModules++;
+
+        const anchors = collectPureAnchors(code, cleanId);
+        const annotateDiscarded = !isEntry && sideEffectFreePkg;
+        const positions =
+          anchors === null
+            ? []
+            : annotateDiscarded
+              ? [...anchors.bound, ...anchors.discarded]
+              : anchors.bound;
+        if (positions.length === 0) {
+          return markSideEffectFree ? { moduleSideEffects: false } : null;
+        }
+        if (stats) {
+          stats.annotatedModules++;
+          stats.annotations += positions.length;
+        }
+        const s = meta.magicString ?? new RolldownMagicString(code);
+        for (const anchor of positions) s.appendLeft(anchor, PURE_COMMENT);
+        return {
+          code: s,
+          moduleSideEffects: markSideEffectFree ? false : null,
+        };
+      },
+    },
+  };
+};
+
+const stripIdSuffix = (id: string): string => id.replace(/[?#].*$/, "");
+
+function inputFilePaths(opts: InputOptions): string[] {
+  const raw: unknown[] =
+    typeof opts.input === "string"
+      ? [opts.input]
+      : Array.isArray(opts.input)
+        ? opts.input
+        : opts.input && typeof opts.input === "object"
+          ? Object.values(opts.input)
+          : [];
+  const cwd = opts.cwd ?? process.cwd();
+  return raw
+    .filter(
+      (entry): entry is string =>
+        typeof entry === "string" && !entry.startsWith("\0"),
+    )
+    .map((entry) => path.resolve(cwd, entry));
+}
+
+interface PackageInfo {
+  readonly name: string | null;
+  readonly sideEffects: unknown;
+}
+
+async function resolvePackageInfo(
+  startDir: string,
+  cache: Map<string, PackageInfo | null>,
+): Promise<PackageInfo | null> {
+  let dir = path.resolve(startDir);
+  const visited: string[] = [];
+  let result: PackageInfo | null = null;
+  for (let i = 0; i < 64; i++) {
+    if (path.basename(dir) === "node_modules") break;
+    const cached = cache.get(dir);
+    if (cached !== undefined) {
+      result = cached;
+      break;
+    }
+    visited.push(dir);
+    const info = await readPackageJson(path.join(dir, "package.json"));
+    if (info !== null) {
+      result = info;
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  for (const v of visited) cache.set(v, result);
+  return result;
+}
+
+async function readPackageJson(file: string): Promise<PackageInfo | null> {
+  try {
+    const json = JSON.parse(await fs.readFile(file, "utf8")) as {
+      name?: unknown;
+      sideEffects?: unknown;
+    };
+    return {
+      name: typeof json.name === "string" ? json.name : null,
+      sideEffects: json.sideEffects,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isSideEffectFree(value: unknown): boolean {
+  if (value === false) return true;
+  if (Array.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+function packageNameFromId(id: string): string | null {
+  const normalized = id.replace(/\\/g, "/");
+  const idx = normalized.lastIndexOf("/node_modules/");
+  if (idx === -1) return null;
+  const parts = normalized.slice(idx + "/node_modules/".length).split("/");
+  if (parts.length === 0 || parts[0] === "") return null;
+  if (parts[0].startsWith("@")) {
+    if (parts.length < 2) return null;
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return parts[0];
+}
+
+interface PureAnchors {
+  readonly bound: number[];
+  readonly discarded: number[];
+}
+
+function collectPureAnchors(
+  code: string,
+  filename: string,
+): PureAnchors | null {
+  let program: Program;
+  try {
+    program = parseAst(code, { sourceType: "module", lang: "ts" }, filename);
+  } catch {
+    return null;
+  }
+  const bound: number[] = [];
+  const discarded: number[] = [];
+
+  const visitCall = (
+    call: CallExpression | NewExpression,
+    isDiscarded: boolean,
+  ) => {
+    if (isIIFE(call)) return;
+    const anchor =
+      call.type === "NewExpression" ? call.start : call.callee.start;
+    if (alreadyAnnotated(code, anchor)) return;
+    (isDiscarded ? discarded : bound).push(anchor);
+  };
+
+  const visitExpression = (
+    expr: Expression | null | undefined,
+    isDiscarded: boolean,
+  ) => {
+    if (!expr) return;
+    switch (expr.type) {
+      case "CallExpression":
+      case "NewExpression":
+        visitCall(expr, isDiscarded);
+        return;
+      case "SequenceExpression": {
+        const exprs = expr.expressions;
+        for (let i = 0; i < exprs.length; i++) {
+          visitExpression(exprs[i], i < exprs.length - 1 ? true : isDiscarded);
+        }
+        return;
+      }
+      case "ParenthesizedExpression":
+        visitExpression(expr.expression, isDiscarded);
+        return;
+      case "LogicalExpression":
+        visitExpression(expr.left, isDiscarded);
+        visitExpression(expr.right, isDiscarded);
+        return;
+      case "ConditionalExpression":
+        visitExpression(expr.consequent, isDiscarded);
+        visitExpression(expr.alternate, isDiscarded);
+        return;
+      case "AssignmentExpression":
+        visitExpression(expr.right, false);
+        return;
+      case "TSAsExpression":
+      case "TSSatisfiesExpression":
+      case "TSNonNullExpression":
+      case "TSTypeAssertion":
+        visitExpression(expr.expression, isDiscarded);
+        return;
+      case "ChainExpression": {
+        const inner = expr.expression;
+        if (inner.type === "CallExpression") visitCall(inner, isDiscarded);
+        return;
+      }
+      default:
+        return;
+    }
+  };
+
+  const visitTopLevel = (node: Statement) => {
+    switch (node.type) {
+      case "ExpressionStatement":
+        visitExpression((node as ExpressionStatement).expression, true);
+        return;
+      case "VariableDeclaration":
+        for (const decl of (node as VariableDeclaration).declarations) {
+          visitExpression(decl.init, false);
+        }
+        return;
+      case "ExportNamedDeclaration": {
+        const decl = (node as ExportNamedDeclaration).declaration;
+        if (decl) visitTopLevel(decl as Statement);
+        return;
+      }
+      case "ExportDefaultDeclaration": {
+        const decl = (node as ExportDefaultDeclaration).declaration;
+        if (
+          decl &&
+          decl.type !== "FunctionDeclaration" &&
+          decl.type !== "ClassDeclaration" &&
+          decl.type !== "TSInterfaceDeclaration"
+        ) {
+          visitExpression(decl as Expression, false);
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  };
+
+  for (const node of program.body) visitTopLevel(node as Statement);
+
+  return bound.length === 0 && discarded.length === 0
+    ? null
+    : { bound, discarded };
+}
+
+function isIIFE(node: CallExpression | NewExpression): boolean {
+  let callee: Expression = node.callee;
+  while (callee.type === "ParenthesizedExpression") {
+    callee = callee.expression;
+  }
+  return (
+    callee.type === "FunctionExpression" ||
+    callee.type === "ArrowFunctionExpression"
+  );
+}
+
+function alreadyAnnotated(code: string, pos: number): boolean {
+  const start = Math.max(0, pos - 32);
+  const slice = code.slice(start, pos);
+  return slice.includes("/*#__PURE__*/") || slice.includes("/*@__PURE__*/");
+}

--- a/benches/bundle/tsconfig.json
+++ b/benches/bundle/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    // Hand-written — always check it for real.
+    "noCheck": false,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "composite": false,
+    "types": ["bun"],
+    // Resolve the SDKs from source (what the `bun` export condition does at
+    // bundle time) so the fixtures typecheck without a `tsc -b` of every
+    // package first. Same approach as benches/runtime.
+    "paths": {
+      "@distilled.cloud/core/*": ["../../packages/core/src/*"],
+      "@distilled.cloud/aws": ["../../packages/aws/src/index.ts"],
+      "@distilled.cloud/aws/Credentials": [
+        "../../packages/aws/src/credentials.ts"
+      ],
+      "@distilled.cloud/aws/*": ["../../packages/aws/src/services/*"],
+      "@distilled.cloud/cloudflare": ["../../packages/cloudflare/src/index.ts"],
+      "@distilled.cloud/cloudflare/Credentials": [
+        "../../packages/cloudflare/src/credentials.ts"
+      ],
+      "@distilled.cloud/cloudflare/*": [
+        "../../packages/cloudflare/src/services/*"
+      ]
+    }
+  },
+  "include": ["run.ts", "src/**/*.ts", "fixtures/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ catalogs:
     mitata:
       specifier: ^1.0.34
       version: 1.0.34
+    rolldown:
+      specifier: 1.2.5
+      version: 1.2.5
   build:
     typescript:
       specifier: ^7.0.2
@@ -94,6 +97,37 @@ importers:
       oxlint:
         specifier: catalog:tooling
         version: 1.81.0
+      typescript:
+        specifier: catalog:build
+        version: 7.0.2
+
+  benches/bundle:
+    dependencies:
+      '@distilled.cloud/aws':
+        specifier: workspace:*
+        version: link:../../packages/aws
+      '@distilled.cloud/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/cloudflare
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@oxc-project/types':
+        specifier: ^0.146.0
+        version: 0.146.0
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.4.1
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.4.1
+      rolldown:
+        specifier: catalog:bench
+        version: 1.2.5
       typescript:
         specifier: catalog:build
         version: 7.0.2
@@ -2351,6 +2385,9 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
+
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
 
@@ -2659,6 +2696,12 @@ packages:
     peerDependencies:
       '@redis/client': ^6.2.1
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm-eabi@1.2.6':
     resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2667,6 +2710,12 @@ packages:
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -2683,6 +2732,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.2.6':
     resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2691,6 +2746,12 @@ packages:
 
   '@rolldown/binding-darwin-x64@1.1.5':
     resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2707,6 +2768,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.2.6':
     resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2719,6 +2786,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2727,6 +2800,13 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2746,6 +2826,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.2.6':
     resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2755,6 +2842,13 @@ packages:
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2774,6 +2868,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
     resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2783,6 +2884,13 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2802,6 +2910,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-x64-musl@1.2.6':
     resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2811,6 +2926,12 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2832,6 +2953,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
     resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2840,6 +2967,12 @@ packages:
 
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3976,6 +4109,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.2.6:
     resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5002,6 +5140,8 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@oxc-project/types@0.146.0': {}
+
   '@oxc-project/types@0.147.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.66.0':
@@ -5175,10 +5315,16 @@ snapshots:
     dependencies:
       '@redis/client': 6.2.1
 
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    optional: true
+
   '@rolldown/binding-android-arm-eabi@1.2.6':
     optional: true
 
   '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.5':
     optional: true
 
   '@rolldown/binding-android-arm64@1.2.6':
@@ -5187,10 +5333,16 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.6':
@@ -5199,10 +5351,16 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
@@ -5211,10 +5369,16 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.6':
@@ -5223,10 +5387,16 @@ snapshots:
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
@@ -5235,16 +5405,25 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.6':
@@ -5260,10 +5439,16 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.6':
@@ -6361,6 +6546,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.5
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
+
+  rolldown@1.2.5:
+    dependencies:
+      '@oxc-project/types': 0.146.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
 
   rolldown@1.2.6:
     dependencies:


### PR DESCRIPTION
Stacked on #567 (workspace wiring: `benches/*`, `catalogs.bench`, root `bench:*` scripts). Only the top commit is new here; base to `main` after #567 merges.

## What

`benches/bundle` — a **rolldown 1.2.5** measurement harness (not pass/fail) that bundles small Alchemy-worker-shaped entries against the workspace SDK sources and reports, per fixture:

- cold / warm bundle time (fresh `bun` process per fixture)
- bytes / gzip of the single minified ESM chunk
- tree-shake: used-op literal present; other ops of the service, other services, other provider absent; `retained/total` ops
- composition: rendered bytes per package, and per service module the retained top-level bindings split by kind (endpoint rules / error classes / schemas / operations) with **unreferenced** ones flagged

Settings mirror Alchemy's `Bundle.ts` (`bun,module,default` conditions, `__ALCHEMY_RUNTIME__` define, `inlineConst smart/3`, `minify` + `keepNames` + `strictExecutionOrder`) and `src/pure-plugin.ts` is a dependency-free port of `PurePlugin.ts` with the same anchor rules. `+nopure` / `+nominify` variants are available.

```sh
pnpm bench:bundle                       # ~25 s
bun benches/bundle/run.ts --only aws-s3-deep --runs 5 --all-variants --keep
```

## First numbers

| fixture | variant | cold | bytes | gzip | shake |
|---|---|---:|---:|---:|---|
| aws-s3-deep | bun | ~320 ms | 410.7 KB | 118.4 KB | ✅ s3 1/112 ops |
| aws-s3-deep | bun+nopure | ~150 ms | 412.3 KB | 118.9 KB | ✅ |
| aws-barrel | bun | ~320 ms | 410.7 KB | 118.7 KB | ✅ |
| aws-services-index (430 svcs) | bun | ~4200 ms | 410.7 KB | 118.4 KB | ✅ identical bytes, 13× time |
| cf-workers-deep | bun | ~300 ms | 222.2 KB | 61.7 KB | ✅ workers 1/74 ops |
| cf-workers-deep | bun+nopure | ~120 ms | 225.2 KB | 62.6 KB | ✅ |
| cf-barrel | bun | ~1600 ms | 222.2 KB | 61.7 KB | ✅ identical bytes, 5× time |
| combined-worker | bun | ~450 ms | 464.8 KB | 129.7 KB | ✅ |

## Findings (details in `benches/bundle/README.md`)

1. Service- and op-level shaking is clean in every fixture.
2. Barrels cost bundle time, not bytes.
3. The PURE annotator buys 0.5–1.5% bytes for ~2× bundle time — generated code is already annotated at the top level.
4. Inside a used service, two generator shapes are **not** shaken because the *inner* call is unannotated: `S.Unknown.pipe(T.UnionCases([...]))` (106 unreferenced schemas in `workers.ts`, ≈19 KB minified, 70% of the module) and error classes whose constructor call sits in class heritage (`class X extends /*PURE*/ TaggedError()(…).pipe(…) {}` / `extends applyErrorMatchers(/*PURE*/ …)`) — 39/49 in `s3.ts`, 35/37 in `workers.ts`. A micro-fixture confirms annotating the inner call / hoisting the heritage to a `/*PURE*/ const` shakes both to zero. No generator changes in this PR.
5. 75% of retained `s3.ts` is the `EndpointResolver` rules function (needed by the op).

Lockfile diff is only the `benches/bundle` importer plus `rolldown@1.2.5` entries; `pnpm install --frozen-lockfile` passes.