### PR TITLE
fix(gcp): add GcpUserAccessBinding.restrictedClientApplications

### DIFF
--- a/packages/gcp/.generated-specs/stable/accesscontextmanager_v1.json
+++ b/packages/gcp/.generated-specs/stable/accesscontextmanager_v1.json
@@ -8,18 +8,108 @@
     "distilled.finalized": true
   },
   "shapes": {
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse": {
+    "com.gcp.accesscontextmanager_v1#IngressPolicy": {
       "type": "structure",
       "members": {
-        "permissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "ingressTo": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressTo",
           "traits": {
-            "smithy.api#documentation": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed."
+            "smithy.api#documentation": "Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply."
+          }
+        },
+        "ingressFrom": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressFrom",
+          "traits": {
+            "smithy.api#documentation": "Defines the conditions on the source of a request causing this IngressPolicy to apply."
+          }
+        },
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Response message for `TestIamPermissions` method."
+        "smithy.api#documentation": "Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse": {
+      "type": "structure",
+      "members": {
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        },
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
+          "traits": {
+            "smithy.api#documentation": "List of the Access Level instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListAccessLevelsRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessLevelList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#VpcNetworkSource": {
+      "type": "structure",
+      "members": {
+        "vpcSubnetwork": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcSubNetwork",
+          "traits": {
+            "smithy.api#documentation": "Sub-segment ranges of a VPC network."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The originating network source in Google Cloud."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServices": {
+      "type": "structure",
+      "members": {
+        "allowedServicePatterns": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePatternList",
+          "traits": {
+            "smithy.api#documentation": "Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter."
+          }
+        },
+        "enableRestriction": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'."
+          }
+        },
+        "allowedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter."
+          }
+        },
+        "servicePatternsEnforcementScopes": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Defines the enforcement scopes of service patterns."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies how APIs are allowed to communicate within the Service Perimeter."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePatternList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ServicePattern"
       }
     },
     "com.gcp.accesscontextmanager_v1#StringList": {
@@ -28,100 +118,118 @@
         "target": "smithy.api#String"
       }
     },
-    "com.gcp.accesscontextmanager_v1#AccessSettings": {
-      "type": "structure",
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum": {
+      "type": "enum",
       "members": {
-        "sessionSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
+        "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#documentation": "Optional. Session settings applied to user access on a given AccessScope."
+            "smithy.api#enumValue": "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
           }
         },
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "GOOGLE_APIS_VIA_PRIVATE_PATH": {
+          "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+            "smithy.api#enumValue": "GOOGLE_APIS_VIA_PRIVATE_PATH"
           }
         }
-      },
-      "traits": {
-        "smithy.api#documentation": "Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set."
       }
     },
-    "com.gcp.accesscontextmanager_v1#Condition": {
-      "type": "structure",
-      "members": {
-        "requiredAccessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: \"`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME\"`"
-          }
-        },
-        "ipSubnetworks": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. Similarly, for IPv6, \"2001:db8::/32\" is accepted whereas \"2001:db8::1/32\" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed."
-          }
-        },
-        "devicePolicy": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicy",
-          "traits": {
-            "smithy.api#documentation": "Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed."
-          }
-        },
-        "negate": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false."
-          }
-        },
-        "members": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user."
-          }
-        },
-        "regions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes."
-          }
-        },
-        "vpcNetworkSources": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList",
-          "traits": {
-            "smithy.api#documentation": "The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList": {
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSource"
+        "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum"
       }
     },
-    "com.gcp.accesscontextmanager_v1#Application": {
+    "com.gcp.accesscontextmanager_v1#Empty": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ClientScope": {
       "type": "structure",
       "members": {
-        "clientId": {
-          "target": "smithy.api#String",
+        "restrictedClientApplication": {
+          "target": "com.gcp.accesscontextmanager_v1#Application",
           "traits": {
-            "smithy.api#documentation": "The OAuth client ID of the application."
+            "smithy.api#documentation": "Optional. The application that is subject to this binding's scope."
           }
         },
-        "name": {
-          "target": "smithy.api#String",
+        "restrictedProject": {
+          "target": "com.gcp.accesscontextmanager_v1#Project",
           "traits": {
-            "smithy.api#documentation": "The name of the application. Example: \"Cloud Console\""
+            "smithy.api#documentation": "Optional. The Google Cloud project that is subject to this binding's scope."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "An application that accesses Google Cloud APIs."
+        "smithy.api#documentation": "Client scope represents the application, etc. subject to this binding's restrictions."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePattern": {
+      "type": "structure",
+      "members": {
+        "pattern": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "URL pattern to allow. Only patterns of \".googleapis.com/*\", \"www.googleapis.com//*\" and \"*.appspot.com/* forms are supported, where should be an alphanumeric name."
+          }
+        },
+        "service": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Supported service to allow."
+          }
+        },
+        "modifiers": {
+          "target": "com.gcp.accesscontextmanager_v1#ModifierList",
+          "traits": {
+            "smithy.api#documentation": "Modifiers to apply to the requests that match the URL pattern."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Service patterns used to allow access."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ModifierList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Modifier"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse": {
+      "type": "structure",
+      "members": {
+        "restrictedResource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The resource (e.g. \"projects/123\", \"folders/456\") that directly owns/is restricted by the enforced perimeter."
+          }
+        },
+        "servicePerimeter": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Fully qualified name of the configured enforced perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no enforced perimeter applies."
+          }
+        },
+        "restrictedResourceDryRun": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The resource (e.g. \"projects/123\", \"folders/456\") that directly owns/is restricted by the dry-run perimeter."
+          }
+        },
+        "servicePerimeterDryRun": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Fully qualified name of the configured dry-run perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no dry-run perimeter configuration applies."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A configured service perimeter returned by Access Context Manager."
       }
     },
     "com.gcp.accesscontextmanager_v1#ListAuthorizedOrgsDescsResponse": {
@@ -150,127 +258,110 @@
         "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
       }
     },
-    "com.gcp.accesscontextmanager_v1#IngressPolicy": {
+    "com.gcp.accesscontextmanager_v1#SessionSettings": {
       "type": "structure",
       "members": {
-        "title": {
+        "sessionLength": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
+            "smithy.api#documentation": "Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset."
           }
         },
-        "ingressTo": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressTo",
+        "useOidcMaxAge": {
+          "target": "smithy.api#Boolean",
           "traits": {
-            "smithy.api#documentation": "Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply."
+            "smithy.api#documentation": "Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param."
           }
         },
-        "ingressFrom": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressFrom",
+        "sessionReauthMethod": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum",
           "traits": {
-            "smithy.api#documentation": "Defines the conditions on the source of a request causing this IngressPolicy to apply."
+            "smithy.api#documentation": "Optional. Session method when user's Google Cloud session is up."
+          }
+        },
+        "maxInactivity": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps."
+          }
+        },
+        "sessionLengthEnabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field."
+        "smithy.api#documentation": "Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListOperationsResponse": {
+    "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum": {
+      "type": "enum",
+      "members": {
+        "SESSION_REAUTH_METHOD_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SESSION_REAUTH_METHOD_UNSPECIFIED"
+          }
+        },
+        "LOGIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOGIN"
+          }
+        },
+        "SECURITY_KEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECURITY_KEY"
+          }
+        },
+        "PASSWORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PASSWORD"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressSource": {
       "type": "structure",
       "members": {
-        "unreachable": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations."
-          }
-        },
-        "nextPageToken": {
+        "resource": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The standard List next-page token."
+            "smithy.api#documentation": "A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported."
           }
         },
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#OperationList",
+        "accessLevel": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "A list of operations that matches the specified filter in the request."
+            "smithy.api#documentation": "An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed."
+          }
+        },
+        "pscEndpoint": {
+          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
+          "traits": {
+            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "The response message for Operations.ListOperations."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#OperationList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        },
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeterList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Expr": {
-      "type": "structure",
-      "members": {
-        "expression": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Textual representation of an expression in Common Expression Language syntax."
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
-          }
-        },
-        "location": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file."
-          }
-        },
-        "description": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() < 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information."
+        "smithy.api#documentation": "The source that IngressPolicy authorizes access from."
       }
     },
     "com.gcp.accesscontextmanager_v1#SupportedService": {
       "type": "structure",
       "members": {
-        "supportStage": {
-          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceSupportStageEnum",
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The service name or address of the supported service, such as `service.googleapis.com`."
+          }
+        },
+        "serviceSupportStage": {
+          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceServiceSupportStageEnum",
           "traits": {
             "smithy.api#documentation": "The support stage of the service."
           }
@@ -279,6 +370,12 @@
           "target": "smithy.api#Boolean",
           "traits": {
             "smithy.api#documentation": "True if the service is supported with some limitations. Check [documentation](https://cloud.google.com/vpc-service-controls/docs/supported-products) for details."
+          }
+        },
+        "supportStage": {
+          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceSupportStageEnum",
+          "traits": {
+            "smithy.api#documentation": "The support stage of the service."
           }
         },
         "availableOnRestrictedVip": {
@@ -293,27 +390,44 @@
             "smithy.api#documentation": "The name of the supported product, such as 'Cloud Product API'."
           }
         },
-        "serviceSupportStage": {
-          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceServiceSupportStageEnum",
-          "traits": {
-            "smithy.api#documentation": "The support stage of the service."
-          }
-        },
         "supportedMethods": {
           "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
           "traits": {
             "smithy.api#documentation": "The list of the supported methods. This field exists only in response to GetSupportedService"
           }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The service name or address of the supported service, such as `service.googleapis.com`."
-          }
         }
       },
       "traits": {
         "smithy.api#documentation": "`SupportedService` specifies the VPC Service Controls and its properties."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SupportedServiceServiceSupportStageEnum": {
+      "type": "enum",
+      "members": {
+        "SERVICE_SUPPORT_STAGE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SERVICE_SUPPORT_STAGE_UNSPECIFIED"
+          }
+        },
+        "GA": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GA"
+          }
+        },
+        "PREVIEW": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PREVIEW"
+          }
+        },
+        "DEPRECATED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DEPRECATED"
+          }
+        }
       }
     },
     "com.gcp.accesscontextmanager_v1#SupportedServiceSupportStageEnum": {
@@ -369,53 +483,78 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#SupportedServiceServiceSupportStageEnum": {
-      "type": "enum",
-      "members": {
-        "SERVICE_SUPPORT_STAGE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SERVICE_SUPPORT_STAGE_UNSPECIFIED"
-          }
-        },
-        "GA": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "GA"
-          }
-        },
-        "PREVIEW": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "PREVIEW"
-          }
-        },
-        "DEPRECATED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DEPRECATED"
-          }
-        }
-      }
-    },
     "com.gcp.accesscontextmanager_v1#MethodSelectorList": {
       "type": "list",
       "member": {
         "target": "com.gcp.accesscontextmanager_v1#MethodSelector"
       }
     },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest": {
+    "com.gcp.accesscontextmanager_v1#ApiOperation": {
       "type": "structure",
       "members": {
-        "permissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "serviceName": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)."
+            "smithy.api#documentation": "The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services."
+          }
+        },
+        "methodSelectors": {
+          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
+          "traits": {
+            "smithy.api#documentation": "API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Request message for `TestIamPermissions` method."
+        "smithy.api#documentation": "Identification for an API Operation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "options": {
+          "target": "com.gcp.accesscontextmanager_v1#GetPolicyOptions",
+          "traits": {
+            "smithy.api#documentation": "OPTIONAL: A `GetPolicyOptions` object for specifying options to `GetIamPolicy`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Request message for `GetIamPolicy` method."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#MethodSelector": {
+      "type": "structure",
+      "members": {
+        "permission": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation."
+          }
+        },
+        "method": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An allowed method or permission of a service specified in ApiOperation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Modifier": {
+      "type": "structure",
+      "members": {
+        "addRequestHeader": {
+          "target": "com.gcp.accesscontextmanager_v1#AddRequestHeader",
+          "traits": {
+            "smithy.api#documentation": "Adds an additional HTTP request header."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Modifier to apply to the API requests."
       }
     },
     "com.gcp.accesscontextmanager_v1#VpcSubNetwork": {
@@ -438,44 +577,50 @@
         "smithy.api#documentation": "Sub-segment ranges inside of a VPC Network."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ClientScope": {
+    "com.gcp.accesscontextmanager_v1#Principal": {
       "type": "structure",
       "members": {
-        "restrictedClientApplication": {
-          "target": "com.gcp.accesscontextmanager_v1#Application",
-          "traits": {
-            "smithy.api#documentation": "Optional. The application that is subject to this binding's scope."
-          }
-        },
-        "restrictedProject": {
-          "target": "com.gcp.accesscontextmanager_v1#Project",
-          "traits": {
-            "smithy.api#documentation": "Optional. The Google Cloud project that is subject to this binding's scope."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Client scope represents the application, etc. subject to this binding's restrictions."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest": {
-      "type": "structure",
-      "members": {
-        "updateMask": {
+        "federatedPrincipal": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: \"bindings, etag\"`"
+            "smithy.api#documentation": "Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed."
           }
         },
-        "policy": {
-          "target": "com.gcp.accesscontextmanager_v1#Policy",
+        "serviceAccountProjectNumber": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
+            "smithy.api#documentation": "Immutable. Cloud project number used to assign policies to all service accounts owned by the project."
+          }
+        },
+        "serviceAccount": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Request message for `SetIamPolicy` method."
+        "smithy.api#documentation": "The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AddRequestHeader": {
+      "type": "structure",
+      "members": {
+        "value": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "HTTP header value."
+          }
+        },
+        "key": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "HTTP header key."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Adds a request header to the API."
       }
     },
     "com.gcp.accesscontextmanager_v1#AuditLogConfig": {
@@ -527,346 +672,62 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CustomLevel": {
+    "com.gcp.accesscontextmanager_v1#EgressFrom": {
       "type": "structure",
       "members": {
-        "expr": {
-          "target": "com.gcp.accesscontextmanager_v1#Expr",
-          "traits": {
-            "smithy.api#documentation": "Required. A Cloud CEL expression evaluating to a boolean."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse": {
-      "type": "structure",
-      "members": {
-        "accessPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of the AccessPolicy instances."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListAccessPoliciesRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessPolicyList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcNetworkSource": {
-      "type": "structure",
-      "members": {
-        "vpcSubnetwork": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcSubNetwork",
-          "traits": {
-            "smithy.api#documentation": "Sub-segment ranges of a VPC network."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The originating network source in Google Cloud."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Operation": {
-      "type": "structure",
-      "members": {
-        "error": {
-          "target": "com.gcp.accesscontextmanager_v1#Status",
-          "traits": {
-            "smithy.api#documentation": "The error result of the operation in case of failure or cancellation."
-          }
-        },
-        "done": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
-          }
-        },
-        "metadata": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
-          "traits": {
-            "smithy.api#documentation": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
-          }
-        },
-        "response": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
-          "traits": {
-            "smithy.api#documentation": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "This resource represents a long-running operation that is the result of a network API call."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DocumentMap": {
-      "type": "map",
-      "key": {
-        "target": "smithy.api#String"
-      },
-      "value": {
-        "target": "smithy.api#Document"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressSource": {
-      "type": "structure",
-      "members": {
-        "pscEndpoint": {
-          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
-          "traits": {
-            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
-          }
-        },
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported."
-          }
-        },
-        "accessLevel": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The source that IngressPolicy authorizes access from."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessScope": {
-      "type": "structure",
-      "members": {
-        "clientScope": {
-          "target": "com.gcp.accesscontextmanager_v1#ClientScope",
-          "traits": {
-            "smithy.api#documentation": "Optional. Client scope for this access scope."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Access scope represents the client scope, etc. to which the settings will be applied to."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessContextManagerOperationMetadata": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "Metadata of Access Context Manager's Long Running Operations."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse": {
-      "type": "structure",
-      "members": {
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Token to get the next page of items. If blank, there are no more items."
-          }
-        },
-        "gcpUserAccessBindings": {
-          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList",
-          "traits": {
-            "smithy.api#documentation": "GcpUserAccessBinding"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Response of ListGcpUserAccessBindings."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServices": {
-      "type": "structure",
-      "members": {
-        "allowedServicePatterns": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePatternList",
-          "traits": {
-            "smithy.api#documentation": "Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter."
-          }
-        },
-        "servicePatternsEnforcementScopes": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList",
-          "traits": {
-            "smithy.api#documentation": "Defines the enforcement scopes of service patterns."
-          }
-        },
-        "allowedServices": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter."
-          }
-        },
-        "enableRestriction": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies how APIs are allowed to communicate within the Service Perimeter."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePatternList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ServicePattern"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum": {
-      "type": "enum",
-      "members": {
-        "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
-          }
-        },
-        "GOOGLE_APIS_VIA_PRIVATE_PATH": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "GOOGLE_APIS_VIA_PRIVATE_PATH"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditConfig": {
-      "type": "structure",
-      "members": {
-        "service": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services."
-          }
-        },
-        "auditLogConfigs": {
-          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigList",
-          "traits": {
-            "smithy.api#documentation": "The configuration for logging of each type of permission."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { \"audit_configs\": [ { \"service\": \"allServices\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" }, { \"log_type\": \"ADMIN_READ\" } ] }, { \"service\": \"sampleservice.googleapis.com\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\" }, { \"log_type\": \"DATA_WRITE\", \"exempted_members\": [ \"user:aliya@example.com\" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditLogConfigList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AuditLogConfig"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Principal": {
-      "type": "structure",
-      "members": {
-        "serviceAccount": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement."
-          }
-        },
-        "serviceAccountProjectNumber": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Cloud project number used to assign policies to all service accounts owned by the project."
-          }
-        },
-        "federatedPrincipal": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsResponse": {
-      "type": "structure",
-      "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "List of the Access Level instances."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to ReplaceAccessLevelsRequest. This will be put inside of Operation.response field."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessLevelList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressFrom": {
-      "type": "structure",
-      "members": {
-        "sources": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressSourceList",
-          "traits": {
-            "smithy.api#documentation": "Sources that this IngressPolicy authorizes access from."
-          }
-        },
-        "identityType": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
-          }
-        },
         "identities": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
+            "smithy.api#documentation": "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
+          }
+        },
+        "sourceRestriction": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`."
+          }
+        },
+        "identityType": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
+          }
+        },
+        "sources": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressSourceList",
+          "traits": {
+            "smithy.api#documentation": "Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match."
+        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed."
       }
     },
-    "com.gcp.accesscontextmanager_v1#IngressSourceList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#IngressSource"
+    "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum": {
+      "type": "enum",
+      "members": {
+        "SOURCE_RESTRICTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_UNSPECIFIED"
+          }
+        },
+        "SOURCE_RESTRICTION_ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_ENABLED"
+          }
+        },
+        "SOURCE_RESTRICTION_DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_DISABLED"
+          }
+        }
       }
     },
-    "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum": {
+    "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum": {
       "type": "enum",
       "members": {
         "IDENTITY_TYPE_UNSPECIFIED": {
@@ -895,35 +756,15 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy."
-          }
-        },
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically."
+    "com.gcp.accesscontextmanager_v1#EgressSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#EgressSource"
       }
     },
     "com.gcp.accesscontextmanager_v1#EgressSource": {
       "type": "structure",
       "members": {
-        "pscEndpoint": {
-          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
-          "traits": {
-            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
-          }
-        },
         "resource": {
           "target": "smithy.api#String",
           "traits": {
@@ -935,45 +776,986 @@
           "traits": {
             "smithy.api#documentation": "An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed."
           }
+        },
+        "pscEndpoint": {
+          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
+          "traits": {
+            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
+          }
         }
       },
       "traits": {
         "smithy.api#documentation": "The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse": {
+    "com.gcp.accesscontextmanager_v1#AccessSettings": {
       "type": "structure",
       "members": {
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+          }
+        },
+        "sessionSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. Session settings applied to user access on a given AccessScope."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of the Service Perimeter instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to ReplaceServicePerimetersRequest. This will be put inside of Operation.response field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePerimeterList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Status": {
+      "type": "structure",
+      "members": {
+        "details": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMapList",
+          "traits": {
+            "smithy.api#documentation": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
+          }
+        },
+        "code": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "The status code, which should be an enum value of google.rpc.Code."
+          }
+        },
+        "message": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DocumentMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#Document"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DocumentMapList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DocumentMap"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of the Service Perimeter instances."
+          }
+        },
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListServicePerimetersRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`."
+          }
+        },
+        "orgs": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456`"
+          }
+        },
+        "authorizationDirection": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum",
+          "traits": {
+            "smithy.api#documentation": "The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource."
+          }
+        },
+        "authorizationType": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`."
+          }
+        },
+        "assetType": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`AuthorizedOrgsDesc` contains data for an organization's authorization policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum": {
+      "type": "enum",
+      "members": {
+        "AUTHORIZATION_DIRECTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_UNSPECIFIED"
+          }
+        },
+        "AUTHORIZATION_DIRECTION_TO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_TO"
+          }
+        },
+        "AUTHORIZATION_DIRECTION_FROM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_FROM"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum": {
+      "type": "enum",
+      "members": {
+        "AUTHORIZATION_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_TYPE_UNSPECIFIED"
+          }
+        },
+        "AUTHORIZATION_TYPE_TRUST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_TYPE_TRUST"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum": {
+      "type": "enum",
+      "members": {
+        "ASSET_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_UNSPECIFIED"
+          }
+        },
+        "ASSET_TYPE_DEVICE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_DEVICE"
+          }
+        },
+        "ASSET_TYPE_CREDENTIAL_STRENGTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_CREDENTIAL_STRENGTH"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressPolicy": {
+      "type": "structure",
+      "members": {
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
+          }
+        },
+        "egressFrom": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFrom",
+          "traits": {
+            "smithy.api#documentation": "Defines conditions on the source of a request causing this EgressPolicy to apply."
+          }
+        },
+        "egressTo": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressTo",
+          "traits": {
+            "smithy.api#documentation": "Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        },
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
+          "traits": {
+            "smithy.api#documentation": "Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CustomLevel": {
+      "type": "structure",
+      "members": {
+        "expr": {
+          "target": "com.gcp.accesscontextmanager_v1#Expr",
+          "traits": {
+            "smithy.api#documentation": "Required. A Cloud CEL expression evaluating to a boolean."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse": {
+      "type": "structure",
+      "members": {
+        "supportedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceList",
+          "traits": {
+            "smithy.api#documentation": "List of services supported by VPC Service Controls instances."
+          }
+        },
         "nextPageToken": {
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
           }
-        },
-        "supportedPermissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListSupportedServicesRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SupportedServiceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BasicLevel": {
+      "type": "structure",
+      "members": {
+        "combiningFunction": {
+          "target": "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum",
           "traits": {
-            "smithy.api#documentation": "List of VPC Service Controls supported permissions."
+            "smithy.api#documentation": "How the `conditions` list should be combined to determine if a request is granted this `AccessLevel`. If AND is used, each `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. If OR is used, at least one `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. Default behavior is AND."
+          }
+        },
+        "conditions": {
+          "target": "com.gcp.accesscontextmanager_v1#ConditionList",
+          "traits": {
+            "smithy.api#documentation": "Required. A list of requirements for the `AccessLevel` to be granted."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A response to `ListSupportedPermissionsRequest`."
+        "smithy.api#documentation": "`BasicLevel` is an `AccessLevel` using a set of recommended features."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum": {
+      "type": "enum",
+      "members": {
+        "AND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AND"
+          }
+        },
+        "OR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OR"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ConditionList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Condition"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressTo": {
+      "type": "structure",
+      "members": {
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter."
+          }
+        },
+        "externalResources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed."
+          }
+        },
+        "roles": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter."
+          }
+        },
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ApiOperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ApiOperation"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessScope": {
+      "type": "structure",
+      "members": {
+        "clientScope": {
+          "target": "com.gcp.accesscontextmanager_v1#ClientScope",
+          "traits": {
+            "smithy.api#documentation": "Optional. Client scope for this access scope."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Access scope represents the client scope, etc. to which the settings will be applied to."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Application": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the application. Example: \"Cloud Console\""
+          }
+        },
+        "clientId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The OAuth client ID of the application."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An application that accesses Google Cloud APIs."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "policy": {
+          "target": "com.gcp.accesscontextmanager_v1#Policy",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
+          }
+        },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: \"bindings, etag\"`"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Request message for `SetIamPolicy` method."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicy": {
+      "type": "structure",
+      "members": {
+        "requireScreenlock": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`."
+          }
+        },
+        "requireAdminApproval": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether the device needs to be approved by the customer admin."
+          }
+        },
+        "allowedEncryptionStatuses": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Allowed encryptions statuses, an empty list allows all statuses."
+          }
+        },
+        "osConstraints": {
+          "target": "com.gcp.accesscontextmanager_v1#OsConstraintList",
+          "traits": {
+            "smithy.api#documentation": "Allowed OS versions, an empty list allows all types and all versions."
+          }
+        },
+        "requireCorpOwned": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether the device needs to be corp owned."
+          }
+        },
+        "allowedDeviceManagementLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Allowed device management levels, an empty list allows all management levels."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum": {
+      "type": "enum",
+      "members": {
+        "ENCRYPTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTION_UNSPECIFIED"
+          }
+        },
+        "ENCRYPTION_UNSUPPORTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTION_UNSUPPORTED"
+          }
+        },
+        "UNENCRYPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNENCRYPTED"
+          }
+        },
+        "ENCRYPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#OsConstraintList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#OsConstraint"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum": {
+      "type": "enum",
+      "members": {
+        "MANAGEMENT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGEMENT_UNSPECIFIED"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "BASIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BASIC"
+          }
+        },
+        "COMPLETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETE"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse": {
+      "type": "structure",
+      "members": {
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        },
+        "accessPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of the AccessPolicy instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListAccessPoliciesRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessPolicyList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessContextManagerOperationMetadata": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "Metadata of Access Context Manager's Long Running Operations."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig": {
+      "type": "structure",
+      "members": {
+        "egressPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge."
+          }
+        },
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`."
+          }
+        },
+        "restrictedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions."
+          }
+        },
+        "ingressPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge."
+          }
+        },
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `\"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL\"`. For Service Perimeter Bridge, must be empty."
+          }
+        },
+        "vpcAccessibleServices": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServices",
+          "traits": {
+            "smithy.api#documentation": "Configuration for APIs allowed within Perimeter."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressPolicyList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#EgressPolicy"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressPolicyList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#IngressPolicy"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Operation": {
+      "type": "structure",
+      "members": {
+        "response": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
+          "traits": {
+            "smithy.api#documentation": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`."
+          }
+        },
+        "error": {
+          "target": "com.gcp.accesscontextmanager_v1#Status",
+          "traits": {
+            "smithy.api#documentation": "The error result of the operation in case of failure or cancellation."
+          }
+        },
+        "done": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+          }
+        },
+        "metadata": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
+          "traits": {
+            "smithy.api#documentation": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "This resource represents a long-running operation that is the result of a network API call."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ScopedAccessSettings": {
+      "type": "structure",
+      "members": {
+        "scope": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessScope",
+          "traits": {
+            "smithy.api#documentation": "Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty."
+          }
+        },
+        "activeSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set."
+          }
+        },
+        "dryRunSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A relationship between access settings and its scope."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingOperationMetadata": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "Metadata of Google Cloud Access Binding Long Running Operations."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy."
+          }
+        },
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListOperationsResponse": {
+      "type": "structure",
+      "members": {
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#OperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of operations that matches the specified filter in the request."
+          }
+        },
+        "unreachable": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations."
+          }
+        },
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The standard List next-page token."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The response message for Operations.ListOperations."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#OperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of all the Service Perimeter instances in the Access Policy."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to CommitServicePerimetersRequest. This will be put inside of Operation.response field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessLevel": {
+      "type": "structure",
+      "members": {
+        "custom": {
+          "target": "com.gcp.accesscontextmanager_v1#CustomLevel",
+          "traits": {
+            "smithy.api#documentation": "A `CustomLevel` written in the Common Expression Language."
+          }
+        },
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
+          }
+        },
+        "description": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Description of the `AccessLevel` and its use. Does not affect behavior."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`."
+          }
+        },
+        "basic": {
+          "target": "com.gcp.accesscontextmanager_v1#BasicLevel",
+          "traits": {
+            "smithy.api#documentation": "A `BasicLevel` composed of `Conditions`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An `AccessLevel` is a label that can be applied to requests to Google Cloud services, along with a list of requirements necessary for the label to be applied."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse": {
+      "type": "structure",
+      "members": {
+        "permissions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Response message for `TestIamPermissions` method."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint": {
+      "type": "structure",
+      "members": {
+        "forwardingRule": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies the Private Service Connect endpoint that an API call refers to."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\""
+          }
+        },
+        "dryRunAccessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+          }
+        },
+        "groupKey": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See \"id\" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: \"01d520gv4vjcrht\""
+          }
+        },
+        "principal": {
+          "target": "com.gcp.accesscontextmanager_v1#Principal",
+          "traits": {
+            "smithy.api#documentation": "Optional. Immutable. The principal that is subject to the access policies in this policy binding."
+          }
+        },
+        "scopedAccessSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList",
+          "traits": {
+            "smithy.api#documentation": "Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set."
+          }
+        },
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+          }
+        },
+        "sessionSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. The Google Cloud session length (GCSL) policy for the group key."
+          }
+        },
+        "restrictedClientApplications": {
+          "target": "com.gcp.accesscontextmanager_v1#ApplicationList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettings"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressTo": {
+      "type": "structure",
+      "members": {
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed."
+          }
+        },
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter."
+          }
+        },
+        "roles": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Expr": {
+      "type": "structure",
+      "members": {
+        "location": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file."
+          }
+        },
+        "expression": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Textual representation of an expression in Common Expression Language syntax."
+          }
+        },
+        "description": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
+          }
+        },
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() < 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information."
       }
     },
     "com.gcp.accesscontextmanager_v1#OsConstraint": {
       "type": "structure",
       "members": {
-        "osType": {
-          "target": "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Required. The allowed OS type."
-          }
-        },
         "minimumVersion": {
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `\"major.minor.patch\"`. Examples: `\"10.5.301\"`, `\"9.2.1\"`."
+          }
+        },
+        "osType": {
+          "target": "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Required. The allowed OS type."
           }
         },
         "requireVerifiedChromeOs": {
@@ -1034,391 +1816,135 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#Project": {
+    "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse": {
       "type": "structure",
       "members": {
-        "name": {
+        "gcpUserAccessBindings": {
+          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList",
+          "traits": {
+            "smithy.api#documentation": "GcpUserAccessBinding"
+          }
+        },
+        "nextPageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890`"
+            "smithy.api#documentation": "Token to get the next page of items. If blank, there are no more items."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A Google Cloud project which contains applications and resources that users can access."
+        "smithy.api#documentation": "Response of ListGcpUserAccessBindings."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersResponse": {
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Condition": {
       "type": "structure",
       "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+        "members": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "List of the Service Perimeter instances."
+            "smithy.api#documentation": "The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user."
           }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to ReplaceServicePerimetersRequest. This will be put inside of Operation.response field."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicy": {
-      "type": "structure",
-      "members": {
-        "requireCorpOwned": {
+        },
+        "regions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes."
+          }
+        },
+        "vpcNetworkSources": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList",
+          "traits": {
+            "smithy.api#documentation": "The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`."
+          }
+        },
+        "ipSubnetworks": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. Similarly, for IPv6, \"2001:db8::/32\" is accepted whereas \"2001:db8::1/32\" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed."
+          }
+        },
+        "negate": {
           "target": "smithy.api#Boolean",
           "traits": {
-            "smithy.api#documentation": "Whether the device needs to be corp owned."
+            "smithy.api#documentation": "Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false."
           }
         },
-        "osConstraints": {
-          "target": "com.gcp.accesscontextmanager_v1#OsConstraintList",
+        "devicePolicy": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicy",
           "traits": {
-            "smithy.api#documentation": "Allowed OS versions, an empty list allows all types and all versions."
+            "smithy.api#documentation": "Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed."
           }
         },
-        "allowedEncryptionStatuses": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList",
+        "requiredAccessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Allowed encryptions statuses, an empty list allows all statuses."
-          }
-        },
-        "allowedDeviceManagementLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList",
-          "traits": {
-            "smithy.api#documentation": "Allowed device management levels, an empty list allows all management levels."
-          }
-        },
-        "requireScreenlock": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`."
-          }
-        },
-        "requireAdminApproval": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether the device needs to be approved by the customer admin."
+            "smithy.api#documentation": "A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: \"`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME\"`"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "`DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops."
+        "smithy.api#documentation": "A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction."
       }
     },
-    "com.gcp.accesscontextmanager_v1#OsConstraintList": {
+    "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#OsConstraint"
+        "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSource"
       }
     },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum": {
-      "type": "enum",
-      "members": {
-        "ENCRYPTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTION_UNSPECIFIED"
-          }
-        },
-        "ENCRYPTION_UNSUPPORTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTION_UNSUPPORTED"
-          }
-        },
-        "UNENCRYPTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "UNENCRYPTED"
-          }
-        },
-        "ENCRYPTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum": {
-      "type": "enum",
-      "members": {
-        "MANAGEMENT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "MANAGEMENT_UNSPECIFIED"
-          }
-        },
-        "NONE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "NONE"
-          }
-        },
-        "BASIC": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "BASIC"
-          }
-        },
-        "COMPLETE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "COMPLETE"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressPolicy": {
+    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsResponse": {
       "type": "structure",
       "members": {
-        "egressFrom": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFrom",
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
           "traits": {
-            "smithy.api#documentation": "Defines conditions on the source of a request causing this EgressPolicy to apply."
-          }
-        },
-        "egressTo": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressTo",
-          "traits": {
-            "smithy.api#documentation": "Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply."
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
+            "smithy.api#documentation": "List of the Access Level instances."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo."
+        "smithy.api#documentation": "A response to ReplaceAccessLevelsRequest. This will be put inside of Operation.response field."
       }
     },
-    "com.gcp.accesscontextmanager_v1#Modifier": {
+    "com.gcp.accesscontextmanager_v1#IngressFrom": {
       "type": "structure",
       "members": {
-        "addRequestHeader": {
-          "target": "com.gcp.accesscontextmanager_v1#AddRequestHeader",
-          "traits": {
-            "smithy.api#documentation": "Adds an additional HTTP request header."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Modifier to apply to the API requests."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Status": {
-      "type": "structure",
-      "members": {
-        "message": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
-          }
-        },
-        "details": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMapList",
-          "traits": {
-            "smithy.api#documentation": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
-          }
-        },
-        "code": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "The status code, which should be an enum value of google.rpc.Code."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DocumentMapList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DocumentMap"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Policy": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost."
-          }
-        },
-        "auditConfigs": {
-          "target": "com.gcp.accesscontextmanager_v1#AuditConfigList",
-          "traits": {
-            "smithy.api#documentation": "Specifies cloud audit logging configuration for this policy."
-          }
-        },
-        "bindings": {
-          "target": "com.gcp.accesscontextmanager_v1#BindingList",
-          "traits": {
-            "smithy.api#documentation": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`."
-          }
-        },
-        "version": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/)."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditConfigList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AuditConfig"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#BindingList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Binding"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#MethodSelector": {
-      "type": "structure",
-      "members": {
-        "method": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed."
-          }
-        },
-        "permission": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An allowed method or permission of a service specified in ApiOperation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ApiOperation": {
-      "type": "structure",
-      "members": {
-        "methodSelectors": {
-          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
-          "traits": {
-            "smithy.api#documentation": "API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`."
-          }
-        },
-        "serviceName": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Identification for an API Operation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Empty": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CancelOperationRequest": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "The request message for Operations.CancelOperation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AddRequestHeader": {
-      "type": "structure",
-      "members": {
-        "key": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "HTTP header key."
-          }
-        },
-        "value": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "HTTP header value."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Adds a request header to the API."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest": {
-      "type": "structure",
-      "members": {
-        "options": {
-          "target": "com.gcp.accesscontextmanager_v1#GetPolicyOptions",
-          "traits": {
-            "smithy.api#documentation": "OPTIONAL: A `GetPolicyOptions` object for specifying options to `GetIamPolicy`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Request message for `GetIamPolicy` method."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressFrom": {
-      "type": "structure",
-      "members": {
-        "identityType": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
-          }
-        },
-        "sourceRestriction": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum",
-          "traits": {
-            "smithy.api#documentation": "Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`."
-          }
-        },
-        "sources": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressSourceList",
-          "traits": {
-            "smithy.api#documentation": "Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`."
-          }
-        },
         "identities": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
+            "smithy.api#documentation": "A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
+          }
+        },
+        "sources": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressSourceList",
+          "traits": {
+            "smithy.api#documentation": "Sources that this IngressPolicy authorizes access from."
+          }
+        },
+        "identityType": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed."
+        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match."
       }
     },
-    "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum": {
+    "com.gcp.accesscontextmanager_v1#IngressSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#IngressSource"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum": {
       "type": "enum",
       "members": {
         "IDENTITY_TYPE_UNSPECIFIED": {
@@ -1447,241 +1973,73 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum": {
-      "type": "enum",
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest": {
+      "type": "structure",
       "members": {
-        "SOURCE_RESTRICTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
+        "permissions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_UNSPECIFIED"
-          }
-        },
-        "SOURCE_RESTRICTION_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_ENABLED"
-          }
-        },
-        "SOURCE_RESTRICTION_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_DISABLED"
+            "smithy.api#documentation": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)."
           }
         }
+      },
+      "traits": {
+        "smithy.api#documentation": "Request message for `TestIamPermissions` method."
       }
     },
-    "com.gcp.accesscontextmanager_v1#EgressSourceList": {
+    "com.gcp.accesscontextmanager_v1#AuditConfig": {
+      "type": "structure",
+      "members": {
+        "service": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services."
+          }
+        },
+        "auditLogConfigs": {
+          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigList",
+          "traits": {
+            "smithy.api#documentation": "The configuration for logging of each type of permission."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { \"audit_configs\": [ { \"service\": \"allServices\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" }, { \"log_type\": \"ADMIN_READ\" } ] }, { \"service\": \"sampleservice.googleapis.com\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\" }, { \"log_type\": \"DATA_WRITE\", \"exempted_members\": [ \"user:aliya@example.com\" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditLogConfigList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#EgressSource"
+        "target": "com.gcp.accesscontextmanager_v1#AuditLogConfig"
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetPolicyOptions": {
+    "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse": {
       "type": "structure",
       "members": {
-        "requestedPolicyVersion": {
-          "target": "smithy.api#Integer",
+        "supportedPermissions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Encapsulates settings provided to GetIamPolicy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ScopedAccessSettings": {
-      "type": "structure",
-      "members": {
-        "scope": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessScope",
-          "traits": {
-            "smithy.api#documentation": "Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty."
+            "smithy.api#documentation": "List of VPC Service Controls supported permissions."
           }
         },
-        "dryRunSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set."
-          }
-        },
-        "activeSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A relationship between access settings and its scope."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessLevel": {
-      "type": "structure",
-      "members": {
-        "custom": {
-          "target": "com.gcp.accesscontextmanager_v1#CustomLevel",
-          "traits": {
-            "smithy.api#documentation": "A `CustomLevel` written in the Common Expression Language."
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`."
-          }
-        },
-        "basic": {
-          "target": "com.gcp.accesscontextmanager_v1#BasicLevel",
-          "traits": {
-            "smithy.api#documentation": "A `BasicLevel` composed of `Conditions`."
-          }
-        },
-        "description": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Description of the `AccessLevel` and its use. Does not affect behavior."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An `AccessLevel` is a label that can be applied to requests to Google Cloud services, along with a list of requirements necessary for the label to be applied."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse": {
-      "type": "structure",
-      "members": {
         "nextPageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
-          }
-        },
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "List of the Service Perimeter instances."
+            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A response to `ListServicePerimetersRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc": {
-      "type": "structure",
-      "members": {
-        "orgs": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456`"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`."
-          }
-        },
-        "authorizationType": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`."
-          }
-        },
-        "assetType": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`."
-          }
-        },
-        "authorizationDirection": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum",
-          "traits": {
-            "smithy.api#documentation": "The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`AuthorizedOrgsDesc` contains data for an organization's authorization policy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum": {
-      "type": "enum",
-      "members": {
-        "AUTHORIZATION_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_TYPE_UNSPECIFIED"
-          }
-        },
-        "AUTHORIZATION_TYPE_TRUST": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_TYPE_TRUST"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum": {
-      "type": "enum",
-      "members": {
-        "ASSET_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_UNSPECIFIED"
-          }
-        },
-        "ASSET_TYPE_DEVICE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_DEVICE"
-          }
-        },
-        "ASSET_TYPE_CREDENTIAL_STRENGTH": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_CREDENTIAL_STRENGTH"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum": {
-      "type": "enum",
-      "members": {
-        "AUTHORIZATION_DIRECTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_UNSPECIFIED"
-          }
-        },
-        "AUTHORIZATION_DIRECTION_TO": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_TO"
-          }
-        },
-        "AUTHORIZATION_DIRECTION_FROM": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_FROM"
-          }
-        }
+        "smithy.api#documentation": "A response to `ListSupportedPermissionsRequest`."
       }
     },
     "com.gcp.accesscontextmanager_v1#ServicePerimeter": {
       "type": "structure",
       "members": {
-        "title": {
-          "target": "smithy.api#String",
+        "perimeterType": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum",
           "traits": {
-            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
+            "smithy.api#documentation": "Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty."
           }
         },
         "description": {
@@ -1720,10 +2078,10 @@
             "smithy.api#documentation": "Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries."
           }
         },
-        "perimeterType": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum",
+        "title": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty."
+            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
           }
         }
       },
@@ -1748,47 +2106,33 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersResponse": {
+    "com.gcp.accesscontextmanager_v1#GetPolicyOptions": {
       "type": "structure",
       "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+        "requestedPolicyVersion": {
+          "target": "smithy.api#Integer",
           "traits": {
-            "smithy.api#documentation": "List of all the Service Perimeter instances in the Access Policy."
+            "smithy.api#documentation": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A response to CommitServicePerimetersRequest. This will be put inside of Operation.response field."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this commit operation is to be performed on. If, at the time of commit, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the commit operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to commit dry-run specs in all Service Perimeters belonging to an Access Policy."
+        "smithy.api#documentation": "Encapsulates settings provided to GetIamPolicy."
       }
     },
     "com.gcp.accesscontextmanager_v1#Binding": {
       "type": "structure",
       "members": {
-        "role": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles)."
-          }
-        },
         "members": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
             "smithy.api#documentation": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`."
+          }
+        },
+        "role": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles)."
           }
         },
         "condition": {
@@ -1802,273 +2146,25 @@
         "smithy.api#documentation": "Associates `members`, or principals, with a `role`."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse": {
+    "com.gcp.accesscontextmanager_v1#Project": {
       "type": "structure",
       "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "List of the Access Level instances."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListAccessLevelsRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePattern": {
-      "type": "structure",
-      "members": {
-        "modifiers": {
-          "target": "com.gcp.accesscontextmanager_v1#ModifierList",
-          "traits": {
-            "smithy.api#documentation": "Modifiers to apply to the requests that match the URL pattern."
-          }
-        },
-        "service": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Supported service to allow."
-          }
-        },
-        "pattern": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "URL pattern to allow. Only patterns of \".googleapis.com/*\", \"www.googleapis.com//*\" and \"*.appspot.com/* forms are supported, where should be an alphanumeric name."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Service patterns used to allow access."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ModifierList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Modifier"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding": {
-      "type": "structure",
-      "members": {
-        "groupKey": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See \"id\" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: \"01d520gv4vjcrht\""
-          }
-        },
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
-          }
-        },
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\""
-          }
-        },
-        "dryRunAccessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
-          }
-        },
-        "restrictedClientApplications": {
-          "target": "com.gcp.accesscontextmanager_v1#ApplicationList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications."
-          }
-        },
-        "sessionSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. The Google Cloud session length (GCSL) policy for the group key."
-          }
-        },
-        "principal": {
-          "target": "com.gcp.accesscontextmanager_v1#Principal",
-          "traits": {
-            "smithy.api#documentation": "Optional. Immutable. The principal that is subject to the access policies in this policy binding."
-          }
-        },
-        "scopedAccessSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList",
-          "traits": {
-            "smithy.api#documentation": "Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set."
+            "smithy.api#documentation": "The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890`"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access."
+        "smithy.api#documentation": "A Google Cloud project which contains applications and resources that users can access."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ApplicationList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Application"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettings"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig": {
+    "com.gcp.accesscontextmanager_v1#CancelOperationRequest": {
       "type": "structure",
-      "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `\"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL\"`. For Service Perimeter Bridge, must be empty."
-          }
-        },
-        "resources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`."
-          }
-        },
-        "vpcAccessibleServices": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServices",
-          "traits": {
-            "smithy.api#documentation": "Configuration for APIs allowed within Perimeter."
-          }
-        },
-        "restrictedServices": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions."
-          }
-        },
-        "ingressPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge."
-          }
-        },
-        "egressPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge."
-          }
-        }
-      },
+      "members": {},
       "traits": {
-        "smithy.api#documentation": "`ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressPolicyList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#IngressPolicy"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressPolicyList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#EgressPolicy"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SessionSettings": {
-      "type": "structure",
-      "members": {
-        "useOidcMaxAge": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param."
-          }
-        },
-        "maxInactivity": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps."
-          }
-        },
-        "sessionReauthMethod": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. Session method when user's Google Cloud session is up."
-          }
-        },
-        "sessionLength": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset."
-          }
-        },
-        "sessionLengthEnabled": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum": {
-      "type": "enum",
-      "members": {
-        "SESSION_REAUTH_METHOD_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SESSION_REAUTH_METHOD_UNSPECIFIED"
-          }
-        },
-        "LOGIN": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "LOGIN"
-          }
-        },
-        "SECURITY_KEY": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SECURITY_KEY"
-          }
-        },
-        "PASSWORD": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "PASSWORD"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse": {
-      "type": "structure",
-      "members": {
-        "supportedServices": {
-          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceList",
-          "traits": {
-            "smithy.api#documentation": "List of services supported by VPC Service Controls instances."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListSupportedServicesRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SupportedServiceList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
+        "smithy.api#documentation": "The request message for Operations.CancelOperation."
       }
     },
     "com.gcp.accesscontextmanager_v1#AccessPolicy": {
@@ -2078,12 +2174,6 @@
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "Required. The parent of this `AccessPolicy` in the Cloud Resource Hierarchy. Currently immutable once created. Format: `organizations/{organization_id}`"
-          }
-        },
-        "scopes": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=[\"folders/123\"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}`"
           }
         },
         "name": {
@@ -2103,155 +2193,85 @@
           "traits": {
             "smithy.api#documentation": "Required. Human readable title. Does not affect behavior."
           }
+        },
+        "scopes": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=[\"folders/123\"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}`"
+          }
         }
       },
       "traits": {
         "smithy.api#documentation": "`AccessPolicy` is a container for `AccessLevels` (which define the necessary attributes to use Google Cloud services) and `ServicePerimeters` (which define regions of services able to freely pass data within a perimeter). An access policy is globally visible within an organization, and the restrictions it specifies apply to all projects within an organization."
       }
     },
-    "com.gcp.accesscontextmanager_v1#BasicLevel": {
+    "com.gcp.accesscontextmanager_v1#Policy": {
       "type": "structure",
       "members": {
-        "combiningFunction": {
-          "target": "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum",
+        "bindings": {
+          "target": "com.gcp.accesscontextmanager_v1#BindingList",
           "traits": {
-            "smithy.api#documentation": "How the `conditions` list should be combined to determine if a request is granted this `AccessLevel`. If AND is used, each `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. If OR is used, at least one `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. Default behavior is AND."
+            "smithy.api#documentation": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`."
           }
         },
-        "conditions": {
-          "target": "com.gcp.accesscontextmanager_v1#ConditionList",
-          "traits": {
-            "smithy.api#documentation": "Required. A list of requirements for the `AccessLevel` to be granted."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`BasicLevel` is an `AccessLevel` using a set of recommended features."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum": {
-      "type": "enum",
-      "members": {
-        "AND": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AND"
-          }
-        },
-        "OR": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "OR"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ConditionList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Condition"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint": {
-      "type": "structure",
-      "members": {
-        "forwardingRule": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies the Private Service Connect endpoint that an API call refers to."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressTo": {
-      "type": "structure",
-      "members": {
-        "resources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed."
-          }
-        },
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
-          "traits": {
-            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter."
-          }
-        },
-        "roles": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ApiOperationList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ApiOperation"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingOperationMetadata": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "Metadata of Google Cloud Access Binding Long Running Operations."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressTo": {
-      "type": "structure",
-      "members": {
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
-          "traits": {
-            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list."
-          }
-        },
-        "resources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter."
-          }
-        },
-        "roles": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter."
-          }
-        },
-        "externalResources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListPermissionsRequest": {
-      "type": "structure",
-      "members": {
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Use this token to retrieve a specific page of results. Default is the first page.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "pageSize": {
+        "version": {
           "target": "smithy.api#Integer",
           "traits": {
-            "smithy.api#documentation": "Optional. This flag specifies the maximum number of services to return per page. Default value is 100.",
-            "smithy.api#httpQuery": "pageSize"
+            "smithy.api#documentation": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+          }
+        },
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost."
+          }
+        },
+        "auditConfigs": {
+          "target": "com.gcp.accesscontextmanager_v1#AuditConfigList",
+          "traits": {
+            "smithy.api#documentation": "Specifies cloud audit logging configuration for this policy."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/)."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BindingList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Binding"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AuditConfig"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this commit operation is to be performed on. If, at the time of commit, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the commit operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to commit dry-run specs in all Service Perimeters belonging to an Access Policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetServicesRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the service to get information about. The names must be in the same format as used in defining a service perimeter, for example, `storage.googleapis.com`.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
           }
         }
       }
@@ -2282,13 +2302,13 @@
         ]
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListPermissions": {
+    "com.gcp.accesscontextmanager_v1#GetServices": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListPermissionsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#GetServicesRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse"
+        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
       },
       "errors": [
         {
@@ -2301,35 +2321,78 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/permissions"
+          "uri": "v1/services/{name}"
         },
-        "smithy.api#documentation": "Lists all supported permissions in VPC Service Controls ingress and egress rules for Granular Controls.",
+        "smithy.api#documentation": "Returns a VPC-SC supported service based on the service name. **IAM Permissions**: Requires the following IAM permissions to use this method: - `serviceusage.services.use` on the project."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListServicesRequest": {
+      "type": "structure",
+      "members": {
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "This flag specifies the maximum number of services to return per page. Default value is 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Use this token to retrieve a specific page of results. Default is the first page.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListServices": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListServicesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/services"
+        },
+        "smithy.api#documentation": "Lists all VPC-SC supported services. **IAM Permissions**: Requires the following IAM permissions to use this method: - `serviceusage.services.use` on the project.",
         "smithy.api#paginated": {
           "inputToken": "pageToken",
           "outputToken": "nextPageToken"
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesRequest": {
+    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFoldersRequest": {
       "type": "structure",
       "members": {
-        "name": {
+        "resource": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to get. Format `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Required. The Resource to resolve (e.g. \"projects/123\", \"folders/456\").",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetAccessPolicies": {
+    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFolders": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesRequest"
+        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFoldersRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
+        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse"
       },
       "errors": [
         {
@@ -2342,20 +2405,41 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/{+name}"
+          "uri": "v1/{+resource}:lookupConfiguredServicePerimeter"
         },
-        "smithy.api#documentation": "Returns an access policy based on the name."
+        "smithy.api#documentation": "Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']."
       }
     },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesRequest": {
+    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest": {
       "type": "structure",
       "members": {
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Only the fields specified in this mask are updated. Because name and group_key cannot be changed, update_mask is required and may only contain the following fields: `access_levels`, `dry_run_access_levels`, `session_settings`, `scoped_access_settings`. update_mask { paths: \"access_levels\" }",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to delete. Format `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
+          }
+        },
+        "append": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when \"scoped_access_settings\" is not set in the update_mask.",
+            "smithy.api#httpQuery": "append"
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
           }
         }
       }
@@ -2384,1698 +2468,6 @@
             "status": 409
           }
         ]
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes an access policy based on the resource name. The long-running operation has a successful status after the access policy is removed from long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessPolicy",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/accessPolicies"
-        },
-        "smithy.api#documentation": "Creates an access policy. This method fails if the organization already has an access policy. The long-running operation has a successful status after the access policy propagates to long-lasting storage. Syntactic and basic semantic errors are returned in `metadata` as a BadRequest proto."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}`",
-            "smithy.api#httpQuery": "parent"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Number of AccessPolicy instances to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/accessPolicies"
-        },
-        "smithy.api#documentation": "Lists all access policies in an organization.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:testIamPermissions"
-        },
-        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Policy"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:setIamPolicy"
-        },
-        "smithy.api#documentation": "Sets the IAM policy for the specified Access Context Manager access policy. This method replaces the existing IAM policy on the access policy. The IAM policy controls the set of users who can perform specific operations on the Access Context Manager access policy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessPolicy",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Updates an access policy. The long-running operation from this RPC has a successful status after the changes to the access policy propagate to long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Policy"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:getIamPolicy"
-        },
-        "smithy.api#documentation": "Gets the IAM policy for the specified Access Context Manager access policy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes an access level based on the resource name. The long-running operation from this RPC has a successful status after the access level has been removed from long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:testIamPermissions"
-        },
-        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
-      "type": "enum",
-      "members": {
-        "LEVEL_FORMAT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
-          }
-        },
-        "AS_DEFINED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AS_DEFINED"
-          }
-        },
-        "CEL": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "CEL"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "accessLevelFormat": {
-          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum",
-          "traits": {
-            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined.",
-            "smithy.api#httpQuery": "accessLevelFormat"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Access Level instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Number of Access Levels to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+parent}/accessLevels"
-        },
-        "smithy.api#documentation": "Lists all access levels for an access policy.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Access Levels. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/accessLevels:replaceAll"
-        },
-        "smithy.api#documentation": "Replaces all existing access levels in an access policy with the access levels provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. If the replacement contains errors, an error response is returned for the first error encountered. Upon error, the replacement is cancelled, and existing access levels are not affected. The Operation.response field contains ReplaceAccessLevelsResponse. Removing access levels contained in existing service perimeters result in an error."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Updates an access level. The long-running operation from this RPC has a successful status after the changes to the access level propagate to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
-      "type": "enum",
-      "members": {
-        "LEVEL_FORMAT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
-          }
-        },
-        "AS_DEFINED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AS_DEFINED"
-          }
-        },
-        "CEL": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "CEL"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "accessLevelFormat": {
-          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum",
-          "traits": {
-            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`.",
-            "smithy.api#httpQuery": "accessLevelFormat"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets an access level based on the resource name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Access Level. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/accessLevels"
-        },
-        "smithy.api#documentation": "Creates an access level. The long-running operation from this RPC has a successful status after the access level propagates to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Service Perimeters. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/servicePerimeters:replaceAll"
-        },
-        "smithy.api#documentation": "Replace all existing service perimeters in an access policy with the service perimeters provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. Replacements containing errors result in an error response for the first error encountered. Upon an error, replacements are cancelled and existing service perimeters are not affected. The Operation.response field contains ReplaceServicePerimetersResponse."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the parent Access Policy which owns all Service Perimeters in scope for the commit operation. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/servicePerimeters:commit"
-        },
-        "smithy.api#documentation": "Commits the dry-run specification for all the service perimeters in an access policy. A commit operation on a service perimeter involves copying its `spec` field to the `status` field of the service perimeter. Only service perimeters with `use_explicit_dry_run_spec` field set to true are affected by a commit operation. The long-running operation from this RPC has a successful status after the dry-run specifications for all the service perimeters have been committed. If a commit fails, it causes the long-running operation to return an error response and the entire commit operation is cancelled. When successful, the Operation.response field contains CommitServicePerimetersResponse. The `dry_run` and the `spec` fields are cleared after a successful commit operation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeter_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes a service perimeter based on the resource name. The long-running operation from this RPC has a successful status after the service perimeter is removed from long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Service Perimeter. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/servicePerimeters"
-        },
-        "smithy.api#documentation": "Creates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
-      "type": "enum",
-      "members": {
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "deletedPrincipalSyntax": {
-          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
-            "smithy.api#httpQuery": "deletedPrincipalSyntax"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets a service perimeter based on the resource name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:testIamPermissions"
-        },
-        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
-      "type": "enum",
-      "members": {
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "deletedPrincipalSyntax": {
-          "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax.",
-            "smithy.api#httpQuery": "deletedPrincipalSyntax"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Updates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
-      "type": "enum",
-      "members": {
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "deletedPrincipalSyntax": {
-          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
-            "smithy.api#httpQuery": "deletedPrincipalSyntax"
-          }
-        },
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Number of Service Perimeters to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+parent}/servicePerimeters"
-        },
-        "smithy.api#documentation": "Lists all service perimeters for an access policy.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDescs/{authorized_orgs_descs_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets an authorized orgs desc based on the resource name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Updates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. Only the organization list in `AuthorizedOrgsDesc` can be updated. The name, authorization_type, asset_type and authorization_direction cannot be updated."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDesc/{authorized_orgs_desc_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes an authorized orgs desc based on the resource name. The long-running operation from this RPC has a successful status after the authorized orgs desc is removed from long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Number of Authorized Orgs Descs to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAuthorizedOrgsDescsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+parent}/authorizedOrgsDescs"
-        },
-        "smithy.api#documentation": "Lists all authorized orgs descs for an access policy.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Authorized Orgs Desc. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/authorizedOrgsDescs"
-        },
-        "smithy.api#documentation": "Creates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. The name of this `AuthorizedOrgsDesc` will be assigned during creation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the operation resource to be deleted.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteOperations": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Empty"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CancelOperationsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the operation resource to be cancelled.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#CancelOperationRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CancelOperations": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CancelOperationsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Empty"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+name}:cancel"
-        },
-        "smithy.api#documentation": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListOperationsRequest": {
-      "type": "structure",
-      "members": {
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The standard list page token.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "filter": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The standard list filter.",
-            "smithy.api#httpQuery": "filter"
-          }
-        },
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "The standard list page size.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "returnPartialSuccess": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "When set to `true`, operations that are reachable are returned as normal, and those that are unreachable are returned in the ListOperationsResponse.unreachable field. This can only be `true` when reading across collections. For example, when `parent` is set to `\"projects/example/locations/-\"`. This field is not supported by default and will result in an `UNIMPLEMENTED` error if set unless explicitly documented otherwise in service or product specific documentation.",
-            "smithy.api#httpQuery": "returnPartialSuccess"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the operation's parent resource.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListOperations": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListOperationsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListOperationsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetOperationsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the operation resource.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetOperations": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetOperationsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest": {
-      "type": "structure",
-      "members": {
-        "append": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when \"scoped_access_settings\" is not set in the update_mask.",
-            "smithy.api#httpQuery": "append"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Only the fields specified in this mask are updated. Because name and group_key cannot be changed, update_mask is required and may only contain the following fields: `access_levels`, `dry_run_access_levels`, `session_settings`, `scoped_access_settings`. update_mask { paths: \"access_levels\" }",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
       }
     },
     "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindings": {
@@ -4168,19 +2560,19 @@
             "smithy.api#httpQuery": "pageSize"
           }
         },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
         "parent": {
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "Required. Example: \"organizations/256\"",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation.",
+            "smithy.api#httpQuery": "pageToken"
           }
         },
         "filter": {
@@ -4300,26 +2692,26 @@
         "smithy.api#documentation": "Gets the GcpUserAccessBinding with the given name."
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetServicesRequest": {
+    "com.gcp.accesscontextmanager_v1#GetOperationsRequest": {
       "type": "structure",
       "members": {
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The name of the service to get information about. The names must be in the same format as used in defining a service perimeter, for example, `storage.googleapis.com`.",
+            "smithy.api#documentation": "The name of the operation resource.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetServices": {
+    "com.gcp.accesscontextmanager_v1#GetOperations": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetServicesRequest"
+        "target": "com.gcp.accesscontextmanager_v1#GetOperationsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
       },
       "errors": [
         {
@@ -4332,37 +2724,109 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/services/{name}"
+          "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Returns a VPC-SC supported service based on the service name. **IAM Permissions**: Requires the following IAM permissions to use this method: - `serviceusage.services.use` on the project."
+        "smithy.api#documentation": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListServicesRequest": {
+    "com.gcp.accesscontextmanager_v1#CancelOperationsRequest": {
       "type": "structure",
       "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the operation resource to be cancelled.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#CancelOperationRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CancelOperations": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CancelOperationsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Empty"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+name}:cancel"
+        },
+        "smithy.api#documentation": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListOperationsRequest": {
+      "type": "structure",
+      "members": {
+        "returnPartialSuccess": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "When set to `true`, operations that are reachable are returned as normal, and those that are unreachable are returned in the ListOperationsResponse.unreachable field. This can only be `true` when reading across collections. For example, when `parent` is set to `\"projects/example/locations/-\"`. This field is not supported by default and will result in an `UNIMPLEMENTED` error if set unless explicitly documented otherwise in service or product specific documentation.",
+            "smithy.api#httpQuery": "returnPartialSuccess"
+          }
+        },
+        "filter": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The standard list filter.",
+            "smithy.api#httpQuery": "filter"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the operation's parent resource.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
         "pageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Use this token to retrieve a specific page of results. Default is the first page.",
+            "smithy.api#documentation": "The standard list page token.",
             "smithy.api#httpQuery": "pageToken"
           }
         },
         "pageSize": {
           "target": "smithy.api#Integer",
           "traits": {
-            "smithy.api#documentation": "This flag specifies the maximum number of services to return per page. Default value is 100.",
+            "smithy.api#documentation": "The standard list page size.",
             "smithy.api#httpQuery": "pageSize"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListServices": {
+    "com.gcp.accesscontextmanager_v1#ListOperations": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListServicesRequest"
+        "target": "com.gcp.accesscontextmanager_v1#ListOperationsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse"
+        "target": "com.gcp.accesscontextmanager_v1#ListOperationsResponse"
       },
       "errors": [
         {
@@ -4375,13 +2839,1655 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/services"
+          "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Lists all VPC-SC supported services. **IAM Permissions**: Requires the following IAM permissions to use this method: - `serviceusage.services.use` on the project.",
+        "smithy.api#documentation": "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`.",
         "smithy.api#paginated": {
           "inputToken": "pageToken",
           "outputToken": "nextPageToken"
         }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the operation resource to be deleted.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteOperations": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Empty"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjectsRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. The Resource to resolve (e.g. \"projects/123\", \"folders/456\").",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjects": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjectsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+resource}:lookupConfiguredServicePerimeter"
+        },
+        "smithy.api#documentation": "Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListPermissionsRequest": {
+      "type": "structure",
+      "members": {
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Optional. This flag specifies the maximum number of services to return per page. Default value is 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Use this token to retrieve a specific page of results. Default is the first page.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListPermissions": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListPermissionsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/permissions"
+        },
+        "smithy.api#documentation": "Lists all supported permissions in VPC Service Controls ingress and egress rules for Granular Controls.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to get. Format `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Returns an access policy based on the name."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:testIamPermissions"
+        },
+        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Policy"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:getIamPolicy"
+        },
+        "smithy.api#documentation": "Gets the IAM policy for the specified Access Context Manager access policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}`",
+            "smithy.api#httpQuery": "parent"
+          }
+        },
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of AccessPolicy instances to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/accessPolicies"
+        },
+        "smithy.api#documentation": "Lists all access policies in an organization.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessPolicy",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/accessPolicies"
+        },
+        "smithy.api#documentation": "Creates an access policy. This method fails if the organization already has an access policy. The long-running operation has a successful status after the access policy propagates to long-lasting storage. Syntactic and basic semantic errors are returned in `metadata` as a BadRequest proto."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to delete. Format `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes an access policy based on the resource name. The long-running operation has a successful status after the access policy is removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessPolicy",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates an access policy. The long-running operation from this RPC has a successful status after the changes to the access policy propagate to long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being specified. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Policy"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:setIamPolicy"
+        },
+        "smithy.api#documentation": "Sets the IAM policy for the specified Access Context Manager access policy. This method replaces the existing IAM policy on the access policy. The IAM policy controls the set of users who can perform specific operations on the Access Context Manager access policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
+      "type": "enum",
+      "members": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "deletedPrincipalSyntax": {
+          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
+          "traits": {
+            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
+            "smithy.api#httpQuery": "deletedPrincipalSyntax"
+          }
+        },
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of Service Perimeters to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+parent}/servicePerimeters"
+        },
+        "smithy.api#documentation": "Lists all service perimeters for an access policy.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Service Perimeters. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/servicePerimeters:replaceAll"
+        },
+        "smithy.api#documentation": "Replace all existing service perimeters in an access policy with the service perimeters provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. Replacements containing errors result in an error response for the first error encountered. Upon an error, replacements are cancelled and existing service perimeters are not affected. The Operation.response field contains ReplaceServicePerimetersResponse."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:testIamPermissions"
+        },
+        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Service Perimeter. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/servicePerimeters"
+        },
+        "smithy.api#documentation": "Creates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the parent Access Policy which owns all Service Perimeters in scope for the commit operation. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/servicePerimeters:commit"
+        },
+        "smithy.api#documentation": "Commits the dry-run specification for all the service perimeters in an access policy. A commit operation on a service perimeter involves copying its `spec` field to the `status` field of the service perimeter. Only service perimeters with `use_explicit_dry_run_spec` field set to true are affected by a commit operation. The long-running operation from this RPC has a successful status after the dry-run specifications for all the service perimeters have been committed. If a commit fails, it causes the long-running operation to return an error response and the entire commit operation is cancelled. When successful, the Operation.response field contains CommitServicePerimetersResponse. The `dry_run` and the `spec` fields are cleared after a successful commit operation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
+      "type": "enum",
+      "members": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "deletedPrincipalSyntax": {
+          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
+          "traits": {
+            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
+            "smithy.api#httpQuery": "deletedPrincipalSyntax"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Gets a service perimeter based on the resource name."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeter_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes a service perimeter based on the resource name. The long-running operation from this RPC has a successful status after the service perimeter is removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
+      "type": "enum",
+      "members": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
+          }
+        },
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "deletedPrincipalSyntax": {
+          "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
+          "traits": {
+            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax.",
+            "smithy.api#httpQuery": "deletedPrincipalSyntax"
+          }
+        },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Access Levels. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/accessLevels:replaceAll"
+        },
+        "smithy.api#documentation": "Replaces all existing access levels in an access policy with the access levels provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. If the replacement contains errors, an error response is returned for the first error encountered. Upon error, the replacement is cancelled, and existing access levels are not affected. The Operation.response field contains ReplaceAccessLevelsResponse. Removing access levels contained in existing service perimeters result in an error."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:testIamPermissions"
+        },
+        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+      "type": "enum",
+      "members": {
+        "LEVEL_FORMAT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+          }
+        },
+        "AS_DEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AS_DEFINED"
+          }
+        },
+        "CEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CEL"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of Access Levels to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "accessLevelFormat": {
+          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined.",
+            "smithy.api#httpQuery": "accessLevelFormat"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of Access Level instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+parent}/accessLevels"
+        },
+        "smithy.api#documentation": "Lists all access levels for an access policy.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes an access level based on the resource name. The long-running operation from this RPC has a successful status after the access level has been removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates an access level. The long-running operation from this RPC has a successful status after the changes to the access level propagate to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+      "type": "enum",
+      "members": {
+        "LEVEL_FORMAT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+          }
+        },
+        "AS_DEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AS_DEFINED"
+          }
+        },
+        "CEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CEL"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "accessLevelFormat": {
+          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`.",
+            "smithy.api#httpQuery": "accessLevelFormat"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Gets an access level based on the resource name."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Access Level. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/accessLevels"
+        },
+        "smithy.api#documentation": "Creates an access level. The long-running operation from this RPC has a successful status after the access level propagates to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Authorized Orgs Desc. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/authorizedOrgsDescs"
+        },
+        "smithy.api#documentation": "Creates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. The name of this `AuthorizedOrgsDesc` will be assigned during creation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of Authorized Orgs Descs to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAuthorizedOrgsDescsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+parent}/authorizedOrgsDescs"
+        },
+        "smithy.api#documentation": "Lists all authorized orgs descs for an access policy.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDesc/{authorized_orgs_desc_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes an authorized orgs desc based on the resource name. The long-running operation from this RPC has a successful status after the authorized orgs desc is removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDescs/{authorized_orgs_descs_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Gets an authorized orgs desc based on the resource name."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. Only the organization list in `AuthorizedOrgsDesc` can be updated. The name, authorization_type, asset_type and authorization_direction cannot be updated."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ApplicationList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Application"
       }
     }
   }

--- a/packages/gcp/.generated-specs/stable/accesscontextmanager_v1.json
+++ b/packages/gcp/.generated-specs/stable/accesscontextmanager_v1.json
@@ -8,246 +8,18 @@
     "distilled.finalized": true
   },
   "shapes": {
-    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse": {
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse": {
       "type": "structure",
       "members": {
-        "servicePerimeterDryRun": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Fully qualified name of the configured dry-run perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no dry-run perimeter configuration applies."
-          }
-        },
-        "servicePerimeter": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Fully qualified name of the configured enforced perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no enforced perimeter applies."
-          }
-        },
-        "restrictedResource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The resource (e.g. \"projects/123\", \"folders/456\") that directly owns/is restricted by the enforced perimeter."
-          }
-        },
-        "restrictedResourceDryRun": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The resource (e.g. \"projects/123\", \"folders/456\") that directly owns/is restricted by the dry-run perimeter."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A configured service perimeter returned by Access Context Manager."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse": {
-      "type": "structure",
-      "members": {
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Token to get the next page of items. If blank, there are no more items."
-          }
-        },
-        "gcpUserAccessBindings": {
-          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList",
-          "traits": {
-            "smithy.api#documentation": "GcpUserAccessBinding"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Response of ListGcpUserAccessBindings."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse": {
-      "type": "structure",
-      "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "List of the Access Level instances."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListAccessLevelsRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessLevelList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CustomLevel": {
-      "type": "structure",
-      "members": {
-        "expr": {
-          "target": "com.gcp.accesscontextmanager_v1#Expr",
-          "traits": {
-            "smithy.api#documentation": "Required. A Cloud CEL expression evaluating to a boolean."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy."
-          }
-        },
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeterList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse": {
-      "type": "structure",
-      "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "List of the Service Perimeter instances."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListServicePerimetersRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Principal": {
-      "type": "structure",
-      "members": {
-        "serviceAccountProjectNumber": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Cloud project number used to assign policies to all service accounts owned by the project."
-          }
-        },
-        "federatedPrincipal": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed."
-          }
-        },
-        "serviceAccount": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AddRequestHeader": {
-      "type": "structure",
-      "members": {
-        "key": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "HTTP header key."
-          }
-        },
-        "value": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "HTTP header value."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Adds a request header to the API."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePattern": {
-      "type": "structure",
-      "members": {
-        "pattern": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "URL pattern to allow. Only patterns of \".googleapis.com/*\", \"www.googleapis.com//*\" and \"*.appspot.com/* forms are supported, where should be an alphanumeric name."
-          }
-        },
-        "modifiers": {
-          "target": "com.gcp.accesscontextmanager_v1#ModifierList",
-          "traits": {
-            "smithy.api#documentation": "Modifiers to apply to the requests that match the URL pattern."
-          }
-        },
-        "service": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Supported service to allow."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Service patterns used to allow access."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ModifierList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Modifier"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditLogConfig": {
-      "type": "structure",
-      "members": {
-        "exemptedMembers": {
+        "permissions": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members."
-          }
-        },
-        "logType": {
-          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigLogTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "The log type that this config enables."
+            "smithy.api#documentation": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Provides the configuration for logging a type of permissions. Example: { \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" } ] } This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting jose@example.com from DATA_READ logging."
+        "smithy.api#documentation": "Response message for `TestIamPermissions` method."
       }
     },
     "com.gcp.accesscontextmanager_v1#StringList": {
@@ -256,834 +28,100 @@
         "target": "smithy.api#String"
       }
     },
-    "com.gcp.accesscontextmanager_v1#AuditLogConfigLogTypeEnum": {
-      "type": "enum",
-      "members": {
-        "LOG_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "LOG_TYPE_UNSPECIFIED"
-          }
-        },
-        "ADMIN_READ": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ADMIN_READ"
-          }
-        },
-        "DATA_WRITE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DATA_WRITE"
-          }
-        },
-        "DATA_READ": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DATA_READ"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig": {
+    "com.gcp.accesscontextmanager_v1#AccessSettings": {
       "type": "structure",
       "members": {
-        "vpcAccessibleServices": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServices",
+        "sessionSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
           "traits": {
-            "smithy.api#documentation": "Configuration for APIs allowed within Perimeter."
-          }
-        },
-        "ingressPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge."
-          }
-        },
-        "egressPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge."
+            "smithy.api#documentation": "Optional. Session settings applied to user access on a given AccessScope."
           }
         },
         "accessLevels": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `\"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL\"`. For Service Perimeter Bridge, must be empty."
+            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
           }
-        },
-        "resources": {
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Condition": {
+      "type": "structure",
+      "members": {
+        "requiredAccessLevels": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`."
+            "smithy.api#documentation": "A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: \"`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME\"`"
           }
         },
-        "restrictedServices": {
+        "ipSubnetworks": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressPolicyList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#IngressPolicy"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressPolicyList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#EgressPolicy"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessLevel": {
-      "type": "structure",
-      "members": {
-        "description": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Description of the `AccessLevel` and its use. Does not affect behavior."
+            "smithy.api#documentation": "CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. Similarly, for IPv6, \"2001:db8::/32\" is accepted whereas \"2001:db8::1/32\" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed."
           }
         },
-        "name": {
-          "target": "smithy.api#String",
+        "devicePolicy": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicy",
           "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`."
+            "smithy.api#documentation": "Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed."
           }
         },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
-          }
-        },
-        "basic": {
-          "target": "com.gcp.accesscontextmanager_v1#BasicLevel",
-          "traits": {
-            "smithy.api#documentation": "A `BasicLevel` composed of `Conditions`."
-          }
-        },
-        "custom": {
-          "target": "com.gcp.accesscontextmanager_v1#CustomLevel",
-          "traits": {
-            "smithy.api#documentation": "A `CustomLevel` written in the Common Expression Language."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An `AccessLevel` is a label that can be applied to requests to Google Cloud services, along with a list of requirements necessary for the label to be applied."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Modifier": {
-      "type": "structure",
-      "members": {
-        "addRequestHeader": {
-          "target": "com.gcp.accesscontextmanager_v1#AddRequestHeader",
-          "traits": {
-            "smithy.api#documentation": "Adds an additional HTTP request header."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Modifier to apply to the API requests."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Operation": {
-      "type": "structure",
-      "members": {
-        "done": {
+        "negate": {
           "target": "smithy.api#Boolean",
           "traits": {
-            "smithy.api#documentation": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+            "smithy.api#documentation": "Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false."
           }
         },
-        "response": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
-          "traits": {
-            "smithy.api#documentation": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`."
-          }
-        },
-        "metadata": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
-          "traits": {
-            "smithy.api#documentation": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
-          }
-        },
-        "error": {
-          "target": "com.gcp.accesscontextmanager_v1#Status",
-          "traits": {
-            "smithy.api#documentation": "The error result of the operation in case of failure or cancellation."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "This resource represents a long-running operation that is the result of a network API call."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DocumentMap": {
-      "type": "map",
-      "key": {
-        "target": "smithy.api#String"
-      },
-      "value": {
-        "target": "smithy.api#Document"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcNetworkSource": {
-      "type": "structure",
-      "members": {
-        "vpcSubnetwork": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcSubNetwork",
-          "traits": {
-            "smithy.api#documentation": "Sub-segment ranges of a VPC network."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The originating network source in Google Cloud."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#BasicLevel": {
-      "type": "structure",
-      "members": {
-        "conditions": {
-          "target": "com.gcp.accesscontextmanager_v1#ConditionList",
-          "traits": {
-            "smithy.api#documentation": "Required. A list of requirements for the `AccessLevel` to be granted."
-          }
-        },
-        "combiningFunction": {
-          "target": "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum",
-          "traits": {
-            "smithy.api#documentation": "How the `conditions` list should be combined to determine if a request is granted this `AccessLevel`. If AND is used, each `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. If OR is used, at least one `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. Default behavior is AND."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`BasicLevel` is an `AccessLevel` using a set of recommended features."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ConditionList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Condition"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum": {
-      "type": "enum",
-      "members": {
-        "AND": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AND"
-          }
-        },
-        "OR": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "OR"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest": {
-      "type": "structure",
-      "members": {
-        "permissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Request message for `TestIamPermissions` method."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessScope": {
-      "type": "structure",
-      "members": {
-        "clientScope": {
-          "target": "com.gcp.accesscontextmanager_v1#ClientScope",
-          "traits": {
-            "smithy.api#documentation": "Optional. Client scope for this access scope."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Access scope represents the client scope, etc. to which the settings will be applied to."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetPolicyOptions": {
-      "type": "structure",
-      "members": {
-        "requestedPolicyVersion": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Encapsulates settings provided to GetIamPolicy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse": {
-      "type": "structure",
-      "members": {
-        "supportedPermissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "List of VPC Service Controls supported permissions."
-          }
-        },
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to `ListSupportedPermissionsRequest`."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this commit operation is to be performed on. If, at the time of commit, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the commit operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to commit dry-run specs in all Service Perimeters belonging to an Access Policy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc": {
-      "type": "structure",
-      "members": {
-        "assetType": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`."
-          }
-        },
-        "authorizationDirection": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum",
-          "traits": {
-            "smithy.api#documentation": "The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource."
-          }
-        },
-        "authorizationType": {
-          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`."
-          }
-        },
-        "orgs": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456`"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`AuthorizedOrgsDesc` contains data for an organization's authorization policy."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum": {
-      "type": "enum",
-      "members": {
-        "ASSET_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_UNSPECIFIED"
-          }
-        },
-        "ASSET_TYPE_DEVICE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_DEVICE"
-          }
-        },
-        "ASSET_TYPE_CREDENTIAL_STRENGTH": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ASSET_TYPE_CREDENTIAL_STRENGTH"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum": {
-      "type": "enum",
-      "members": {
-        "AUTHORIZATION_DIRECTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_UNSPECIFIED"
-          }
-        },
-        "AUTHORIZATION_DIRECTION_TO": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_TO"
-          }
-        },
-        "AUTHORIZATION_DIRECTION_FROM": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_FROM"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum": {
-      "type": "enum",
-      "members": {
-        "AUTHORIZATION_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_TYPE_UNSPECIFIED"
-          }
-        },
-        "AUTHORIZATION_TYPE_TRUST": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "AUTHORIZATION_TYPE_TRUST"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressFrom": {
-      "type": "structure",
-      "members": {
-        "identities": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
-          }
-        },
-        "sourceRestriction": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum",
-          "traits": {
-            "smithy.api#documentation": "Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`."
-          }
-        },
-        "sources": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressSourceList",
-          "traits": {
-            "smithy.api#documentation": "Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`."
-          }
-        },
-        "identityType": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum": {
-      "type": "enum",
-      "members": {
-        "SOURCE_RESTRICTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_UNSPECIFIED"
-          }
-        },
-        "SOURCE_RESTRICTION_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_ENABLED"
-          }
-        },
-        "SOURCE_RESTRICTION_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SOURCE_RESTRICTION_DISABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressSourceList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#EgressSource"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum": {
-      "type": "enum",
-      "members": {
-        "IDENTITY_TYPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "IDENTITY_TYPE_UNSPECIFIED"
-          }
-        },
-        "ANY_IDENTITY": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ANY_IDENTITY"
-          }
-        },
-        "ANY_USER_ACCOUNT": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ANY_USER_ACCOUNT"
-          }
-        },
-        "ANY_SERVICE_ACCOUNT": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ANY_SERVICE_ACCOUNT"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditConfig": {
-      "type": "structure",
-      "members": {
-        "service": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services."
-          }
-        },
-        "auditLogConfigs": {
-          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigList",
-          "traits": {
-            "smithy.api#documentation": "The configuration for logging of each type of permission."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { \"audit_configs\": [ { \"service\": \"allServices\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" }, { \"log_type\": \"ADMIN_READ\" } ] }, { \"service\": \"sampleservice.googleapis.com\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\" }, { \"log_type\": \"DATA_WRITE\", \"exempted_members\": [ \"user:aliya@example.com\" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditLogConfigList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AuditLogConfig"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#OsConstraint": {
-      "type": "structure",
-      "members": {
-        "osType": {
-          "target": "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Required. The allowed OS type."
-          }
-        },
-        "requireVerifiedChromeOs": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request."
-          }
-        },
-        "minimumVersion": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `\"major.minor.patch\"`. Examples: `\"10.5.301\"`, `\"9.2.1\"`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A restriction on the OS type and version of devices making requests."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum": {
-      "type": "enum",
-      "members": {
-        "OS_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "OS_UNSPECIFIED"
-          }
-        },
-        "DESKTOP_MAC": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DESKTOP_MAC"
-          }
-        },
-        "DESKTOP_WINDOWS": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DESKTOP_WINDOWS"
-          }
-        },
-        "DESKTOP_LINUX": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DESKTOP_LINUX"
-          }
-        },
-        "DESKTOP_CHROME_OS": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DESKTOP_CHROME_OS"
-          }
-        },
-        "ANDROID": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ANDROID"
-          }
-        },
-        "IOS": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "IOS"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SessionSettings": {
-      "type": "structure",
-      "members": {
-        "sessionLength": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset."
-          }
-        },
-        "useOidcMaxAge": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param."
-          }
-        },
-        "maxInactivity": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps."
-          }
-        },
-        "sessionLengthEnabled": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false."
-          }
-        },
-        "sessionReauthMethod": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. Session method when user's Google Cloud session is up."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum": {
-      "type": "enum",
-      "members": {
-        "SESSION_REAUTH_METHOD_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SESSION_REAUTH_METHOD_UNSPECIFIED"
-          }
-        },
-        "LOGIN": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "LOGIN"
-          }
-        },
-        "SECURITY_KEY": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SECURITY_KEY"
-          }
-        },
-        "PASSWORD": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "PASSWORD"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CancelOperationRequest": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "The request message for Operations.CancelOperation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Project": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890`"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A Google Cloud project which contains applications and resources that users can access."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessContextManagerOperationMetadata": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#documentation": "Metadata of Access Context Manager's Long Running Operations."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ScopedAccessSettings": {
-      "type": "structure",
-      "members": {
-        "scope": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessScope",
-          "traits": {
-            "smithy.api#documentation": "Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty."
-          }
-        },
-        "activeSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set."
-          }
-        },
-        "dryRunSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A relationship between access settings and its scope."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Policy": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost."
-          }
-        },
-        "bindings": {
-          "target": "com.gcp.accesscontextmanager_v1#BindingList",
-          "traits": {
-            "smithy.api#documentation": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`."
-          }
-        },
-        "version": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
-          }
-        },
-        "auditConfigs": {
-          "target": "com.gcp.accesscontextmanager_v1#AuditConfigList",
-          "traits": {
-            "smithy.api#documentation": "Specifies cloud audit logging configuration for this policy."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/)."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#BindingList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Binding"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AuditConfigList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AuditConfig"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Binding": {
-      "type": "structure",
-      "members": {
         "members": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`."
+            "smithy.api#documentation": "The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user."
           }
         },
-        "condition": {
-          "target": "com.gcp.accesscontextmanager_v1#Expr",
+        "regions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+            "smithy.api#documentation": "The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes."
           }
         },
-        "role": {
-          "target": "smithy.api#String",
+        "vpcNetworkSources": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList",
           "traits": {
-            "smithy.api#documentation": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles)."
+            "smithy.api#documentation": "The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Associates `members`, or principals, with a `role`."
+        "smithy.api#documentation": "A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction."
       }
     },
-    "com.gcp.accesscontextmanager_v1#Expr": {
+    "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSource"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Application": {
       "type": "structure",
       "members": {
-        "location": {
+        "clientId": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file."
+            "smithy.api#documentation": "The OAuth client ID of the application."
           }
         },
-        "description": {
+        "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
-          }
-        },
-        "expression": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Textual representation of an expression in Common Expression Language syntax."
+            "smithy.api#documentation": "The name of the application. Example: \"Cloud Console\""
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() < 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information."
+        "smithy.api#documentation": "An application that accesses Google Cloud APIs."
       }
     },
     "com.gcp.accesscontextmanager_v1#ListAuthorizedOrgsDescsResponse": {
@@ -1112,74 +150,6 @@
         "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
       }
     },
-    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        },
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsResponse": {
-      "type": "structure",
-      "members": {
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
-          "traits": {
-            "smithy.api#documentation": "List of the Access Level instances."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to ReplaceAccessLevelsRequest. This will be put inside of Operation.response field."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest": {
-      "type": "structure",
-      "members": {
-        "policy": {
-          "target": "com.gcp.accesscontextmanager_v1#Policy",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
-          }
-        },
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: \"bindings, etag\"`"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Request message for `SetIamPolicy` method."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersResponse": {
-      "type": "structure",
-      "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "List of all the Service Perimeter instances in the Access Policy."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to CommitServicePerimetersRequest. This will be put inside of Operation.response field."
-      }
-    },
     "com.gcp.accesscontextmanager_v1#IngressPolicy": {
       "type": "structure",
       "members": {
@@ -1189,16 +159,16 @@
             "smithy.api#documentation": "Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
           }
         },
-        "ingressFrom": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressFrom",
-          "traits": {
-            "smithy.api#documentation": "Defines the conditions on the source of a request causing this IngressPolicy to apply."
-          }
-        },
         "ingressTo": {
           "target": "com.gcp.accesscontextmanager_v1#IngressTo",
           "traits": {
             "smithy.api#documentation": "Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply."
+          }
+        },
+        "ingressFrom": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressFrom",
+          "traits": {
+            "smithy.api#documentation": "Defines the conditions on the source of a request causing this IngressPolicy to apply."
           }
         }
       },
@@ -1206,514 +176,103 @@
         "smithy.api#documentation": "Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field."
       }
     },
-    "com.gcp.accesscontextmanager_v1#MethodSelector": {
+    "com.gcp.accesscontextmanager_v1#ListOperationsResponse": {
       "type": "structure",
       "members": {
-        "method": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed."
-          }
-        },
-        "permission": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An allowed method or permission of a service specified in ApiOperation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Status": {
-      "type": "structure",
-      "members": {
-        "message": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
-          }
-        },
-        "details": {
-          "target": "com.gcp.accesscontextmanager_v1#DocumentMapList",
-          "traits": {
-            "smithy.api#documentation": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
-          }
-        },
-        "code": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "The status code, which should be an enum value of google.rpc.Code."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DocumentMapList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DocumentMap"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServices": {
-      "type": "structure",
-      "members": {
-        "servicePatternsEnforcementScopes": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList",
-          "traits": {
-            "smithy.api#documentation": "Defines the enforcement scopes of service patterns."
-          }
-        },
-        "enableRestriction": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'."
-          }
-        },
-        "allowedServices": {
+        "unreachable": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter."
-          }
-        },
-        "allowedServicePatterns": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePatternList",
-          "traits": {
-            "smithy.api#documentation": "Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies how APIs are allowed to communicate within the Service Perimeter."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum": {
-      "type": "enum",
-      "members": {
-        "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
-          }
-        },
-        "GOOGLE_APIS_VIA_PRIVATE_PATH": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "GOOGLE_APIS_VIA_PRIVATE_PATH"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePatternList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ServicePattern"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressSource": {
-      "type": "structure",
-      "members": {
-        "accessLevel": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed."
-          }
-        },
-        "pscEndpoint": {
-          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
-          "traits": {
-            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
-          }
-        },
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "A Google Cloud resource from the service perimeter that you want to allow to access data outside the perimeter. This field supports only projects. The project format is `projects/{project_number}`. You can't use `*` in this field to allow all Google Cloud resources."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersResponse": {
-      "type": "structure",
-      "members": {
-        "servicePerimeters": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
-          "traits": {
-            "smithy.api#documentation": "List of the Service Perimeter instances."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A response to ReplaceServicePerimetersRequest. This will be put inside of Operation.response field."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ClientScope": {
-      "type": "structure",
-      "members": {
-        "restrictedProject": {
-          "target": "com.gcp.accesscontextmanager_v1#Project",
-          "traits": {
-            "smithy.api#documentation": "Optional. The Google Cloud project that is subject to this binding's scope."
-          }
-        },
-        "restrictedClientApplication": {
-          "target": "com.gcp.accesscontextmanager_v1#Application",
-          "traits": {
-            "smithy.api#documentation": "Optional. The application that is subject to this binding's scope."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Client scope represents the application, etc. subject to this binding's restrictions."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessSettings": {
-      "type": "structure",
-      "members": {
-        "sessionSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. Session settings applied to user access on a given AccessScope."
-          }
-        },
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ApiOperation": {
-      "type": "structure",
-      "members": {
-        "serviceName": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services."
-          }
-        },
-        "methodSelectors": {
-          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
-          "traits": {
-            "smithy.api#documentation": "API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Identification for an API Operation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#MethodSelectorList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#MethodSelector"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicy": {
-      "type": "structure",
-      "members": {
-        "requireScreenlock": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`."
-          }
-        },
-        "allowedEncryptionStatuses": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList",
-          "traits": {
-            "smithy.api#documentation": "Allowed encryptions statuses, an empty list allows all statuses."
-          }
-        },
-        "requireAdminApproval": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether the device needs to be approved by the customer admin."
-          }
-        },
-        "requireCorpOwned": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether the device needs to be corp owned."
-          }
-        },
-        "allowedDeviceManagementLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList",
-          "traits": {
-            "smithy.api#documentation": "Allowed device management levels, an empty list allows all management levels."
-          }
-        },
-        "osConstraints": {
-          "target": "com.gcp.accesscontextmanager_v1#OsConstraintList",
-          "traits": {
-            "smithy.api#documentation": "Allowed OS versions, an empty list allows all types and all versions."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum": {
-      "type": "enum",
-      "members": {
-        "ENCRYPTION_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTION_UNSPECIFIED"
-          }
-        },
-        "ENCRYPTION_UNSUPPORTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTION_UNSUPPORTED"
-          }
-        },
-        "UNENCRYPTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "UNENCRYPTED"
-          }
-        },
-        "ENCRYPTED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "ENCRYPTED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum": {
-      "type": "enum",
-      "members": {
-        "MANAGEMENT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "MANAGEMENT_UNSPECIFIED"
-          }
-        },
-        "NONE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "NONE"
-          }
-        },
-        "BASIC": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "BASIC"
-          }
-        },
-        "COMPLETE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "COMPLETE"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#OsConstraintList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#OsConstraint"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Application": {
-      "type": "structure",
-      "members": {
-        "clientId": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The OAuth client ID of the application."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The name of the application. Example: \"Cloud Console\""
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "An application that accesses Google Cloud APIs."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest": {
-      "type": "structure",
-      "members": {
-        "options": {
-          "target": "com.gcp.accesscontextmanager_v1#GetPolicyOptions",
-          "traits": {
-            "smithy.api#documentation": "OPTIONAL: A `GetPolicyOptions` object for specifying options to `GetIamPolicy`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Request message for `GetIamPolicy` method."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Condition": {
-      "type": "structure",
-      "members": {
-        "vpcNetworkSources": {
-          "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList",
-          "traits": {
-            "smithy.api#documentation": "The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`."
-          }
-        },
-        "ipSubnetworks": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. Similarly, for IPv6, \"2001:db8::/32\" is accepted whereas \"2001:db8::1/32\" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed."
-          }
-        },
-        "requiredAccessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: \"`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME\"`"
-          }
-        },
-        "members": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user."
-          }
-        },
-        "devicePolicy": {
-          "target": "com.gcp.accesscontextmanager_v1#DevicePolicy",
-          "traits": {
-            "smithy.api#documentation": "Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed."
-          }
-        },
-        "regions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes."
-          }
-        },
-        "negate": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#VpcNetworkSourceList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#VpcNetworkSource"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse": {
-      "type": "structure",
-      "members": {
-        "accessPolicies": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessPolicyList",
-          "traits": {
-            "smithy.api#documentation": "List of the AccessPolicy instances."
+            "smithy.api#documentation": "Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations."
           }
         },
         "nextPageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+            "smithy.api#documentation": "The standard List next-page token."
+          }
+        },
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#OperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of operations that matches the specified filter in the request."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A response to `ListAccessPoliciesRequest`."
+        "smithy.api#documentation": "The response message for Operations.ListOperations."
       }
     },
-    "com.gcp.accesscontextmanager_v1#AccessPolicyList": {
+    "com.gcp.accesscontextmanager_v1#OperationList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
       }
     },
-    "com.gcp.accesscontextmanager_v1#VpcSubNetwork": {
+    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersRequest": {
       "type": "structure",
       "members": {
-        "vpcIpSubnetworks": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "CIDR block IP subnetwork specification. The IP address must be an IPv4 address and can be a public or private IP address. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. If empty, all IP addresses are allowed."
-          }
-        },
-        "network": {
+        "etag": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Network name. If the network is not part of the organization, the `compute.network.get` permission must be granted to the caller. Format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NETWORK_NAME}` Example: `//compute.googleapis.com/projects/my-project/global/networks/network-1`"
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        },
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Sub-segment ranges inside of a VPC Network."
+        "smithy.api#documentation": "A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically."
       }
     },
-    "com.gcp.accesscontextmanager_v1#IngressSource": {
+    "com.gcp.accesscontextmanager_v1#ServicePerimeterList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Expr": {
       "type": "structure",
       "members": {
-        "resource": {
+        "expression": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported."
+            "smithy.api#documentation": "Textual representation of an expression in Common Expression Language syntax."
           }
         },
-        "accessLevel": {
+        "title": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed."
+            "smithy.api#documentation": "Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression."
           }
         },
-        "pscEndpoint": {
-          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
+        "location": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
+            "smithy.api#documentation": "Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file."
+          }
+        },
+        "description": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "The source that IngressPolicy authorizes access from."
+        "smithy.api#documentation": "Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: \"Summary size limit\" description: \"Determines if a summary is less than 100 chars\" expression: \"document.summary.size() < 100\" Example (Equality): title: \"Requestor is owner\" description: \"Determines if requestor is the document owner\" expression: \"document.owner == request.auth.claims.email\" Example (Logic): title: \"Public documents\" description: \"Determine whether the document should be publicly visible\" expression: \"document.type != 'private' && document.type != 'internal'\" Example (Data Manipulation): title: \"Notification string\" description: \"Create a notification string with a timestamp.\" expression: \"'New message received at ' + string(document.create_time)\" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information."
       }
     },
     "com.gcp.accesscontextmanager_v1#SupportedService": {
       "type": "structure",
       "members": {
-        "name": {
-          "target": "smithy.api#String",
+        "supportStage": {
+          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceSupportStageEnum",
           "traits": {
-            "smithy.api#documentation": "The service name or address of the supported service, such as `service.googleapis.com`."
+            "smithy.api#documentation": "The support stage of the service."
           }
         },
         "knownLimitations": {
@@ -1722,16 +281,10 @@
             "smithy.api#documentation": "True if the service is supported with some limitations. Check [documentation](https://cloud.google.com/vpc-service-controls/docs/supported-products) for details."
           }
         },
-        "supportedMethods": {
-          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
+        "availableOnRestrictedVip": {
+          "target": "smithy.api#Boolean",
           "traits": {
-            "smithy.api#documentation": "The list of the supported methods. This field exists only in response to GetSupportedService"
-          }
-        },
-        "supportStage": {
-          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceSupportStageEnum",
-          "traits": {
-            "smithy.api#documentation": "The support stage of the service."
+            "smithy.api#documentation": "True if the service is available on the restricted VIP. Services on the restricted VIP typically either support VPC Service Controls or are core infrastructure services required for the functioning of Google Cloud."
           }
         },
         "title": {
@@ -1746,10 +299,16 @@
             "smithy.api#documentation": "The support stage of the service."
           }
         },
-        "availableOnRestrictedVip": {
-          "target": "smithy.api#Boolean",
+        "supportedMethods": {
+          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
           "traits": {
-            "smithy.api#documentation": "True if the service is available on the restricted VIP. Services on the restricted VIP typically either support VPC Service Controls or are core infrastructure services required for the functioning of Google Cloud."
+            "smithy.api#documentation": "The list of the supported methods. This field exists only in response to GetSupportedService"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The service name or address of the supported service, such as `service.googleapis.com`."
           }
         }
       },
@@ -1839,297 +398,455 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListOperationsResponse": {
+    "com.gcp.accesscontextmanager_v1#MethodSelectorList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#MethodSelector"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest": {
       "type": "structure",
       "members": {
-        "nextPageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The standard List next-page token."
-          }
-        },
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#OperationList",
-          "traits": {
-            "smithy.api#documentation": "A list of operations that matches the specified filter in the request."
-          }
-        },
-        "unreachable": {
+        "permissions": {
           "target": "com.gcp.accesscontextmanager_v1#StringList",
           "traits": {
-            "smithy.api#documentation": "Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations."
+            "smithy.api#documentation": "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "The response message for Operations.ListOperations."
+        "smithy.api#documentation": "Request message for `TestIamPermissions` method."
       }
     },
-    "com.gcp.accesscontextmanager_v1#OperationList": {
+    "com.gcp.accesscontextmanager_v1#VpcSubNetwork": {
+      "type": "structure",
+      "members": {
+        "network": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Network name. If the network is not part of the organization, the `compute.network.get` permission must be granted to the caller. Format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NETWORK_NAME}` Example: `//compute.googleapis.com/projects/my-project/global/networks/network-1`"
+          }
+        },
+        "vpcIpSubnetworks": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "CIDR block IP subnetwork specification. The IP address must be an IPv4 address and can be a public or private IP address. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, \"192.0.2.0/24\" is accepted but \"192.0.2.1/24\" is not. If empty, all IP addresses are allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Sub-segment ranges inside of a VPC Network."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ClientScope": {
+      "type": "structure",
+      "members": {
+        "restrictedClientApplication": {
+          "target": "com.gcp.accesscontextmanager_v1#Application",
+          "traits": {
+            "smithy.api#documentation": "Optional. The application that is subject to this binding's scope."
+          }
+        },
+        "restrictedProject": {
+          "target": "com.gcp.accesscontextmanager_v1#Project",
+          "traits": {
+            "smithy.api#documentation": "Optional. The Google Cloud project that is subject to this binding's scope."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Client scope represents the application, etc. subject to this binding's restrictions."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SetIamPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: \"bindings, etag\"`"
+          }
+        },
+        "policy": {
+          "target": "com.gcp.accesscontextmanager_v1#Policy",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Request message for `SetIamPolicy` method."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditLogConfig": {
+      "type": "structure",
+      "members": {
+        "logType": {
+          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigLogTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "The log type that this config enables."
+          }
+        },
+        "exemptedMembers": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Provides the configuration for logging a type of permissions. Example: { \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" } ] } This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting jose@example.com from DATA_READ logging."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditLogConfigLogTypeEnum": {
+      "type": "enum",
+      "members": {
+        "LOG_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOG_TYPE_UNSPECIFIED"
+          }
+        },
+        "ADMIN_READ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ADMIN_READ"
+          }
+        },
+        "DATA_WRITE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_WRITE"
+          }
+        },
+        "DATA_READ": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DATA_READ"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CustomLevel": {
+      "type": "structure",
+      "members": {
+        "expr": {
+          "target": "com.gcp.accesscontextmanager_v1#Expr",
+          "traits": {
+            "smithy.api#documentation": "Required. A Cloud CEL expression evaluating to a boolean."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse": {
+      "type": "structure",
+      "members": {
+        "accessPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of the AccessPolicy instances."
+          }
+        },
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListAccessPoliciesRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessPolicyList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
+        "target": "com.gcp.accesscontextmanager_v1#AccessPolicy"
       }
     },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingOperationMetadata": {
+    "com.gcp.accesscontextmanager_v1#VpcNetworkSource": {
+      "type": "structure",
+      "members": {
+        "vpcSubnetwork": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcSubNetwork",
+          "traits": {
+            "smithy.api#documentation": "Sub-segment ranges of a VPC network."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The originating network source in Google Cloud."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Operation": {
+      "type": "structure",
+      "members": {
+        "error": {
+          "target": "com.gcp.accesscontextmanager_v1#Status",
+          "traits": {
+            "smithy.api#documentation": "The error result of the operation in case of failure or cancellation."
+          }
+        },
+        "done": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+          }
+        },
+        "metadata": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
+          "traits": {
+            "smithy.api#documentation": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
+          }
+        },
+        "response": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMap",
+          "traits": {
+            "smithy.api#documentation": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "This resource represents a long-running operation that is the result of a network API call."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DocumentMap": {
+      "type": "map",
+      "key": {
+        "target": "smithy.api#String"
+      },
+      "value": {
+        "target": "smithy.api#Document"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressSource": {
+      "type": "structure",
+      "members": {
+        "pscEndpoint": {
+          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
+          "traits": {
+            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
+          }
+        },
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported."
+          }
+        },
+        "accessLevel": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The source that IngressPolicy authorizes access from."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessScope": {
+      "type": "structure",
+      "members": {
+        "clientScope": {
+          "target": "com.gcp.accesscontextmanager_v1#ClientScope",
+          "traits": {
+            "smithy.api#documentation": "Optional. Client scope for this access scope."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Access scope represents the client scope, etc. to which the settings will be applied to."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessContextManagerOperationMetadata": {
       "type": "structure",
       "members": {},
       "traits": {
-        "smithy.api#documentation": "Metadata of Google Cloud Access Binding Long Running Operations."
+        "smithy.api#documentation": "Metadata of Access Context Manager's Long Running Operations."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeter": {
+    "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse": {
       "type": "structure",
       "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`."
-          }
-        },
-        "description": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Description of the `ServicePerimeter` and its use. Does not affect behavior."
-          }
-        },
-        "spec": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig",
-          "traits": {
-            "smithy.api#documentation": "Proposed (or dry run) ServicePerimeter configuration. This configuration allows to specify and test ServicePerimeter configuration without enforcing actual access restrictions. Only allowed to be set when the \"use_explicit_dry_run_spec\" flag is set."
-          }
-        },
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. An opaque identifier for the current version of the `ServicePerimeter`. This identifier does not follow any specific format. If an etag is not provided, the operation will be performed as if a valid etag is provided."
-          }
-        },
-        "status": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig",
-          "traits": {
-            "smithy.api#documentation": "Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries."
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
-          }
-        },
-        "perimeterType": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty."
-          }
-        },
-        "useExplicitDryRunSpec": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly exists for all Service Perimeters, and that spec is identical to the status for those Service Perimeters. When this flag is set, it inhibits the generation of the implicit spec, thereby allowing the user to explicitly provide a configuration (\"spec\") to use in a dry-run version of the Service Perimeter. This allows the user to test changes to the enforced config (\"status\") without actually enforcing them. This testing is done through analyzing the differences between currently enforced and suggested restrictions. use_explicit_dry_run_spec must bet set to True if any of the fields in the spec are set to non-default values."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`ServicePerimeter` describes a set of Google Cloud resources which can freely import and export data amongst themselves, but not export outside of the `ServicePerimeter`. If a request with a source within this `ServicePerimeter` has a target outside of the `ServicePerimeter`, the request will be blocked. Otherwise the request is allowed. There are two types of Service Perimeter - Regular and Bridge. Regular Service Perimeters cannot overlap, a single Google Cloud project or VPC network can only belong to a single regular Service Perimeter. Service Perimeter Bridges can contain only Google Cloud projects as members, a single Google Cloud project may belong to multiple Service Perimeter Bridges."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum": {
-      "type": "enum",
-      "members": {
-        "PERIMETER_TYPE_REGULAR": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "PERIMETER_TYPE_REGULAR"
-          }
-        },
-        "PERIMETER_TYPE_BRIDGE": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "PERIMETER_TYPE_BRIDGE"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint": {
-      "type": "structure",
-      "members": {
-        "forwardingRule": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Specifies the Private Service Connect endpoint that an API call refers to."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding": {
-      "type": "structure",
-      "members": {
-        "scopedAccessSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList",
-          "traits": {
-            "smithy.api#documentation": "Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications."
-          }
-        },
-        "sessionSettings": {
-          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
-          "traits": {
-            "smithy.api#documentation": "Optional. The Google Cloud session length (GCSL) policy for the group key."
-          }
-        },
-        "accessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
-          }
-        },
-        "dryRunAccessLevels": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\""
-          }
-        },
-        "principal": {
-          "target": "com.gcp.accesscontextmanager_v1#Principal",
-          "traits": {
-            "smithy.api#documentation": "Optional. Immutable. The principal that is subject to the access policies in this policy binding."
-          }
-        },
-        "groupKey": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See \"id\" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: \"01d520gv4vjcrht\""
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettings"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#IngressTo": {
-      "type": "structure",
-      "members": {
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
-          "traits": {
-            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter."
-          }
-        },
-        "roles": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter."
-          }
-        },
-        "resources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed."
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ApiOperationList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#ApiOperation"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#AccessPolicy": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. The parent of this `AccessPolicy` in the Cloud Resource Hierarchy. Currently immutable once created. Format: `organizations/{organization_id}`"
-          }
-        },
-        "title": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Human readable title. Does not affect behavior."
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}`"
-          }
-        },
-        "etag": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Output only. An opaque identifier for the current version of the `AccessPolicy`. This will always be a strongly validated etag, meaning that two Access Policies will be identical if and only if their etags are identical. Clients should not expect this to be in any specific format."
-          }
-        },
-        "scopes": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=[\"folders/123\"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}`"
-          }
-        }
-      },
-      "traits": {
-        "smithy.api#documentation": "`AccessPolicy` is a container for `AccessLevels` (which define the necessary attributes to use Google Cloud services) and `ServicePerimeters` (which define regions of services able to freely pass data within a perimeter). An access policy is globally visible within an organization, and the restrictions it specifies apply to all projects within an organization."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse": {
-      "type": "structure",
-      "members": {
-        "supportedServices": {
-          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceList",
-          "traits": {
-            "smithy.api#documentation": "List of services supported by VPC Service Controls instances."
-          }
-        },
         "nextPageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
+            "smithy.api#documentation": "Token to get the next page of items. If blank, there are no more items."
+          }
+        },
+        "gcpUserAccessBindings": {
+          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList",
+          "traits": {
+            "smithy.api#documentation": "GcpUserAccessBinding"
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "A response to `ListSupportedServicesRequest`."
+        "smithy.api#documentation": "Response of ListGcpUserAccessBindings."
       }
     },
-    "com.gcp.accesscontextmanager_v1#SupportedServiceList": {
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingList": {
       "type": "list",
       "member": {
-        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
+        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServices": {
+      "type": "structure",
+      "members": {
+        "allowedServicePatterns": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePatternList",
+          "traits": {
+            "smithy.api#documentation": "Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter."
+          }
+        },
+        "servicePatternsEnforcementScopes": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Defines the enforcement scopes of service patterns."
+          }
+        },
+        "allowedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter."
+          }
+        },
+        "enableRestriction": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies how APIs are allowed to communicate within the Service Perimeter."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePatternList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ServicePattern"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum": {
+      "type": "enum",
+      "members": {
+        "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
+          }
+        },
+        "GOOGLE_APIS_VIA_PRIVATE_PATH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "GOOGLE_APIS_VIA_PRIVATE_PATH"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditConfig": {
+      "type": "structure",
+      "members": {
+        "service": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services."
+          }
+        },
+        "auditLogConfigs": {
+          "target": "com.gcp.accesscontextmanager_v1#AuditLogConfigList",
+          "traits": {
+            "smithy.api#documentation": "The configuration for logging of each type of permission."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { \"audit_configs\": [ { \"service\": \"allServices\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\", \"exempted_members\": [ \"user:jose@example.com\" ] }, { \"log_type\": \"DATA_WRITE\" }, { \"log_type\": \"ADMIN_READ\" } ] }, { \"service\": \"sampleservice.googleapis.com\", \"audit_log_configs\": [ { \"log_type\": \"DATA_READ\" }, { \"log_type\": \"DATA_WRITE\", \"exempted_members\": [ \"user:aliya@example.com\" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditLogConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AuditLogConfig"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Principal": {
+      "type": "structure",
+      "members": {
+        "serviceAccount": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement."
+          }
+        },
+        "serviceAccountProjectNumber": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. Cloud project number used to assign policies to all service accounts owned by the project."
+          }
+        },
+        "federatedPrincipal": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsResponse": {
+      "type": "structure",
+      "members": {
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
+          "traits": {
+            "smithy.api#documentation": "List of the Access Level instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to ReplaceAccessLevelsRequest. This will be put inside of Operation.response field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessLevelList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
       }
     },
     "com.gcp.accesscontextmanager_v1#IngressFrom": {
       "type": "structure",
       "members": {
-        "identityType": {
-          "target": "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum",
-          "traits": {
-            "smithy.api#documentation": "Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
-          }
-        },
         "sources": {
           "target": "com.gcp.accesscontextmanager_v1#IngressSourceList",
           "traits": {
             "smithy.api#documentation": "Sources that this IngressPolicy authorizes access from."
+          }
+        },
+        "identityType": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
           }
         },
         "identities": {
@@ -2141,6 +858,12 @@
       },
       "traits": {
         "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#IngressSource"
       }
     },
     "com.gcp.accesscontextmanager_v1#IngressFromIdentityTypeEnum": {
@@ -2172,51 +895,300 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#IngressSourceList": {
-      "type": "list",
-      "member": {
-        "target": "com.gcp.accesscontextmanager_v1#IngressSource"
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#EgressTo": {
+    "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest": {
       "type": "structure",
       "members": {
-        "resources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
           "traits": {
-            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter."
+            "smithy.api#documentation": "Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy."
           }
         },
-        "externalResources": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "etag": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed."
-          }
-        },
-        "operations": {
-          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
-          "traits": {
-            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list."
-          }
-        },
-        "roles": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
-          "traits": {
-            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter."
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter."
+        "smithy.api#documentation": "A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressSource": {
+      "type": "structure",
+      "members": {
+        "pscEndpoint": {
+          "target": "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint",
+          "traits": {
+            "smithy.api#documentation": "A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in."
+          }
+        },
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A Google Cloud resource from the service perimeter that you want to allow to access data outside the perimeter. This field supports only projects. The project format is `projects/{project_number}`. You can't use `*` in this field to allow all Google Cloud resources."
+          }
+        },
+        "accessLevel": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse": {
+      "type": "structure",
+      "members": {
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
+          }
+        },
+        "supportedPermissions": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "List of VPC Service Controls supported permissions."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListSupportedPermissionsRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#OsConstraint": {
+      "type": "structure",
+      "members": {
+        "osType": {
+          "target": "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Required. The allowed OS type."
+          }
+        },
+        "minimumVersion": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `\"major.minor.patch\"`. Examples: `\"10.5.301\"`, `\"9.2.1\"`."
+          }
+        },
+        "requireVerifiedChromeOs": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A restriction on the OS type and version of devices making requests."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#OsConstraintOsTypeEnum": {
+      "type": "enum",
+      "members": {
+        "OS_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OS_UNSPECIFIED"
+          }
+        },
+        "DESKTOP_MAC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESKTOP_MAC"
+          }
+        },
+        "DESKTOP_WINDOWS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESKTOP_WINDOWS"
+          }
+        },
+        "DESKTOP_LINUX": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESKTOP_LINUX"
+          }
+        },
+        "DESKTOP_CHROME_OS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "DESKTOP_CHROME_OS"
+          }
+        },
+        "ANDROID": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ANDROID"
+          }
+        },
+        "IOS": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IOS"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Project": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890`"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A Google Cloud project which contains applications and resources that users can access."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of the Service Perimeter instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to ReplaceServicePerimetersRequest. This will be put inside of Operation.response field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicy": {
+      "type": "structure",
+      "members": {
+        "requireCorpOwned": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether the device needs to be corp owned."
+          }
+        },
+        "osConstraints": {
+          "target": "com.gcp.accesscontextmanager_v1#OsConstraintList",
+          "traits": {
+            "smithy.api#documentation": "Allowed OS versions, an empty list allows all types and all versions."
+          }
+        },
+        "allowedEncryptionStatuses": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Allowed encryptions statuses, an empty list allows all statuses."
+          }
+        },
+        "allowedDeviceManagementLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList",
+          "traits": {
+            "smithy.api#documentation": "Allowed device management levels, an empty list allows all management levels."
+          }
+        },
+        "requireScreenlock": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`."
+          }
+        },
+        "requireAdminApproval": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether the device needs to be approved by the customer admin."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#OsConstraintList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#OsConstraint"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum": {
+      "type": "enum",
+      "members": {
+        "ENCRYPTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTION_UNSPECIFIED"
+          }
+        },
+        "ENCRYPTION_UNSUPPORTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTION_UNSUPPORTED"
+          }
+        },
+        "UNENCRYPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "UNENCRYPTED"
+          }
+        },
+        "ENCRYPTED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ENCRYPTED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnumList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedEncryptionStatusesItemEnum"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum": {
+      "type": "enum",
+      "members": {
+        "MANAGEMENT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "MANAGEMENT_UNSPECIFIED"
+          }
+        },
+        "NONE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "NONE"
+          }
+        },
+        "BASIC": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "BASIC"
+          }
+        },
+        "COMPLETE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "COMPLETE"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnumList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DevicePolicyAllowedDeviceManagementLevelsItemEnum"
       }
     },
     "com.gcp.accesscontextmanager_v1#EgressPolicy": {
       "type": "structure",
       "members": {
-        "title": {
-          "target": "smithy.api#String",
+        "egressFrom": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFrom",
           "traits": {
-            "smithy.api#documentation": "Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
+            "smithy.api#documentation": "Defines conditions on the source of a request causing this EgressPolicy to apply."
           }
         },
         "egressTo": {
@@ -2225,10 +1197,10 @@
             "smithy.api#documentation": "Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply."
           }
         },
-        "egressFrom": {
-          "target": "com.gcp.accesscontextmanager_v1#EgressFrom",
+        "title": {
+          "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Defines conditions on the source of a request causing this EgressPolicy to apply."
+            "smithy.api#documentation": "Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters."
           }
         }
       },
@@ -2236,18 +1208,134 @@
         "smithy.api#documentation": "Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo."
       }
     },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse": {
+    "com.gcp.accesscontextmanager_v1#Modifier": {
       "type": "structure",
       "members": {
-        "permissions": {
-          "target": "com.gcp.accesscontextmanager_v1#StringList",
+        "addRequestHeader": {
+          "target": "com.gcp.accesscontextmanager_v1#AddRequestHeader",
           "traits": {
-            "smithy.api#documentation": "A subset of `TestPermissionsRequest.permissions` that the caller is allowed."
+            "smithy.api#documentation": "Adds an additional HTTP request header."
           }
         }
       },
       "traits": {
-        "smithy.api#documentation": "Response message for `TestIamPermissions` method."
+        "smithy.api#documentation": "Modifier to apply to the API requests."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Status": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+          }
+        },
+        "details": {
+          "target": "com.gcp.accesscontextmanager_v1#DocumentMapList",
+          "traits": {
+            "smithy.api#documentation": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
+          }
+        },
+        "code": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "The status code, which should be an enum value of google.rpc.Code."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors)."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DocumentMapList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#DocumentMap"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Policy": {
+      "type": "structure",
+      "members": {
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "`etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost."
+          }
+        },
+        "auditConfigs": {
+          "target": "com.gcp.accesscontextmanager_v1#AuditConfigList",
+          "traits": {
+            "smithy.api#documentation": "Specifies cloud audit logging configuration for this policy."
+          }
+        },
+        "bindings": {
+          "target": "com.gcp.accesscontextmanager_v1#BindingList",
+          "traits": {
+            "smithy.api#documentation": "Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`."
+          }
+        },
+        "version": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { \"bindings\": [ { \"role\": \"roles/resourcemanager.organizationAdmin\", \"members\": [ \"user:mike@example.com\", \"group:admins@example.com\", \"domain:google.com\", \"serviceAccount:my-project-id@appspot.gserviceaccount.com\" ] }, { \"role\": \"roles/resourcemanager.organizationViewer\", \"members\": [ \"user:eve@example.com\" ], \"condition\": { \"title\": \"expirable access\", \"description\": \"Does not grant access after Sep 2020\", \"expression\": \"request.time < timestamp('2020-10-01T00:00:00.000Z')\", } } ], \"etag\": \"BwWWja0YfJA=\", \"version\": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/)."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuditConfigList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#AuditConfig"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BindingList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Binding"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#MethodSelector": {
+      "type": "structure",
+      "members": {
+        "method": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed."
+          }
+        },
+        "permission": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An allowed method or permission of a service specified in ApiOperation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ApiOperation": {
+      "type": "structure",
+      "members": {
+        "methodSelectors": {
+          "target": "com.gcp.accesscontextmanager_v1#MethodSelectorList",
+          "traits": {
+            "smithy.api#documentation": "API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`."
+          }
+        },
+        "serviceName": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Identification for an API Operation."
       }
     },
     "com.gcp.accesscontextmanager_v1#Empty": {
@@ -2257,15 +1345,913 @@
         "smithy.api#documentation": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }"
       }
     },
-    "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindingsRequest": {
+    "com.gcp.accesscontextmanager_v1#CancelOperationRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "The request message for Operations.CancelOperation."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AddRequestHeader": {
       "type": "structure",
       "members": {
+        "key": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "HTTP header key."
+          }
+        },
+        "value": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "HTTP header value."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Adds a request header to the API."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest": {
+      "type": "structure",
+      "members": {
+        "options": {
+          "target": "com.gcp.accesscontextmanager_v1#GetPolicyOptions",
+          "traits": {
+            "smithy.api#documentation": "OPTIONAL: A `GetPolicyOptions` object for specifying options to `GetIamPolicy`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Request message for `GetIamPolicy` method."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressFrom": {
+      "type": "structure",
+      "members": {
+        "identityType": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access."
+          }
+        },
+        "sourceRestriction": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`."
+          }
+        },
+        "sources": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressSourceList",
+          "traits": {
+            "smithy.api#documentation": "Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`."
+          }
+        },
+        "identities": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressFromIdentityTypeEnum": {
+      "type": "enum",
+      "members": {
+        "IDENTITY_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "IDENTITY_TYPE_UNSPECIFIED"
+          }
+        },
+        "ANY_IDENTITY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ANY_IDENTITY"
+          }
+        },
+        "ANY_USER_ACCOUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ANY_USER_ACCOUNT"
+          }
+        },
+        "ANY_SERVICE_ACCOUNT": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ANY_SERVICE_ACCOUNT"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressFromSourceRestrictionEnum": {
+      "type": "enum",
+      "members": {
+        "SOURCE_RESTRICTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_UNSPECIFIED"
+          }
+        },
+        "SOURCE_RESTRICTION_ENABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_ENABLED"
+          }
+        },
+        "SOURCE_RESTRICTION_DISABLED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SOURCE_RESTRICTION_DISABLED"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#EgressSource"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetPolicyOptions": {
+      "type": "structure",
+      "members": {
+        "requestedPolicyVersion": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Optional. The maximum policy version that will be used to format the policy. Valid values are 0, 1, and 3. Requests specifying an invalid value will be rejected. Requests for policies with any conditional role bindings must specify version 3. Policies with no conditional role bindings may specify any valid value or leave the field unset. The policy in the response might use the policy version that you specified, or it might use a lower policy version. For example, if you specify version 3, but the policy has no conditional role bindings, the response uses version 1. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Encapsulates settings provided to GetIamPolicy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ScopedAccessSettings": {
+      "type": "structure",
+      "members": {
+        "scope": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessScope",
+          "traits": {
+            "smithy.api#documentation": "Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty."
+          }
+        },
+        "dryRunSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set."
+          }
+        },
+        "activeSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A relationship between access settings and its scope."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessLevel": {
+      "type": "structure",
+      "members": {
+        "custom": {
+          "target": "com.gcp.accesscontextmanager_v1#CustomLevel",
+          "traits": {
+            "smithy.api#documentation": "A `CustomLevel` written in the Common Expression Language."
+          }
+        },
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
+          }
+        },
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
+            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`."
+          }
+        },
+        "basic": {
+          "target": "com.gcp.accesscontextmanager_v1#BasicLevel",
+          "traits": {
+            "smithy.api#documentation": "A `BasicLevel` composed of `Conditions`."
+          }
+        },
+        "description": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Description of the `AccessLevel` and its use. Does not affect behavior."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "An `AccessLevel` is a label that can be applied to requests to Google Cloud services, along with a list of requirements necessary for the label to be applied."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        },
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of the Service Perimeter instances."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListServicePerimetersRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc": {
+      "type": "structure",
+      "members": {
+        "orgs": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456`"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`."
+          }
+        },
+        "authorizationType": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`."
+          }
+        },
+        "assetType": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`."
+          }
+        },
+        "authorizationDirection": {
+          "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum",
+          "traits": {
+            "smithy.api#documentation": "The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`AuthorizedOrgsDesc` contains data for an organization's authorization policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationTypeEnum": {
+      "type": "enum",
+      "members": {
+        "AUTHORIZATION_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_TYPE_UNSPECIFIED"
+          }
+        },
+        "AUTHORIZATION_TYPE_TRUST": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_TYPE_TRUST"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAssetTypeEnum": {
+      "type": "enum",
+      "members": {
+        "ASSET_TYPE_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_UNSPECIFIED"
+          }
+        },
+        "ASSET_TYPE_DEVICE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_DEVICE"
+          }
+        },
+        "ASSET_TYPE_CREDENTIAL_STRENGTH": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "ASSET_TYPE_CREDENTIAL_STRENGTH"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDescAuthorizationDirectionEnum": {
+      "type": "enum",
+      "members": {
+        "AUTHORIZATION_DIRECTION_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_UNSPECIFIED"
+          }
+        },
+        "AUTHORIZATION_DIRECTION_TO": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_TO"
+          }
+        },
+        "AUTHORIZATION_DIRECTION_FROM": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AUTHORIZATION_DIRECTION_FROM"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePerimeter": {
+      "type": "structure",
+      "members": {
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Human readable title. Must be unique within the Policy."
+          }
+        },
+        "description": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Description of the `ServicePerimeter` and its use. Does not affect behavior."
+          }
+        },
+        "spec": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig",
+          "traits": {
+            "smithy.api#documentation": "Proposed (or dry run) ServicePerimeter configuration. This configuration allows to specify and test ServicePerimeter configuration without enforcing actual access restrictions. Only allowed to be set when the \"use_explicit_dry_run_spec\" flag is set."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`."
+          }
+        },
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. An opaque identifier for the current version of the `ServicePerimeter`. This identifier does not follow any specific format. If an etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        },
+        "useExplicitDryRunSpec": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly exists for all Service Perimeters, and that spec is identical to the status for those Service Perimeters. When this flag is set, it inhibits the generation of the implicit spec, thereby allowing the user to explicitly provide a configuration (\"spec\") to use in a dry-run version of the Service Perimeter. This allows the user to test changes to the enforced config (\"status\") without actually enforcing them. This testing is done through analyzing the differences between currently enforced and suggested restrictions. use_explicit_dry_run_spec must bet set to True if any of the fields in the spec are set to non-default values."
+          }
+        },
+        "status": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig",
+          "traits": {
+            "smithy.api#documentation": "Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries."
+          }
+        },
+        "perimeterType": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum",
+          "traits": {
+            "smithy.api#documentation": "Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`ServicePerimeter` describes a set of Google Cloud resources which can freely import and export data amongst themselves, but not export outside of the `ServicePerimeter`. If a request with a source within this `ServicePerimeter` has a target outside of the `ServicePerimeter`, the request will be blocked. Otherwise the request is allowed. There are two types of Service Perimeter - Regular and Bridge. Regular Service Perimeters cannot overlap, a single Google Cloud project or VPC network can only belong to a single regular Service Perimeter. Service Perimeter Bridges can contain only Google Cloud projects as members, a single Google Cloud project may belong to multiple Service Perimeter Bridges."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePerimeterPerimeterTypeEnum": {
+      "type": "enum",
+      "members": {
+        "PERIMETER_TYPE_REGULAR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERIMETER_TYPE_REGULAR"
+          }
+        },
+        "PERIMETER_TYPE_BRIDGE": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PERIMETER_TYPE_BRIDGE"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersResponse": {
+      "type": "structure",
+      "members": {
+        "servicePerimeters": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeterList",
+          "traits": {
+            "smithy.api#documentation": "List of all the Service Perimeter instances in the Access Policy."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to CommitServicePerimetersRequest. This will be put inside of Operation.response field."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The etag for the version of the Access Policy that this commit operation is to be performed on. If, at the time of commit, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the commit operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A request to commit dry-run specs in all Service Perimeters belonging to an Access Policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Binding": {
+      "type": "structure",
+      "members": {
+        "role": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles)."
+          }
+        },
+        "members": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`."
+          }
+        },
+        "condition": {
+          "target": "com.gcp.accesscontextmanager_v1#Expr",
+          "traits": {
+            "smithy.api#documentation": "The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Associates `members`, or principals, with a `role`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse": {
+      "type": "structure",
+      "members": {
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevelList",
+          "traits": {
+            "smithy.api#documentation": "List of the Access Level instances."
+          }
+        },
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The pagination token to retrieve the next page of results. If the value is empty, no further results remain."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListAccessLevelsRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePattern": {
+      "type": "structure",
+      "members": {
+        "modifiers": {
+          "target": "com.gcp.accesscontextmanager_v1#ModifierList",
+          "traits": {
+            "smithy.api#documentation": "Modifiers to apply to the requests that match the URL pattern."
+          }
+        },
+        "service": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Supported service to allow."
+          }
+        },
+        "pattern": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "URL pattern to allow. Only patterns of \".googleapis.com/*\", \"www.googleapis.com//*\" and \"*.appspot.com/* forms are supported, where should be an alphanumeric name."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Service patterns used to allow access."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ModifierList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Modifier"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding": {
+      "type": "structure",
+      "members": {
+        "groupKey": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See \"id\" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: \"01d520gv4vjcrht\""
+          }
+        },
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\""
+          }
+        },
+        "dryRunAccessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: \"accessPolicies/9522/accessLevels/device_trusted\""
+          }
+        },
+        "restrictedClientApplications": {
+          "target": "com.gcp.accesscontextmanager_v1#ApplicationList",
+          "traits": {
+            "smithy.api#documentation": "Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications."
+          }
+        },
+        "sessionSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettings",
+          "traits": {
+            "smithy.api#documentation": "Optional. The Google Cloud session length (GCSL) policy for the group key."
+          }
+        },
+        "principal": {
+          "target": "com.gcp.accesscontextmanager_v1#Principal",
+          "traits": {
+            "smithy.api#documentation": "Optional. Immutable. The principal that is subject to the access policies in this policy binding."
+          }
+        },
+        "scopedAccessSettings": {
+          "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList",
+          "traits": {
+            "smithy.api#documentation": "Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ApplicationList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Application"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ScopedAccessSettingsList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ScopedAccessSettings"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ServicePerimeterConfig": {
+      "type": "structure",
+      "members": {
+        "accessLevels": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `\"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL\"`. For Service Perimeter Bridge, must be empty."
+          }
+        },
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`."
+          }
+        },
+        "vpcAccessibleServices": {
+          "target": "com.gcp.accesscontextmanager_v1#VpcAccessibleServices",
+          "traits": {
+            "smithy.api#documentation": "Configuration for APIs allowed within Perimeter."
+          }
+        },
+        "restrictedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions."
+          }
+        },
+        "ingressPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#IngressPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge."
+          }
+        },
+        "egressPolicies": {
+          "target": "com.gcp.accesscontextmanager_v1#EgressPolicyList",
+          "traits": {
+            "smithy.api#documentation": "List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressPolicyList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#IngressPolicy"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressPolicyList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#EgressPolicy"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SessionSettings": {
+      "type": "structure",
+      "members": {
+        "useOidcMaxAge": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param."
+          }
+        },
+        "maxInactivity": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps."
+          }
+        },
+        "sessionReauthMethod": {
+          "target": "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum",
+          "traits": {
+            "smithy.api#documentation": "Optional. Session method when user's Google Cloud session is up."
+          }
+        },
+        "sessionLength": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset."
+          }
+        },
+        "sessionLengthEnabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SessionSettingsSessionReauthMethodEnum": {
+      "type": "enum",
+      "members": {
+        "SESSION_REAUTH_METHOD_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SESSION_REAUTH_METHOD_UNSPECIFIED"
+          }
+        },
+        "LOGIN": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LOGIN"
+          }
+        },
+        "SECURITY_KEY": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "SECURITY_KEY"
+          }
+        },
+        "PASSWORD": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "PASSWORD"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListSupportedServicesResponse": {
+      "type": "structure",
+      "members": {
+        "supportedServices": {
+          "target": "com.gcp.accesscontextmanager_v1#SupportedServiceList",
+          "traits": {
+            "smithy.api#documentation": "List of services supported by VPC Service Controls instances."
+          }
+        },
+        "nextPageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "A response to `ListSupportedServicesRequest`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#SupportedServiceList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#SupportedService"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#AccessPolicy": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. The parent of this `AccessPolicy` in the Cloud Resource Hierarchy. Currently immutable once created. Format: `organizations/{organization_id}`"
+          }
+        },
+        "scopes": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=[\"folders/123\"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}`"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}`"
+          }
+        },
+        "etag": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Output only. An opaque identifier for the current version of the `AccessPolicy`. This will always be a strongly validated etag, meaning that two Access Policies will be identical if and only if their etags are identical. Clients should not expect this to be in any specific format."
+          }
+        },
+        "title": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Human readable title. Does not affect behavior."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`AccessPolicy` is a container for `AccessLevels` (which define the necessary attributes to use Google Cloud services) and `ServicePerimeters` (which define regions of services able to freely pass data within a perimeter). An access policy is globally visible within an organization, and the restrictions it specifies apply to all projects within an organization."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BasicLevel": {
+      "type": "structure",
+      "members": {
+        "combiningFunction": {
+          "target": "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum",
+          "traits": {
+            "smithy.api#documentation": "How the `conditions` list should be combined to determine if a request is granted this `AccessLevel`. If AND is used, each `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. If OR is used, at least one `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. Default behavior is AND."
+          }
+        },
+        "conditions": {
+          "target": "com.gcp.accesscontextmanager_v1#ConditionList",
+          "traits": {
+            "smithy.api#documentation": "Required. A list of requirements for the `AccessLevel` to be granted."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "`BasicLevel` is an `AccessLevel` using a set of recommended features."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BasicLevelCombiningFunctionEnum": {
+      "type": "enum",
+      "members": {
+        "AND": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AND"
+          }
+        },
+        "OR": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "OR"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ConditionList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#Condition"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#PrivateServiceConnectEndpoint": {
+      "type": "structure",
+      "members": {
+        "forwardingRule": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Specifies the Private Service Connect endpoint that an API call refers to."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#IngressTo": {
+      "type": "structure",
+      "members": {
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed."
+          }
+        },
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter."
+          }
+        },
+        "roles": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ApiOperationList": {
+      "type": "list",
+      "member": {
+        "target": "com.gcp.accesscontextmanager_v1#ApiOperation"
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GcpUserAccessBindingOperationMetadata": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#documentation": "Metadata of Google Cloud Access Binding Long Running Operations."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#EgressTo": {
+      "type": "structure",
+      "members": {
+        "operations": {
+          "target": "com.gcp.accesscontextmanager_v1#ApiOperationList",
+          "traits": {
+            "smithy.api#documentation": "A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list."
+          }
+        },
+        "resources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter."
+          }
+        },
+        "roles": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter."
+          }
+        },
+        "externalResources": {
+          "target": "com.gcp.accesscontextmanager_v1#StringList",
+          "traits": {
+            "smithy.api#documentation": "A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListPermissionsRequest": {
+      "type": "structure",
+      "members": {
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. Use this token to retrieve a specific page of results. Default is the first page.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Optional. This flag specifies the maximum number of services to return per page. Default value is 100.",
+            "smithy.api#httpQuery": "pageSize"
           }
         }
       }
@@ -2296,196 +2282,13 @@
         ]
       }
     },
-    "com.gcp.accesscontextmanager_v1#BadRequest": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#error": "client",
-        "smithy.api#httpError": 400,
-        "com.gcp.protocols#errorMatchers": [
-          {
-            "status": 400
-          }
-        ]
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#Conflict": {
-      "type": "structure",
-      "members": {},
-      "traits": {
-        "smithy.api#error": "client",
-        "smithy.api#httpError": 409,
-        "com.gcp.protocols#errorMatchers": [
-          {
-            "status": 409
-          }
-        ]
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindings": {
+    "com.gcp.accesscontextmanager_v1#ListPermissions": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindingsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#ListPermissionsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes a GcpUserAccessBinding. Completion of this long-running operation does not necessarily signify that the binding deletion is deployed onto all affected users, which may take more time."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindingsRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Example: \"organizations/256\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindings": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindingsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/gcpUserAccessBindings"
-        },
-        "smithy.api#documentation": "Creates a GcpUserAccessBinding. If the client specifies a name, the server ignores it. Fails if a resource already exists with the same group_key. Completion of this long-running operation does not necessarily signify that the new binding is deployed onto all affected users, which may take more time."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest": {
-      "type": "structure",
-      "members": {
-        "append": {
-          "target": "smithy.api#Boolean",
-          "traits": {
-            "smithy.api#documentation": "Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when \"scoped_access_settings\" is not set in the update_mask.",
-            "smithy.api#httpQuery": "append"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Only the fields specified in this mask are updated. Because name and group_key cannot be changed, update_mask is required and may only contain the following fields: `access_levels`, `dry_run_access_levels`, `session_settings`, `scoped_access_settings`. update_mask { paths: \"access_levels\" }",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindings": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Updates a GcpUserAccessBinding. Completion of this long-running operation does not necessarily signify that the changed binding is deployed onto all affected users, which may take more time."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindingsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindings": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindingsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
+        "target": "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse"
       },
       "errors": [
         {
@@ -2498,67 +2301,9 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/{+name}"
+          "uri": "v1/permissions"
         },
-        "smithy.api#documentation": "Gets the GcpUserAccessBinding with the given name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindingsRequest": {
-      "type": "structure",
-      "members": {
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Optional. Maximum number of items to return. The server may return fewer items. If left blank, the server may return any number of items.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "filter": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. The literal filter to apply to the results returned. See https://google.aip.dev/160 for more details. Accepts values: * `principal:group_key` * `principal:service_account` OR `principal:service_account_project_number`. If this field is empty or not one of the above, the default value is `\"principal:group_key\"`.",
-            "smithy.api#httpQuery": "filter"
-          }
-        },
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Example: \"organizations/256\"",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindings": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindingsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+parent}/gcpUserAccessBindings"
-        },
-        "smithy.api#documentation": "Lists all GcpUserAccessBindings for a Google Cloud organization.",
+        "smithy.api#documentation": "Lists all supported permissions in VPC Service Controls ingress and egress rules for Granular Controls.",
         "smithy.api#paginated": {
           "inputToken": "pageToken",
           "outputToken": "nextPageToken"
@@ -2602,110 +2347,6 @@
         "smithy.api#documentation": "Returns an access policy based on the name."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Number of AccessPolicy instances to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}`",
-            "smithy.api#httpQuery": "parent"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/accessPolicies"
-        },
-        "smithy.api#documentation": "Lists all access policies in an organization.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPolicies": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Policy"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:getIamPolicy"
-        },
-        "smithy.api#documentation": "Gets the IAM policy for the specified Access Context Manager access policy."
-      }
-    },
     "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesRequest": {
       "type": "structure",
       "members": {
@@ -2717,6 +2358,32 @@
             "smithy.api#required": {}
           }
         }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#BadRequest": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 400,
+        "com.gcp.protocols#errorMatchers": [
+          {
+            "status": 400
+          }
+        ]
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#Conflict": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#error": "client",
+        "smithy.api#httpError": 409,
+        "com.gcp.protocols#errorMatchers": [
+          {
+            "status": 409
+          }
+        ]
       }
     },
     "com.gcp.accesscontextmanager_v1#DeleteAccessPolicies": {
@@ -2789,6 +2456,110 @@
           "uri": "v1/accessPolicies"
         },
         "smithy.api#documentation": "Creates an access policy. This method fails if the organization already has an access policy. The long-running operation has a successful status after the access policy propagates to long-lasting storage. Syntactic and basic semantic errors are returned in `metadata` as a BadRequest proto."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}`",
+            "smithy.api#httpQuery": "parent"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of AccessPolicy instances to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/accessPolicies"
+        },
+        "smithy.api#documentation": "Lists all access policies in an organization.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:testIamPermissions"
+        },
+        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
       }
     },
     "com.gcp.accesscontextmanager_v1#SetIamPolicyAccessPoliciesRequest": {
@@ -2898,7 +2669,100 @@
         "smithy.api#documentation": "Updates an access policy. The long-running operation from this RPC has a successful status after the changes to the access policy propagate to long-lasting storage."
       }
     },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest": {
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest": {
+      "type": "structure",
+      "members": {
+        "resource": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "REQUIRED: The resource for which the policy is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPolicies": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetIamPolicyAccessPoliciesRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Policy"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+resource}:getIamPolicy"
+        },
+        "smithy.api#documentation": "Gets the IAM policy for the specified Access Context Manager access policy."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes an access level based on the resource name. The long-running operation from this RPC has a successful status after the access level has been removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest": {
       "type": "structure",
       "members": {
         "resource": {
@@ -2918,10 +2782,10 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPolicies": {
+    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevels": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesRequest"
+        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest"
       },
       "output": {
         "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
@@ -2948,19 +2812,104 @@
         "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
       }
     },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest": {
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+      "type": "enum",
+      "members": {
+        "LEVEL_FORMAT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+          }
+        },
+        "AS_DEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AS_DEFINED"
+          }
+        },
+        "CEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CEL"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "accessLevelFormat": {
+          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined.",
+            "smithy.api#httpQuery": "accessLevelFormat"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of Access Level instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Number of Access Levels to include in the list. Default 100.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+parent}/accessLevels"
+        },
+        "smithy.api#documentation": "Lists all access levels for an access policy.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest": {
       "type": "structure",
       "members": {
         "parent": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Service Perimeter. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Access Levels. Format: `accessPolicies/{policy_id}`",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         },
         "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
+          "target": "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest",
           "traits": {
             "smithy.api#httpPayload": {},
             "smithy.api#documentation": "Request body"
@@ -2968,10 +2917,10 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimeters": {
+    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevels": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest"
+        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest"
       },
       "output": {
         "target": "com.gcp.accesscontextmanager_v1#Operation"
@@ -2993,75 +2942,118 @@
       "traits": {
         "smithy.api#http": {
           "method": "POST",
-          "uri": "v1/{+parent}/servicePerimeters"
+          "uri": "v1/{+parent}/accessLevels:replaceAll"
         },
-        "smithy.api#documentation": "Creates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
+        "smithy.api#documentation": "Replaces all existing access levels in an access policy with the access levels provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. If the replacement contains errors, an error response is returned for the first error encountered. Upon error, the replacement is cancelled, and existing access levels are not affected. The Operation.response field contains ReplaceAccessLevelsResponse. Removing access levels contained in existing service perimeters result in an error."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
-      "type": "enum",
-      "members": {
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest": {
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest": {
       "type": "structure",
       "members": {
-        "parent": {
+        "updateMask": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         },
-        "pageSize": {
-          "target": "smithy.api#Integer",
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
           "traits": {
-            "smithy.api#documentation": "Number of Service Perimeters to include in the list. Default 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "deletedPrincipalSyntax": {
-          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
-            "smithy.api#httpQuery": "deletedPrincipalSyntax"
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimeters": {
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevels": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest"
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse"
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates an access level. The long-running operation from this RPC has a successful status after the changes to the access level propagate to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+      "type": "enum",
+      "members": {
+        "LEVEL_FORMAT_UNSPECIFIED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+          }
+        },
+        "AS_DEFINED": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "AS_DEFINED"
+          }
+        },
+        "CEL": {
+          "target": "smithy.api#Unit",
+          "traits": {
+            "smithy.api#enumValue": "CEL"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "accessLevelFormat": {
+          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum",
+          "traits": {
+            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`.",
+            "smithy.api#httpQuery": "accessLevelFormat"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
       },
       "errors": [
         {
@@ -3074,13 +3066,59 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/{+parent}/servicePerimeters"
+          "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Lists all service perimeters for an access policy.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
+        "smithy.api#documentation": "Gets an access level based on the resource name."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Access Level. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
         }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevels": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/accessLevels"
+        },
+        "smithy.api#documentation": "Creates an access level. The long-running operation from this RPC has a successful status after the access level propagates to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
       }
     },
     "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesServicePerimetersRequest": {
@@ -3133,56 +3171,19 @@
         "smithy.api#documentation": "Replace all existing service perimeters in an access policy with the service perimeters provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. Replacements containing errors result in an error response for the first error encountered. Upon an error, replacements are cancelled and existing service perimeters are not affected. The Operation.response field contains ReplaceServicePerimetersResponse."
       }
     },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
-      "type": "enum",
-      "members": {
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
-          }
-        },
-        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
-          "target": "smithy.api#Unit",
-          "traits": {
-            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest": {
+    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest": {
       "type": "structure",
       "members": {
-        "updateMask": {
+        "parent": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`.",
+            "smithy.api#documentation": "Required. Resource name for the parent Access Policy which owns all Service Perimeters in scope for the commit operation. Format: `accessPolicies/{policy_id}`",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         },
-        "deletedPrincipalSyntax": {
-          "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
-          "traits": {
-            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax.",
-            "smithy.api#httpQuery": "deletedPrincipalSyntax"
-          }
-        },
         "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
+          "target": "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest",
           "traits": {
             "smithy.api#httpPayload": {},
             "smithy.api#documentation": "Request body"
@@ -3190,10 +3191,10 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimeters": {
+    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimeters": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest"
+        "target": "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest"
       },
       "output": {
         "target": "com.gcp.accesscontextmanager_v1#Operation"
@@ -3214,10 +3215,10 @@
       ],
       "traits": {
         "smithy.api#http": {
-          "method": "PATCH",
-          "uri": "v1/{+name}"
+          "method": "POST",
+          "uri": "v1/{+parent}/servicePerimeters:commit"
         },
-        "smithy.api#documentation": "Updates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
+        "smithy.api#documentation": "Commits the dry-run specification for all the service perimeters in an access policy. A commit operation on a service perimeter involves copying its `spec` field to the `status` field of the service perimeter. Only service perimeters with `use_explicit_dry_run_spec` field set to true are affected by a commit operation. The long-running operation from this RPC has a successful status after the dry-run specifications for all the service perimeters have been committed. If a commit fails, it causes the long-running operation to return an error response and the entire commit operation is cancelled. When successful, the Operation.response field contains CommitServicePerimetersResponse. The `dry_run` and the `spec` fields are cleared after a successful commit operation."
       }
     },
     "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesServicePerimetersRequest": {
@@ -3261,6 +3262,56 @@
           "uri": "v1/{+name}"
         },
         "smithy.api#documentation": "Deletes a service perimeter based on the resource name. The long-running operation from this RPC has a successful status after the service perimeter is removed from long-lasting storage."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Service Perimeter. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimeters": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesServicePerimetersRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+parent}/servicePerimeters"
+        },
+        "smithy.api#documentation": "Creates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
       }
     },
     "com.gcp.accesscontextmanager_v1#GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
@@ -3380,269 +3431,47 @@
         "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
       }
     },
-    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the parent Access Policy which owns all Service Perimeters in scope for the commit operation. Format: `accessPolicies/{policy_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#CommitServicePerimetersRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimeters": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CommitAccessPoliciesServicePerimetersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/servicePerimeters:commit"
-        },
-        "smithy.api#documentation": "Commits the dry-run specification for all the service perimeters in an access policy. A commit operation on a service perimeter involves copying its `spec` field to the `status` field of the service perimeter. Only service perimeters with `use_explicit_dry_run_spec` field set to true are affected by a commit operation. The long-running operation from this RPC has a successful status after the dry-run specifications for all the service perimeters have been committed. If a commit fails, it causes the long-running operation to return an error response and the entire commit operation is cancelled. When successful, the Operation.response field contains CommitServicePerimetersResponse. The `dry_run` and the `spec` fields are cleared after a successful commit operation."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "REQUIRED: The resource for which the policy detail is being requested. See [Resource names](https://cloud.google.com/apis/design/resource_names) for the appropriate value for this field.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#TestIamPermissionsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+resource}:testIamPermissions"
-        },
-        "smithy.api#documentation": "Returns the IAM permissions that the caller has on the specified Access Context Manager resource. The resource can be an AccessPolicy, AccessLevel, or ServicePerimeter. This method does not support other resources. **IAM Permissions**: No specific IAM permission is required to call this method. It returns the subset of the requested permissions that the caller possesses."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
       "type": "enum",
       "members": {
-        "LEVEL_FORMAT_UNSPECIFIED": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
           }
         },
-        "AS_DEFINED": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "AS_DEFINED"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
           }
         },
-        "CEL": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "CEL"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest": {
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest": {
       "type": "structure",
       "members": {
-        "accessLevelFormat": {
-          "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsAccessLevelFormatEnum",
+        "deletedPrincipalSyntax": {
+          "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
           "traits": {
-            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`.",
-            "smithy.api#httpQuery": "accessLevelFormat"
+            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax.",
+            "smithy.api#httpQuery": "deletedPrincipalSyntax"
           }
         },
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#AccessLevel"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets an access level based on the resource name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "DELETE",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Deletes an access level based on the resource name. The long-running operation from this RPC has a successful status after the access level has been removed from long-lasting storage."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
-        "parent": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns these Access Levels. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#ReplaceAccessLevelsRequest",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevels": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ReplaceAllAccessPoliciesAccessLevelsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/accessLevels:replaceAll"
-        },
-        "smithy.api#documentation": "Replaces all existing access levels in an access policy with the access levels provided. This is done atomically. The long-running operation from this RPC has a successful status after all replacements propagate to long-lasting storage. If the replacement contains errors, an error response is returned for the first error encountered. Upon error, the replacement is cancelled, and existing access levels are not affected. The Operation.response field contains ReplaceAccessLevelsResponse. Removing access levels contained in existing service perimeters result in an error."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest": {
-      "type": "structure",
-      "members": {
         "updateMask": {
           "target": "smithy.api#String",
           "traits": {
@@ -3650,16 +3479,8 @@
             "smithy.api#httpQuery": "updateMask"
           }
         },
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`.",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        },
         "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
+          "target": "com.gcp.accesscontextmanager_v1#ServicePerimeter",
           "traits": {
             "smithy.api#httpPayload": {},
             "smithy.api#documentation": "Request body"
@@ -3667,10 +3488,10 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevels": {
+    "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimeters": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAccessLevelsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesServicePerimetersRequest"
       },
       "output": {
         "target": "com.gcp.accesscontextmanager_v1#Operation"
@@ -3694,46 +3515,53 @@
           "method": "PATCH",
           "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Updates an access level. The long-running operation from this RPC has a successful status after the changes to the access level propagate to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
+        "smithy.api#documentation": "Updates a service perimeter. The long-running operation from this RPC has a successful status after the service perimeter propagates to long-lasting storage. If a service perimeter contains errors, an error response is returned for the first error encountered."
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum": {
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum": {
       "type": "enum",
       "members": {
-        "LEVEL_FORMAT_UNSPECIFIED": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "LEVEL_FORMAT_UNSPECIFIED"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_UNSPECIFIED"
           }
         },
-        "AS_DEFINED": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "AS_DEFINED"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_DISABLED"
           }
         },
-        "CEL": {
+        "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED": {
           "target": "smithy.api#Unit",
           "traits": {
-            "smithy.api#enumValue": "CEL"
+            "smithy.api#enumValue": "DELETED_PRINCIPAL_SYNTAX_SUPPORT_ENABLED"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest": {
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest": {
       "type": "structure",
       "members": {
+        "deletedPrincipalSyntax": {
+          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum",
+          "traits": {
+            "smithy.api#documentation": "Optional. If true, the response will contain the deleted principal syntax for identities that support it.",
+            "smithy.api#httpQuery": "deletedPrincipalSyntax"
+          }
+        },
         "pageSize": {
           "target": "smithy.api#Integer",
           "traits": {
-            "smithy.api#documentation": "Number of Access Levels to include in the list. Default 100.",
+            "smithy.api#documentation": "Number of Service Perimeters to include in the list. Default 100.",
             "smithy.api#httpQuery": "pageSize"
           }
         },
         "parent": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}`",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
@@ -3741,26 +3569,19 @@
         "pageToken": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Access Level instances. Defaults to the first page of results.",
+            "smithy.api#documentation": "Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results.",
             "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "accessLevelFormat": {
-          "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsAccessLevelFormatEnum",
-          "traits": {
-            "smithy.api#documentation": "Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined.",
-            "smithy.api#httpQuery": "accessLevelFormat"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevels": {
+    "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimeters": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAccessLevelsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#ListAccessPoliciesServicePerimetersRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListAccessLevelsResponse"
+        "target": "com.gcp.accesscontextmanager_v1#ListServicePerimetersResponse"
       },
       "errors": [
         {
@@ -3773,42 +3594,35 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/{+parent}/accessLevels"
+          "uri": "v1/{+parent}/servicePerimeters"
         },
-        "smithy.api#documentation": "Lists all access levels for an access policy.",
+        "smithy.api#documentation": "Lists all service perimeters for an access policy.",
         "smithy.api#paginated": {
           "inputToken": "pageToken",
           "outputToken": "nextPageToken"
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest": {
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest": {
       "type": "structure",
       "members": {
-        "parent": {
+        "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the access policy which owns this Access Level. Format: `accessPolicies/{policy_id}`",
+            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDescs/{authorized_orgs_descs_id}`",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
-          }
-        },
-        "body": {
-          "target": "com.gcp.accesscontextmanager_v1#AccessLevel",
-          "traits": {
-            "smithy.api#httpPayload": {},
-            "smithy.api#documentation": "Request body"
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevels": {
+    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescs": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CreateAccessPoliciesAccessLevelsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
+        "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
       },
       "errors": [
         {
@@ -3816,38 +3630,32 @@
         },
         {
           "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Conflict"
         }
       ],
       "traits": {
         "smithy.api#http": {
-          "method": "POST",
-          "uri": "v1/{+parent}/accessLevels"
+          "method": "GET",
+          "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Creates an access level. The long-running operation from this RPC has a successful status after the access level propagates to long-lasting storage. If access levels contain errors, an error response is returned for the first error encountered."
+        "smithy.api#documentation": "Gets an authorized orgs desc based on the resource name."
       }
     },
     "com.gcp.accesscontextmanager_v1#PatchAccessPoliciesAuthorizedOrgsDescsRequest": {
       "type": "structure",
       "members": {
-        "updateMask": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
-            "smithy.api#httpQuery": "updateMask"
-          }
-        },
         "name": {
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
+          }
+        },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Mask to control which fields get updated. Must be non-empty.",
+            "smithy.api#httpQuery": "updateMask"
           }
         },
         "body": {
@@ -3889,6 +3697,49 @@
         "smithy.api#documentation": "Updates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. Only the organization list in `AuthorizedOrgsDesc` can be updated. The name, authorization_type, asset_type and authorization_direction cannot be updated."
       }
     },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDesc/{authorized_orgs_desc_id}`",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescs": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Deletes an authorized orgs desc based on the resource name. The long-running operation from this RPC has a successful status after the authorized orgs desc is removed from long-lasting storage."
+      }
+    },
     "com.gcp.accesscontextmanager_v1#ListAccessPoliciesAuthorizedOrgsDescsRequest": {
       "type": "structure",
       "members": {
@@ -3899,19 +3750,19 @@
             "smithy.api#httpQuery": "pageSize"
           }
         },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
         "parent": {
           "target": "smithy.api#String",
           "traits": {
             "smithy.api#documentation": "Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}`",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results.",
-            "smithy.api#httpQuery": "pageToken"
           }
         }
       }
@@ -3994,63 +3845,26 @@
         "smithy.api#documentation": "Creates an authorized orgs desc. The long-running operation from this RPC has a successful status after the authorized orgs desc propagates to long-lasting storage. If a authorized orgs desc contains errors, an error response is returned for the first error encountered. The name of this `AuthorizedOrgsDesc` will be assigned during creation."
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest": {
+    "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest": {
       "type": "structure",
       "members": {
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDescs/{authorized_orgs_descs_id}`",
+            "smithy.api#documentation": "The name of the operation resource to be deleted.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescs": {
+    "com.gcp.accesscontextmanager_v1#DeleteOperations": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#GetAccessPoliciesAuthorizedOrgsDescsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#AuthorizedOrgsDesc"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+name}"
-        },
-        "smithy.api#documentation": "Gets an authorized orgs desc based on the resource name."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest": {
-      "type": "structure",
-      "members": {
-        "name": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. Resource name for the Authorized Orgs Desc. Format: `accessPolicies/{policy_id}/authorizedOrgsDesc/{authorized_orgs_desc_id}`",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescs": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteAccessPoliciesAuthorizedOrgsDescsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Operation"
+        "target": "com.gcp.accesscontextmanager_v1#Empty"
       },
       "errors": [
         {
@@ -4071,12 +3885,76 @@
           "method": "DELETE",
           "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Deletes an authorized orgs desc based on the resource name. The long-running operation from this RPC has a successful status after the authorized orgs desc is removed from long-lasting storage."
+        "smithy.api#documentation": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CancelOperationsRequest": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The name of the operation resource to be cancelled.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#CancelOperationRequest",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CancelOperations": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CancelOperationsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Empty"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "v1/{+name}:cancel"
+        },
+        "smithy.api#documentation": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`."
       }
     },
     "com.gcp.accesscontextmanager_v1#ListOperationsRequest": {
       "type": "structure",
       "members": {
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The standard list page token.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
+        "filter": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "The standard list filter.",
+            "smithy.api#httpQuery": "filter"
+          }
+        },
         "pageSize": {
           "target": "smithy.api#Integer",
           "traits": {
@@ -4097,20 +3975,6 @@
             "smithy.api#documentation": "The name of the operation's parent resource.",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The standard list page token.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        },
-        "filter": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "The standard list filter.",
-            "smithy.api#httpQuery": "filter"
           }
         }
       }
@@ -4180,19 +4044,33 @@
         "smithy.api#documentation": "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service."
       }
     },
-    "com.gcp.accesscontextmanager_v1#CancelOperationsRequest": {
+    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest": {
       "type": "structure",
       "members": {
+        "append": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when \"scoped_access_settings\" is not set in the update_mask.",
+            "smithy.api#httpQuery": "append"
+          }
+        },
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The name of the operation resource to be cancelled.",
+            "smithy.api#documentation": "Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         },
+        "updateMask": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Only the fields specified in this mask are updated. Because name and group_key cannot be changed, update_mask is required and may only contain the following fields: `access_levels`, `dry_run_access_levels`, `session_settings`, `scoped_access_settings`. update_mask { paths: \"access_levels\" }",
+            "smithy.api#httpQuery": "updateMask"
+          }
+        },
         "body": {
-          "target": "com.gcp.accesscontextmanager_v1#CancelOperationRequest",
+          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
           "traits": {
             "smithy.api#httpPayload": {},
             "smithy.api#documentation": "Request body"
@@ -4200,13 +4078,63 @@
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#CancelOperations": {
+    "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindings": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#CancelOperationsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#PatchOrganizationsGcpUserAccessBindingsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Empty"
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#BadRequest"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Conflict"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "PATCH",
+          "uri": "v1/{+name}"
+        },
+        "smithy.api#documentation": "Updates a GcpUserAccessBinding. Completion of this long-running operation does not necessarily signify that the changed binding is deployed onto all affected users, which may take more time."
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindingsRequest": {
+      "type": "structure",
+      "members": {
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Example: \"organizations/256\"",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "body": {
+          "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding",
+          "traits": {
+            "smithy.api#httpPayload": {},
+            "smithy.api#documentation": "Request body"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindings": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#CreateOrganizationsGcpUserAccessBindingsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
       },
       "errors": [
         {
@@ -4225,31 +4153,93 @@
       "traits": {
         "smithy.api#http": {
           "method": "POST",
-          "uri": "v1/{+name}:cancel"
+          "uri": "v1/{+parent}/gcpUserAccessBindings"
         },
-        "smithy.api#documentation": "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`. Clients can use Operations.GetOperation or other methods to check whether the cancellation succeeded or whether the operation completed despite cancellation. On successful cancellation, the operation is not deleted; instead, it becomes an operation with an Operation.error value with a google.rpc.Status.code of `1`, corresponding to `Code.CANCELLED`."
+        "smithy.api#documentation": "Creates a GcpUserAccessBinding. If the client specifies a name, the server ignores it. Fails if a resource already exists with the same group_key. Completion of this long-running operation does not necessarily signify that the new binding is deployed onto all affected users, which may take more time."
       }
     },
-    "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest": {
+    "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindingsRequest": {
+      "type": "structure",
+      "members": {
+        "pageSize": {
+          "target": "smithy.api#Integer",
+          "traits": {
+            "smithy.api#documentation": "Optional. Maximum number of items to return. The server may return fewer items. If left blank, the server may return any number of items.",
+            "smithy.api#httpQuery": "pageSize"
+          }
+        },
+        "pageToken": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation.",
+            "smithy.api#httpQuery": "pageToken"
+          }
+        },
+        "parent": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Required. Example: \"organizations/256\"",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "filter": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Optional. The literal filter to apply to the results returned. See https://google.aip.dev/160 for more details. Accepts values: * `principal:group_key` * `principal:service_account` OR `principal:service_account_project_number`. If this field is empty or not one of the above, the default value is `\"principal:group_key\"`.",
+            "smithy.api#httpQuery": "filter"
+          }
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindings": {
+      "type": "operation",
+      "input": {
+        "target": "com.gcp.accesscontextmanager_v1#ListOrganizationsGcpUserAccessBindingsRequest"
+      },
+      "output": {
+        "target": "com.gcp.accesscontextmanager_v1#ListGcpUserAccessBindingsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.gcp.accesscontextmanager_v1#NotFound"
+        },
+        {
+          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "v1/{+parent}/gcpUserAccessBindings"
+        },
+        "smithy.api#documentation": "Lists all GcpUserAccessBindings for a Google Cloud organization.",
+        "smithy.api#paginated": {
+          "inputToken": "pageToken",
+          "outputToken": "nextPageToken"
+        }
+      }
+    },
+    "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindingsRequest": {
       "type": "structure",
       "members": {
         "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "The name of the operation resource to be deleted.",
+            "smithy.api#documentation": "Required. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#DeleteOperations": {
+    "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindings": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#DeleteOperationsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#DeleteOrganizationsGcpUserAccessBindingsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#Empty"
+        "target": "com.gcp.accesscontextmanager_v1#Operation"
       },
       "errors": [
         {
@@ -4270,29 +4260,29 @@
           "method": "DELETE",
           "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If the server doesn't support this method, it returns `google.rpc.Code.UNIMPLEMENTED`."
+        "smithy.api#documentation": "Deletes a GcpUserAccessBinding. Completion of this long-running operation does not necessarily signify that the binding deletion is deployed onto all affected users, which may take more time."
       }
     },
-    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjectsRequest": {
+    "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindingsRequest": {
       "type": "structure",
       "members": {
-        "resource": {
+        "name": {
           "target": "smithy.api#String",
           "traits": {
-            "smithy.api#documentation": "Required. The Resource to resolve (e.g. \"projects/123\", \"folders/456\").",
+            "smithy.api#documentation": "Required. Example: \"organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N\"",
             "smithy.api#httpLabel": {},
             "smithy.api#required": {}
           }
         }
       }
     },
-    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjects": {
+    "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindings": {
       "type": "operation",
       "input": {
-        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterProjectsRequest"
+        "target": "com.gcp.accesscontextmanager_v1#GetOrganizationsGcpUserAccessBindingsRequest"
       },
       "output": {
-        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse"
+        "target": "com.gcp.accesscontextmanager_v1#GcpUserAccessBinding"
       },
       "errors": [
         {
@@ -4305,56 +4295,9 @@
       "traits": {
         "smithy.api#http": {
           "method": "GET",
-          "uri": "v1/{+resource}:lookupConfiguredServicePerimeter"
+          "uri": "v1/{+name}"
         },
-        "smithy.api#documentation": "Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']."
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListPermissionsRequest": {
-      "type": "structure",
-      "members": {
-        "pageSize": {
-          "target": "smithy.api#Integer",
-          "traits": {
-            "smithy.api#documentation": "Optional. This flag specifies the maximum number of services to return per page. Default value is 100.",
-            "smithy.api#httpQuery": "pageSize"
-          }
-        },
-        "pageToken": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Optional. Use this token to retrieve a specific page of results. Default is the first page.",
-            "smithy.api#httpQuery": "pageToken"
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#ListPermissions": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#ListPermissionsRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#ListSupportedPermissionsResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/permissions"
-        },
-        "smithy.api#documentation": "Lists all supported permissions in VPC Service Controls ingress and egress rules for Granular Controls.",
-        "smithy.api#paginated": {
-          "inputToken": "pageToken",
-          "outputToken": "nextPageToken"
-        }
+        "smithy.api#documentation": "Gets the GcpUserAccessBinding with the given name."
       }
     },
     "com.gcp.accesscontextmanager_v1#GetServicesRequest": {
@@ -4439,43 +4382,6 @@
           "inputToken": "pageToken",
           "outputToken": "nextPageToken"
         }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFoldersRequest": {
-      "type": "structure",
-      "members": {
-        "resource": {
-          "target": "smithy.api#String",
-          "traits": {
-            "smithy.api#documentation": "Required. The Resource to resolve (e.g. \"projects/123\", \"folders/456\").",
-            "smithy.api#httpLabel": {},
-            "smithy.api#required": {}
-          }
-        }
-      }
-    },
-    "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFolders": {
-      "type": "operation",
-      "input": {
-        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterFoldersRequest"
-      },
-      "output": {
-        "target": "com.gcp.accesscontextmanager_v1#LookupConfiguredServicePerimeterResponse"
-      },
-      "errors": [
-        {
-          "target": "com.gcp.accesscontextmanager_v1#NotFound"
-        },
-        {
-          "target": "com.gcp.accesscontextmanager_v1#Forbidden"
-        }
-      ],
-      "traits": {
-        "smithy.api#http": {
-          "method": "GET",
-          "uri": "v1/{+resource}:lookupConfiguredServicePerimeter"
-        },
-        "smithy.api#documentation": "Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']."
       }
     }
   }

--- a/packages/gcp/patches/accesscontextmanager_v1/restrictedClientApplications.json
+++ b/packages/gcp/patches/accesscontextmanager_v1/restrictedClientApplications.json
@@ -1,0 +1,30 @@
+{
+  "description": "Keep GcpUserAccessBinding.restrictedClientApplications (array of Application) after Google's discovery drop. The property is deprecated in favor of scoped_access_settings, but Alchemy still sends it. spec-mirror dbcaa3b (discovery revision 20260819) still has it; live discovery 20260827 removed it. Convert emits the member from the mirror; this patch re-adds ApplicationList, the member, and the scopedAccessSettings mutual-exclusion sentence so a later specs:update does not regress.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/shapes/com.gcp.accesscontextmanager_v1#ApplicationList",
+      "value": {
+        "type": "list",
+        "member": {
+          "target": "com.gcp.accesscontextmanager_v1#Application"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.gcp.accesscontextmanager_v1#GcpUserAccessBinding/members/restrictedClientApplications",
+      "value": {
+        "target": "com.gcp.accesscontextmanager_v1#ApplicationList",
+        "traits": {
+          "smithy.api#documentation": "Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications."
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/shapes/com.gcp.accesscontextmanager_v1#GcpUserAccessBinding/members/scopedAccessSettings/traits/smithy.api#documentation",
+      "value": "Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set."
+    }
+  ]
+}

--- a/packages/gcp/patches/accesscontextmanager_v1/restrictedClientApplications.json
+++ b/packages/gcp/patches/accesscontextmanager_v1/restrictedClientApplications.json
@@ -1,5 +1,5 @@
 {
-  "description": "Keep GcpUserAccessBinding.restrictedClientApplications (array of Application) after Google's discovery drop. The property is deprecated in favor of scoped_access_settings, but Alchemy still sends it. spec-mirror dbcaa3b (discovery revision 20260819) still has it; live discovery 20260827 removed it. Convert emits the member from the mirror; this patch re-adds ApplicationList, the member, and the scopedAccessSettings mutual-exclusion sentence so a later specs:update does not regress.",
+  "description": "Keep GcpUserAccessBinding.restrictedClientApplications (array of Application) after Google's discovery drop. The property is deprecated in favor of scoped_access_settings, but Alchemy still sends it. spec-mirror 436cb36 (discovery revision 20260827) removed it. This patch re-adds ApplicationList, the member, and the scopedAccessSettings mutual-exclusion sentence.",
   "patches": [
     {
       "op": "add",

--- a/packages/gcp/scripts/convert.ts
+++ b/packages/gcp/scripts/convert.ts
@@ -765,6 +765,17 @@ console.log(
   `✅ Converted ${converted} discovery documents to Smithy models` +
     (failed ? ` (${failed} failed)` : ""),
 );
-await finalizeConvert({ root, outDir: ".generated-specs/stable" });
-await finalizeConvert({ root, outDir: ".generated-specs/unstable" });
+// A filtered run only rewrote those models; siblings in the output dirs
+// already carry `distilled.finalized` and must not be walked.
+const include = serviceFilter
+  ? (resource: string) => {
+      const prefix = ident(serviceFilter);
+      if (versionFilter) {
+        return resource === `${prefix}_${ident(versionFilter)}`;
+      }
+      return resource === prefix || resource.startsWith(`${prefix}_`);
+    }
+  : undefined;
+await finalizeConvert({ root, outDir: ".generated-specs/stable", include });
+await finalizeConvert({ root, outDir: ".generated-specs/unstable", include });
 if (failed) process.exit(1);

--- a/packages/gcp/scripts/convert.ts
+++ b/packages/gcp/scripts/convert.ts
@@ -742,6 +742,7 @@ fs.mkdirSync(UNSTABLE_DIR, { recursive: true });
 
 let converted = 0;
 let failed = 0;
+const written = new Set<string>();
 for (const entry of entries) {
   try {
     const doc: DiscoveryDoc = JSON.parse(
@@ -755,6 +756,7 @@ for (const entry of entries) {
       JSON.stringify(model, null, 2) + "\n",
       "utf-8",
     );
+    written.add(outName.replace(/\.json$/, ""));
     converted++;
   } catch (err) {
     failed++;
@@ -765,17 +767,19 @@ console.log(
   `✅ Converted ${converted} discovery documents to Smithy models` +
     (failed ? ` (${failed} failed)` : ""),
 );
-// A filtered run only rewrote those models; siblings in the output dirs
-// already carry `distilled.finalized` and must not be walked.
+// A filtered run only rewrites the matching models; skip already-finalized
+// siblings or finalizeConvert throws (it is not idempotent).
 const include = serviceFilter
-  ? (resource: string) => {
-      const prefix = ident(serviceFilter);
-      if (versionFilter) {
-        return resource === `${prefix}_${ident(versionFilter)}`;
-      }
-      return resource === prefix || resource.startsWith(`${prefix}_`);
-    }
+  ? (resource: string) => written.has(resource)
   : undefined;
-await finalizeConvert({ root, outDir: ".generated-specs/stable", include });
-await finalizeConvert({ root, outDir: ".generated-specs/unstable", include });
+await finalizeConvert({
+  root,
+  outDir: ".generated-specs/stable",
+  include,
+});
+await finalizeConvert({
+  root,
+  outDir: ".generated-specs/unstable",
+  include,
+});
 if (failed) process.exit(1);

--- a/packages/gcp/src/services/accesscontextmanager_v1.ts
+++ b/packages/gcp/src/services/accesscontextmanager_v1.ts
@@ -165,24 +165,24 @@ export const Status = /*@__PURE__*/ S.suspend(() =>
 
 /** This resource represents a long-running operation that is the result of a network API call. */
 export interface Operation {
-  /** If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available. */
-  done?: boolean;
-  /** The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`. */
-  response?: DocumentMap;
-  /** Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any. */
-  metadata?: DocumentMap;
   /** The error result of the operation in case of failure or cancellation. */
   error?: Status;
+  /** If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available. */
+  done?: boolean;
   /** The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`. */
   name?: string;
+  /** Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any. */
+  metadata?: DocumentMap;
+  /** The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`. */
+  response?: DocumentMap;
 }
 export const Operation = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    done: S.optional(S.Boolean),
-    response: S.optional(DocumentMap),
-    metadata: S.optional(DocumentMap),
     error: S.optional(Status),
+    done: S.optional(S.Boolean),
     name: S.optional(S.String),
+    metadata: S.optional(DocumentMap),
+    response: S.optional(DocumentMap),
   }),
 ).annotate({ identifier: "Operation" }) as any as S.Schema<Operation>;
 
@@ -195,22 +195,22 @@ export const StringList = /*@__PURE__*/ S.Array(
 export interface AccessPolicy {
   /** Required. The parent of this `AccessPolicy` in the Cloud Resource Hierarchy. Currently immutable once created. Format: `organizations/{organization_id}` */
   parent?: string;
-  /** Required. Human readable title. Does not affect behavior. */
-  title?: string;
+  /** The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=["folders/123"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}` */
+  scopes?: StringList;
   /** Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}` */
   name?: string;
   /** Output only. An opaque identifier for the current version of the `AccessPolicy`. This will always be a strongly validated etag, meaning that two Access Policies will be identical if and only if their etags are identical. Clients should not expect this to be in any specific format. */
   etag?: string;
-  /** The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=["folders/123"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}` */
-  scopes?: StringList;
+  /** Required. Human readable title. Does not affect behavior. */
+  title?: string;
 }
 export const AccessPolicy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     parent: S.optional(S.String),
-    title: S.optional(S.String),
+    scopes: S.optional(StringList),
     name: S.optional(S.String),
     etag: S.optional(S.String),
-    scopes: S.optional(StringList),
+    title: S.optional(S.String),
   }),
 ).annotate({ identifier: "AccessPolicy" }) as any as S.Schema<AccessPolicy>;
 
@@ -232,37 +232,71 @@ export const CreateAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "CreateAccessPoliciesRequest",
 }) as any as S.Schema<CreateAccessPoliciesRequest>;
 
-/** Sub-segment ranges inside of a VPC Network. */
-export interface VpcSubNetwork {
-  /** CIDR block IP subnetwork specification. The IP address must be an IPv4 address and can be a public or private IP address. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. If empty, all IP addresses are allowed. */
-  vpcIpSubnetworks?: StringList;
-  /** Required. Network name. If the network is not part of the organization, the `compute.network.get` permission must be granted to the caller. Format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NETWORK_NAME}` Example: `//compute.googleapis.com/projects/my-project/global/networks/network-1` */
-  network?: string;
+/** Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information. */
+export interface Expr {
+  /** Textual representation of an expression in Common Expression Language syntax. */
+  expression?: string;
+  /** Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression. */
+  title?: string;
+  /** Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file. */
+  location?: string;
+  /** Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI. */
+  description?: string;
 }
-export const VpcSubNetwork = /*@__PURE__*/ S.suspend(() =>
+export const Expr = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    vpcIpSubnetworks: S.optional(StringList),
-    network: S.optional(S.String),
+    expression: S.optional(S.String),
+    title: S.optional(S.String),
+    location: S.optional(S.String),
+    description: S.optional(S.String),
   }),
-).annotate({ identifier: "VpcSubNetwork" }) as any as S.Schema<VpcSubNetwork>;
+).annotate({ identifier: "Expr" }) as any as S.Schema<Expr>;
 
-/** The originating network source in Google Cloud. */
-export interface VpcNetworkSource {
-  /** Sub-segment ranges of a VPC network. */
-  vpcSubnetwork?: VpcSubNetwork;
+/** `CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec */
+export interface CustomLevel {
+  /** Required. A Cloud CEL expression evaluating to a boolean. */
+  expr?: Expr;
 }
-export const VpcNetworkSource = /*@__PURE__*/ S.suspend(() =>
+export const CustomLevel = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    vpcSubnetwork: S.optional(VpcSubNetwork),
+    expr: S.optional(Expr),
   }),
-).annotate({
-  identifier: "VpcNetworkSource",
-}) as any as S.Schema<VpcNetworkSource>;
+).annotate({ identifier: "CustomLevel" }) as any as S.Schema<CustomLevel>;
 
-export type VpcNetworkSourceList = Array<VpcNetworkSource>;
-export const VpcNetworkSourceList = /*@__PURE__*/ S.Array(
-  VpcNetworkSource,
-) as any as S.Schema<VpcNetworkSourceList>;
+export type BasicLevelCombiningFunctionEnum = "AND" | "OR";
+export const BasicLevelCombiningFunctionEnum = /*@__PURE__*/ S.String;
+
+export type OsConstraintOsTypeEnum =
+  | "OS_UNSPECIFIED"
+  | "DESKTOP_MAC"
+  | "DESKTOP_WINDOWS"
+  | "DESKTOP_LINUX"
+  | "DESKTOP_CHROME_OS"
+  | "ANDROID"
+  | "IOS";
+export const OsConstraintOsTypeEnum = /*@__PURE__*/ S.String;
+
+/** A restriction on the OS type and version of devices making requests. */
+export interface OsConstraint {
+  /** Required. The allowed OS type. */
+  osType?: OsConstraintOsTypeEnum | (string & {});
+  /** The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `"major.minor.patch"`. Examples: `"10.5.301"`, `"9.2.1"`. */
+  minimumVersion?: string;
+  /** Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request. */
+  requireVerifiedChromeOs?: boolean;
+}
+export const OsConstraint = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    osType: S.optional(OsConstraintOsTypeEnum),
+    minimumVersion: S.optional(S.String),
+    requireVerifiedChromeOs: S.optional(S.Boolean),
+  }),
+).annotate({ identifier: "OsConstraint" }) as any as S.Schema<OsConstraint>;
+
+export type OsConstraintList = Array<OsConstraint>;
+export const OsConstraintList = /*@__PURE__*/ S.Array(
+  OsConstraint,
+) as any as S.Schema<OsConstraintList>;
 
 export type DevicePolicyAllowedEncryptionStatusesItemEnum =
   | "ENCRYPTION_UNSPECIFIED"
@@ -296,94 +330,94 @@ export const DevicePolicyAllowedDeviceManagementLevelsItemEnumList =
     DevicePolicyAllowedDeviceManagementLevelsItemEnum,
   ) as any as S.Schema<DevicePolicyAllowedDeviceManagementLevelsItemEnumList>;
 
-export type OsConstraintOsTypeEnum =
-  | "OS_UNSPECIFIED"
-  | "DESKTOP_MAC"
-  | "DESKTOP_WINDOWS"
-  | "DESKTOP_LINUX"
-  | "DESKTOP_CHROME_OS"
-  | "ANDROID"
-  | "IOS";
-export const OsConstraintOsTypeEnum = /*@__PURE__*/ S.String;
-
-/** A restriction on the OS type and version of devices making requests. */
-export interface OsConstraint {
-  /** Required. The allowed OS type. */
-  osType?: OsConstraintOsTypeEnum | (string & {});
-  /** Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request. */
-  requireVerifiedChromeOs?: boolean;
-  /** The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `"major.minor.patch"`. Examples: `"10.5.301"`, `"9.2.1"`. */
-  minimumVersion?: string;
-}
-export const OsConstraint = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    osType: S.optional(OsConstraintOsTypeEnum),
-    requireVerifiedChromeOs: S.optional(S.Boolean),
-    minimumVersion: S.optional(S.String),
-  }),
-).annotate({ identifier: "OsConstraint" }) as any as S.Schema<OsConstraint>;
-
-export type OsConstraintList = Array<OsConstraint>;
-export const OsConstraintList = /*@__PURE__*/ S.Array(
-  OsConstraint,
-) as any as S.Schema<OsConstraintList>;
-
 /** `DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops. */
 export interface DevicePolicy {
-  /** Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`. */
-  requireScreenlock?: boolean;
-  /** Allowed encryptions statuses, an empty list allows all statuses. */
-  allowedEncryptionStatuses?: DevicePolicyAllowedEncryptionStatusesItemEnumList;
-  /** Whether the device needs to be approved by the customer admin. */
-  requireAdminApproval?: boolean;
   /** Whether the device needs to be corp owned. */
   requireCorpOwned?: boolean;
-  /** Allowed device management levels, an empty list allows all management levels. */
-  allowedDeviceManagementLevels?: DevicePolicyAllowedDeviceManagementLevelsItemEnumList;
   /** Allowed OS versions, an empty list allows all types and all versions. */
   osConstraints?: OsConstraintList;
+  /** Allowed encryptions statuses, an empty list allows all statuses. */
+  allowedEncryptionStatuses?: DevicePolicyAllowedEncryptionStatusesItemEnumList;
+  /** Allowed device management levels, an empty list allows all management levels. */
+  allowedDeviceManagementLevels?: DevicePolicyAllowedDeviceManagementLevelsItemEnumList;
+  /** Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`. */
+  requireScreenlock?: boolean;
+  /** Whether the device needs to be approved by the customer admin. */
+  requireAdminApproval?: boolean;
 }
 export const DevicePolicy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    requireScreenlock: S.optional(S.Boolean),
+    requireCorpOwned: S.optional(S.Boolean),
+    osConstraints: S.optional(OsConstraintList),
     allowedEncryptionStatuses: S.optional(
       DevicePolicyAllowedEncryptionStatusesItemEnumList,
     ),
-    requireAdminApproval: S.optional(S.Boolean),
-    requireCorpOwned: S.optional(S.Boolean),
     allowedDeviceManagementLevels: S.optional(
       DevicePolicyAllowedDeviceManagementLevelsItemEnumList,
     ),
-    osConstraints: S.optional(OsConstraintList),
+    requireScreenlock: S.optional(S.Boolean),
+    requireAdminApproval: S.optional(S.Boolean),
   }),
 ).annotate({ identifier: "DevicePolicy" }) as any as S.Schema<DevicePolicy>;
 
+/** Sub-segment ranges inside of a VPC Network. */
+export interface VpcSubNetwork {
+  /** Required. Network name. If the network is not part of the organization, the `compute.network.get` permission must be granted to the caller. Format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NETWORK_NAME}` Example: `//compute.googleapis.com/projects/my-project/global/networks/network-1` */
+  network?: string;
+  /** CIDR block IP subnetwork specification. The IP address must be an IPv4 address and can be a public or private IP address. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. If empty, all IP addresses are allowed. */
+  vpcIpSubnetworks?: StringList;
+}
+export const VpcSubNetwork = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    network: S.optional(S.String),
+    vpcIpSubnetworks: S.optional(StringList),
+  }),
+).annotate({ identifier: "VpcSubNetwork" }) as any as S.Schema<VpcSubNetwork>;
+
+/** The originating network source in Google Cloud. */
+export interface VpcNetworkSource {
+  /** Sub-segment ranges of a VPC network. */
+  vpcSubnetwork?: VpcSubNetwork;
+}
+export const VpcNetworkSource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    vpcSubnetwork: S.optional(VpcSubNetwork),
+  }),
+).annotate({
+  identifier: "VpcNetworkSource",
+}) as any as S.Schema<VpcNetworkSource>;
+
+export type VpcNetworkSourceList = Array<VpcNetworkSource>;
+export const VpcNetworkSourceList = /*@__PURE__*/ S.Array(
+  VpcNetworkSource,
+) as any as S.Schema<VpcNetworkSourceList>;
+
 /** A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction. */
 export interface Condition {
-  /** The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`. */
-  vpcNetworkSources?: VpcNetworkSourceList;
-  /** CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly, for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed. */
-  ipSubnetworks?: StringList;
   /** A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: "`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME"` */
   requiredAccessLevels?: StringList;
-  /** The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user. */
-  members?: StringList;
+  /** CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly, for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed. */
+  ipSubnetworks?: StringList;
   /** Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed. */
   devicePolicy?: DevicePolicy;
-  /** The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes. */
-  regions?: StringList;
   /** Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false. */
   negate?: boolean;
+  /** The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user. */
+  members?: StringList;
+  /** The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes. */
+  regions?: StringList;
+  /** The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`. */
+  vpcNetworkSources?: VpcNetworkSourceList;
 }
 export const Condition = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    vpcNetworkSources: S.optional(VpcNetworkSourceList),
-    ipSubnetworks: S.optional(StringList),
     requiredAccessLevels: S.optional(StringList),
-    members: S.optional(StringList),
+    ipSubnetworks: S.optional(StringList),
     devicePolicy: S.optional(DevicePolicy),
-    regions: S.optional(StringList),
     negate: S.optional(S.Boolean),
+    members: S.optional(StringList),
+    regions: S.optional(StringList),
+    vpcNetworkSources: S.optional(VpcNetworkSourceList),
   }),
 ).annotate({ identifier: "Condition" }) as any as S.Schema<Condition>;
 
@@ -392,74 +426,40 @@ export const ConditionList = /*@__PURE__*/ S.Array(
   Condition,
 ) as any as S.Schema<ConditionList>;
 
-export type BasicLevelCombiningFunctionEnum = "AND" | "OR";
-export const BasicLevelCombiningFunctionEnum = /*@__PURE__*/ S.String;
-
 /** `BasicLevel` is an `AccessLevel` using a set of recommended features. */
 export interface BasicLevel {
-  /** Required. A list of requirements for the `AccessLevel` to be granted. */
-  conditions?: ConditionList;
   /** How the `conditions` list should be combined to determine if a request is granted this `AccessLevel`. If AND is used, each `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. If OR is used, at least one `Condition` in `conditions` must be satisfied for the `AccessLevel` to be applied. Default behavior is AND. */
   combiningFunction?: BasicLevelCombiningFunctionEnum | (string & {});
+  /** Required. A list of requirements for the `AccessLevel` to be granted. */
+  conditions?: ConditionList;
 }
 export const BasicLevel = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    conditions: S.optional(ConditionList),
     combiningFunction: S.optional(BasicLevelCombiningFunctionEnum),
+    conditions: S.optional(ConditionList),
   }),
 ).annotate({ identifier: "BasicLevel" }) as any as S.Schema<BasicLevel>;
 
-/** Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information. */
-export interface Expr {
-  /** Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file. */
-  location?: string;
-  /** Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI. */
-  description?: string;
-  /** Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression. */
-  title?: string;
-  /** Textual representation of an expression in Common Expression Language syntax. */
-  expression?: string;
-}
-export const Expr = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    location: S.optional(S.String),
-    description: S.optional(S.String),
-    title: S.optional(S.String),
-    expression: S.optional(S.String),
-  }),
-).annotate({ identifier: "Expr" }) as any as S.Schema<Expr>;
-
-/** `CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. See CEL spec at: https://github.com/google/cel-spec */
-export interface CustomLevel {
-  /** Required. A Cloud CEL expression evaluating to a boolean. */
-  expr?: Expr;
-}
-export const CustomLevel = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    expr: S.optional(Expr),
-  }),
-).annotate({ identifier: "CustomLevel" }) as any as S.Schema<CustomLevel>;
-
 /** An `AccessLevel` is a label that can be applied to requests to Google Cloud services, along with a list of requirements necessary for the label to be applied. */
 export interface AccessLevel {
-  /** Description of the `AccessLevel` and its use. Does not affect behavior. */
-  description?: string;
-  /** Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`. */
-  name?: string;
-  /** Human readable title. Must be unique within the Policy. */
-  title?: string;
-  /** A `BasicLevel` composed of `Conditions`. */
-  basic?: BasicLevel;
   /** A `CustomLevel` written in the Common Expression Language. */
   custom?: CustomLevel;
+  /** Human readable title. Must be unique within the Policy. */
+  title?: string;
+  /** Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`. */
+  name?: string;
+  /** A `BasicLevel` composed of `Conditions`. */
+  basic?: BasicLevel;
+  /** Description of the `AccessLevel` and its use. Does not affect behavior. */
+  description?: string;
 }
 export const AccessLevel = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    description: S.optional(S.String),
-    name: S.optional(S.String),
-    title: S.optional(S.String),
-    basic: S.optional(BasicLevel),
     custom: S.optional(CustomLevel),
+    title: S.optional(S.String),
+    name: S.optional(S.String),
+    basic: S.optional(BasicLevel),
+    description: S.optional(S.String),
   }),
 ).annotate({ identifier: "AccessLevel" }) as any as S.Schema<AccessLevel>;
 
@@ -485,6 +485,11 @@ export const CreateAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   identifier: "CreateAccessPoliciesAccessLevelsRequest",
 }) as any as S.Schema<CreateAccessPoliciesAccessLevelsRequest>;
 
+export type AuthorizedOrgsDescAuthorizationTypeEnum =
+  | "AUTHORIZATION_TYPE_UNSPECIFIED"
+  | "AUTHORIZATION_TYPE_TRUST";
+export const AuthorizedOrgsDescAuthorizationTypeEnum = /*@__PURE__*/ S.String;
+
 export type AuthorizedOrgsDescAssetTypeEnum =
   | "ASSET_TYPE_UNSPECIFIED"
   | "ASSET_TYPE_DEVICE"
@@ -498,35 +503,30 @@ export type AuthorizedOrgsDescAuthorizationDirectionEnum =
 export const AuthorizedOrgsDescAuthorizationDirectionEnum =
   /*@__PURE__*/ S.String;
 
-export type AuthorizedOrgsDescAuthorizationTypeEnum =
-  | "AUTHORIZATION_TYPE_UNSPECIFIED"
-  | "AUTHORIZATION_TYPE_TRUST";
-export const AuthorizedOrgsDescAuthorizationTypeEnum = /*@__PURE__*/ S.String;
-
 /** `AuthorizedOrgsDesc` contains data for an organization's authorization policy. */
 export interface AuthorizedOrgsDesc {
-  /** The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`. */
-  assetType?: AuthorizedOrgsDescAssetTypeEnum | (string & {});
+  /** The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456` */
+  orgs?: StringList;
   /** Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`. */
   name?: string;
+  /** A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`. */
+  authorizationType?: AuthorizedOrgsDescAuthorizationTypeEnum | (string & {});
+  /** The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`. */
+  assetType?: AuthorizedOrgsDescAssetTypeEnum | (string & {});
   /** The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource. */
   authorizationDirection?:
     | AuthorizedOrgsDescAuthorizationDirectionEnum
     | (string & {});
-  /** A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`. */
-  authorizationType?: AuthorizedOrgsDescAuthorizationTypeEnum | (string & {});
-  /** The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456` */
-  orgs?: StringList;
 }
 export const AuthorizedOrgsDesc = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    assetType: S.optional(AuthorizedOrgsDescAssetTypeEnum),
+    orgs: S.optional(StringList),
     name: S.optional(S.String),
+    authorizationType: S.optional(AuthorizedOrgsDescAuthorizationTypeEnum),
+    assetType: S.optional(AuthorizedOrgsDescAssetTypeEnum),
     authorizationDirection: S.optional(
       AuthorizedOrgsDescAuthorizationDirectionEnum,
     ),
-    authorizationType: S.optional(AuthorizedOrgsDescAuthorizationTypeEnum),
-    orgs: S.optional(StringList),
   }),
 ).annotate({
   identifier: "AuthorizedOrgsDesc",
@@ -553,22 +553,6 @@ export const CreateAccessPoliciesAuthorizedOrgsDescsRequest =
   ).annotate({
     identifier: "CreateAccessPoliciesAuthorizedOrgsDescsRequest",
   }) as any as S.Schema<CreateAccessPoliciesAuthorizedOrgsDescsRequest>;
-
-export type VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum =
-  | "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
-  | "GOOGLE_APIS_VIA_PRIVATE_PATH";
-export const VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum =
-  /*@__PURE__*/ S.String;
-
-export type VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList =
-  Array<
-    | VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum
-    | (string & {})
-  >;
-export const VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList =
-  /*@__PURE__*/ S.Array(
-    VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum,
-  ) as any as S.Schema<VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList>;
 
 /** Adds a request header to the API. */
 export interface AddRequestHeader {
@@ -604,18 +588,18 @@ export const ModifierList = /*@__PURE__*/ S.Array(
 
 /** Service patterns used to allow access. */
 export interface ServicePattern {
-  /** URL pattern to allow. Only patterns of ".googleapis.com/*", "www.googleapis.com//*" and "*.appspot.com/* forms are supported, where should be an alphanumeric name. */
-  pattern?: string;
   /** Modifiers to apply to the requests that match the URL pattern. */
   modifiers?: ModifierList;
   /** Supported service to allow. */
   service?: string;
+  /** URL pattern to allow. Only patterns of ".googleapis.com/*", "www.googleapis.com//*" and "*.appspot.com/* forms are supported, where should be an alphanumeric name. */
+  pattern?: string;
 }
 export const ServicePattern = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pattern: S.optional(S.String),
     modifiers: S.optional(ModifierList),
     service: S.optional(S.String),
+    pattern: S.optional(S.String),
   }),
 ).annotate({ identifier: "ServicePattern" }) as any as S.Schema<ServicePattern>;
 
@@ -624,88 +608,45 @@ export const ServicePatternList = /*@__PURE__*/ S.Array(
   ServicePattern,
 ) as any as S.Schema<ServicePatternList>;
 
+export type VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum =
+  | "SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED"
+  | "GOOGLE_APIS_VIA_PRIVATE_PATH";
+export const VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum =
+  /*@__PURE__*/ S.String;
+
+export type VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList =
+  Array<
+    | VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum
+    | (string & {})
+  >;
+export const VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList =
+  /*@__PURE__*/ S.Array(
+    VpcAccessibleServicesServicePatternsEnforcementScopesItemEnum,
+  ) as any as S.Schema<VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList>;
+
 /** Specifies how APIs are allowed to communicate within the Service Perimeter. */
 export interface VpcAccessibleServices {
-  /** Defines the enforcement scopes of service patterns. */
-  servicePatternsEnforcementScopes?: VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList;
-  /** Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'. */
-  enableRestriction?: boolean;
-  /** The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter. */
-  allowedServices?: StringList;
   /** Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter. */
   allowedServicePatterns?: ServicePatternList;
+  /** Defines the enforcement scopes of service patterns. */
+  servicePatternsEnforcementScopes?: VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList;
+  /** The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter. */
+  allowedServices?: StringList;
+  /** Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'. */
+  enableRestriction?: boolean;
 }
 export const VpcAccessibleServices = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    allowedServicePatterns: S.optional(ServicePatternList),
     servicePatternsEnforcementScopes: S.optional(
       VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList,
     ),
-    enableRestriction: S.optional(S.Boolean),
     allowedServices: S.optional(StringList),
-    allowedServicePatterns: S.optional(ServicePatternList),
+    enableRestriction: S.optional(S.Boolean),
   }),
 ).annotate({
   identifier: "VpcAccessibleServices",
 }) as any as S.Schema<VpcAccessibleServices>;
-
-export type IngressFromIdentityTypeEnum =
-  | "IDENTITY_TYPE_UNSPECIFIED"
-  | "ANY_IDENTITY"
-  | "ANY_USER_ACCOUNT"
-  | "ANY_SERVICE_ACCOUNT";
-export const IngressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
-
-/** Specifies the Private Service Connect endpoint that an API call refers to. */
-export interface PrivateServiceConnectEndpoint {
-  /** The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`. */
-  forwardingRule?: string;
-}
-export const PrivateServiceConnectEndpoint = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    forwardingRule: S.optional(S.String),
-  }),
-).annotate({
-  identifier: "PrivateServiceConnectEndpoint",
-}) as any as S.Schema<PrivateServiceConnectEndpoint>;
-
-/** The source that IngressPolicy authorizes access from. */
-export interface IngressSource {
-  /** A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported. */
-  resource?: string;
-  /** An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed. */
-  accessLevel?: string;
-  /** A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
-  pscEndpoint?: PrivateServiceConnectEndpoint;
-}
-export const IngressSource = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    resource: S.optional(S.String),
-    accessLevel: S.optional(S.String),
-    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
-  }),
-).annotate({ identifier: "IngressSource" }) as any as S.Schema<IngressSource>;
-
-export type IngressSourceList = Array<IngressSource>;
-export const IngressSourceList = /*@__PURE__*/ S.Array(
-  IngressSource,
-) as any as S.Schema<IngressSourceList>;
-
-/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match. */
-export interface IngressFrom {
-  /** Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
-  identityType?: IngressFromIdentityTypeEnum | (string & {});
-  /** Sources that this IngressPolicy authorizes access from. */
-  sources?: IngressSourceList;
-  /** A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
-  identities?: StringList;
-}
-export const IngressFrom = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    identityType: S.optional(IngressFromIdentityTypeEnum),
-    sources: S.optional(IngressSourceList),
-    identities: S.optional(StringList),
-  }),
-).annotate({ identifier: "IngressFrom" }) as any as S.Schema<IngressFrom>;
 
 /** An allowed method or permission of a service specified in ApiOperation. */
 export interface MethodSelector {
@@ -728,15 +669,15 @@ export const MethodSelectorList = /*@__PURE__*/ S.Array(
 
 /** Identification for an API Operation. */
 export interface ApiOperation {
-  /** The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services. */
-  serviceName?: string;
   /** API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`. */
   methodSelectors?: MethodSelectorList;
+  /** The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services. */
+  serviceName?: string;
 }
 export const ApiOperation = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    serviceName: S.optional(S.String),
     methodSelectors: S.optional(MethodSelectorList),
+    serviceName: S.optional(S.String),
   }),
 ).annotate({ identifier: "ApiOperation" }) as any as S.Schema<ApiOperation>;
 
@@ -747,35 +688,94 @@ export const ApiOperationList = /*@__PURE__*/ S.Array(
 
 /** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match. */
 export interface IngressTo {
+  /** A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed. */
+  resources?: StringList;
   /** A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter. */
   operations?: ApiOperationList;
   /** IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter. */
   roles?: StringList;
-  /** A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed. */
-  resources?: StringList;
 }
 export const IngressTo = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    resources: S.optional(StringList),
     operations: S.optional(ApiOperationList),
     roles: S.optional(StringList),
-    resources: S.optional(StringList),
   }),
 ).annotate({ identifier: "IngressTo" }) as any as S.Schema<IngressTo>;
+
+/** Specifies the Private Service Connect endpoint that an API call refers to. */
+export interface PrivateServiceConnectEndpoint {
+  /** The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`. */
+  forwardingRule?: string;
+}
+export const PrivateServiceConnectEndpoint = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    forwardingRule: S.optional(S.String),
+  }),
+).annotate({
+  identifier: "PrivateServiceConnectEndpoint",
+}) as any as S.Schema<PrivateServiceConnectEndpoint>;
+
+/** The source that IngressPolicy authorizes access from. */
+export interface IngressSource {
+  /** A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
+  pscEndpoint?: PrivateServiceConnectEndpoint;
+  /** A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported. */
+  resource?: string;
+  /** An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed. */
+  accessLevel?: string;
+}
+export const IngressSource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
+    resource: S.optional(S.String),
+    accessLevel: S.optional(S.String),
+  }),
+).annotate({ identifier: "IngressSource" }) as any as S.Schema<IngressSource>;
+
+export type IngressSourceList = Array<IngressSource>;
+export const IngressSourceList = /*@__PURE__*/ S.Array(
+  IngressSource,
+) as any as S.Schema<IngressSourceList>;
+
+export type IngressFromIdentityTypeEnum =
+  | "IDENTITY_TYPE_UNSPECIFIED"
+  | "ANY_IDENTITY"
+  | "ANY_USER_ACCOUNT"
+  | "ANY_SERVICE_ACCOUNT";
+export const IngressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
+
+/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match. */
+export interface IngressFrom {
+  /** Sources that this IngressPolicy authorizes access from. */
+  sources?: IngressSourceList;
+  /** Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
+  identityType?: IngressFromIdentityTypeEnum | (string & {});
+  /** A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
+  identities?: StringList;
+}
+export const IngressFrom = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    sources: S.optional(IngressSourceList),
+    identityType: S.optional(IngressFromIdentityTypeEnum),
+    identities: S.optional(StringList),
+  }),
+).annotate({ identifier: "IngressFrom" }) as any as S.Schema<IngressFrom>;
 
 /** Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field. */
 export interface IngressPolicy {
   /** Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
   title?: string;
-  /** Defines the conditions on the source of a request causing this IngressPolicy to apply. */
-  ingressFrom?: IngressFrom;
   /** Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply. */
   ingressTo?: IngressTo;
+  /** Defines the conditions on the source of a request causing this IngressPolicy to apply. */
+  ingressFrom?: IngressFrom;
 }
 export const IngressPolicy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     title: S.optional(S.String),
-    ingressFrom: S.optional(IngressFrom),
     ingressTo: S.optional(IngressTo),
+    ingressFrom: S.optional(IngressFrom),
   }),
 ).annotate({ identifier: "IngressPolicy" }) as any as S.Schema<IngressPolicy>;
 
@@ -784,25 +784,12 @@ export const IngressPolicyList = /*@__PURE__*/ S.Array(
   IngressPolicy,
 ) as any as S.Schema<IngressPolicyList>;
 
-/** Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter. */
-export interface EgressTo {
-  /** A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter. */
-  resources?: StringList;
-  /** A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed. */
-  externalResources?: StringList;
-  /** A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list. */
-  operations?: ApiOperationList;
-  /** IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter. */
-  roles?: StringList;
-}
-export const EgressTo = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    resources: S.optional(StringList),
-    externalResources: S.optional(StringList),
-    operations: S.optional(ApiOperationList),
-    roles: S.optional(StringList),
-  }),
-).annotate({ identifier: "EgressTo" }) as any as S.Schema<EgressTo>;
+export type EgressFromIdentityTypeEnum =
+  | "IDENTITY_TYPE_UNSPECIFIED"
+  | "ANY_IDENTITY"
+  | "ANY_USER_ACCOUNT"
+  | "ANY_SERVICE_ACCOUNT";
+export const EgressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
 
 export type EgressFromSourceRestrictionEnum =
   | "SOURCE_RESTRICTION_UNSPECIFIED"
@@ -812,18 +799,18 @@ export const EgressFromSourceRestrictionEnum = /*@__PURE__*/ S.String;
 
 /** The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries. */
 export interface EgressSource {
-  /** An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed. */
-  accessLevel?: string;
   /** A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
   pscEndpoint?: PrivateServiceConnectEndpoint;
   /** A Google Cloud resource from the service perimeter that you want to allow to access data outside the perimeter. This field supports only projects. The project format is `projects/{project_number}`. You can't use `*` in this field to allow all Google Cloud resources. */
   resource?: string;
+  /** An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed. */
+  accessLevel?: string;
 }
 export const EgressSource = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    accessLevel: S.optional(S.String),
     pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
     resource: S.optional(S.String),
+    accessLevel: S.optional(S.String),
   }),
 ).annotate({ identifier: "EgressSource" }) as any as S.Schema<EgressSource>;
 
@@ -832,47 +819,60 @@ export const EgressSourceList = /*@__PURE__*/ S.Array(
   EgressSource,
 ) as any as S.Schema<EgressSourceList>;
 
-export type EgressFromIdentityTypeEnum =
-  | "IDENTITY_TYPE_UNSPECIFIED"
-  | "ANY_IDENTITY"
-  | "ANY_USER_ACCOUNT"
-  | "ANY_SERVICE_ACCOUNT";
-export const EgressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
-
 /** Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. */
 export interface EgressFrom {
-  /** A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
-  identities?: StringList;
+  /** Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
+  identityType?: EgressFromIdentityTypeEnum | (string & {});
   /** Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`. */
   sourceRestriction?: EgressFromSourceRestrictionEnum | (string & {});
   /** Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`. */
   sources?: EgressSourceList;
-  /** Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
-  identityType?: EgressFromIdentityTypeEnum | (string & {});
+  /** A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
+  identities?: StringList;
 }
 export const EgressFrom = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    identities: S.optional(StringList),
+    identityType: S.optional(EgressFromIdentityTypeEnum),
     sourceRestriction: S.optional(EgressFromSourceRestrictionEnum),
     sources: S.optional(EgressSourceList),
-    identityType: S.optional(EgressFromIdentityTypeEnum),
+    identities: S.optional(StringList),
   }),
 ).annotate({ identifier: "EgressFrom" }) as any as S.Schema<EgressFrom>;
 
+/** Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter. */
+export interface EgressTo {
+  /** A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list. */
+  operations?: ApiOperationList;
+  /** A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter. */
+  resources?: StringList;
+  /** IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter. */
+  roles?: StringList;
+  /** A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed. */
+  externalResources?: StringList;
+}
+export const EgressTo = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    operations: S.optional(ApiOperationList),
+    resources: S.optional(StringList),
+    roles: S.optional(StringList),
+    externalResources: S.optional(StringList),
+  }),
+).annotate({ identifier: "EgressTo" }) as any as S.Schema<EgressTo>;
+
 /** Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo. */
 export interface EgressPolicy {
-  /** Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
-  title?: string;
-  /** Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply. */
-  egressTo?: EgressTo;
   /** Defines conditions on the source of a request causing this EgressPolicy to apply. */
   egressFrom?: EgressFrom;
+  /** Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply. */
+  egressTo?: EgressTo;
+  /** Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
+  title?: string;
 }
 export const EgressPolicy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    title: S.optional(S.String),
-    egressTo: S.optional(EgressTo),
     egressFrom: S.optional(EgressFrom),
+    egressTo: S.optional(EgressTo),
+    title: S.optional(S.String),
   }),
 ).annotate({ identifier: "EgressPolicy" }) as any as S.Schema<EgressPolicy>;
 
@@ -883,27 +883,27 @@ export const EgressPolicyList = /*@__PURE__*/ S.Array(
 
 /** `ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration. */
 export interface ServicePerimeterConfig {
-  /** Configuration for APIs allowed within Perimeter. */
-  vpcAccessibleServices?: VpcAccessibleServices;
-  /** List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge. */
-  ingressPolicies?: IngressPolicyList;
-  /** List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge. */
-  egressPolicies?: EgressPolicyList;
   /** A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL"`. For Service Perimeter Bridge, must be empty. */
   accessLevels?: StringList;
   /** A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. */
   resources?: StringList;
+  /** Configuration for APIs allowed within Perimeter. */
+  vpcAccessibleServices?: VpcAccessibleServices;
   /** Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions. */
   restrictedServices?: StringList;
+  /** List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge. */
+  ingressPolicies?: IngressPolicyList;
+  /** List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge. */
+  egressPolicies?: EgressPolicyList;
 }
 export const ServicePerimeterConfig = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    vpcAccessibleServices: S.optional(VpcAccessibleServices),
-    ingressPolicies: S.optional(IngressPolicyList),
-    egressPolicies: S.optional(EgressPolicyList),
     accessLevels: S.optional(StringList),
     resources: S.optional(StringList),
+    vpcAccessibleServices: S.optional(VpcAccessibleServices),
     restrictedServices: S.optional(StringList),
+    ingressPolicies: S.optional(IngressPolicyList),
+    egressPolicies: S.optional(EgressPolicyList),
   }),
 ).annotate({
   identifier: "ServicePerimeterConfig",
@@ -916,33 +916,33 @@ export const ServicePerimeterPerimeterTypeEnum = /*@__PURE__*/ S.String;
 
 /** `ServicePerimeter` describes a set of Google Cloud resources which can freely import and export data amongst themselves, but not export outside of the `ServicePerimeter`. If a request with a source within this `ServicePerimeter` has a target outside of the `ServicePerimeter`, the request will be blocked. Otherwise the request is allowed. There are two types of Service Perimeter - Regular and Bridge. Regular Service Perimeters cannot overlap, a single Google Cloud project or VPC network can only belong to a single regular Service Perimeter. Service Perimeter Bridges can contain only Google Cloud projects as members, a single Google Cloud project may belong to multiple Service Perimeter Bridges. */
 export interface ServicePerimeter {
-  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
-  name?: string;
+  /** Human readable title. Must be unique within the Policy. */
+  title?: string;
   /** Description of the `ServicePerimeter` and its use. Does not affect behavior. */
   description?: string;
   /** Proposed (or dry run) ServicePerimeter configuration. This configuration allows to specify and test ServicePerimeter configuration without enforcing actual access restrictions. Only allowed to be set when the "use_explicit_dry_run_spec" flag is set. */
   spec?: ServicePerimeterConfig;
+  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
+  name?: string;
   /** Optional. An opaque identifier for the current version of the `ServicePerimeter`. This identifier does not follow any specific format. If an etag is not provided, the operation will be performed as if a valid etag is provided. */
   etag?: string;
-  /** Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries. */
-  status?: ServicePerimeterConfig;
-  /** Human readable title. Must be unique within the Policy. */
-  title?: string;
-  /** Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty. */
-  perimeterType?: ServicePerimeterPerimeterTypeEnum | (string & {});
   /** Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly exists for all Service Perimeters, and that spec is identical to the status for those Service Perimeters. When this flag is set, it inhibits the generation of the implicit spec, thereby allowing the user to explicitly provide a configuration ("spec") to use in a dry-run version of the Service Perimeter. This allows the user to test changes to the enforced config ("status") without actually enforcing them. This testing is done through analyzing the differences between currently enforced and suggested restrictions. use_explicit_dry_run_spec must bet set to True if any of the fields in the spec are set to non-default values. */
   useExplicitDryRunSpec?: boolean;
+  /** Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries. */
+  status?: ServicePerimeterConfig;
+  /** Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty. */
+  perimeterType?: ServicePerimeterPerimeterTypeEnum | (string & {});
 }
 export const ServicePerimeter = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    name: S.optional(S.String),
+    title: S.optional(S.String),
     description: S.optional(S.String),
     spec: S.optional(ServicePerimeterConfig),
+    name: S.optional(S.String),
     etag: S.optional(S.String),
-    status: S.optional(ServicePerimeterConfig),
-    title: S.optional(S.String),
-    perimeterType: S.optional(ServicePerimeterPerimeterTypeEnum),
     useExplicitDryRunSpec: S.optional(S.Boolean),
+    status: S.optional(ServicePerimeterConfig),
+    perimeterType: S.optional(ServicePerimeterPerimeterTypeEnum),
   }),
 ).annotate({
   identifier: "ServicePerimeter",
@@ -970,17 +970,6 @@ export const CreateAccessPoliciesServicePerimetersRequest =
     identifier: "CreateAccessPoliciesServicePerimetersRequest",
   }) as any as S.Schema<CreateAccessPoliciesServicePerimetersRequest>;
 
-/** A Google Cloud project which contains applications and resources that users can access. */
-export interface Project {
-  /** The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890` */
-  name?: string;
-}
-export const Project = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    name: S.optional(S.String),
-  }),
-).annotate({ identifier: "Project" }) as any as S.Schema<Project>;
-
 /** An application that accesses Google Cloud APIs. */
 export interface Application {
   /** The OAuth client ID of the application. */
@@ -995,17 +984,82 @@ export const Application = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "Application" }) as any as S.Schema<Application>;
 
+export type ApplicationList = Array<Application>;
+export const ApplicationList = /*@__PURE__*/ S.Array(
+  Application,
+) as any as S.Schema<ApplicationList>;
+
+export type SessionSettingsSessionReauthMethodEnum =
+  | "SESSION_REAUTH_METHOD_UNSPECIFIED"
+  | "LOGIN"
+  | "SECURITY_KEY"
+  | "PASSWORD";
+export const SessionSettingsSessionReauthMethodEnum = /*@__PURE__*/ S.String;
+
+/** Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings. */
+export interface SessionSettings {
+  /** Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param. */
+  useOidcMaxAge?: boolean;
+  /** Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps. */
+  maxInactivity?: string;
+  /** Optional. Session method when user's Google Cloud session is up. */
+  sessionReauthMethod?: SessionSettingsSessionReauthMethodEnum | (string & {});
+  /** Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset. */
+  sessionLength?: string;
+  /** Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false. */
+  sessionLengthEnabled?: boolean;
+}
+export const SessionSettings = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    useOidcMaxAge: S.optional(S.Boolean),
+    maxInactivity: S.optional(S.String),
+    sessionReauthMethod: S.optional(SessionSettingsSessionReauthMethodEnum),
+    sessionLength: S.optional(S.String),
+    sessionLengthEnabled: S.optional(S.Boolean),
+  }),
+).annotate({
+  identifier: "SessionSettings",
+}) as any as S.Schema<SessionSettings>;
+
+/** The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding. */
+export interface Principal {
+  /** Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement. */
+  serviceAccount?: string;
+  /** Immutable. Cloud project number used to assign policies to all service accounts owned by the project. */
+  serviceAccountProjectNumber?: string;
+  /** Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed. */
+  federatedPrincipal?: string;
+}
+export const Principal = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    serviceAccount: S.optional(S.String),
+    serviceAccountProjectNumber: S.optional(S.String),
+    federatedPrincipal: S.optional(S.String),
+  }),
+).annotate({ identifier: "Principal" }) as any as S.Schema<Principal>;
+
+/** A Google Cloud project which contains applications and resources that users can access. */
+export interface Project {
+  /** The Google Cloud project resource name. Format: `projects/{project_number}`. Only the project number is supported. Example: `projects/1234567890` */
+  name?: string;
+}
+export const Project = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    name: S.optional(S.String),
+  }),
+).annotate({ identifier: "Project" }) as any as S.Schema<Project>;
+
 /** Client scope represents the application, etc. subject to this binding's restrictions. */
 export interface ClientScope {
-  /** Optional. The Google Cloud project that is subject to this binding's scope. */
-  restrictedProject?: Project;
   /** Optional. The application that is subject to this binding's scope. */
   restrictedClientApplication?: Application;
+  /** Optional. The Google Cloud project that is subject to this binding's scope. */
+  restrictedProject?: Project;
 }
 export const ClientScope = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    restrictedProject: S.optional(Project),
     restrictedClientApplication: S.optional(Application),
+    restrictedProject: S.optional(Project),
   }),
 ).annotate({ identifier: "ClientScope" }) as any as S.Schema<ClientScope>;
 
@@ -1019,38 +1073,6 @@ export const AccessScope = /*@__PURE__*/ S.suspend(() =>
     clientScope: S.optional(ClientScope),
   }),
 ).annotate({ identifier: "AccessScope" }) as any as S.Schema<AccessScope>;
-
-export type SessionSettingsSessionReauthMethodEnum =
-  | "SESSION_REAUTH_METHOD_UNSPECIFIED"
-  | "LOGIN"
-  | "SECURITY_KEY"
-  | "PASSWORD";
-export const SessionSettingsSessionReauthMethodEnum = /*@__PURE__*/ S.String;
-
-/** Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings. */
-export interface SessionSettings {
-  /** Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset. */
-  sessionLength?: string;
-  /** Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param. */
-  useOidcMaxAge?: boolean;
-  /** Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps. */
-  maxInactivity?: string;
-  /** Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false. */
-  sessionLengthEnabled?: boolean;
-  /** Optional. Session method when user's Google Cloud session is up. */
-  sessionReauthMethod?: SessionSettingsSessionReauthMethodEnum | (string & {});
-}
-export const SessionSettings = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    sessionLength: S.optional(S.String),
-    useOidcMaxAge: S.optional(S.Boolean),
-    maxInactivity: S.optional(S.String),
-    sessionLengthEnabled: S.optional(S.Boolean),
-    sessionReauthMethod: S.optional(SessionSettingsSessionReauthMethodEnum),
-  }),
-).annotate({
-  identifier: "SessionSettings",
-}) as any as S.Schema<SessionSettings>;
 
 /** Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set. */
 export interface AccessSettings {
@@ -1070,16 +1092,16 @@ export const AccessSettings = /*@__PURE__*/ S.suspend(() =>
 export interface ScopedAccessSettings {
   /** Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty. */
   scope?: AccessScope;
-  /** Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set. */
-  activeSettings?: AccessSettings;
   /** Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set. */
   dryRunSettings?: AccessSettings;
+  /** Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set. */
+  activeSettings?: AccessSettings;
 }
 export const ScopedAccessSettings = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     scope: S.optional(AccessScope),
-    activeSettings: S.optional(AccessSettings),
     dryRunSettings: S.optional(AccessSettings),
+    activeSettings: S.optional(AccessSettings),
   }),
 ).annotate({
   identifier: "ScopedAccessSettings",
@@ -1090,49 +1112,35 @@ export const ScopedAccessSettingsList = /*@__PURE__*/ S.Array(
   ScopedAccessSettings,
 ) as any as S.Schema<ScopedAccessSettingsList>;
 
-/** The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding. */
-export interface Principal {
-  /** Immutable. Cloud project number used to assign policies to all service accounts owned by the project. */
-  serviceAccountProjectNumber?: string;
-  /** Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed. */
-  federatedPrincipal?: string;
-  /** Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement. */
-  serviceAccount?: string;
-}
-export const Principal = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    serviceAccountProjectNumber: S.optional(S.String),
-    federatedPrincipal: S.optional(S.String),
-    serviceAccount: S.optional(S.String),
-  }),
-).annotate({ identifier: "Principal" }) as any as S.Schema<Principal>;
-
 /** Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access. */
 export interface GcpUserAccessBinding {
-  /** Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. */
-  scopedAccessSettings?: ScopedAccessSettingsList;
-  /** Optional. The Google Cloud session length (GCSL) policy for the group key. */
-  sessionSettings?: SessionSettings;
-  /** Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
-  accessLevels?: StringList;
-  /** Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
-  dryRunAccessLevels?: StringList;
-  /** Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N" */
-  name?: string;
-  /** Optional. Immutable. The principal that is subject to the access policies in this policy binding. */
-  principal?: Principal;
   /** Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See "id" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: "01d520gv4vjcrht" */
   groupKey?: string;
+  /** Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
+  accessLevels?: StringList;
+  /** Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N" */
+  name?: string;
+  /** Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
+  dryRunAccessLevels?: StringList;
+  /** Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications. */
+  restrictedClientApplications?: ApplicationList;
+  /** Optional. The Google Cloud session length (GCSL) policy for the group key. */
+  sessionSettings?: SessionSettings;
+  /** Optional. Immutable. The principal that is subject to the access policies in this policy binding. */
+  principal?: Principal;
+  /** Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set. */
+  scopedAccessSettings?: ScopedAccessSettingsList;
 }
 export const GcpUserAccessBinding = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    scopedAccessSettings: S.optional(ScopedAccessSettingsList),
-    sessionSettings: S.optional(SessionSettings),
-    accessLevels: S.optional(StringList),
-    dryRunAccessLevels: S.optional(StringList),
-    name: S.optional(S.String),
-    principal: S.optional(Principal),
     groupKey: S.optional(S.String),
+    accessLevels: S.optional(StringList),
+    name: S.optional(S.String),
+    dryRunAccessLevels: S.optional(StringList),
+    restrictedClientApplications: S.optional(ApplicationList),
+    sessionSettings: S.optional(SessionSettings),
+    principal: S.optional(Principal),
+    scopedAccessSettings: S.optional(ScopedAccessSettingsList),
   }),
 ).annotate({
   identifier: "GcpUserAccessBinding",
@@ -1298,20 +1306,20 @@ export const GetAccessPoliciesAccessLevelsAccessLevelFormatEnum =
   /*@__PURE__*/ S.String;
 
 export interface GetAccessPoliciesAccessLevelsRequest {
+  /** Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}` */
+  name: string;
   /** Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`. */
   accessLevelFormat?:
     | GetAccessPoliciesAccessLevelsAccessLevelFormatEnum
     | (string & {});
-  /** Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}` */
-  name: string;
 }
 export const GetAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   () =>
     S.Struct({
+      name: S.String.pipe(T.Label()),
       accessLevelFormat: S.optional(
         GetAccessPoliciesAccessLevelsAccessLevelFormatEnum.pipe(T.Query()),
       ),
-      name: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1424,28 +1432,6 @@ export const GetIamPolicyAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "GetIamPolicyAccessPoliciesRequest",
 }) as any as S.Schema<GetIamPolicyAccessPoliciesRequest>;
 
-/** Associates `members`, or principals, with a `role`. */
-export interface Binding {
-  /** Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`. */
-  members?: StringList;
-  /** The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
-  condition?: Expr;
-  /** Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles). */
-  role?: string;
-}
-export const Binding = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    members: S.optional(StringList),
-    condition: S.optional(Expr),
-    role: S.optional(S.String),
-  }),
-).annotate({ identifier: "Binding" }) as any as S.Schema<Binding>;
-
-export type BindingList = Array<Binding>;
-export const BindingList = /*@__PURE__*/ S.Array(
-  Binding,
-) as any as S.Schema<BindingList>;
-
 export type AuditLogConfigLogTypeEnum =
   | "LOG_TYPE_UNSPECIFIED"
   | "ADMIN_READ"
@@ -1455,15 +1441,15 @@ export const AuditLogConfigLogTypeEnum = /*@__PURE__*/ S.String;
 
 /** Provides the configuration for logging a type of permissions. Example: { "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [ "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" } ] } This enables 'DATA_READ' and 'DATA_WRITE' logging, while exempting jose@example.com from DATA_READ logging. */
 export interface AuditLogConfig {
-  /** Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members. */
-  exemptedMembers?: StringList;
   /** The log type that this config enables. */
   logType?: AuditLogConfigLogTypeEnum | (string & {});
+  /** Specifies the identities that do not cause logging for this type of permission. Follows the same format of Binding.members. */
+  exemptedMembers?: StringList;
 }
 export const AuditLogConfig = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    exemptedMembers: S.optional(StringList),
     logType: S.optional(AuditLogConfigLogTypeEnum),
+    exemptedMembers: S.optional(StringList),
   }),
 ).annotate({ identifier: "AuditLogConfig" }) as any as S.Schema<AuditLogConfig>;
 
@@ -1491,23 +1477,45 @@ export const AuditConfigList = /*@__PURE__*/ S.Array(
   AuditConfig,
 ) as any as S.Schema<AuditConfigList>;
 
+/** Associates `members`, or principals, with a `role`. */
+export interface Binding {
+  /** Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles). */
+  role?: string;
+  /** Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`. */
+  members?: StringList;
+  /** The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
+  condition?: Expr;
+}
+export const Binding = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    role: S.optional(S.String),
+    members: S.optional(StringList),
+    condition: S.optional(Expr),
+  }),
+).annotate({ identifier: "Binding" }) as any as S.Schema<Binding>;
+
+export type BindingList = Array<Binding>;
+export const BindingList = /*@__PURE__*/ S.Array(
+  Binding,
+) as any as S.Schema<BindingList>;
+
 /** An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/). */
 export interface Policy {
   /** `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. */
   etag?: string;
+  /** Specifies cloud audit logging configuration for this policy. */
+  auditConfigs?: AuditConfigList;
   /** Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`. */
   bindings?: BindingList;
   /** Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
   version?: number;
-  /** Specifies cloud audit logging configuration for this policy. */
-  auditConfigs?: AuditConfigList;
 }
 export const Policy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     etag: S.optional(S.String),
+    auditConfigs: S.optional(AuditConfigList),
     bindings: S.optional(BindingList),
     version: S.optional(S.Number),
-    auditConfigs: S.optional(AuditConfigList),
   }),
 ).annotate({ identifier: "Policy" }) as any as S.Schema<Policy>;
 
@@ -1586,48 +1594,48 @@ export const SupportedServiceServiceSupportStageEnum = /*@__PURE__*/ S.String;
 
 /** `SupportedService` specifies the VPC Service Controls and its properties. */
 export interface SupportedService {
-  /** The service name or address of the supported service, such as `service.googleapis.com`. */
-  name?: string;
-  /** True if the service is supported with some limitations. Check [documentation](https://cloud.google.com/vpc-service-controls/docs/supported-products) for details. */
-  knownLimitations?: boolean;
-  /** The list of the supported methods. This field exists only in response to GetSupportedService */
-  supportedMethods?: MethodSelectorList;
   /** The support stage of the service. */
   supportStage?: SupportedServiceSupportStageEnum;
+  /** True if the service is supported with some limitations. Check [documentation](https://cloud.google.com/vpc-service-controls/docs/supported-products) for details. */
+  knownLimitations?: boolean;
+  /** True if the service is available on the restricted VIP. Services on the restricted VIP typically either support VPC Service Controls or are core infrastructure services required for the functioning of Google Cloud. */
+  availableOnRestrictedVip?: boolean;
   /** The name of the supported product, such as 'Cloud Product API'. */
   title?: string;
   /** The support stage of the service. */
   serviceSupportStage?: SupportedServiceServiceSupportStageEnum;
-  /** True if the service is available on the restricted VIP. Services on the restricted VIP typically either support VPC Service Controls or are core infrastructure services required for the functioning of Google Cloud. */
-  availableOnRestrictedVip?: boolean;
+  /** The list of the supported methods. This field exists only in response to GetSupportedService */
+  supportedMethods?: MethodSelectorList;
+  /** The service name or address of the supported service, such as `service.googleapis.com`. */
+  name?: string;
 }
 export const SupportedService = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    name: S.optional(S.String),
-    knownLimitations: S.optional(S.Boolean),
-    supportedMethods: S.optional(MethodSelectorList),
     supportStage: S.optional(SupportedServiceSupportStageEnum),
+    knownLimitations: S.optional(S.Boolean),
+    availableOnRestrictedVip: S.optional(S.Boolean),
     title: S.optional(S.String),
     serviceSupportStage: S.optional(SupportedServiceServiceSupportStageEnum),
-    availableOnRestrictedVip: S.optional(S.Boolean),
+    supportedMethods: S.optional(MethodSelectorList),
+    name: S.optional(S.String),
   }),
 ).annotate({
   identifier: "SupportedService",
 }) as any as S.Schema<SupportedService>;
 
 export interface ListAccessPoliciesRequest {
-  /** Number of AccessPolicy instances to include in the list. Default 100. */
-  pageSize?: number;
   /** Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}` */
   parent?: string;
   /** Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results. */
   pageToken?: string;
+  /** Number of AccessPolicy instances to include in the list. Default 100. */
+  pageSize?: number;
 }
 export const ListAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pageSize: S.optional(S.Number.pipe(T.Query())),
     parent: S.optional(S.String.pipe(T.Query())),
     pageToken: S.optional(S.String.pipe(T.Query())),
+    pageSize: S.optional(S.Number.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1668,26 +1676,26 @@ export const ListAccessPoliciesAccessLevelsAccessLevelFormatEnum =
   /*@__PURE__*/ S.String;
 
 export interface ListAccessPoliciesAccessLevelsRequest {
-  /** Number of Access Levels to include in the list. Default 100. */
-  pageSize?: number;
-  /** Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}` */
-  parent: string;
-  /** Next page token for the next batch of Access Level instances. Defaults to the first page of results. */
-  pageToken?: string;
   /** Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined. */
   accessLevelFormat?:
     | ListAccessPoliciesAccessLevelsAccessLevelFormatEnum
     | (string & {});
+  /** Next page token for the next batch of Access Level instances. Defaults to the first page of results. */
+  pageToken?: string;
+  /** Number of Access Levels to include in the list. Default 100. */
+  pageSize?: number;
+  /** Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}` */
+  parent: string;
 }
 export const ListAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   () =>
     S.Struct({
-      pageSize: S.optional(S.Number.pipe(T.Query())),
-      parent: S.String.pipe(T.Label()),
-      pageToken: S.optional(S.String.pipe(T.Query())),
       accessLevelFormat: S.optional(
         ListAccessPoliciesAccessLevelsAccessLevelFormatEnum.pipe(T.Query()),
       ),
+      pageToken: S.optional(S.String.pipe(T.Query())),
+      pageSize: S.optional(S.Number.pipe(T.Query())),
+      parent: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1723,17 +1731,17 @@ export const ListAccessLevelsResponse = /*@__PURE__*/ S.suspend(() =>
 export interface ListAccessPoliciesAuthorizedOrgsDescsRequest {
   /** Number of Authorized Orgs Descs to include in the list. Default 100. */
   pageSize?: number;
-  /** Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}` */
-  parent: string;
   /** Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results. */
   pageToken?: string;
+  /** Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}` */
+  parent: string;
 }
 export const ListAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
       pageSize: S.optional(S.Number.pipe(T.Query())),
-      parent: S.String.pipe(T.Label()),
       pageToken: S.optional(S.String.pipe(T.Query())),
+      parent: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1774,28 +1782,28 @@ export const ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum =
   /*@__PURE__*/ S.String;
 
 export interface ListAccessPoliciesServicePerimetersRequest {
-  /** Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}` */
-  parent: string;
-  /** Number of Service Perimeters to include in the list. Default 100. */
-  pageSize?: number;
-  /** Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results. */
-  pageToken?: string;
   /** Optional. If true, the response will contain the deleted principal syntax for identities that support it. */
   deletedPrincipalSyntax?:
     | ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum
     | (string & {});
+  /** Number of Service Perimeters to include in the list. Default 100. */
+  pageSize?: number;
+  /** Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}` */
+  parent: string;
+  /** Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results. */
+  pageToken?: string;
 }
 export const ListAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      parent: S.String.pipe(T.Label()),
-      pageSize: S.optional(S.Number.pipe(T.Query())),
-      pageToken: S.optional(S.String.pipe(T.Query())),
       deletedPrincipalSyntax: S.optional(
         ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum.pipe(
           T.Query(),
         ),
       ),
+      pageSize: S.optional(S.Number.pipe(T.Query())),
+      parent: S.String.pipe(T.Label()),
+      pageToken: S.optional(S.String.pipe(T.Query())),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1814,39 +1822,39 @@ export const ServicePerimeterList = /*@__PURE__*/ S.Array(
 
 /** A response to `ListServicePerimetersRequest`. */
 export interface ListServicePerimetersResponse {
-  /** List of the Service Perimeter instances. */
-  servicePerimeters?: ServicePerimeterList;
   /** The pagination token to retrieve the next page of results. If the value is empty, no further results remain. */
   nextPageToken?: string;
+  /** List of the Service Perimeter instances. */
+  servicePerimeters?: ServicePerimeterList;
 }
 export const ListServicePerimetersResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    servicePerimeters: S.optional(ServicePerimeterList),
     nextPageToken: S.optional(S.String),
+    servicePerimeters: S.optional(ServicePerimeterList),
   }),
 ).annotate({
   identifier: "ListServicePerimetersResponse",
 }) as any as S.Schema<ListServicePerimetersResponse>;
 
 export interface ListOperationsRequest {
+  /** The standard list page token. */
+  pageToken?: string;
+  /** The standard list filter. */
+  filter?: string;
   /** The standard list page size. */
   pageSize?: number;
   /** When set to `true`, operations that are reachable are returned as normal, and those that are unreachable are returned in the ListOperationsResponse.unreachable field. This can only be `true` when reading across collections. For example, when `parent` is set to `"projects/example/locations/-"`. This field is not supported by default and will result in an `UNIMPLEMENTED` error if set unless explicitly documented otherwise in service or product specific documentation. */
   returnPartialSuccess?: boolean;
   /** The name of the operation's parent resource. */
   name: string;
-  /** The standard list page token. */
-  pageToken?: string;
-  /** The standard list filter. */
-  filter?: string;
 }
 export const ListOperationsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    pageToken: S.optional(S.String.pipe(T.Query())),
+    filter: S.optional(S.String.pipe(T.Query())),
     pageSize: S.optional(S.Number.pipe(T.Query())),
     returnPartialSuccess: S.optional(S.Boolean.pipe(T.Query())),
     name: S.String.pipe(T.Label()),
-    pageToken: S.optional(S.String.pipe(T.Query())),
-    filter: S.optional(S.String.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1865,18 +1873,18 @@ export const OperationList = /*@__PURE__*/ S.Array(
 
 /** The response message for Operations.ListOperations. */
 export interface ListOperationsResponse {
+  /** Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations. */
+  unreachable?: StringList;
   /** The standard List next-page token. */
   nextPageToken?: string;
   /** A list of operations that matches the specified filter in the request. */
   operations?: OperationList;
-  /** Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations. */
-  unreachable?: StringList;
 }
 export const ListOperationsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    unreachable: S.optional(StringList),
     nextPageToken: S.optional(S.String),
     operations: S.optional(OperationList),
-    unreachable: S.optional(StringList),
   }),
 ).annotate({
   identifier: "ListOperationsResponse",
@@ -1887,18 +1895,18 @@ export interface ListOrganizationsGcpUserAccessBindingsRequest {
   pageSize?: number;
   /** Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation. */
   pageToken?: string;
-  /** Optional. The literal filter to apply to the results returned. See https://google.aip.dev/160 for more details. Accepts values: * `principal:group_key` * `principal:service_account` OR `principal:service_account_project_number`. If this field is empty or not one of the above, the default value is `"principal:group_key"`. */
-  filter?: string;
   /** Required. Example: "organizations/256" */
   parent: string;
+  /** Optional. The literal filter to apply to the results returned. See https://google.aip.dev/160 for more details. Accepts values: * `principal:group_key` * `principal:service_account` OR `principal:service_account_project_number`. If this field is empty or not one of the above, the default value is `"principal:group_key"`. */
+  filter?: string;
 }
 export const ListOrganizationsGcpUserAccessBindingsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
       pageSize: S.optional(S.Number.pipe(T.Query())),
       pageToken: S.optional(S.String.pipe(T.Query())),
-      filter: S.optional(S.String.pipe(T.Query())),
       parent: S.String.pipe(T.Label()),
+      filter: S.optional(S.String.pipe(T.Query())),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1932,15 +1940,15 @@ export const ListGcpUserAccessBindingsResponse = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<ListGcpUserAccessBindingsResponse>;
 
 export interface ListPermissionsRequest {
-  /** Optional. This flag specifies the maximum number of services to return per page. Default value is 100. */
-  pageSize?: number;
   /** Optional. Use this token to retrieve a specific page of results. Default is the first page. */
   pageToken?: string;
+  /** Optional. This flag specifies the maximum number of services to return per page. Default value is 100. */
+  pageSize?: number;
 }
 export const ListPermissionsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pageSize: S.optional(S.Number.pipe(T.Query())),
     pageToken: S.optional(S.String.pipe(T.Query())),
+    pageSize: S.optional(S.Number.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1954,15 +1962,15 @@ export const ListPermissionsRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** A response to `ListSupportedPermissionsRequest`. */
 export interface ListSupportedPermissionsResponse {
-  /** List of VPC Service Controls supported permissions. */
-  supportedPermissions?: StringList;
   /** Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available. */
   nextPageToken?: string;
+  /** List of VPC Service Controls supported permissions. */
+  supportedPermissions?: StringList;
 }
 export const ListSupportedPermissionsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    supportedPermissions: S.optional(StringList),
     nextPageToken: S.optional(S.String),
+    supportedPermissions: S.optional(StringList),
   }),
 ).annotate({
   identifier: "ListSupportedPermissionsResponse",
@@ -2009,67 +2017,6 @@ export const ListSupportedServicesResponse = /*@__PURE__*/ S.suspend(() =>
 ).annotate({
   identifier: "ListSupportedServicesResponse",
 }) as any as S.Schema<ListSupportedServicesResponse>;
-
-export interface LookupConfiguredServicePerimeterFoldersRequest {
-  /** Required. The Resource to resolve (e.g. "projects/123", "folders/456"). */
-  resource: string;
-}
-export const LookupConfiguredServicePerimeterFoldersRequest =
-  /*@__PURE__*/ S.suspend(() =>
-    S.Struct({
-      resource: S.String.pipe(T.Label()),
-    }).pipe(
-      T.Http({
-        method: "GET",
-        uri: "v1/{+resource}:lookupConfiguredServicePerimeter",
-        baseUrl: "https://accesscontextmanager.googleapis.com/",
-      }),
-    ),
-  ).annotate({
-    identifier: "LookupConfiguredServicePerimeterFoldersRequest",
-  }) as any as S.Schema<LookupConfiguredServicePerimeterFoldersRequest>;
-
-/** A configured service perimeter returned by Access Context Manager. */
-export interface LookupConfiguredServicePerimeterResponse {
-  /** Fully qualified name of the configured dry-run perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no dry-run perimeter configuration applies. */
-  servicePerimeterDryRun?: string;
-  /** Fully qualified name of the configured enforced perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no enforced perimeter applies. */
-  servicePerimeter?: string;
-  /** The resource (e.g. "projects/123", "folders/456") that directly owns/is restricted by the enforced perimeter. */
-  restrictedResource?: string;
-  /** The resource (e.g. "projects/123", "folders/456") that directly owns/is restricted by the dry-run perimeter. */
-  restrictedResourceDryRun?: string;
-}
-export const LookupConfiguredServicePerimeterResponse = /*@__PURE__*/ S.suspend(
-  () =>
-    S.Struct({
-      servicePerimeterDryRun: S.optional(S.String),
-      servicePerimeter: S.optional(S.String),
-      restrictedResource: S.optional(S.String),
-      restrictedResourceDryRun: S.optional(S.String),
-    }),
-).annotate({
-  identifier: "LookupConfiguredServicePerimeterResponse",
-}) as any as S.Schema<LookupConfiguredServicePerimeterResponse>;
-
-export interface LookupConfiguredServicePerimeterProjectsRequest {
-  /** Required. The Resource to resolve (e.g. "projects/123", "folders/456"). */
-  resource: string;
-}
-export const LookupConfiguredServicePerimeterProjectsRequest =
-  /*@__PURE__*/ S.suspend(() =>
-    S.Struct({
-      resource: S.String.pipe(T.Label()),
-    }).pipe(
-      T.Http({
-        method: "GET",
-        uri: "v1/{+resource}:lookupConfiguredServicePerimeter",
-        baseUrl: "https://accesscontextmanager.googleapis.com/",
-      }),
-    ),
-  ).annotate({
-    identifier: "LookupConfiguredServicePerimeterProjectsRequest",
-  }) as any as S.Schema<LookupConfiguredServicePerimeterProjectsRequest>;
 
 export interface PatchAccessPoliciesRequest {
   /** Required. Mask to control which fields get updated. Must be non-empty. */
@@ -2121,18 +2068,18 @@ export const PatchAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<PatchAccessPoliciesAccessLevelsRequest>;
 
 export interface PatchAccessPoliciesAuthorizedOrgsDescsRequest {
-  /** Required. Mask to control which fields get updated. Must be non-empty. */
-  updateMask?: string;
   /** Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`. */
   name: string;
+  /** Required. Mask to control which fields get updated. Must be non-empty. */
+  updateMask?: string;
   /** Request body */
   body?: AuthorizedOrgsDesc;
 }
 export const PatchAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      updateMask: S.optional(S.String.pipe(T.Query())),
       name: S.String.pipe(T.Label()),
+      updateMask: S.optional(S.String.pipe(T.Query())),
       body: S.optional(AuthorizedOrgsDesc.pipe(T.HttpBody())),
     }).pipe(
       T.Http({
@@ -2153,27 +2100,27 @@ export const PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum =
   /*@__PURE__*/ S.String;
 
 export interface PatchAccessPoliciesServicePerimetersRequest {
-  /** Required. Mask to control which fields get updated. Must be non-empty. */
-  updateMask?: string;
-  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
-  name: string;
   /** Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax. */
   deletedPrincipalSyntax?:
     | PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum
     | (string & {});
+  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
+  name: string;
+  /** Required. Mask to control which fields get updated. Must be non-empty. */
+  updateMask?: string;
   /** Request body */
   body?: ServicePerimeter;
 }
 export const PatchAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      updateMask: S.optional(S.String.pipe(T.Query())),
-      name: S.String.pipe(T.Label()),
       deletedPrincipalSyntax: S.optional(
         PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum.pipe(
           T.Query(),
         ),
       ),
+      name: S.String.pipe(T.Label()),
+      updateMask: S.optional(S.String.pipe(T.Query())),
       body: S.optional(ServicePerimeter.pipe(T.HttpBody())),
     }).pipe(
       T.Http({
@@ -2216,15 +2163,15 @@ export const PatchOrganizationsGcpUserAccessBindingsRequest =
 
 /** A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically. */
 export interface ReplaceAccessLevelsRequest {
-  /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
-  etag?: string;
   /** Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy. */
   accessLevels?: AccessLevelList;
+  /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
+  etag?: string;
 }
 export const ReplaceAccessLevelsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    etag: S.optional(S.String),
     accessLevels: S.optional(AccessLevelList),
+    etag: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ReplaceAccessLevelsRequest",
@@ -2254,15 +2201,15 @@ export const ReplaceAllAccessPoliciesAccessLevelsRequest =
 
 /** A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically. */
 export interface ReplaceServicePerimetersRequest {
-  /** Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy. */
-  servicePerimeters?: ServicePerimeterList;
   /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
   etag?: string;
+  /** Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy. */
+  servicePerimeters?: ServicePerimeterList;
 }
 export const ReplaceServicePerimetersRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    servicePerimeters: S.optional(ServicePerimeterList),
     etag: S.optional(S.String),
+    servicePerimeters: S.optional(ServicePerimeterList),
   }),
 ).annotate({
   identifier: "ReplaceServicePerimetersRequest",
@@ -2292,15 +2239,15 @@ export const ReplaceAllAccessPoliciesServicePerimetersRequest =
 
 /** Request message for `SetIamPolicy` method. */
 export interface SetIamPolicyRequest {
-  /** REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them. */
-  policy?: Policy;
   /** OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: "bindings, etag"` */
   updateMask?: string;
+  /** REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them. */
+  policy?: Policy;
 }
 export const SetIamPolicyRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    policy: S.optional(Policy),
     updateMask: S.optional(S.String),
+    policy: S.optional(Policy),
   }),
 ).annotate({
   identifier: "SetIamPolicyRequest",
@@ -2987,42 +2934,6 @@ export const listServices: API.PaginatedOperationMethod<
     outputToken: "nextPageToken",
   } as const,
 })) as any;
-
-export type LookupConfiguredServicePerimeterFoldersError =
-  | NotFound
-  | Forbidden
-  | GcpOpError;
-/** Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']. */
-export const lookupConfiguredServicePerimeterFolders: API.OperationMethod<
-  LookupConfiguredServicePerimeterFoldersRequest,
-  LookupConfiguredServicePerimeterResponse,
-  LookupConfiguredServicePerimeterFoldersError,
-  GcpOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: LookupConfiguredServicePerimeterFoldersRequest,
-  output: LookupConfiguredServicePerimeterResponse,
-  errors: [NotFound, Forbidden, UnknownGCPError],
-  protocol: GcpProtocol,
-  retry: Retry.Retry,
-}));
-
-export type LookupConfiguredServicePerimeterProjectsError =
-  | NotFound
-  | Forbidden
-  | GcpOpError;
-/** Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']. */
-export const lookupConfiguredServicePerimeterProjects: API.OperationMethod<
-  LookupConfiguredServicePerimeterProjectsRequest,
-  LookupConfiguredServicePerimeterResponse,
-  LookupConfiguredServicePerimeterProjectsError,
-  GcpOpContext
-> = /*@__PURE__*/ API.make(() => ({
-  input: LookupConfiguredServicePerimeterProjectsRequest,
-  output: LookupConfiguredServicePerimeterResponse,
-  errors: [NotFound, Forbidden, UnknownGCPError],
-  protocol: GcpProtocol,
-  retry: Retry.Retry,
-}));
 
 export type PatchAccessPoliciesError =
   | NotFound

--- a/packages/gcp/src/services/accesscontextmanager_v1.ts
+++ b/packages/gcp/src/services/accesscontextmanager_v1.ts
@@ -148,23 +148,25 @@ export const DocumentMapList = /*@__PURE__*/ S.Array(
 
 /** The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors). */
 export interface Status {
-  /** A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client. */
-  message?: string;
   /** A list of messages that carry the error details. There is a common set of message types for APIs to use. */
   details?: DocumentMapList;
   /** The status code, which should be an enum value of google.rpc.Code. */
   code?: number;
+  /** A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client. */
+  message?: string;
 }
 export const Status = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    message: S.optional(S.String),
     details: S.optional(DocumentMapList),
     code: S.optional(S.Number),
+    message: S.optional(S.String),
   }),
 ).annotate({ identifier: "Status" }) as any as S.Schema<Status>;
 
 /** This resource represents a long-running operation that is the result of a network API call. */
 export interface Operation {
+  /** The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`. */
+  response?: DocumentMap;
   /** The error result of the operation in case of failure or cancellation. */
   error?: Status;
   /** If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available. */
@@ -173,16 +175,14 @@ export interface Operation {
   name?: string;
   /** Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any. */
   metadata?: DocumentMap;
-  /** The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`. */
-  response?: DocumentMap;
 }
 export const Operation = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    response: S.optional(DocumentMap),
     error: S.optional(Status),
     done: S.optional(S.Boolean),
     name: S.optional(S.String),
     metadata: S.optional(DocumentMap),
-    response: S.optional(DocumentMap),
   }),
 ).annotate({ identifier: "Operation" }) as any as S.Schema<Operation>;
 
@@ -195,22 +195,22 @@ export const StringList = /*@__PURE__*/ S.Array(
 export interface AccessPolicy {
   /** Required. The parent of this `AccessPolicy` in the Cloud Resource Hierarchy. Currently immutable once created. Format: `organizations/{organization_id}` */
   parent?: string;
-  /** The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=["folders/123"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}` */
-  scopes?: StringList;
   /** Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}` */
   name?: string;
   /** Output only. An opaque identifier for the current version of the `AccessPolicy`. This will always be a strongly validated etag, meaning that two Access Policies will be identical if and only if their etags are identical. Clients should not expect this to be in any specific format. */
   etag?: string;
   /** Required. Human readable title. Does not affect behavior. */
   title?: string;
+  /** The scopes of the AccessPolicy. Scopes define which resources a policy can restrict and where its resources can be referenced. For example, policy A with `scopes=["folders/123"]` has the following behavior: - ServicePerimeter can only restrict projects within `folders/123`. - ServicePerimeter within policy A can only reference access levels defined within policy A. - Only one policy can include a given scope; thus, attempting to create a second policy which includes `folders/123` will result in an error. If no scopes are provided, then any resource within the organization can be restricted. Scopes cannot be modified after a policy is created. Policies can only have a single scope. Format: list of `folders/{folder_number}` or `projects/{project_number}` */
+  scopes?: StringList;
 }
 export const AccessPolicy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     parent: S.optional(S.String),
-    scopes: S.optional(StringList),
     name: S.optional(S.String),
     etag: S.optional(S.String),
     title: S.optional(S.String),
+    scopes: S.optional(StringList),
   }),
 ).annotate({ identifier: "AccessPolicy" }) as any as S.Schema<AccessPolicy>;
 
@@ -234,21 +234,21 @@ export const CreateAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec. Example (Comparison): title: "Summary size limit" description: "Determines if a summary is less than 100 chars" expression: "document.summary.size() < 100" Example (Equality): title: "Requestor is owner" description: "Determines if requestor is the document owner" expression: "document.owner == request.auth.claims.email" Example (Logic): title: "Public documents" description: "Determine whether the document should be publicly visible" expression: "document.type != 'private' && document.type != 'internal'" Example (Data Manipulation): title: "Notification string" description: "Create a notification string with a timestamp." expression: "'New message received at ' + string(document.create_time)" The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information. */
 export interface Expr {
-  /** Textual representation of an expression in Common Expression Language syntax. */
-  expression?: string;
-  /** Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression. */
-  title?: string;
   /** Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file. */
   location?: string;
+  /** Textual representation of an expression in Common Expression Language syntax. */
+  expression?: string;
   /** Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI. */
   description?: string;
+  /** Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression. */
+  title?: string;
 }
 export const Expr = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    expression: S.optional(S.String),
-    title: S.optional(S.String),
     location: S.optional(S.String),
+    expression: S.optional(S.String),
     description: S.optional(S.String),
+    title: S.optional(S.String),
   }),
 ).annotate({ identifier: "Expr" }) as any as S.Schema<Expr>;
 
@@ -265,100 +265,6 @@ export const CustomLevel = /*@__PURE__*/ S.suspend(() =>
 
 export type BasicLevelCombiningFunctionEnum = "AND" | "OR";
 export const BasicLevelCombiningFunctionEnum = /*@__PURE__*/ S.String;
-
-export type OsConstraintOsTypeEnum =
-  | "OS_UNSPECIFIED"
-  | "DESKTOP_MAC"
-  | "DESKTOP_WINDOWS"
-  | "DESKTOP_LINUX"
-  | "DESKTOP_CHROME_OS"
-  | "ANDROID"
-  | "IOS";
-export const OsConstraintOsTypeEnum = /*@__PURE__*/ S.String;
-
-/** A restriction on the OS type and version of devices making requests. */
-export interface OsConstraint {
-  /** Required. The allowed OS type. */
-  osType?: OsConstraintOsTypeEnum | (string & {});
-  /** The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `"major.minor.patch"`. Examples: `"10.5.301"`, `"9.2.1"`. */
-  minimumVersion?: string;
-  /** Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request. */
-  requireVerifiedChromeOs?: boolean;
-}
-export const OsConstraint = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    osType: S.optional(OsConstraintOsTypeEnum),
-    minimumVersion: S.optional(S.String),
-    requireVerifiedChromeOs: S.optional(S.Boolean),
-  }),
-).annotate({ identifier: "OsConstraint" }) as any as S.Schema<OsConstraint>;
-
-export type OsConstraintList = Array<OsConstraint>;
-export const OsConstraintList = /*@__PURE__*/ S.Array(
-  OsConstraint,
-) as any as S.Schema<OsConstraintList>;
-
-export type DevicePolicyAllowedEncryptionStatusesItemEnum =
-  | "ENCRYPTION_UNSPECIFIED"
-  | "ENCRYPTION_UNSUPPORTED"
-  | "UNENCRYPTED"
-  | "ENCRYPTED";
-export const DevicePolicyAllowedEncryptionStatusesItemEnum =
-  /*@__PURE__*/ S.String;
-
-export type DevicePolicyAllowedEncryptionStatusesItemEnumList = Array<
-  DevicePolicyAllowedEncryptionStatusesItemEnum | (string & {})
->;
-export const DevicePolicyAllowedEncryptionStatusesItemEnumList =
-  /*@__PURE__*/ S.Array(
-    DevicePolicyAllowedEncryptionStatusesItemEnum,
-  ) as any as S.Schema<DevicePolicyAllowedEncryptionStatusesItemEnumList>;
-
-export type DevicePolicyAllowedDeviceManagementLevelsItemEnum =
-  | "MANAGEMENT_UNSPECIFIED"
-  | "NONE"
-  | "BASIC"
-  | "COMPLETE";
-export const DevicePolicyAllowedDeviceManagementLevelsItemEnum =
-  /*@__PURE__*/ S.String;
-
-export type DevicePolicyAllowedDeviceManagementLevelsItemEnumList = Array<
-  DevicePolicyAllowedDeviceManagementLevelsItemEnum | (string & {})
->;
-export const DevicePolicyAllowedDeviceManagementLevelsItemEnumList =
-  /*@__PURE__*/ S.Array(
-    DevicePolicyAllowedDeviceManagementLevelsItemEnum,
-  ) as any as S.Schema<DevicePolicyAllowedDeviceManagementLevelsItemEnumList>;
-
-/** `DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops. */
-export interface DevicePolicy {
-  /** Whether the device needs to be corp owned. */
-  requireCorpOwned?: boolean;
-  /** Allowed OS versions, an empty list allows all types and all versions. */
-  osConstraints?: OsConstraintList;
-  /** Allowed encryptions statuses, an empty list allows all statuses. */
-  allowedEncryptionStatuses?: DevicePolicyAllowedEncryptionStatusesItemEnumList;
-  /** Allowed device management levels, an empty list allows all management levels. */
-  allowedDeviceManagementLevels?: DevicePolicyAllowedDeviceManagementLevelsItemEnumList;
-  /** Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`. */
-  requireScreenlock?: boolean;
-  /** Whether the device needs to be approved by the customer admin. */
-  requireAdminApproval?: boolean;
-}
-export const DevicePolicy = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    requireCorpOwned: S.optional(S.Boolean),
-    osConstraints: S.optional(OsConstraintList),
-    allowedEncryptionStatuses: S.optional(
-      DevicePolicyAllowedEncryptionStatusesItemEnumList,
-    ),
-    allowedDeviceManagementLevels: S.optional(
-      DevicePolicyAllowedDeviceManagementLevelsItemEnumList,
-    ),
-    requireScreenlock: S.optional(S.Boolean),
-    requireAdminApproval: S.optional(S.Boolean),
-  }),
-).annotate({ identifier: "DevicePolicy" }) as any as S.Schema<DevicePolicy>;
 
 /** Sub-segment ranges inside of a VPC Network. */
 export interface VpcSubNetwork {
@@ -392,32 +298,126 @@ export const VpcNetworkSourceList = /*@__PURE__*/ S.Array(
   VpcNetworkSource,
 ) as any as S.Schema<VpcNetworkSourceList>;
 
+export type DevicePolicyAllowedEncryptionStatusesItemEnum =
+  | "ENCRYPTION_UNSPECIFIED"
+  | "ENCRYPTION_UNSUPPORTED"
+  | "UNENCRYPTED"
+  | "ENCRYPTED";
+export const DevicePolicyAllowedEncryptionStatusesItemEnum =
+  /*@__PURE__*/ S.String;
+
+export type DevicePolicyAllowedEncryptionStatusesItemEnumList = Array<
+  DevicePolicyAllowedEncryptionStatusesItemEnum | (string & {})
+>;
+export const DevicePolicyAllowedEncryptionStatusesItemEnumList =
+  /*@__PURE__*/ S.Array(
+    DevicePolicyAllowedEncryptionStatusesItemEnum,
+  ) as any as S.Schema<DevicePolicyAllowedEncryptionStatusesItemEnumList>;
+
+export type OsConstraintOsTypeEnum =
+  | "OS_UNSPECIFIED"
+  | "DESKTOP_MAC"
+  | "DESKTOP_WINDOWS"
+  | "DESKTOP_LINUX"
+  | "DESKTOP_CHROME_OS"
+  | "ANDROID"
+  | "IOS";
+export const OsConstraintOsTypeEnum = /*@__PURE__*/ S.String;
+
+/** A restriction on the OS type and version of devices making requests. */
+export interface OsConstraint {
+  /** The minimum allowed OS version. If not set, any version of this OS satisfies the constraint. Format: `"major.minor.patch"`. Examples: `"10.5.301"`, `"9.2.1"`. */
+  minimumVersion?: string;
+  /** Required. The allowed OS type. */
+  osType?: OsConstraintOsTypeEnum | (string & {});
+  /** Only allows requests from devices with a verified Chrome OS. Verifications includes requirements that the device is enterprise-managed, conformant to domain policies, and the caller has permission to call the API targeted by the request. */
+  requireVerifiedChromeOs?: boolean;
+}
+export const OsConstraint = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    minimumVersion: S.optional(S.String),
+    osType: S.optional(OsConstraintOsTypeEnum),
+    requireVerifiedChromeOs: S.optional(S.Boolean),
+  }),
+).annotate({ identifier: "OsConstraint" }) as any as S.Schema<OsConstraint>;
+
+export type OsConstraintList = Array<OsConstraint>;
+export const OsConstraintList = /*@__PURE__*/ S.Array(
+  OsConstraint,
+) as any as S.Schema<OsConstraintList>;
+
+export type DevicePolicyAllowedDeviceManagementLevelsItemEnum =
+  | "MANAGEMENT_UNSPECIFIED"
+  | "NONE"
+  | "BASIC"
+  | "COMPLETE";
+export const DevicePolicyAllowedDeviceManagementLevelsItemEnum =
+  /*@__PURE__*/ S.String;
+
+export type DevicePolicyAllowedDeviceManagementLevelsItemEnumList = Array<
+  DevicePolicyAllowedDeviceManagementLevelsItemEnum | (string & {})
+>;
+export const DevicePolicyAllowedDeviceManagementLevelsItemEnumList =
+  /*@__PURE__*/ S.Array(
+    DevicePolicyAllowedDeviceManagementLevelsItemEnum,
+  ) as any as S.Schema<DevicePolicyAllowedDeviceManagementLevelsItemEnumList>;
+
+/** `DevicePolicy` specifies device specific restrictions necessary to acquire a given access level. A `DevicePolicy` specifies requirements for requests from devices to be granted access levels, it does not do any enforcement on the device. `DevicePolicy` acts as an AND over all specified fields, and each repeated field is an OR over its elements. Any unset fields are ignored. For example, if the proto is { os_type : DESKTOP_WINDOWS, os_type : DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be true for requests originating from encrypted Linux desktops and encrypted Windows desktops. */
+export interface DevicePolicy {
+  /** Whether or not screenlock is required for the DevicePolicy to be true. Defaults to `false`. */
+  requireScreenlock?: boolean;
+  /** Whether the device needs to be approved by the customer admin. */
+  requireAdminApproval?: boolean;
+  /** Allowed encryptions statuses, an empty list allows all statuses. */
+  allowedEncryptionStatuses?: DevicePolicyAllowedEncryptionStatusesItemEnumList;
+  /** Allowed OS versions, an empty list allows all types and all versions. */
+  osConstraints?: OsConstraintList;
+  /** Whether the device needs to be corp owned. */
+  requireCorpOwned?: boolean;
+  /** Allowed device management levels, an empty list allows all management levels. */
+  allowedDeviceManagementLevels?: DevicePolicyAllowedDeviceManagementLevelsItemEnumList;
+}
+export const DevicePolicy = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    requireScreenlock: S.optional(S.Boolean),
+    requireAdminApproval: S.optional(S.Boolean),
+    allowedEncryptionStatuses: S.optional(
+      DevicePolicyAllowedEncryptionStatusesItemEnumList,
+    ),
+    osConstraints: S.optional(OsConstraintList),
+    requireCorpOwned: S.optional(S.Boolean),
+    allowedDeviceManagementLevels: S.optional(
+      DevicePolicyAllowedDeviceManagementLevelsItemEnumList,
+    ),
+  }),
+).annotate({ identifier: "DevicePolicy" }) as any as S.Schema<DevicePolicy>;
+
 /** A condition necessary for an `AccessLevel` to be granted. The Condition is an AND over its fields. So a Condition is true if: 1) the request IP is from one of the listed subnetworks AND 2) the originating device complies with the listed device policy AND 3) all listed access levels are granted AND 4) the request was sent at a time allowed by the DateTimeRestriction. */
 export interface Condition {
-  /** A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: "`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME"` */
-  requiredAccessLevels?: StringList;
-  /** CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly, for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed. */
-  ipSubnetworks?: StringList;
-  /** Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed. */
-  devicePolicy?: DevicePolicy;
-  /** Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false. */
-  negate?: boolean;
   /** The request must be made by one of the provided user or service accounts. Groups are not supported. Syntax: `user:{emailid}` `serviceAccount:{emailid}` If not specified, a request may come from any user. */
   members?: StringList;
   /** The request must originate from one of the provided countries/regions. Must be valid ISO 3166-1 alpha-2 codes. */
   regions?: StringList;
   /** The request must originate from one of the provided VPC networks in Google Cloud. Cannot specify this field together with `ip_subnetworks`. */
   vpcNetworkSources?: VpcNetworkSourceList;
+  /** CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for a CIDR IP address block, the specified IP address portion must be properly truncated (i.e. all the host bits must be zero) or the input is considered malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is not. Similarly, for IPv6, "2001:db8::/32" is accepted whereas "2001:db8::1/32" is not. The originating IP of a request must be in one of the listed subnets in order for this Condition to be true. If empty, all IP addresses are allowed. */
+  ipSubnetworks?: StringList;
+  /** Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields. Any non-empty field criteria evaluating to false will result in the Condition to be satisfied. Defaults to false. */
+  negate?: boolean;
+  /** Device specific restrictions, all restrictions must hold for the Condition to be true. If not specified, all devices are allowed. */
+  devicePolicy?: DevicePolicy;
+  /** A list of other access levels defined in the same `Policy`, referenced by resource name. Referencing an `AccessLevel` which does not exist is an error. All access levels listed must be granted for the Condition to be true. Example: "`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME"` */
+  requiredAccessLevels?: StringList;
 }
 export const Condition = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    requiredAccessLevels: S.optional(StringList),
-    ipSubnetworks: S.optional(StringList),
-    devicePolicy: S.optional(DevicePolicy),
-    negate: S.optional(S.Boolean),
     members: S.optional(StringList),
     regions: S.optional(StringList),
     vpcNetworkSources: S.optional(VpcNetworkSourceList),
+    ipSubnetworks: S.optional(StringList),
+    negate: S.optional(S.Boolean),
+    devicePolicy: S.optional(DevicePolicy),
+    requiredAccessLevels: S.optional(StringList),
   }),
 ).annotate({ identifier: "Condition" }) as any as S.Schema<Condition>;
 
@@ -446,20 +446,20 @@ export interface AccessLevel {
   custom?: CustomLevel;
   /** Human readable title. Must be unique within the Policy. */
   title?: string;
+  /** Description of the `AccessLevel` and its use. Does not affect behavior. */
+  description?: string;
   /** Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`. */
   name?: string;
   /** A `BasicLevel` composed of `Conditions`. */
   basic?: BasicLevel;
-  /** Description of the `AccessLevel` and its use. Does not affect behavior. */
-  description?: string;
 }
 export const AccessLevel = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     custom: S.optional(CustomLevel),
     title: S.optional(S.String),
+    description: S.optional(S.String),
     name: S.optional(S.String),
     basic: S.optional(BasicLevel),
-    description: S.optional(S.String),
   }),
 ).annotate({ identifier: "AccessLevel" }) as any as S.Schema<AccessLevel>;
 
@@ -485,6 +485,13 @@ export const CreateAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   identifier: "CreateAccessPoliciesAccessLevelsRequest",
 }) as any as S.Schema<CreateAccessPoliciesAccessLevelsRequest>;
 
+export type AuthorizedOrgsDescAuthorizationDirectionEnum =
+  | "AUTHORIZATION_DIRECTION_UNSPECIFIED"
+  | "AUTHORIZATION_DIRECTION_TO"
+  | "AUTHORIZATION_DIRECTION_FROM";
+export const AuthorizedOrgsDescAuthorizationDirectionEnum =
+  /*@__PURE__*/ S.String;
+
 export type AuthorizedOrgsDescAuthorizationTypeEnum =
   | "AUTHORIZATION_TYPE_UNSPECIFIED"
   | "AUTHORIZATION_TYPE_TRUST";
@@ -496,37 +503,30 @@ export type AuthorizedOrgsDescAssetTypeEnum =
   | "ASSET_TYPE_CREDENTIAL_STRENGTH";
 export const AuthorizedOrgsDescAssetTypeEnum = /*@__PURE__*/ S.String;
 
-export type AuthorizedOrgsDescAuthorizationDirectionEnum =
-  | "AUTHORIZATION_DIRECTION_UNSPECIFIED"
-  | "AUTHORIZATION_DIRECTION_TO"
-  | "AUTHORIZATION_DIRECTION_FROM";
-export const AuthorizedOrgsDescAuthorizationDirectionEnum =
-  /*@__PURE__*/ S.String;
-
 /** `AuthorizedOrgsDesc` contains data for an organization's authorization policy. */
 export interface AuthorizedOrgsDesc {
-  /** The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456` */
-  orgs?: StringList;
   /** Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`. */
   name?: string;
-  /** A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`. */
-  authorizationType?: AuthorizedOrgsDescAuthorizationTypeEnum | (string & {});
-  /** The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`. */
-  assetType?: AuthorizedOrgsDescAssetTypeEnum | (string & {});
+  /** The list of organization ids in this AuthorizedOrgsDesc. Format: `organizations/` Example: `organizations/123456` */
+  orgs?: StringList;
   /** The direction of the authorization relationship between this organization and the organizations listed in the `orgs` field. The valid values for this field include the following: `AUTHORIZATION_DIRECTION_FROM`: Allows this organization to evaluate traffic in the organizations listed in the `orgs` field. `AUTHORIZATION_DIRECTION_TO`: Allows the organizations listed in the `orgs` field to evaluate the traffic in this organization. For the authorization relationship to take effect, all of the organizations must authorize and specify the appropriate relationship direction. For example, if organization A authorized organization B and C to evaluate its traffic, by specifying `AUTHORIZATION_DIRECTION_TO` as the authorization direction, organizations B and C must specify `AUTHORIZATION_DIRECTION_FROM` as the authorization direction in their `AuthorizedOrgsDesc` resource. */
   authorizationDirection?:
     | AuthorizedOrgsDescAuthorizationDirectionEnum
     | (string & {});
+  /** A granular control type for authorization levels. Valid value is `AUTHORIZATION_TYPE_TRUST`. */
+  authorizationType?: AuthorizedOrgsDescAuthorizationTypeEnum | (string & {});
+  /** The asset type of this authorized orgs desc. Valid values are `ASSET_TYPE_DEVICE`, and `ASSET_TYPE_CREDENTIAL_STRENGTH`. */
+  assetType?: AuthorizedOrgsDescAssetTypeEnum | (string & {});
 }
 export const AuthorizedOrgsDesc = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    orgs: S.optional(StringList),
     name: S.optional(S.String),
-    authorizationType: S.optional(AuthorizedOrgsDescAuthorizationTypeEnum),
-    assetType: S.optional(AuthorizedOrgsDescAssetTypeEnum),
+    orgs: S.optional(StringList),
     authorizationDirection: S.optional(
       AuthorizedOrgsDescAuthorizationDirectionEnum,
     ),
+    authorizationType: S.optional(AuthorizedOrgsDescAuthorizationTypeEnum),
+    assetType: S.optional(AuthorizedOrgsDescAssetTypeEnum),
   }),
 ).annotate({
   identifier: "AuthorizedOrgsDesc",
@@ -554,17 +554,255 @@ export const CreateAccessPoliciesAuthorizedOrgsDescsRequest =
     identifier: "CreateAccessPoliciesAuthorizedOrgsDescsRequest",
   }) as any as S.Schema<CreateAccessPoliciesAuthorizedOrgsDescsRequest>;
 
+export type ServicePerimeterPerimeterTypeEnum =
+  | "PERIMETER_TYPE_REGULAR"
+  | "PERIMETER_TYPE_BRIDGE";
+export const ServicePerimeterPerimeterTypeEnum = /*@__PURE__*/ S.String;
+
+export type EgressFromSourceRestrictionEnum =
+  | "SOURCE_RESTRICTION_UNSPECIFIED"
+  | "SOURCE_RESTRICTION_ENABLED"
+  | "SOURCE_RESTRICTION_DISABLED";
+export const EgressFromSourceRestrictionEnum = /*@__PURE__*/ S.String;
+
+export type EgressFromIdentityTypeEnum =
+  | "IDENTITY_TYPE_UNSPECIFIED"
+  | "ANY_IDENTITY"
+  | "ANY_USER_ACCOUNT"
+  | "ANY_SERVICE_ACCOUNT";
+export const EgressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
+
+/** Specifies the Private Service Connect endpoint that an API call refers to. */
+export interface PrivateServiceConnectEndpoint {
+  /** The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`. */
+  forwardingRule?: string;
+}
+export const PrivateServiceConnectEndpoint = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    forwardingRule: S.optional(S.String),
+  }),
+).annotate({
+  identifier: "PrivateServiceConnectEndpoint",
+}) as any as S.Schema<PrivateServiceConnectEndpoint>;
+
+/** The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries. */
+export interface EgressSource {
+  /** A Google Cloud resource from the service perimeter that you want to allow to access data outside the perimeter. This field supports only projects. The project format is `projects/{project_number}`. You can't use `*` in this field to allow all Google Cloud resources. */
+  resource?: string;
+  /** An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed. */
+  accessLevel?: string;
+  /** A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
+  pscEndpoint?: PrivateServiceConnectEndpoint;
+}
+export const EgressSource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    resource: S.optional(S.String),
+    accessLevel: S.optional(S.String),
+    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
+  }),
+).annotate({ identifier: "EgressSource" }) as any as S.Schema<EgressSource>;
+
+export type EgressSourceList = Array<EgressSource>;
+export const EgressSourceList = /*@__PURE__*/ S.Array(
+  EgressSource,
+) as any as S.Schema<EgressSourceList>;
+
+/** Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. */
+export interface EgressFrom {
+  /** A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
+  identities?: StringList;
+  /** Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`. */
+  sourceRestriction?: EgressFromSourceRestrictionEnum | (string & {});
+  /** Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
+  identityType?: EgressFromIdentityTypeEnum | (string & {});
+  /** Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`. */
+  sources?: EgressSourceList;
+}
+export const EgressFrom = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    identities: S.optional(StringList),
+    sourceRestriction: S.optional(EgressFromSourceRestrictionEnum),
+    identityType: S.optional(EgressFromIdentityTypeEnum),
+    sources: S.optional(EgressSourceList),
+  }),
+).annotate({ identifier: "EgressFrom" }) as any as S.Schema<EgressFrom>;
+
+/** An allowed method or permission of a service specified in ApiOperation. */
+export interface MethodSelector {
+  /** A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation. */
+  permission?: string;
+  /** A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed. */
+  method?: string;
+}
+export const MethodSelector = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    permission: S.optional(S.String),
+    method: S.optional(S.String),
+  }),
+).annotate({ identifier: "MethodSelector" }) as any as S.Schema<MethodSelector>;
+
+export type MethodSelectorList = Array<MethodSelector>;
+export const MethodSelectorList = /*@__PURE__*/ S.Array(
+  MethodSelector,
+) as any as S.Schema<MethodSelectorList>;
+
+/** Identification for an API Operation. */
+export interface ApiOperation {
+  /** The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services. */
+  serviceName?: string;
+  /** API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`. */
+  methodSelectors?: MethodSelectorList;
+}
+export const ApiOperation = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    serviceName: S.optional(S.String),
+    methodSelectors: S.optional(MethodSelectorList),
+  }),
+).annotate({ identifier: "ApiOperation" }) as any as S.Schema<ApiOperation>;
+
+export type ApiOperationList = Array<ApiOperation>;
+export const ApiOperationList = /*@__PURE__*/ S.Array(
+  ApiOperation,
+) as any as S.Schema<ApiOperationList>;
+
+/** Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter. */
+export interface EgressTo {
+  /** A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter. */
+  resources?: StringList;
+  /** A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed. */
+  externalResources?: StringList;
+  /** IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter. */
+  roles?: StringList;
+  /** A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list. */
+  operations?: ApiOperationList;
+}
+export const EgressTo = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    resources: S.optional(StringList),
+    externalResources: S.optional(StringList),
+    roles: S.optional(StringList),
+    operations: S.optional(ApiOperationList),
+  }),
+).annotate({ identifier: "EgressTo" }) as any as S.Schema<EgressTo>;
+
+/** Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo. */
+export interface EgressPolicy {
+  /** Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
+  title?: string;
+  /** Defines conditions on the source of a request causing this EgressPolicy to apply. */
+  egressFrom?: EgressFrom;
+  /** Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply. */
+  egressTo?: EgressTo;
+}
+export const EgressPolicy = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    title: S.optional(S.String),
+    egressFrom: S.optional(EgressFrom),
+    egressTo: S.optional(EgressTo),
+  }),
+).annotate({ identifier: "EgressPolicy" }) as any as S.Schema<EgressPolicy>;
+
+export type EgressPolicyList = Array<EgressPolicy>;
+export const EgressPolicyList = /*@__PURE__*/ S.Array(
+  EgressPolicy,
+) as any as S.Schema<EgressPolicyList>;
+
+/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match. */
+export interface IngressTo {
+  /** A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed. */
+  resources?: StringList;
+  /** A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter. */
+  operations?: ApiOperationList;
+  /** IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter. */
+  roles?: StringList;
+}
+export const IngressTo = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    resources: S.optional(StringList),
+    operations: S.optional(ApiOperationList),
+    roles: S.optional(StringList),
+  }),
+).annotate({ identifier: "IngressTo" }) as any as S.Schema<IngressTo>;
+
+/** The source that IngressPolicy authorizes access from. */
+export interface IngressSource {
+  /** A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported. */
+  resource?: string;
+  /** An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed. */
+  accessLevel?: string;
+  /** A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
+  pscEndpoint?: PrivateServiceConnectEndpoint;
+}
+export const IngressSource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    resource: S.optional(S.String),
+    accessLevel: S.optional(S.String),
+    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
+  }),
+).annotate({ identifier: "IngressSource" }) as any as S.Schema<IngressSource>;
+
+export type IngressSourceList = Array<IngressSource>;
+export const IngressSourceList = /*@__PURE__*/ S.Array(
+  IngressSource,
+) as any as S.Schema<IngressSourceList>;
+
+export type IngressFromIdentityTypeEnum =
+  | "IDENTITY_TYPE_UNSPECIFIED"
+  | "ANY_IDENTITY"
+  | "ANY_USER_ACCOUNT"
+  | "ANY_SERVICE_ACCOUNT";
+export const IngressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
+
+/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match. */
+export interface IngressFrom {
+  /** A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
+  identities?: StringList;
+  /** Sources that this IngressPolicy authorizes access from. */
+  sources?: IngressSourceList;
+  /** Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
+  identityType?: IngressFromIdentityTypeEnum | (string & {});
+}
+export const IngressFrom = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    identities: S.optional(StringList),
+    sources: S.optional(IngressSourceList),
+    identityType: S.optional(IngressFromIdentityTypeEnum),
+  }),
+).annotate({ identifier: "IngressFrom" }) as any as S.Schema<IngressFrom>;
+
+/** Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field. */
+export interface IngressPolicy {
+  /** Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply. */
+  ingressTo?: IngressTo;
+  /** Defines the conditions on the source of a request causing this IngressPolicy to apply. */
+  ingressFrom?: IngressFrom;
+  /** Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
+  title?: string;
+}
+export const IngressPolicy = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    ingressTo: S.optional(IngressTo),
+    ingressFrom: S.optional(IngressFrom),
+    title: S.optional(S.String),
+  }),
+).annotate({ identifier: "IngressPolicy" }) as any as S.Schema<IngressPolicy>;
+
+export type IngressPolicyList = Array<IngressPolicy>;
+export const IngressPolicyList = /*@__PURE__*/ S.Array(
+  IngressPolicy,
+) as any as S.Schema<IngressPolicyList>;
+
 /** Adds a request header to the API. */
 export interface AddRequestHeader {
-  /** HTTP header key. */
-  key?: string;
   /** HTTP header value. */
   value?: string;
+  /** HTTP header key. */
+  key?: string;
 }
 export const AddRequestHeader = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    key: S.optional(S.String),
     value: S.optional(S.String),
+    key: S.optional(S.String),
   }),
 ).annotate({
   identifier: "AddRequestHeader",
@@ -588,18 +826,18 @@ export const ModifierList = /*@__PURE__*/ S.Array(
 
 /** Service patterns used to allow access. */
 export interface ServicePattern {
-  /** Modifiers to apply to the requests that match the URL pattern. */
-  modifiers?: ModifierList;
-  /** Supported service to allow. */
-  service?: string;
   /** URL pattern to allow. Only patterns of ".googleapis.com/*", "www.googleapis.com//*" and "*.appspot.com/* forms are supported, where should be an alphanumeric name. */
   pattern?: string;
+  /** Supported service to allow. */
+  service?: string;
+  /** Modifiers to apply to the requests that match the URL pattern. */
+  modifiers?: ModifierList;
 }
 export const ServicePattern = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    modifiers: S.optional(ModifierList),
-    service: S.optional(S.String),
     pattern: S.optional(S.String),
+    service: S.optional(S.String),
+    modifiers: S.optional(ModifierList),
   }),
 ).annotate({ identifier: "ServicePattern" }) as any as S.Schema<ServicePattern>;
 
@@ -628,296 +866,58 @@ export const VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList =
 export interface VpcAccessibleServices {
   /** Specifies which Google services are allowed to be accessed from VPC networks in the service perimeter. */
   allowedServicePatterns?: ServicePatternList;
-  /** Defines the enforcement scopes of service patterns. */
-  servicePatternsEnforcementScopes?: VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList;
-  /** The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter. */
-  allowedServices?: StringList;
   /** Whether to restrict API calls within the Service Perimeter to the list of APIs specified in 'allowed_services'. */
   enableRestriction?: boolean;
+  /** The list of APIs usable within the Service Perimeter. Must be empty unless 'enable_restriction' is True. You can specify a list of individual services, as well as include the 'RESTRICTED-SERVICES' value, which automatically includes all of the services protected by the perimeter. */
+  allowedServices?: StringList;
+  /** Defines the enforcement scopes of service patterns. */
+  servicePatternsEnforcementScopes?: VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList;
 }
 export const VpcAccessibleServices = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     allowedServicePatterns: S.optional(ServicePatternList),
+    enableRestriction: S.optional(S.Boolean),
+    allowedServices: S.optional(StringList),
     servicePatternsEnforcementScopes: S.optional(
       VpcAccessibleServicesServicePatternsEnforcementScopesItemEnumList,
     ),
-    allowedServices: S.optional(StringList),
-    enableRestriction: S.optional(S.Boolean),
   }),
 ).annotate({
   identifier: "VpcAccessibleServices",
 }) as any as S.Schema<VpcAccessibleServices>;
 
-/** An allowed method or permission of a service specified in ApiOperation. */
-export interface MethodSelector {
-  /** A valid method name for the corresponding `service_name` in ApiOperation. If `*` is used as the value for the `method`, then ALL methods and permissions are allowed. */
-  method?: string;
-  /** A valid Cloud IAM permission for the corresponding `service_name` in ApiOperation. */
-  permission?: string;
-}
-export const MethodSelector = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    method: S.optional(S.String),
-    permission: S.optional(S.String),
-  }),
-).annotate({ identifier: "MethodSelector" }) as any as S.Schema<MethodSelector>;
-
-export type MethodSelectorList = Array<MethodSelector>;
-export const MethodSelectorList = /*@__PURE__*/ S.Array(
-  MethodSelector,
-) as any as S.Schema<MethodSelectorList>;
-
-/** Identification for an API Operation. */
-export interface ApiOperation {
-  /** API methods or permissions to allow. Method or permission must belong to the service specified by `service_name` field. A single MethodSelector entry with `*` specified for the `method` field will allow all methods AND permissions for the service specified in `service_name`. */
-  methodSelectors?: MethodSelectorList;
-  /** The name of the API whose methods or permissions the IngressPolicy or EgressPolicy want to allow. A single ApiOperation with `service_name` field set to `*` will allow all methods AND permissions for all services. */
-  serviceName?: string;
-}
-export const ApiOperation = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    methodSelectors: S.optional(MethodSelectorList),
-    serviceName: S.optional(S.String),
-  }),
-).annotate({ identifier: "ApiOperation" }) as any as S.Schema<ApiOperation>;
-
-export type ApiOperationList = Array<ApiOperation>;
-export const ApiOperationList = /*@__PURE__*/ S.Array(
-  ApiOperation,
-) as any as S.Schema<ApiOperationList>;
-
-/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the target resource of the request. The request must satisfy what is defined in `operations` AND `resources` in order to match. */
-export interface IngressTo {
-  /** A list of resources, currently only projects in the form `projects/`, protected by this ServicePerimeter that are allowed to be accessed by sources defined in the corresponding IngressFrom. If a single `*` is specified, then access to all resources inside the perimeter are allowed. */
-  resources?: StringList;
-  /** A list of ApiOperations allowed to be performed by the sources specified in corresponding IngressFrom in this ServicePerimeter. */
-  operations?: ApiOperationList;
-  /** IAM roles that represent the set of operations that the sources specified in the corresponding IngressFrom are allowed to perform in this ServicePerimeter. */
-  roles?: StringList;
-}
-export const IngressTo = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    resources: S.optional(StringList),
-    operations: S.optional(ApiOperationList),
-    roles: S.optional(StringList),
-  }),
-).annotate({ identifier: "IngressTo" }) as any as S.Schema<IngressTo>;
-
-/** Specifies the Private Service Connect endpoint that an API call refers to. */
-export interface PrivateServiceConnectEndpoint {
-  /** The full resource name of the global forwarding rule that identifies a Private Service Connect endpoint. Forwarding rule format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/forwardingRules/{FORWARDING_RULE_ID}`. */
-  forwardingRule?: string;
-}
-export const PrivateServiceConnectEndpoint = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    forwardingRule: S.optional(S.String),
-  }),
-).annotate({
-  identifier: "PrivateServiceConnectEndpoint",
-}) as any as S.Schema<PrivateServiceConnectEndpoint>;
-
-/** The source that IngressPolicy authorizes access from. */
-export interface IngressSource {
-  /** A PrivateServiceConnectEndpoint that is allowed to access the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
-  pscEndpoint?: PrivateServiceConnectEndpoint;
-  /** A Google Cloud resource that is allowed to ingress the perimeter. Requests from these resources will be allowed to access perimeter data. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in. `*` is not allowed, the case of allowing all Google Cloud resources only is not supported. */
-  resource?: string;
-  /** An AccessLevel resource name that allow resources within the ServicePerimeters to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all IngressSources will be allowed. */
-  accessLevel?: string;
-}
-export const IngressSource = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
-    resource: S.optional(S.String),
-    accessLevel: S.optional(S.String),
-  }),
-).annotate({ identifier: "IngressSource" }) as any as S.Schema<IngressSource>;
-
-export type IngressSourceList = Array<IngressSource>;
-export const IngressSourceList = /*@__PURE__*/ S.Array(
-  IngressSource,
-) as any as S.Schema<IngressSourceList>;
-
-export type IngressFromIdentityTypeEnum =
-  | "IDENTITY_TYPE_UNSPECIFIED"
-  | "ANY_IDENTITY"
-  | "ANY_USER_ACCOUNT"
-  | "ANY_SERVICE_ACCOUNT";
-export const IngressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
-
-/** Defines the conditions under which an IngressPolicy matches a request. Conditions are based on information about the source of the request. The request must satisfy what is defined in `sources` AND identity related fields in order to match. */
-export interface IngressFrom {
-  /** Sources that this IngressPolicy authorizes access from. */
-  sources?: IngressSourceList;
-  /** Specifies the type of identities that are allowed access from outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
-  identityType?: IngressFromIdentityTypeEnum | (string & {});
-  /** A list of identities that are allowed access through [IngressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
-  identities?: StringList;
-}
-export const IngressFrom = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    sources: S.optional(IngressSourceList),
-    identityType: S.optional(IngressFromIdentityTypeEnum),
-    identities: S.optional(StringList),
-  }),
-).annotate({ identifier: "IngressFrom" }) as any as S.Schema<IngressFrom>;
-
-/** Policy for ingress into ServicePerimeter. IngressPolicies match requests based on `ingress_from` and `ingress_to` stanzas. For an ingress policy to match, both the `ingress_from` and `ingress_to` stanzas must be matched. If an IngressPolicy matches a request, the request is allowed through the perimeter boundary from outside the perimeter. For example, access from the internet can be allowed either based on an AccessLevel or, for traffic hosted on Google Cloud, the project of the source network. For access from private networks, using the project of the hosting network is required. Individual ingress policies can be limited by restricting which services and/or actions they match using the `ingress_to` field. */
-export interface IngressPolicy {
-  /** Optional. Human-readable title for the ingress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
-  title?: string;
-  /** Defines the conditions on the ApiOperation and request destination that cause this IngressPolicy to apply. */
-  ingressTo?: IngressTo;
-  /** Defines the conditions on the source of a request causing this IngressPolicy to apply. */
-  ingressFrom?: IngressFrom;
-}
-export const IngressPolicy = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    title: S.optional(S.String),
-    ingressTo: S.optional(IngressTo),
-    ingressFrom: S.optional(IngressFrom),
-  }),
-).annotate({ identifier: "IngressPolicy" }) as any as S.Schema<IngressPolicy>;
-
-export type IngressPolicyList = Array<IngressPolicy>;
-export const IngressPolicyList = /*@__PURE__*/ S.Array(
-  IngressPolicy,
-) as any as S.Schema<IngressPolicyList>;
-
-export type EgressFromIdentityTypeEnum =
-  | "IDENTITY_TYPE_UNSPECIFIED"
-  | "ANY_IDENTITY"
-  | "ANY_USER_ACCOUNT"
-  | "ANY_SERVICE_ACCOUNT";
-export const EgressFromIdentityTypeEnum = /*@__PURE__*/ S.String;
-
-export type EgressFromSourceRestrictionEnum =
-  | "SOURCE_RESTRICTION_UNSPECIFIED"
-  | "SOURCE_RESTRICTION_ENABLED"
-  | "SOURCE_RESTRICTION_DISABLED";
-export const EgressFromSourceRestrictionEnum = /*@__PURE__*/ S.String;
-
-/** The source that EgressPolicy authorizes access from inside the ServicePerimeter to somewhere outside the ServicePerimeter boundaries. */
-export interface EgressSource {
-  /** A PrivateServiceConnectEndpoint that is allowed to access data outside the perimeter. The Private Service Connect endpoint may be in any organization, not just the organization that the perimeter is defined in. */
-  pscEndpoint?: PrivateServiceConnectEndpoint;
-  /** A Google Cloud resource from the service perimeter that you want to allow to access data outside the perimeter. This field supports only projects. The project format is `projects/{project_number}`. You can't use `*` in this field to allow all Google Cloud resources. */
-  resource?: string;
-  /** An AccessLevel resource name that allows protected resources inside the ServicePerimeters to access outside the ServicePerimeter boundaries. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel will cause an error. If an AccessLevel name is not specified, only resources within the perimeter can be accessed through Google Cloud calls with request origins within the perimeter. Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If a single `*` is specified for `access_level`, then all EgressSources will be allowed. */
-  accessLevel?: string;
-}
-export const EgressSource = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    pscEndpoint: S.optional(PrivateServiceConnectEndpoint),
-    resource: S.optional(S.String),
-    accessLevel: S.optional(S.String),
-  }),
-).annotate({ identifier: "EgressSource" }) as any as S.Schema<EgressSource>;
-
-export type EgressSourceList = Array<EgressSource>;
-export const EgressSourceList = /*@__PURE__*/ S.Array(
-  EgressSource,
-) as any as S.Schema<EgressSourceList>;
-
-/** Defines the conditions under which an EgressPolicy matches a request. Conditions based on information about the source of the request. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. */
-export interface EgressFrom {
-  /** Specifies the type of identities that are allowed access to outside the perimeter. If left unspecified, then members of `identities` field will be allowed access. */
-  identityType?: EgressFromIdentityTypeEnum | (string & {});
-  /** Whether to enforce traffic restrictions based on `sources` field. If the `sources` fields is non-empty, then this field must be set to `SOURCE_RESTRICTION_ENABLED`. */
-  sourceRestriction?: EgressFromSourceRestrictionEnum | (string & {});
-  /** Sources that this EgressPolicy authorizes access from. If this field is not empty, then `source_restriction` must be set to `SOURCE_RESTRICTION_ENABLED`. */
-  sources?: EgressSourceList;
-  /** A list of identities that are allowed access through [EgressPolicy]. Identities can be an individual user, service account, Google group, third-party identity, or agent identity. For the list of supported identity types, see https://docs.cloud.google.com/vpc-service-controls/docs/supported-identities. */
-  identities?: StringList;
-}
-export const EgressFrom = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    identityType: S.optional(EgressFromIdentityTypeEnum),
-    sourceRestriction: S.optional(EgressFromSourceRestrictionEnum),
-    sources: S.optional(EgressSourceList),
-    identities: S.optional(StringList),
-  }),
-).annotate({ identifier: "EgressFrom" }) as any as S.Schema<EgressFrom>;
-
-/** Defines the conditions under which an EgressPolicy matches a request. Conditions are based on information about the ApiOperation intended to be performed on the `resources` specified. Note that if the destination of the request is also protected by a ServicePerimeter, then that ServicePerimeter must have an IngressPolicy which allows access in order for this request to succeed. The request must match `operations` AND `resources` fields in order to be allowed egress out of the perimeter. */
-export interface EgressTo {
-  /** A list of ApiOperations allowed to be performed by the sources specified in the corresponding EgressFrom. A request matches if it uses an operation/service in this list. */
-  operations?: ApiOperationList;
-  /** A list of resources, currently only projects in the form `projects/`, that are allowed to be accessed by sources defined in the corresponding EgressFrom. A request matches if it contains a resource in this list. If `*` is specified for `resources`, then this EgressTo rule will authorize access to all resources outside the perimeter. */
-  resources?: StringList;
-  /** IAM roles that represent the set of operations that the sources specified in the corresponding EgressFrom. are allowed to perform in this ServicePerimeter. */
-  roles?: StringList;
-  /** A list of external resources that are allowed to be accessed. Only AWS and Azure resources are supported. For Amazon S3, the supported formats are s3://BUCKET_NAME, s3a://BUCKET_NAME, and s3n://BUCKET_NAME. For Azure Storage, the supported format is azure://myaccount.blob.core.windows.net/CONTAINER_NAME. A request matches if it contains an external resource in this list (Example: s3://bucket/path). Currently '*' is not allowed. */
-  externalResources?: StringList;
-}
-export const EgressTo = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    operations: S.optional(ApiOperationList),
-    resources: S.optional(StringList),
-    roles: S.optional(StringList),
-    externalResources: S.optional(StringList),
-  }),
-).annotate({ identifier: "EgressTo" }) as any as S.Schema<EgressTo>;
-
-/** Policy for egress from perimeter. EgressPolicies match requests based on `egress_from` and `egress_to` stanzas. For an EgressPolicy to match, both `egress_from` and `egress_to` stanzas must be matched. If an EgressPolicy matches a request, the request is allowed to span the ServicePerimeter boundary. For example, an EgressPolicy can be used to allow VMs on networks within the ServicePerimeter to access a defined set of projects outside the perimeter in certain contexts (e.g. to read data from a Cloud Storage bucket or query against a BigQuery dataset). EgressPolicies are concerned with the *resources* that a request relates as well as the API services and API actions being used. They do not related to the direction of data movement. More detailed documentation for this concept can be found in the descriptions of EgressFrom and EgressTo. */
-export interface EgressPolicy {
-  /** Defines conditions on the source of a request causing this EgressPolicy to apply. */
-  egressFrom?: EgressFrom;
-  /** Defines the conditions on the ApiOperation and destination resources that cause this EgressPolicy to apply. */
-  egressTo?: EgressTo;
-  /** Optional. Human-readable title for the egress rule. The title must be unique within the perimeter and can not exceed 100 characters. Within the access policy, the combined length of all rule titles must not exceed 240,000 characters. */
-  title?: string;
-}
-export const EgressPolicy = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    egressFrom: S.optional(EgressFrom),
-    egressTo: S.optional(EgressTo),
-    title: S.optional(S.String),
-  }),
-).annotate({ identifier: "EgressPolicy" }) as any as S.Schema<EgressPolicy>;
-
-export type EgressPolicyList = Array<EgressPolicy>;
-export const EgressPolicyList = /*@__PURE__*/ S.Array(
-  EgressPolicy,
-) as any as S.Schema<EgressPolicyList>;
-
 /** `ServicePerimeterConfig` specifies a set of Google Cloud resources that describe specific Service Perimeter configuration. */
 export interface ServicePerimeterConfig {
-  /** A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL"`. For Service Perimeter Bridge, must be empty. */
-  accessLevels?: StringList;
+  /** List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge. */
+  egressPolicies?: EgressPolicyList;
   /** A list of Google Cloud resources that are inside of the service perimeter. Currently only projects and VPCs are allowed. Project format: `projects/{project_number}` VPC network format: `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`. */
   resources?: StringList;
-  /** Configuration for APIs allowed within Perimeter. */
-  vpcAccessibleServices?: VpcAccessibleServices;
   /** Google Cloud services that are subject to the Service Perimeter restrictions. For example, if `storage.googleapis.com` is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions. */
   restrictedServices?: StringList;
   /** List of IngressPolicies to apply to the perimeter. A perimeter may have multiple IngressPolicies, each of which is evaluated separately. Access is granted if any Ingress Policy grants it. Must be empty for a perimeter bridge. */
   ingressPolicies?: IngressPolicyList;
-  /** List of EgressPolicies to apply to the perimeter. A perimeter may have multiple EgressPolicies, each of which is evaluated separately. Access is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge. */
-  egressPolicies?: EgressPolicyList;
+  /** A list of `AccessLevel` resource names that allow resources within the `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed must be in the same policy as this `ServicePerimeter`. Referencing a nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are listed, resources within the perimeter can only be accessed via Google Cloud calls with request origins within the perimeter. Example: `"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL"`. For Service Perimeter Bridge, must be empty. */
+  accessLevels?: StringList;
+  /** Configuration for APIs allowed within Perimeter. */
+  vpcAccessibleServices?: VpcAccessibleServices;
 }
 export const ServicePerimeterConfig = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    accessLevels: S.optional(StringList),
+    egressPolicies: S.optional(EgressPolicyList),
     resources: S.optional(StringList),
-    vpcAccessibleServices: S.optional(VpcAccessibleServices),
     restrictedServices: S.optional(StringList),
     ingressPolicies: S.optional(IngressPolicyList),
-    egressPolicies: S.optional(EgressPolicyList),
+    accessLevels: S.optional(StringList),
+    vpcAccessibleServices: S.optional(VpcAccessibleServices),
   }),
 ).annotate({
   identifier: "ServicePerimeterConfig",
 }) as any as S.Schema<ServicePerimeterConfig>;
 
-export type ServicePerimeterPerimeterTypeEnum =
-  | "PERIMETER_TYPE_REGULAR"
-  | "PERIMETER_TYPE_BRIDGE";
-export const ServicePerimeterPerimeterTypeEnum = /*@__PURE__*/ S.String;
-
 /** `ServicePerimeter` describes a set of Google Cloud resources which can freely import and export data amongst themselves, but not export outside of the `ServicePerimeter`. If a request with a source within this `ServicePerimeter` has a target outside of the `ServicePerimeter`, the request will be blocked. Otherwise the request is allowed. There are two types of Service Perimeter - Regular and Bridge. Regular Service Perimeters cannot overlap, a single Google Cloud project or VPC network can only belong to a single regular Service Perimeter. Service Perimeter Bridges can contain only Google Cloud projects as members, a single Google Cloud project may belong to multiple Service Perimeter Bridges. */
 export interface ServicePerimeter {
-  /** Human readable title. Must be unique within the Policy. */
-  title?: string;
+  /** Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty. */
+  perimeterType?: ServicePerimeterPerimeterTypeEnum | (string & {});
   /** Description of the `ServicePerimeter` and its use. Does not affect behavior. */
   description?: string;
   /** Proposed (or dry run) ServicePerimeter configuration. This configuration allows to specify and test ServicePerimeter configuration without enforcing actual access restrictions. Only allowed to be set when the "use_explicit_dry_run_spec" flag is set. */
@@ -930,19 +930,19 @@ export interface ServicePerimeter {
   useExplicitDryRunSpec?: boolean;
   /** Current ServicePerimeter configuration. Specifies sets of resources, restricted services and access levels that determine perimeter content and boundaries. */
   status?: ServicePerimeterConfig;
-  /** Perimeter type indicator. A single project or VPC network is allowed to be a member of single regular perimeter, but multiple service perimeter bridges. A project cannot be a included in a perimeter bridge without being included in regular perimeter. For perimeter bridges, the restricted service list as well as access level lists must be empty. */
-  perimeterType?: ServicePerimeterPerimeterTypeEnum | (string & {});
+  /** Human readable title. Must be unique within the Policy. */
+  title?: string;
 }
 export const ServicePerimeter = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    title: S.optional(S.String),
+    perimeterType: S.optional(ServicePerimeterPerimeterTypeEnum),
     description: S.optional(S.String),
     spec: S.optional(ServicePerimeterConfig),
     name: S.optional(S.String),
     etag: S.optional(S.String),
     useExplicitDryRunSpec: S.optional(S.Boolean),
     status: S.optional(ServicePerimeterConfig),
-    perimeterType: S.optional(ServicePerimeterPerimeterTypeEnum),
+    title: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ServicePerimeter",
@@ -970,73 +970,36 @@ export const CreateAccessPoliciesServicePerimetersRequest =
     identifier: "CreateAccessPoliciesServicePerimetersRequest",
   }) as any as S.Schema<CreateAccessPoliciesServicePerimetersRequest>;
 
-/** An application that accesses Google Cloud APIs. */
-export interface Application {
-  /** The OAuth client ID of the application. */
-  clientId?: string;
-  /** The name of the application. Example: "Cloud Console" */
-  name?: string;
-}
-export const Application = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    clientId: S.optional(S.String),
-    name: S.optional(S.String),
-  }),
-).annotate({ identifier: "Application" }) as any as S.Schema<Application>;
-
-export type ApplicationList = Array<Application>;
-export const ApplicationList = /*@__PURE__*/ S.Array(
-  Application,
-) as any as S.Schema<ApplicationList>;
-
-export type SessionSettingsSessionReauthMethodEnum =
-  | "SESSION_REAUTH_METHOD_UNSPECIFIED"
-  | "LOGIN"
-  | "SECURITY_KEY"
-  | "PASSWORD";
-export const SessionSettingsSessionReauthMethodEnum = /*@__PURE__*/ S.String;
-
-/** Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings. */
-export interface SessionSettings {
-  /** Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param. */
-  useOidcMaxAge?: boolean;
-  /** Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps. */
-  maxInactivity?: string;
-  /** Optional. Session method when user's Google Cloud session is up. */
-  sessionReauthMethod?: SessionSettingsSessionReauthMethodEnum | (string & {});
-  /** Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset. */
-  sessionLength?: string;
-  /** Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false. */
-  sessionLengthEnabled?: boolean;
-}
-export const SessionSettings = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    useOidcMaxAge: S.optional(S.Boolean),
-    maxInactivity: S.optional(S.String),
-    sessionReauthMethod: S.optional(SessionSettingsSessionReauthMethodEnum),
-    sessionLength: S.optional(S.String),
-    sessionLengthEnabled: S.optional(S.Boolean),
-  }),
-).annotate({
-  identifier: "SessionSettings",
-}) as any as S.Schema<SessionSettings>;
-
 /** The comprehensive identity container supporting identities including groups, service accounts, and federated identities. Only one of them can be set to create an access binding. */
 export interface Principal {
-  /** Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement. */
-  serviceAccount?: string;
-  /** Immutable. Cloud project number used to assign policies to all service accounts owned by the project. */
-  serviceAccountProjectNumber?: string;
   /** Immutable. The IAM principal identifier of the federated workforce or workload to assign the policy to. Examples include the following: * Single principal: `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}` * All workloads in a workload identity pool: `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*` * All Workforce Pools in a Google Cloud organization: `principalSet://cloudresourcemanager.googleapis.com/organizations/{organization_id}/type/WorkforcePool` Bindings created for all Workforce Pools in a Google Cloud organization support only `scoped_access_settings` with the `restricted_project` client scope and active `session_settings`. No other configurations are allowed. */
   federatedPrincipal?: string;
+  /** Immutable. Cloud project number used to assign policies to all service accounts owned by the project. */
+  serviceAccountProjectNumber?: string;
+  /** Immutable. Service account email used to assign policies to a specific service account. If a service account is subject to multiple policies (e.g., if there is a policy for all service accounts in a project and a policy for the service account), the closest (i.e. the most specific) dry-run policy will be used for the dry-run functionality and the closest enforcement policy will be used for the enforcement. */
+  serviceAccount?: string;
 }
 export const Principal = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    serviceAccount: S.optional(S.String),
-    serviceAccountProjectNumber: S.optional(S.String),
     federatedPrincipal: S.optional(S.String),
+    serviceAccountProjectNumber: S.optional(S.String),
+    serviceAccount: S.optional(S.String),
   }),
 ).annotate({ identifier: "Principal" }) as any as S.Schema<Principal>;
+
+/** An application that accesses Google Cloud APIs. */
+export interface Application {
+  /** The name of the application. Example: "Cloud Console" */
+  name?: string;
+  /** The OAuth client ID of the application. */
+  clientId?: string;
+}
+export const Application = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    name: S.optional(S.String),
+    clientId: S.optional(S.String),
+  }),
+).annotate({ identifier: "Application" }) as any as S.Schema<Application>;
 
 /** A Google Cloud project which contains applications and resources that users can access. */
 export interface Project {
@@ -1074,17 +1037,49 @@ export const AccessScope = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "AccessScope" }) as any as S.Schema<AccessScope>;
 
+export type SessionSettingsSessionReauthMethodEnum =
+  | "SESSION_REAUTH_METHOD_UNSPECIFIED"
+  | "LOGIN"
+  | "SECURITY_KEY"
+  | "PASSWORD";
+export const SessionSettingsSessionReauthMethodEnum = /*@__PURE__*/ S.String;
+
+/** Stores settings related to Google Cloud Session Length including session duration, the type of challenge (i.e. method) they should face when their session expires, and other related settings. */
+export interface SessionSettings {
+  /** Optional. The session length. Setting this field to zero allows for sessions that are active indefinitely. Also, setting `session_length_enabled` to `false` disregards session limits, which means that sessions never expire. If `use_oidc_max_age` is `true`, for OIDC apps, the session length will be the minimum of this field and the OIDC `max_age` param. If this field is set to zero, `session_length_enabled` must be set to `false` or left unset. */
+  sessionLength?: string;
+  /** Optional. Only useful for OIDC apps. When false, the OIDC max_age param, if passed in the authentication request will be ignored. When true, the re-auth period will be the minimum of the session_length field and the max_age OIDC param. */
+  useOidcMaxAge?: boolean;
+  /** Optional. Session method when user's Google Cloud session is up. */
+  sessionReauthMethod?: SessionSettingsSessionReauthMethodEnum | (string & {});
+  /** Optional. How long a user is allowed to take between actions before a new access token must be issued. Only set for Google Cloud apps. */
+  maxInactivity?: string;
+  /** Optional. This field enables or disables Google Cloud session length. When false, all fields set above will be disregarded and the session length is basically infinite. If `session_length` is set to zero, this field must be set to false. */
+  sessionLengthEnabled?: boolean;
+}
+export const SessionSettings = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    sessionLength: S.optional(S.String),
+    useOidcMaxAge: S.optional(S.Boolean),
+    sessionReauthMethod: S.optional(SessionSettingsSessionReauthMethodEnum),
+    maxInactivity: S.optional(S.String),
+    sessionLengthEnabled: S.optional(S.Boolean),
+  }),
+).annotate({
+  identifier: "SessionSettings",
+}) as any as S.Schema<SessionSettings>;
+
 /** Access settings represent the set of conditions that must be met for access to be granted. At least one of the fields must be set. */
 export interface AccessSettings {
-  /** Optional. Session settings applied to user access on a given AccessScope. */
-  sessionSettings?: SessionSettings;
   /** Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
   accessLevels?: StringList;
+  /** Optional. Session settings applied to user access on a given AccessScope. */
+  sessionSettings?: SessionSettings;
 }
 export const AccessSettings = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    sessionSettings: S.optional(SessionSettings),
     accessLevels: S.optional(StringList),
+    sessionSettings: S.optional(SessionSettings),
   }),
 ).annotate({ identifier: "AccessSettings" }) as any as S.Schema<AccessSettings>;
 
@@ -1092,16 +1087,16 @@ export const AccessSettings = /*@__PURE__*/ S.suspend(() =>
 export interface ScopedAccessSettings {
   /** Optional. Application, etc. to which the access settings will be applied to. Implicitly, this is the scoped access settings key; as such, it must be unique and non-empty. */
   scope?: AccessScope;
-  /** Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set. */
-  dryRunSettings?: AccessSettings;
   /** Optional. Access settings for this scoped access settings. This field may be empty if dry_run_settings is set. */
   activeSettings?: AccessSettings;
+  /** Optional. Dry-run access settings for this scoped access settings. This field may be empty if active_settings is set. */
+  dryRunSettings?: AccessSettings;
 }
 export const ScopedAccessSettings = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     scope: S.optional(AccessScope),
-    dryRunSettings: S.optional(AccessSettings),
     activeSettings: S.optional(AccessSettings),
+    dryRunSettings: S.optional(AccessSettings),
   }),
 ).annotate({
   identifier: "ScopedAccessSettings",
@@ -1112,35 +1107,40 @@ export const ScopedAccessSettingsList = /*@__PURE__*/ S.Array(
   ScopedAccessSettings,
 ) as any as S.Schema<ScopedAccessSettingsList>;
 
+export type ApplicationList = Array<Application>;
+export const ApplicationList = /*@__PURE__*/ S.Array(
+  Application,
+) as any as S.Schema<ApplicationList>;
+
 /** Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access. */
 export interface GcpUserAccessBinding {
-  /** Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See "id" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: "01d520gv4vjcrht" */
-  groupKey?: string;
-  /** Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
-  accessLevels?: StringList;
   /** Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N" */
   name?: string;
   /** Optional. Dry run access level that will be evaluated but will not be enforced. The access denial based on dry run policy will be logged. Only one access level is supported, not multiple. This list must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
   dryRunAccessLevels?: StringList;
-  /** Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications. */
-  restrictedClientApplications?: ApplicationList;
-  /** Optional. The Google Cloud session length (GCSL) policy for the group key. */
-  sessionSettings?: SessionSettings;
+  /** Optional. Immutable. Google Group id whose users are subject to this binding's restrictions. See "id" in the [Google Workspace Directory API's Group Resource] (https://developers.google.com/admin-sdk/directory/v1/reference/groups#resource). If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: "01d520gv4vjcrht" */
+  groupKey?: string;
   /** Optional. Immutable. The principal that is subject to the access policies in this policy binding. */
   principal?: Principal;
   /** Optional. A list of scoped access settings that set this binding's restrictions on a subset of applications. This field cannot be set if restricted_client_applications is set. */
   scopedAccessSettings?: ScopedAccessSettingsList;
+  /** Optional. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted" */
+  accessLevels?: StringList;
+  /** Optional. The Google Cloud session length (GCSL) policy for the group key. */
+  sessionSettings?: SessionSettings;
+  /** Optional. Deprecated: Use `scoped_access_settings` instead. A list of applications that are subject to this binding's restrictions. If the list is empty, the binding restrictions will universally apply to all applications. */
+  restrictedClientApplications?: ApplicationList;
 }
 export const GcpUserAccessBinding = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    groupKey: S.optional(S.String),
-    accessLevels: S.optional(StringList),
     name: S.optional(S.String),
     dryRunAccessLevels: S.optional(StringList),
-    restrictedClientApplications: S.optional(ApplicationList),
-    sessionSettings: S.optional(SessionSettings),
+    groupKey: S.optional(S.String),
     principal: S.optional(Principal),
     scopedAccessSettings: S.optional(ScopedAccessSettingsList),
+    accessLevels: S.optional(StringList),
+    sessionSettings: S.optional(SessionSettings),
+    restrictedClientApplications: S.optional(ApplicationList),
   }),
 ).annotate({
   identifier: "GcpUserAccessBinding",
@@ -1306,20 +1306,20 @@ export const GetAccessPoliciesAccessLevelsAccessLevelFormatEnum =
   /*@__PURE__*/ S.String;
 
 export interface GetAccessPoliciesAccessLevelsRequest {
-  /** Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}` */
-  name: string;
   /** Whether to return `BasicLevels` in the Cloud Common Expression Language rather than as `BasicLevels`. Defaults to AS_DEFINED, where Access Levels are returned as `BasicLevels` or `CustomLevels` based on how they were created. If set to CEL, all Access Levels are returned as `CustomLevels`. In the CEL case, `BasicLevels` are translated to equivalent `CustomLevels`. */
   accessLevelFormat?:
     | GetAccessPoliciesAccessLevelsAccessLevelFormatEnum
     | (string & {});
+  /** Required. Resource name for the Access Level. Format: `accessPolicies/{policy_id}/accessLevels/{access_level_id}` */
+  name: string;
 }
 export const GetAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   () =>
     S.Struct({
-      name: S.String.pipe(T.Label()),
       accessLevelFormat: S.optional(
         GetAccessPoliciesAccessLevelsAccessLevelFormatEnum.pipe(T.Query()),
       ),
+      name: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1358,22 +1358,22 @@ export const GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum =
   /*@__PURE__*/ S.String;
 
 export interface GetAccessPoliciesServicePerimetersRequest {
-  /** Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}` */
-  name: string;
   /** Optional. If true, the response will contain the deleted principal syntax for identities that support it. */
   deletedPrincipalSyntax?:
     | GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum
     | (string & {});
+  /** Required. Resource name for the Service Perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}` */
+  name: string;
 }
 export const GetAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      name: S.String.pipe(T.Label()),
       deletedPrincipalSyntax: S.optional(
         GetAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum.pipe(
           T.Query(),
         ),
       ),
+      name: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1432,6 +1432,28 @@ export const GetIamPolicyAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "GetIamPolicyAccessPoliciesRequest",
 }) as any as S.Schema<GetIamPolicyAccessPoliciesRequest>;
 
+/** Associates `members`, or principals, with a `role`. */
+export interface Binding {
+  /** Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`. */
+  members?: StringList;
+  /** Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles). */
+  role?: string;
+  /** The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
+  condition?: Expr;
+}
+export const Binding = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    members: S.optional(StringList),
+    role: S.optional(S.String),
+    condition: S.optional(Expr),
+  }),
+).annotate({ identifier: "Binding" }) as any as S.Schema<Binding>;
+
+export type BindingList = Array<Binding>;
+export const BindingList = /*@__PURE__*/ S.Array(
+  Binding,
+) as any as S.Schema<BindingList>;
+
 export type AuditLogConfigLogTypeEnum =
   | "LOG_TYPE_UNSPECIFIED"
   | "ADMIN_READ"
@@ -1477,45 +1499,23 @@ export const AuditConfigList = /*@__PURE__*/ S.Array(
   AuditConfig,
 ) as any as S.Schema<AuditConfigList>;
 
-/** Associates `members`, or principals, with a `role`. */
-export interface Binding {
-  /** Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`. For an overview of the IAM roles and permissions, see the [IAM documentation](https://cloud.google.com/iam/docs/roles-overview). For a list of the available pre-defined roles, see [here](https://cloud.google.com/iam/docs/understanding-roles). */
-  role?: string;
-  /** Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. Does not include identities that come from external identity providers (IdPs) through identity federation. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a Google service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `serviceAccount:{projectid}.svc.id.goog[{namespace}/{kubernetes-sa}]`: An identifier for a [Kubernetes service account](https://cloud.google.com/kubernetes-engine/docs/how-to/kubernetes-service-accounts). For example, `my-project.svc.id.goog[my-namespace/my-kubernetes-sa]`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. * `principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workforce identity pool. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/group/{group_id}`: All workforce identities in a group. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All workforce identities with a specific attribute value. * `principalSet://iam.googleapis.com/locations/global/workforcePools/{pool_id}/*`: All identities in a workforce identity pool. * `principal://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/subject/{subject_attribute_value}`: A single identity in a workload identity pool. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/group/{group_id}`: A workload identity pool group. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/attribute.{attribute_name}/{attribute_value}`: All identities in a workload identity pool with a certain attribute. * `principalSet://iam.googleapis.com/projects/{project_number}/locations/global/workloadIdentityPools/{pool_id}/*`: All identities in a workload identity pool. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `deleted:principal://iam.googleapis.com/locations/global/workforcePools/{pool_id}/subject/{subject_attribute_value}`: Deleted single identity in a workforce identity pool. For example, `deleted:principal://iam.googleapis.com/locations/global/workforcePools/my-pool-id/subject/my-subject-attribute-value`. */
-  members?: StringList;
-  /** The condition that is associated with this binding. If the condition evaluates to `true`, then this binding applies to the current request. If the condition evaluates to `false`, then this binding does not apply to the current request. However, a different role binding might grant the same role to one or more of the principals in this binding. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
-  condition?: Expr;
-}
-export const Binding = /*@__PURE__*/ S.suspend(() =>
-  S.Struct({
-    role: S.optional(S.String),
-    members: S.optional(StringList),
-    condition: S.optional(Expr),
-  }),
-).annotate({ identifier: "Binding" }) as any as S.Schema<Binding>;
-
-export type BindingList = Array<Binding>;
-export const BindingList = /*@__PURE__*/ S.Array(
-  Binding,
-) as any as S.Schema<BindingList>;
-
 /** An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members`, or principals, to a single `role`. Principals can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** ``` { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } ``` **YAML example:** ``` bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 ``` For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/). */
 export interface Policy {
-  /** `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. */
-  etag?: string;
-  /** Specifies cloud audit logging configuration for this policy. */
-  auditConfigs?: AuditConfigList;
   /** Associates a list of `members`, or principals, with a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one principal. The `bindings` in a `Policy` can refer to up to 1,500 principals; up to 250 of these principals can be Google groups. Each occurrence of a principal counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other principal, then you can add another 1,450 principals to the `bindings` in the `Policy`. */
   bindings?: BindingList;
   /** Specifies the format of the policy. Valid values are `0`, `1`, and `3`. Requests that specify an invalid value are rejected. Any operation that affects conditional role bindings must specify version `3`. This requirement applies to the following operations: * Getting a policy that includes a conditional role binding * Adding a conditional role binding to a policy * Changing a conditional role binding in a policy * Removing any role binding, with or without a condition, from a policy that includes conditions **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). */
   version?: number;
+  /** `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy. **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost. */
+  etag?: string;
+  /** Specifies cloud audit logging configuration for this policy. */
+  auditConfigs?: AuditConfigList;
 }
 export const Policy = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    etag: S.optional(S.String),
-    auditConfigs: S.optional(AuditConfigList),
     bindings: S.optional(BindingList),
     version: S.optional(S.Number),
+    etag: S.optional(S.String),
+    auditConfigs: S.optional(AuditConfigList),
   }),
 ).annotate({ identifier: "Policy" }) as any as S.Schema<Policy>;
 
@@ -1574,6 +1574,13 @@ export const GetServicesRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "GetServicesRequest",
 }) as any as S.Schema<GetServicesRequest>;
 
+export type SupportedServiceServiceSupportStageEnum =
+  | "SERVICE_SUPPORT_STAGE_UNSPECIFIED"
+  | "GA"
+  | "PREVIEW"
+  | "DEPRECATED";
+export const SupportedServiceServiceSupportStageEnum = /*@__PURE__*/ S.String;
+
 export type SupportedServiceSupportStageEnum =
   | "LAUNCH_STAGE_UNSPECIFIED"
   | "UNIMPLEMENTED"
@@ -1585,39 +1592,32 @@ export type SupportedServiceSupportStageEnum =
   | "DEPRECATED";
 export const SupportedServiceSupportStageEnum = /*@__PURE__*/ S.String;
 
-export type SupportedServiceServiceSupportStageEnum =
-  | "SERVICE_SUPPORT_STAGE_UNSPECIFIED"
-  | "GA"
-  | "PREVIEW"
-  | "DEPRECATED";
-export const SupportedServiceServiceSupportStageEnum = /*@__PURE__*/ S.String;
-
 /** `SupportedService` specifies the VPC Service Controls and its properties. */
 export interface SupportedService {
+  /** The service name or address of the supported service, such as `service.googleapis.com`. */
+  name?: string;
   /** The support stage of the service. */
-  supportStage?: SupportedServiceSupportStageEnum;
+  serviceSupportStage?: SupportedServiceServiceSupportStageEnum;
   /** True if the service is supported with some limitations. Check [documentation](https://cloud.google.com/vpc-service-controls/docs/supported-products) for details. */
   knownLimitations?: boolean;
+  /** The support stage of the service. */
+  supportStage?: SupportedServiceSupportStageEnum;
   /** True if the service is available on the restricted VIP. Services on the restricted VIP typically either support VPC Service Controls or are core infrastructure services required for the functioning of Google Cloud. */
   availableOnRestrictedVip?: boolean;
   /** The name of the supported product, such as 'Cloud Product API'. */
   title?: string;
-  /** The support stage of the service. */
-  serviceSupportStage?: SupportedServiceServiceSupportStageEnum;
   /** The list of the supported methods. This field exists only in response to GetSupportedService */
   supportedMethods?: MethodSelectorList;
-  /** The service name or address of the supported service, such as `service.googleapis.com`. */
-  name?: string;
 }
 export const SupportedService = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    supportStage: S.optional(SupportedServiceSupportStageEnum),
+    name: S.optional(S.String),
+    serviceSupportStage: S.optional(SupportedServiceServiceSupportStageEnum),
     knownLimitations: S.optional(S.Boolean),
+    supportStage: S.optional(SupportedServiceSupportStageEnum),
     availableOnRestrictedVip: S.optional(S.Boolean),
     title: S.optional(S.String),
-    serviceSupportStage: S.optional(SupportedServiceServiceSupportStageEnum),
     supportedMethods: S.optional(MethodSelectorList),
-    name: S.optional(S.String),
   }),
 ).annotate({
   identifier: "SupportedService",
@@ -1626,16 +1626,16 @@ export const SupportedService = /*@__PURE__*/ S.suspend(() =>
 export interface ListAccessPoliciesRequest {
   /** Required. Resource name for the container to list AccessPolicy instances from. Format: `organizations/{org_id}` */
   parent?: string;
-  /** Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results. */
-  pageToken?: string;
   /** Number of AccessPolicy instances to include in the list. Default 100. */
   pageSize?: number;
+  /** Next page token for the next batch of AccessPolicy instances. Defaults to the first page of results. */
+  pageToken?: string;
 }
 export const ListAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
     parent: S.optional(S.String.pipe(T.Query())),
-    pageToken: S.optional(S.String.pipe(T.Query())),
     pageSize: S.optional(S.Number.pipe(T.Query())),
+    pageToken: S.optional(S.String.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1654,15 +1654,15 @@ export const AccessPolicyList = /*@__PURE__*/ S.Array(
 
 /** A response to `ListAccessPoliciesRequest`. */
 export interface ListAccessPoliciesResponse {
-  /** List of the AccessPolicy instances. */
-  accessPolicies?: AccessPolicyList;
   /** The pagination token to retrieve the next page of results. If the value is empty, no further results remain. */
   nextPageToken?: string;
+  /** List of the AccessPolicy instances. */
+  accessPolicies?: AccessPolicyList;
 }
 export const ListAccessPoliciesResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    accessPolicies: S.optional(AccessPolicyList),
     nextPageToken: S.optional(S.String),
+    accessPolicies: S.optional(AccessPolicyList),
   }),
 ).annotate({
   identifier: "ListAccessPoliciesResponse",
@@ -1676,26 +1676,26 @@ export const ListAccessPoliciesAccessLevelsAccessLevelFormatEnum =
   /*@__PURE__*/ S.String;
 
 export interface ListAccessPoliciesAccessLevelsRequest {
+  /** Number of Access Levels to include in the list. Default 100. */
+  pageSize?: number;
+  /** Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}` */
+  parent: string;
   /** Whether to return `BasicLevels` in the Cloud Common Expression language, as `CustomLevels`, rather than as `BasicLevels`. Defaults to returning `AccessLevels` in the format they were defined. */
   accessLevelFormat?:
     | ListAccessPoliciesAccessLevelsAccessLevelFormatEnum
     | (string & {});
   /** Next page token for the next batch of Access Level instances. Defaults to the first page of results. */
   pageToken?: string;
-  /** Number of Access Levels to include in the list. Default 100. */
-  pageSize?: number;
-  /** Required. Resource name for the access policy to list Access Levels from. Format: `accessPolicies/{policy_id}` */
-  parent: string;
 }
 export const ListAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   () =>
     S.Struct({
+      pageSize: S.optional(S.Number.pipe(T.Query())),
+      parent: S.String.pipe(T.Label()),
       accessLevelFormat: S.optional(
         ListAccessPoliciesAccessLevelsAccessLevelFormatEnum.pipe(T.Query()),
       ),
       pageToken: S.optional(S.String.pipe(T.Query())),
-      pageSize: S.optional(S.Number.pipe(T.Query())),
-      parent: S.String.pipe(T.Label()),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1714,15 +1714,15 @@ export const AccessLevelList = /*@__PURE__*/ S.Array(
 
 /** A response to `ListAccessLevelsRequest`. */
 export interface ListAccessLevelsResponse {
-  /** List of the Access Level instances. */
-  accessLevels?: AccessLevelList;
   /** The pagination token to retrieve the next page of results. If the value is empty, no further results remain. */
   nextPageToken?: string;
+  /** List of the Access Level instances. */
+  accessLevels?: AccessLevelList;
 }
 export const ListAccessLevelsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    accessLevels: S.optional(AccessLevelList),
     nextPageToken: S.optional(S.String),
+    accessLevels: S.optional(AccessLevelList),
   }),
 ).annotate({
   identifier: "ListAccessLevelsResponse",
@@ -1731,17 +1731,17 @@ export const ListAccessLevelsResponse = /*@__PURE__*/ S.suspend(() =>
 export interface ListAccessPoliciesAuthorizedOrgsDescsRequest {
   /** Number of Authorized Orgs Descs to include in the list. Default 100. */
   pageSize?: number;
-  /** Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results. */
-  pageToken?: string;
   /** Required. Resource name for the access policy to list Authorized Orgs Desc from. Format: `accessPolicies/{policy_id}` */
   parent: string;
+  /** Next page token for the next batch of Authorized Orgs Desc instances. Defaults to the first page of results. */
+  pageToken?: string;
 }
 export const ListAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
       pageSize: S.optional(S.Number.pipe(T.Query())),
-      pageToken: S.optional(S.String.pipe(T.Query())),
       parent: S.String.pipe(T.Label()),
+      pageToken: S.optional(S.String.pipe(T.Query())),
     }).pipe(
       T.Http({
         method: "GET",
@@ -1786,10 +1786,10 @@ export interface ListAccessPoliciesServicePerimetersRequest {
   deletedPrincipalSyntax?:
     | ListAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum
     | (string & {});
-  /** Number of Service Perimeters to include in the list. Default 100. */
-  pageSize?: number;
   /** Required. Resource name for the access policy to list Service Perimeters from. Format: `accessPolicies/{policy_id}` */
   parent: string;
+  /** Number of Service Perimeters to include in the list. Default 100. */
+  pageSize?: number;
   /** Next page token for the next batch of Service Perimeter instances. Defaults to the first page of results. */
   pageToken?: string;
 }
@@ -1801,8 +1801,8 @@ export const ListAccessPoliciesServicePerimetersRequest =
           T.Query(),
         ),
       ),
-      pageSize: S.optional(S.Number.pipe(T.Query())),
       parent: S.String.pipe(T.Label()),
+      pageSize: S.optional(S.Number.pipe(T.Query())),
       pageToken: S.optional(S.String.pipe(T.Query())),
     }).pipe(
       T.Http({
@@ -1822,39 +1822,39 @@ export const ServicePerimeterList = /*@__PURE__*/ S.Array(
 
 /** A response to `ListServicePerimetersRequest`. */
 export interface ListServicePerimetersResponse {
-  /** The pagination token to retrieve the next page of results. If the value is empty, no further results remain. */
-  nextPageToken?: string;
   /** List of the Service Perimeter instances. */
   servicePerimeters?: ServicePerimeterList;
+  /** The pagination token to retrieve the next page of results. If the value is empty, no further results remain. */
+  nextPageToken?: string;
 }
 export const ListServicePerimetersResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    nextPageToken: S.optional(S.String),
     servicePerimeters: S.optional(ServicePerimeterList),
+    nextPageToken: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ListServicePerimetersResponse",
 }) as any as S.Schema<ListServicePerimetersResponse>;
 
 export interface ListOperationsRequest {
-  /** The standard list page token. */
-  pageToken?: string;
-  /** The standard list filter. */
-  filter?: string;
-  /** The standard list page size. */
-  pageSize?: number;
   /** When set to `true`, operations that are reachable are returned as normal, and those that are unreachable are returned in the ListOperationsResponse.unreachable field. This can only be `true` when reading across collections. For example, when `parent` is set to `"projects/example/locations/-"`. This field is not supported by default and will result in an `UNIMPLEMENTED` error if set unless explicitly documented otherwise in service or product specific documentation. */
   returnPartialSuccess?: boolean;
+  /** The standard list filter. */
+  filter?: string;
   /** The name of the operation's parent resource. */
   name: string;
+  /** The standard list page token. */
+  pageToken?: string;
+  /** The standard list page size. */
+  pageSize?: number;
 }
 export const ListOperationsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pageToken: S.optional(S.String.pipe(T.Query())),
-    filter: S.optional(S.String.pipe(T.Query())),
-    pageSize: S.optional(S.Number.pipe(T.Query())),
     returnPartialSuccess: S.optional(S.Boolean.pipe(T.Query())),
+    filter: S.optional(S.String.pipe(T.Query())),
     name: S.String.pipe(T.Label()),
+    pageToken: S.optional(S.String.pipe(T.Query())),
+    pageSize: S.optional(S.Number.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1873,18 +1873,18 @@ export const OperationList = /*@__PURE__*/ S.Array(
 
 /** The response message for Operations.ListOperations. */
 export interface ListOperationsResponse {
+  /** A list of operations that matches the specified filter in the request. */
+  operations?: OperationList;
   /** Unordered list. Unreachable resources. Populated when the request sets `ListOperationsRequest.return_partial_success` and reads across collections. For example, when attempting to list all resources across all supported locations. */
   unreachable?: StringList;
   /** The standard List next-page token. */
   nextPageToken?: string;
-  /** A list of operations that matches the specified filter in the request. */
-  operations?: OperationList;
 }
 export const ListOperationsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
+    operations: S.optional(OperationList),
     unreachable: S.optional(StringList),
     nextPageToken: S.optional(S.String),
-    operations: S.optional(OperationList),
   }),
 ).annotate({
   identifier: "ListOperationsResponse",
@@ -1893,10 +1893,10 @@ export const ListOperationsResponse = /*@__PURE__*/ S.suspend(() =>
 export interface ListOrganizationsGcpUserAccessBindingsRequest {
   /** Optional. Maximum number of items to return. The server may return fewer items. If left blank, the server may return any number of items. */
   pageSize?: number;
-  /** Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation. */
-  pageToken?: string;
   /** Required. Example: "organizations/256" */
   parent: string;
+  /** Optional. If left blank, returns the first page. To enumerate all items, use the next_page_token from your previous list operation. */
+  pageToken?: string;
   /** Optional. The literal filter to apply to the results returned. See https://google.aip.dev/160 for more details. Accepts values: * `principal:group_key` * `principal:service_account` OR `principal:service_account_project_number`. If this field is empty or not one of the above, the default value is `"principal:group_key"`. */
   filter?: string;
 }
@@ -1904,8 +1904,8 @@ export const ListOrganizationsGcpUserAccessBindingsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
       pageSize: S.optional(S.Number.pipe(T.Query())),
-      pageToken: S.optional(S.String.pipe(T.Query())),
       parent: S.String.pipe(T.Label()),
+      pageToken: S.optional(S.String.pipe(T.Query())),
       filter: S.optional(S.String.pipe(T.Query())),
     }).pipe(
       T.Http({
@@ -1925,30 +1925,30 @@ export const GcpUserAccessBindingList = /*@__PURE__*/ S.Array(
 
 /** Response of ListGcpUserAccessBindings. */
 export interface ListGcpUserAccessBindingsResponse {
-  /** Token to get the next page of items. If blank, there are no more items. */
-  nextPageToken?: string;
   /** GcpUserAccessBinding */
   gcpUserAccessBindings?: GcpUserAccessBindingList;
+  /** Token to get the next page of items. If blank, there are no more items. */
+  nextPageToken?: string;
 }
 export const ListGcpUserAccessBindingsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    nextPageToken: S.optional(S.String),
     gcpUserAccessBindings: S.optional(GcpUserAccessBindingList),
+    nextPageToken: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ListGcpUserAccessBindingsResponse",
 }) as any as S.Schema<ListGcpUserAccessBindingsResponse>;
 
 export interface ListPermissionsRequest {
-  /** Optional. Use this token to retrieve a specific page of results. Default is the first page. */
-  pageToken?: string;
   /** Optional. This flag specifies the maximum number of services to return per page. Default value is 100. */
   pageSize?: number;
+  /** Optional. Use this token to retrieve a specific page of results. Default is the first page. */
+  pageToken?: string;
 }
 export const ListPermissionsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pageToken: S.optional(S.String.pipe(T.Query())),
     pageSize: S.optional(S.Number.pipe(T.Query())),
+    pageToken: S.optional(S.String.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -1962,30 +1962,30 @@ export const ListPermissionsRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** A response to `ListSupportedPermissionsRequest`. */
 export interface ListSupportedPermissionsResponse {
-  /** Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available. */
-  nextPageToken?: string;
   /** List of VPC Service Controls supported permissions. */
   supportedPermissions?: StringList;
+  /** Use this pagination token to retrieve the next page of results. An empty value indicates that no further results are available. */
+  nextPageToken?: string;
 }
 export const ListSupportedPermissionsResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    nextPageToken: S.optional(S.String),
     supportedPermissions: S.optional(StringList),
+    nextPageToken: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ListSupportedPermissionsResponse",
 }) as any as S.Schema<ListSupportedPermissionsResponse>;
 
 export interface ListServicesRequest {
-  /** Use this token to retrieve a specific page of results. Default is the first page. */
-  pageToken?: string;
   /** This flag specifies the maximum number of services to return per page. Default value is 100. */
   pageSize?: number;
+  /** Use this token to retrieve a specific page of results. Default is the first page. */
+  pageToken?: string;
 }
 export const ListServicesRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    pageToken: S.optional(S.String.pipe(T.Query())),
     pageSize: S.optional(S.Number.pipe(T.Query())),
+    pageToken: S.optional(S.String.pipe(T.Query())),
   }).pipe(
     T.Http({
       method: "GET",
@@ -2018,18 +2018,79 @@ export const ListSupportedServicesResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListSupportedServicesResponse",
 }) as any as S.Schema<ListSupportedServicesResponse>;
 
+export interface LookupConfiguredServicePerimeterFoldersRequest {
+  /** Required. The Resource to resolve (e.g. "projects/123", "folders/456"). */
+  resource: string;
+}
+export const LookupConfiguredServicePerimeterFoldersRequest =
+  /*@__PURE__*/ S.suspend(() =>
+    S.Struct({
+      resource: S.String.pipe(T.Label()),
+    }).pipe(
+      T.Http({
+        method: "GET",
+        uri: "v1/{+resource}:lookupConfiguredServicePerimeter",
+        baseUrl: "https://accesscontextmanager.googleapis.com/",
+      }),
+    ),
+  ).annotate({
+    identifier: "LookupConfiguredServicePerimeterFoldersRequest",
+  }) as any as S.Schema<LookupConfiguredServicePerimeterFoldersRequest>;
+
+/** A configured service perimeter returned by Access Context Manager. */
+export interface LookupConfiguredServicePerimeterResponse {
+  /** The resource (e.g. "projects/123", "folders/456") that directly owns/is restricted by the enforced perimeter. */
+  restrictedResource?: string;
+  /** Fully qualified name of the configured enforced perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no enforced perimeter applies. */
+  servicePerimeter?: string;
+  /** The resource (e.g. "projects/123", "folders/456") that directly owns/is restricted by the dry-run perimeter. */
+  restrictedResourceDryRun?: string;
+  /** Fully qualified name of the configured dry-run perimeter. Format: `accessPolicies/{policy_id}/servicePerimeters/{perimeter_name}` This field is empty if no dry-run perimeter configuration applies. */
+  servicePerimeterDryRun?: string;
+}
+export const LookupConfiguredServicePerimeterResponse = /*@__PURE__*/ S.suspend(
+  () =>
+    S.Struct({
+      restrictedResource: S.optional(S.String),
+      servicePerimeter: S.optional(S.String),
+      restrictedResourceDryRun: S.optional(S.String),
+      servicePerimeterDryRun: S.optional(S.String),
+    }),
+).annotate({
+  identifier: "LookupConfiguredServicePerimeterResponse",
+}) as any as S.Schema<LookupConfiguredServicePerimeterResponse>;
+
+export interface LookupConfiguredServicePerimeterProjectsRequest {
+  /** Required. The Resource to resolve (e.g. "projects/123", "folders/456"). */
+  resource: string;
+}
+export const LookupConfiguredServicePerimeterProjectsRequest =
+  /*@__PURE__*/ S.suspend(() =>
+    S.Struct({
+      resource: S.String.pipe(T.Label()),
+    }).pipe(
+      T.Http({
+        method: "GET",
+        uri: "v1/{+resource}:lookupConfiguredServicePerimeter",
+        baseUrl: "https://accesscontextmanager.googleapis.com/",
+      }),
+    ),
+  ).annotate({
+    identifier: "LookupConfiguredServicePerimeterProjectsRequest",
+  }) as any as S.Schema<LookupConfiguredServicePerimeterProjectsRequest>;
+
 export interface PatchAccessPoliciesRequest {
-  /** Required. Mask to control which fields get updated. Must be non-empty. */
-  updateMask?: string;
   /** Output only. Identifier. Resource name of the `AccessPolicy`. Format: `accessPolicies/{access_policy}` */
   name: string;
+  /** Required. Mask to control which fields get updated. Must be non-empty. */
+  updateMask?: string;
   /** Request body */
   body?: AccessPolicy;
 }
 export const PatchAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    updateMask: S.optional(S.String.pipe(T.Query())),
     name: S.String.pipe(T.Label()),
+    updateMask: S.optional(S.String.pipe(T.Query())),
     body: S.optional(AccessPolicy.pipe(T.HttpBody())),
   }).pipe(
     T.Http({
@@ -2043,18 +2104,18 @@ export const PatchAccessPoliciesRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<PatchAccessPoliciesRequest>;
 
 export interface PatchAccessPoliciesAccessLevelsRequest {
-  /** Required. Mask to control which fields get updated. Must be non-empty. */
-  updateMask?: string;
   /** Identifier. Resource name for the `AccessLevel`. Format: `accessPolicies/{access_policy}/accessLevels/{access_level}`. The `access_level` component must begin with a letter, followed by alphanumeric characters or `_`. Its maximum length is 50 characters. After you create an `AccessLevel`, you cannot change its `name`. */
   name: string;
+  /** Required. Mask to control which fields get updated. Must be non-empty. */
+  updateMask?: string;
   /** Request body */
   body?: AccessLevel;
 }
 export const PatchAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
   () =>
     S.Struct({
-      updateMask: S.optional(S.String.pipe(T.Query())),
       name: S.String.pipe(T.Label()),
+      updateMask: S.optional(S.String.pipe(T.Query())),
       body: S.optional(AccessLevel.pipe(T.HttpBody())),
     }).pipe(
       T.Http({
@@ -2068,18 +2129,18 @@ export const PatchAccessPoliciesAccessLevelsRequest = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<PatchAccessPoliciesAccessLevelsRequest>;
 
 export interface PatchAccessPoliciesAuthorizedOrgsDescsRequest {
-  /** Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`. */
-  name: string;
   /** Required. Mask to control which fields get updated. Must be non-empty. */
   updateMask?: string;
+  /** Identifier. Resource name for the `AuthorizedOrgsDesc`. Format: `accessPolicies/{access_policy}/authorizedOrgsDescs/{authorized_orgs_desc}`. The `authorized_orgs_desc` component must begin with a letter, followed by alphanumeric characters or `_`. After you create an `AuthorizedOrgsDesc`, you cannot change its `name`. */
+  name: string;
   /** Request body */
   body?: AuthorizedOrgsDesc;
 }
 export const PatchAccessPoliciesAuthorizedOrgsDescsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      name: S.String.pipe(T.Label()),
       updateMask: S.optional(S.String.pipe(T.Query())),
+      name: S.String.pipe(T.Label()),
       body: S.optional(AuthorizedOrgsDesc.pipe(T.HttpBody())),
     }).pipe(
       T.Http({
@@ -2100,12 +2161,12 @@ export const PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum =
   /*@__PURE__*/ S.String;
 
 export interface PatchAccessPoliciesServicePerimetersRequest {
+  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
+  name: string;
   /** Optional. If true, the response will contain the deleted principal syntax for identities that support it and the request can contain identities with deleted principal syntax. */
   deletedPrincipalSyntax?:
     | PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum
     | (string & {});
-  /** Identifier. Resource name for the `ServicePerimeter`. Format: `accessPolicies/{access_policy}/servicePerimeters/{service_perimeter}`. The `service_perimeter` component must begin with a letter, followed by alphanumeric characters or `_`. After you create a `ServicePerimeter`, you cannot change its `name`. */
-  name: string;
   /** Required. Mask to control which fields get updated. Must be non-empty. */
   updateMask?: string;
   /** Request body */
@@ -2114,12 +2175,12 @@ export interface PatchAccessPoliciesServicePerimetersRequest {
 export const PatchAccessPoliciesServicePerimetersRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
+      name: S.String.pipe(T.Label()),
       deletedPrincipalSyntax: S.optional(
         PatchAccessPoliciesServicePerimetersDeletedPrincipalSyntaxEnum.pipe(
           T.Query(),
         ),
       ),
-      name: S.String.pipe(T.Label()),
       updateMask: S.optional(S.String.pipe(T.Query())),
       body: S.optional(ServicePerimeter.pipe(T.HttpBody())),
     }).pipe(
@@ -2134,21 +2195,21 @@ export const PatchAccessPoliciesServicePerimetersRequest =
   }) as any as S.Schema<PatchAccessPoliciesServicePerimetersRequest>;
 
 export interface PatchOrganizationsGcpUserAccessBindingsRequest {
-  /** Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when "scoped_access_settings" is not set in the update_mask. */
-  append?: boolean;
-  /** Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N" */
-  name: string;
   /** Required. Only the fields specified in this mask are updated. Because name and group_key cannot be changed, update_mask is required and may only contain the following fields: `access_levels`, `dry_run_access_levels`, `session_settings`, `scoped_access_settings`. update_mask { paths: "access_levels" } */
   updateMask?: string;
+  /** Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by [RFC 3986 Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N" */
+  name: string;
+  /** Optional. This field controls whether or not certain repeated settings in the update request overwrite or append to existing settings on the binding. If true, then append. Otherwise overwrite. So far, only scoped_access_settings with session_settings supports appending. Global access_levels, access_levels in scoped_access_settings, dry_run_access_levels, and session_settings are not compatible with append functionality, and the request will return an error if append=true when these settings are in the update_mask. The request will also return an error if append=true when "scoped_access_settings" is not set in the update_mask. */
+  append?: boolean;
   /** Request body */
   body?: GcpUserAccessBinding;
 }
 export const PatchOrganizationsGcpUserAccessBindingsRequest =
   /*@__PURE__*/ S.suspend(() =>
     S.Struct({
-      append: S.optional(S.Boolean.pipe(T.Query())),
-      name: S.String.pipe(T.Label()),
       updateMask: S.optional(S.String.pipe(T.Query())),
+      name: S.String.pipe(T.Label()),
+      append: S.optional(S.Boolean.pipe(T.Query())),
       body: S.optional(GcpUserAccessBinding.pipe(T.HttpBody())),
     }).pipe(
       T.Http({
@@ -2163,15 +2224,15 @@ export const PatchOrganizationsGcpUserAccessBindingsRequest =
 
 /** A request to replace all existing Access Levels in an Access Policy with the Access Levels provided. This is done atomically. */
 export interface ReplaceAccessLevelsRequest {
-  /** Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy. */
-  accessLevels?: AccessLevelList;
   /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
   etag?: string;
+  /** Required. The desired Access Levels that should replace all existing Access Levels in the Access Policy. */
+  accessLevels?: AccessLevelList;
 }
 export const ReplaceAccessLevelsRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    accessLevels: S.optional(AccessLevelList),
     etag: S.optional(S.String),
+    accessLevels: S.optional(AccessLevelList),
   }),
 ).annotate({
   identifier: "ReplaceAccessLevelsRequest",
@@ -2201,15 +2262,15 @@ export const ReplaceAllAccessPoliciesAccessLevelsRequest =
 
 /** A request to replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically. */
 export interface ReplaceServicePerimetersRequest {
-  /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
-  etag?: string;
   /** Required. The desired Service Perimeters that should replace all existing Service Perimeters in the Access Policy. */
   servicePerimeters?: ServicePerimeterList;
+  /** Optional. The etag for the version of the Access Policy that this replace operation is to be performed on. If, at the time of replace, the etag for the Access Policy stored in Access Context Manager is different from the specified etag, then the replace operation will not be performed and the call will fail. This field is not required. If etag is not provided, the operation will be performed as if a valid etag is provided. */
+  etag?: string;
 }
 export const ReplaceServicePerimetersRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    etag: S.optional(S.String),
     servicePerimeters: S.optional(ServicePerimeterList),
+    etag: S.optional(S.String),
   }),
 ).annotate({
   identifier: "ReplaceServicePerimetersRequest",
@@ -2239,15 +2300,15 @@ export const ReplaceAllAccessPoliciesServicePerimetersRequest =
 
 /** Request message for `SetIamPolicy` method. */
 export interface SetIamPolicyRequest {
-  /** OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: "bindings, etag"` */
-  updateMask?: string;
   /** REQUIRED: The complete policy to be applied to the `resource`. The size of the policy is limited to a few 10s of KB. An empty policy is a valid policy but certain Google Cloud services (such as Projects) might reject them. */
   policy?: Policy;
+  /** OPTIONAL: A FieldMask specifying which fields of the policy to modify. Only the fields in the mask will be modified. If no mask is provided, the following default mask is used: `paths: "bindings, etag"` */
+  updateMask?: string;
 }
 export const SetIamPolicyRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
-    updateMask: S.optional(S.String),
     policy: S.optional(Policy),
+    updateMask: S.optional(S.String),
   }),
 ).annotate({
   identifier: "SetIamPolicyRequest",
@@ -2934,6 +2995,42 @@ export const listServices: API.PaginatedOperationMethod<
     outputToken: "nextPageToken",
   } as const,
 })) as any;
+
+export type LookupConfiguredServicePerimeterFoldersError =
+  | NotFound
+  | Forbidden
+  | GcpOpError;
+/** Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']. */
+export const lookupConfiguredServicePerimeterFolders: API.OperationMethod<
+  LookupConfiguredServicePerimeterFoldersRequest,
+  LookupConfiguredServicePerimeterResponse,
+  LookupConfiguredServicePerimeterFoldersError,
+  GcpOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: LookupConfiguredServicePerimeterFoldersRequest,
+  output: LookupConfiguredServicePerimeterResponse,
+  errors: [NotFound, Forbidden, UnknownGCPError],
+  protocol: GcpProtocol,
+  retry: Retry.Retry,
+}));
+
+export type LookupConfiguredServicePerimeterProjectsError =
+  | NotFound
+  | Forbidden
+  | GcpOpError;
+/** Looks up the configured service perimeter for a given resource Format: ['projects/{projectNumber}', 'folders/{folderNumber}']. */
+export const lookupConfiguredServicePerimeterProjects: API.OperationMethod<
+  LookupConfiguredServicePerimeterProjectsRequest,
+  LookupConfiguredServicePerimeterResponse,
+  LookupConfiguredServicePerimeterProjectsError,
+  GcpOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: LookupConfiguredServicePerimeterProjectsRequest,
+  output: LookupConfiguredServicePerimeterResponse,
+  errors: [NotFound, Forbidden, UnknownGCPError],
+  protocol: GcpProtocol,
+  retry: Retry.Retry,
+}));
 
 export type PatchAccessPoliciesError =
   | NotFound


### PR DESCRIPTION
## Summary

`GcpUserAccessBinding.restrictedClientApplications` (array of `Application`) is still sent by Alchemy, but live discovery **20260827 dropped** the deprecated property.

- Convert + generate **only** `accesscontextmanager` v1 from spec-mirror **436cb36** (discovery revision **20260827**), not 20260819/`dbcaa3b`. Regenerating from 20260819 deleted `lookupConfiguredServicePerimeterFolders` and `lookupConfiguredServicePerimeterProjects` that `origin/main` already ships.
- RFC-6902 patch `packages/gcp/patches/accesscontextmanager_v1/restrictedClientApplications.json` re-adds `ApplicationList`, the member, and the `scopedAccessSettings` mutual-exclusion sentence so the field is still emitted after 20260827 dropped it.
- Do **not** pin Alchemy 1336 until this lands on `origin/main`; the intersection type is fine until then.

Generated surface: `restrictedClientApplications?: ApplicationList` (`Array<Application>` with `clientId` / `name`). Lookup ops match `origin/main`.

## Test plan

- [x] Convert from spec-mirror `436cb36` (discovery 20260827) + patch emits `restrictedClientApplications` targeting `ApplicationList`
- [x] vs `origin/main`: no `-export` of `lookupConfiguredServicePerimeterFolders` / `lookupConfiguredServicePerimeterProjects` (42 ops both sides)
- [x] Generated `GcpUserAccessBinding` includes `restrictedClientApplications?: ApplicationList`
- [x] `pnpm specs:check` not required for a gitlink bump to mirror HEAD; no `.local` in committed strings
- [ ] gcp-quality: do **not** pin Alchemy 1336 until this is on `origin/main`; intersection type until then is fine