### PR TITLE
feat(stripe): type DeleteProduct ProductHasPrices error

### DIFF
--- a/packages/stripe/.generated-specs/stripe.json
+++ b/packages/stripe/.generated-specs/stripe.json
@@ -258645,7 +258645,12 @@
         },
         "smithy.api#documentation": "Delete a product\n\n<p>Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with <code>type=good</code> is only possible if it has no SKUs associated with it.</p>",
         "com.distilled.openapi#contentType": "form-urlencoded"
-      }
+      },
+      "errors": [
+        {
+          "target": "com.stripe.api#ProductHasPrices"
+        }
+      ]
     },
     "com.stripe.api#GetProductFeaturesRequestExpandList": {
       "type": "list",
@@ -409637,6 +409642,30 @@
       "traits": {
         "smithy.api#title": "Stripe API",
         "smithy.api#documentation": "The Stripe REST API. Please see https://stripe.com/docs/api for more details."
+      }
+    },
+    "com.stripe.api#ProductHasPrices": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "smithy.api#Integer"
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "smithy.api#documentation": "The product cannot be deleted because it has one or more user-created prices (Stripe `invalid_request_error`, HTTP 400).",
+        "com.distilled.openapi#errorMatchers": [
+          {
+            "status": 400,
+            "message": {
+              "includes": "user-created prices"
+            }
+          }
+        ]
       }
     }
   }

--- a/packages/stripe/patches/delete-product-has-prices.patch.json
+++ b/packages/stripe/patches/delete-product-has-prices.patch.json
@@ -1,0 +1,32 @@
+{
+  "description": "Type DeleteProduct's InvalidRequestError when the product still has user-created prices. Stripe documents that deleting a product is only possible if it has no prices associated with it; the wire message is 'cannot be deleted because it has one or more user-created prices'. A dedicated ProductHasPrices tag lets callers branch without matching on InvalidRequestError message text.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/shapes/com.stripe.api#ProductHasPrices",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": { "target": "smithy.api#Integer" },
+          "message": { "target": "smithy.api#String" }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "smithy.api#httpError": 400,
+          "smithy.api#documentation": "The product cannot be deleted because it has one or more user-created prices (Stripe `invalid_request_error`, HTTP 400).",
+          "com.distilled.openapi#errorMatchers": [
+            {
+              "status": 400,
+              "message": { "includes": "user-created prices" }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.stripe.api#DeleteProduct/errors",
+      "value": [{ "target": "com.stripe.api#ProductHasPrices" }]
+    }
+  ]
+}

--- a/packages/stripe/scripts/convert.ts
+++ b/packages/stripe/scripts/convert.ts
@@ -16,7 +16,9 @@
  * v0 parity notes:
  *   • `statusToErrorClass: {}` ⇔ v0's `includeOperationErrors: false` —
  *     Stripe answers every failure with the single `{ error: { type, … } }`
- *     envelope, dispatched by the protocol, so no per-op typed errors.
+ *     envelope, dispatched by the protocol, so convert does not emit
+ *     per-status error classes. Per-op tagged errors (e.g. ProductHasPrices)
+ *     are added by patches and matched by the protocol.
  *   • `skipDeprecated: true` is load-bearing (v0 skipped deprecated ops).
  *   • Nearly every operation's request body is
  *     `application/x-www-form-urlencoded` (the converter stamps

--- a/packages/stripe/src/protocol.ts
+++ b/packages/stripe/src/protocol.ts
@@ -21,7 +21,8 @@
  *   response: 2xx JSON is the payload (no envelope) → wire→TS key mapping →
  *             Redacted wrapping of sensitive members; failures parse the
  *             `{ error: { type, code, message, … } }` envelope and dispatch
- *             by `error.type` first (card_error → CardError,
+ *             by per-op matcher classes first (`matchTypedError`, e.g.
+ *             ProductHasPrices), then `error.type` (card_error → CardError,
  *             idempotency_error → IdempotencyError, invalid_request_error →
  *             InvalidRequestError, api_error → ApiError), then the
  *             Stripe-specific status map (402 → PaymentError, 424 →
@@ -46,6 +47,7 @@ import {
   getProps,
   hasPropAnn,
   mapKeys,
+  matchTypedError,
   nameOf,
 } from "@distilled.cloud/core/protocol-http";
 import {
@@ -430,27 +432,39 @@ const coreStatusMap: Readonly<
   Record<number, (new (args: any) => unknown) | undefined>
 > = HTTP_STATUS_MAP;
 
+/** Stripe's `{ error: { type, message, … } }` object, when present. */
+const stripeErrorEnvelope = (
+  errorBody: unknown,
+): Record<string, unknown> | undefined => {
+  const envelope =
+    errorBody !== null && typeof errorBody === "object"
+      ? (errorBody as Record<string, unknown>).error
+      : undefined;
+  return envelope !== null && typeof envelope === "object"
+    ? (envelope as Record<string, unknown>)
+    : undefined;
+};
+
+const stripeErrorMessage = (errorBody: unknown): string | undefined => {
+  const message = stripeErrorEnvelope(errorBody)?.message;
+  return typeof message === "string" ? message : undefined;
+};
+
 /**
  * Match a Stripe API error response to the appropriate error class.
  *
  * Stripe dispatches errors by:
- * 1. The `error.type` field (card_error, idempotency_error,
+ * 1. Per-operation matcher classes (`matchTypedError`) — see decode
+ * 2. The `error.type` field (card_error, idempotency_error,
  *    invalid_request_error, api_error)
- * 2. HTTP status code (402/424 Stripe-specific, then the core status map)
+ * 3. HTTP status code (402/424 Stripe-specific, then the core status map)
  */
 const matchStripeError = (
   status: number,
   errorBody: unknown,
   headers: Record<string, string | undefined>,
 ): unknown => {
-  const envelope =
-    errorBody !== null && typeof errorBody === "object"
-      ? (errorBody as Record<string, unknown>).error
-      : undefined;
-  const err =
-    envelope !== null && typeof envelope === "object"
-      ? (envelope as Record<string, unknown>)
-      : undefined;
+  const err = stripeErrorEnvelope(errorBody);
   // v0 parity: an unparseable envelope (no `error.type` string) is an
   // UnknownStripeError carrying the raw body.
   if (!err || typeof err.type !== "string") {
@@ -533,6 +547,7 @@ const matchStripeError = (
 const decode = ({
   response,
   outputAst,
+  errors: errorClasses,
 }: {
   readonly response: HttpClientResponse.HttpClientResponse;
   readonly outputAst: AST.AST;
@@ -557,9 +572,13 @@ const decode = ({
     const headers = response.headers as Record<string, string | undefined>;
 
     if (status >= 400) {
-      return yield* fail(
-        matchStripeError(status, nonJson ? text : json, headers),
-      );
+      const errorBody: unknown = nonJson ? text : json;
+      const message =
+        stripeErrorMessage(errorBody) ??
+        (nonJson && text.trim() ? text.trim() : `HTTP ${status}`);
+      const typed = matchTypedError(errorClasses, status, [{ message }]);
+      if (typed !== undefined) return yield* fail(typed);
+      return yield* fail(matchStripeError(status, errorBody, headers));
     }
 
     // 2xx: the response body IS the payload (no envelope). Wire→TS key

--- a/packages/stripe/src/services/stripe.ts
+++ b/packages/stripe/src/services/stripe.ts
@@ -2,6 +2,7 @@
 import * as S from "@distilled.cloud/core/schema";
 import * as Redacted from "effect/Redacted";
 import * as API from "@distilled.cloud/core/api";
+import * as C from "@distilled.cloud/core/category";
 import * as T from "../traits.ts";
 import {
   StripeProtocol,
@@ -13,6 +14,16 @@ import { UnknownStripeError } from "../errors.ts";
 import * as Retry from "../retry.ts";
 
 export type { StripeOpError, StripeOpContext };
+
+/** The product cannot be deleted because it has one or more user-created prices (Stripe `invalid_request_error`, HTTP 400). */
+export class ProductHasPrices
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<ProductHasPrices>()("ProductHasPrices", {
+      code: S.Number,
+      message: S.String,
+    }).pipe(C.withBadRequestError),
+    [{ status: 400, message: { includes: "user-created prices" } }],
+  ) {}
 
 /** The applicant's gross annual revenue for its preceding fiscal year. */
 export interface CreateAccountRequestBusinessProfileAnnualRevenue {
@@ -188018,7 +188029,7 @@ export const DeletePlan: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
-export type DeleteProductError = StripeOpError;
+export type DeleteProductError = ProductHasPrices | StripeOpError;
 /** Delete a product <p>Delete a product. Deleting a product is only possible if it has no prices associated with it. Additionally, deleting a product with <code>type=good</code> is only possible if it has no SKUs associated with it.</p> */
 export const DeleteProduct: API.OperationMethod<
   DeleteProductRequest,
@@ -188028,7 +188039,7 @@ export const DeleteProduct: API.OperationMethod<
 > = /*@__PURE__*/ API.make(() => ({
   input: DeleteProductRequest,
   output: DeletedProduct,
-  errors: [UnknownStripeError],
+  errors: [ProductHasPrices, UnknownStripeError],
   protocol: StripeProtocol,
   retry: Retry.Retry,
 }));


### PR DESCRIPTION
## Summary

- Add a Smithy `ProductHasPrices` error (HTTP 400, message includes `user-created prices`) and attach it to `DeleteProduct`. Stripe documents that a product can only be deleted if it has no prices; the wire failure is `invalid_request_error` with that message.
- Run per-op `matchTypedError` in `StripeProtocol` **before** the `error.type` dispatch, so `DeleteProduct` actually throws `ProductHasPrices` instead of `InvalidRequestError`.
- Leave `UpdateProduct` alone — its docs do not mention this failure.

Not blocking alchemy-run/alchemy#1298 (that PR currently message-matches `InvalidRequestError`).

## Generated surface

```ts
export type DeleteProductError = ProductHasPrices | StripeOpError;
// errors: [ProductHasPrices, UnknownStripeError]
```

Matcher: `{ status: 400, message: { includes: "user-created prices" } }`.

## Test plan

- [x] `pnpm --filter @distilled.cloud/stripe run convert` — 2 patch files applied, `ProductHasPrices` on `DeleteProduct` only
- [x] generate + oxfmt
- [x] `pnpm --filter @distilled.cloud/stripe run typecheck`
- [ ] CI `typecheck:ci` / `specs:check`