### PR TITLE
feat(aws): replace aws4fetch with Effect-native SigV4 signer

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -111,7 +111,6 @@
     "@smithy/shared-ini-file-loader": "catalog:aws",
     "@smithy/types": "catalog:aws",
     "@smithy/util-base64": "catalog:aws",
-    "aws4fetch": "catalog:aws",
     "fast-xml-parser": "catalog:shared"
   },
   "devDependencies": {

--- a/packages/aws/src/presign.ts
+++ b/packages/aws/src/presign.ts
@@ -60,7 +60,7 @@ export const presignUrl: (
   options: PresignUrlOptions,
 ) => Effect.Effect<
   string,
-  Credentials.CredentialsError,
+  Credentials.CredentialsError | SigV4.SigningError,
   Credentials.Credentials | Region.Region
 > = Effect.fnUntraced(function* (options: PresignUrlOptions) {
   const credentials = yield* yield* Credentials.Credentials;
@@ -150,7 +150,7 @@ export const presignS3Url: (
   options: PresignS3UrlOptions,
 ) => Effect.Effect<
   string,
-  Credentials.CredentialsError,
+  Credentials.CredentialsError | SigV4.SigningError,
   Credentials.Credentials | Region.Region
 > = Effect.fnUntraced(function* (options: PresignS3UrlOptions) {
   const region = options.region ?? (yield* yield* Region.Region);

--- a/packages/aws/src/presign.ts
+++ b/packages/aws/src/presign.ts
@@ -1,4 +1,3 @@
-import { AwsV4Signer } from "aws4fetch";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
@@ -6,6 +5,7 @@ import * as Redacted from "effect/Redacted";
 import * as Credentials from "./credentials.browser.ts";
 import * as Endpoint from "./endpoint.ts";
 import * as Region from "./region.ts";
+import * as SigV4 from "./sigv4.ts";
 
 /**
  * Options for {@link presignUrl}.
@@ -69,7 +69,7 @@ export const presignUrl: (
   const url = new URL(options.url);
   url.searchParams.set("X-Amz-Expires", String(options.expiresIn ?? 900));
 
-  const signer = new AwsV4Signer({
+  const signed = yield* SigV4.sign({
     method: options.method ?? "GET",
     url: url.toString(),
     headers: options.headers,
@@ -82,15 +82,14 @@ export const presignUrl: (
     region,
     signQuery: true,
     datetime: options.datetime,
-    // aws4fetch excludes `content-type` (among others) from the signature by
+    // The signer excludes `content-type` (among others) from the signature by
     // default (UNSIGNABLE_HEADERS). Callers passing headers here explicitly
     // want them pinned into the signature — e.g. the AWS SDK's getSignedUrl
     // signs `content-type` when a ContentType is given, which is what pins an
     // uploader to the declared type — so opt back in.
     allHeaders: options.headers !== undefined,
   });
-  const signed = yield* Effect.promise(() => signer.sign());
-  return signed.url.toString();
+  return signed.url;
 });
 
 /**

--- a/packages/aws/src/presign.ts
+++ b/packages/aws/src/presign.ts
@@ -74,10 +74,8 @@ export const presignUrl: (
     url: url.toString(),
     headers: options.headers,
     accessKeyId: Redacted.value(credentials.accessKeyId),
-    secretAccessKey: Redacted.value(credentials.secretAccessKey),
-    sessionToken: credentials.sessionToken
-      ? Redacted.value(credentials.sessionToken)
-      : undefined,
+    secretAccessKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken,
     service: options.service,
     region,
     signQuery: true,

--- a/packages/aws/src/protocol.ts
+++ b/packages/aws/src/protocol.ts
@@ -420,10 +420,8 @@ const encode = ({
           ? undefined
           : resolvedRequest.body,
       accessKeyId: Redacted.value(credentials.accessKeyId),
-      secretAccessKey: Redacted.value(credentials.secretAccessKey),
-      sessionToken: credentials.sessionToken
-        ? Redacted.value(credentials.sessionToken)
-        : undefined,
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
       service: signingServiceName,
       region: signingRegion,
     });

--- a/packages/aws/src/protocol.ts
+++ b/packages/aws/src/protocol.ts
@@ -24,7 +24,6 @@
  * rules) is keyed off the operation config's identity, which `API.make`
  * memoizes — so it runs once per operation per process.
  */
-import { AwsV4Signer } from "aws4fetch";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
@@ -46,6 +45,7 @@ import * as Credentials from "./credentials.browser.ts";
 import * as Endpoint from "./endpoint.ts";
 import * as Region from "./region.ts";
 import { makeEndpointResolver } from "./rules-engine/endpoint-resolver.ts";
+import * as SigV4 from "./sigv4.ts";
 import {
   getAwsApiService,
   getAwsAuthSigv2,
@@ -372,7 +372,7 @@ const encode = ({
 
     // S3 Control rejects UNSIGNED-PAYLOAD on several routes (access point
     // operations fail with `InvalidRequest: "Request body cannot be
-    // unsigned"`). aws4fetch injects UNSIGNED-PAYLOAD for any service signing
+    // unsigned"`). The signer injects UNSIGNED-PAYLOAD for any service signing
     // as "s3" when the header is absent, so pre-compute the real payload
     // SHA-256 here (matching the official SDK's applyChecksum behavior).
     // Glacier likewise REQUIRES the x-amz-content-sha256 header on
@@ -408,15 +408,16 @@ const encode = ({
       };
     }
 
-    const signer = new AwsV4Signer({
+    const signedRequest = yield* SigV4.sign({
       method: resolvedRequest.method,
       url: `${endpoint}${fullPath}`,
       headers: signingHeaders,
-      // Don't pass body to signer when using unsigned payload
-      body: useUnsignedPayload
-        ? undefined
-        : resolvedRequest.body instanceof Uint8Array
-          ? Buffer.from(resolvedRequest.body)
+      // Don't pass body to signer when using unsigned payload. A streaming
+      // body only reaches here with an explicit x-amz-content-sha256, in
+      // which case the signer never reads the body.
+      body:
+        useUnsignedPayload || resolvedRequest.body instanceof ReadableStream
+          ? undefined
           : resolvedRequest.body,
       accessKeyId: Redacted.value(credentials.accessKeyId),
       secretAccessKey: Redacted.value(credentials.secretAccessKey),
@@ -426,13 +427,7 @@ const encode = ({
       service: signingServiceName,
       region: signingRegion,
     });
-    const signedRequest = yield* Effect.promise(() => signer.sign());
-
-    // Build headers object from signed request
-    const signedHeaders: Record<string, string> = {};
-    signedRequest.headers.forEach((value, key) => {
-      signedHeaders[key] = value;
-    });
+    const signedHeaders = signedRequest.headers;
 
     // Get content type from signed headers for body constructor
     const contentType = signedHeaders["content-type"];

--- a/packages/aws/src/sigv4.test.ts
+++ b/packages/aws/src/sigv4.test.ts
@@ -10,7 +10,7 @@ import * as SigV4 from "./sigv4.ts";
 // AWS SigV4 test-suite credentials (S3 "GET Object" / "PUT Object" examples).
 const creds = {
   accessKeyId: "AKIAIOSFODNN7EXAMPLE",
-  secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  secretAccessKey: Redacted.make("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
 };
 const datetime = "20130524T000000Z";
 
@@ -38,7 +38,7 @@ describe("SigV4.sign", () => {
     const signed = await Effect.runPromise(
       SigV4.sign({
         ...creds,
-        sessionToken: "TOKEN==",
+        sessionToken: Redacted.make("TOKEN=="),
         method: "POST",
         url: "https://dynamodb.us-west-2.amazonaws.com//x//y?b=2&a=1&a=0&=empty",
         headers: {
@@ -91,7 +91,7 @@ describe("SigV4.sign", () => {
     const signed = await Effect.runPromise(
       SigV4.sign({
         ...creds,
-        sessionToken: "TOK",
+        sessionToken: Redacted.make("TOK"),
         method: "GET",
         url: "https://examplebucket.s3.amazonaws.com/a b/(x)!*'.txt?X-Amz-Expires=900&foo=bar&foo=baz",
         headers: { "content-type": "image/png" },
@@ -133,7 +133,10 @@ describe("SigV4.sign", () => {
     // Churn well past the cache bound with distinct secrets.
     for (let i = 0; i < 200; i++) {
       await Effect.runPromise(
-        SigV4.sign({ ...request, secretAccessKey: `rotated-${i}` }),
+        SigV4.sign({
+          ...request,
+          secretAccessKey: Redacted.make(`rotated-${i}`),
+        }),
       );
     }
     const after = await Effect.runPromise(SigV4.sign(request));
@@ -144,7 +147,7 @@ describe("SigV4.sign", () => {
     const signed = await Effect.runPromise(
       SigV4.sign({
         ...creds,
-        sessionToken: "TOK",
+        sessionToken: Redacted.make("TOK"),
         url: "https://data.iot.us-east-1.amazonaws.com/mqtt",
         service: "iotdevicegateway",
         region: "us-east-1",
@@ -165,7 +168,7 @@ describe("Presign", () => {
       Credentials.Credentials,
       Effect.succeed({
         accessKeyId: Redacted.make(creds.accessKeyId),
-        secretAccessKey: Redacted.make(creds.secretAccessKey),
+        secretAccessKey: creds.secretAccessKey,
         region: "us-east-1" as Region.RegionName,
       }),
     ),

--- a/packages/aws/src/sigv4.test.ts
+++ b/packages/aws/src/sigv4.test.ts
@@ -143,6 +143,32 @@ describe("SigV4.sign", () => {
     expect(after.headers.authorization).toBe(before.headers.authorization);
   });
 
+  test("fails with InvalidSigningUrl for a relative URL", async () => {
+    const error = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        url: "/not/absolute",
+        service: "s3",
+        region: "us-east-1",
+      }).pipe(Effect.flip),
+    );
+    expect(error).toBeInstanceOf(SigV4.InvalidSigningUrl);
+    expect(error._tag).toBe("AWS::SigV4::InvalidSigningUrl");
+  });
+
+  test("fails with InvalidSigningHeaders for an invalid header name", async () => {
+    const error = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        url: "https://examplebucket.s3.amazonaws.com/",
+        headers: { "bad header": "x" },
+        service: "s3",
+        region: "us-east-1",
+      }).pipe(Effect.flip),
+    );
+    expect(error._tag).toBe("AWS::SigV4::InvalidSigningHeaders");
+  });
+
   test("iotdevicegateway appends the session token after the signature", async () => {
     const signed = await Effect.runPromise(
       SigV4.sign({
@@ -169,6 +195,7 @@ describe("Presign", () => {
       Effect.succeed({
         accessKeyId: Redacted.make(creds.accessKeyId),
         secretAccessKey: creds.secretAccessKey,
+        sessionToken: undefined,
         region: "us-east-1" as Region.RegionName,
       }),
     ),

--- a/packages/aws/src/sigv4.test.ts
+++ b/packages/aws/src/sigv4.test.ts
@@ -119,6 +119,27 @@ describe("SigV4.sign", () => {
     expect(signed.headers.authorization).toBeUndefined();
   });
 
+  test("signing stays correct after the derived-key cache evicts entries", async () => {
+    const request = {
+      ...creds,
+      method: "GET",
+      url: "https://examplebucket.s3.amazonaws.com/test.txt",
+      headers: { Range: "bytes=0-9" },
+      service: "s3",
+      region: "us-east-1",
+      datetime,
+    } as const;
+    const before = await Effect.runPromise(SigV4.sign(request));
+    // Churn well past the cache bound with distinct secrets.
+    for (let i = 0; i < 200; i++) {
+      await Effect.runPromise(
+        SigV4.sign({ ...request, secretAccessKey: `rotated-${i}` }),
+      );
+    }
+    const after = await Effect.runPromise(SigV4.sign(request));
+    expect(after.headers.authorization).toBe(before.headers.authorization);
+  });
+
   test("iotdevicegateway appends the session token after the signature", async () => {
     const signed = await Effect.runPromise(
       SigV4.sign({

--- a/packages/aws/src/sigv4.test.ts
+++ b/packages/aws/src/sigv4.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Credentials from "./credentials.browser.ts";
+import * as Presign from "./presign.ts";
+import * as Region from "./region.ts";
+import * as SigV4 from "./sigv4.ts";
+
+// AWS SigV4 test-suite credentials (S3 "GET Object" / "PUT Object" examples).
+const creds = {
+  accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+};
+const datetime = "20130524T000000Z";
+
+describe("SigV4.sign", () => {
+  test("signs S3 GET with UNSIGNED-PAYLOAD and excludes range (AWS docs example)", async () => {
+    const signed = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        method: "GET",
+        url: "https://examplebucket.s3.amazonaws.com/test.txt",
+        headers: { Range: "bytes=0-9" },
+        service: "s3",
+        region: "us-east-1",
+        datetime,
+      }),
+    );
+    expect(signed.headers["x-amz-content-sha256"]).toBe("UNSIGNED-PAYLOAD");
+    expect(signed.headers["x-amz-date"]).toBe(datetime);
+    expect(signed.headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=5c0d4ff29e72b8f94c5b6720369921e587e39bf7a64e456887dec4b43a2d1b77",
+    );
+  });
+
+  test("hashes the body for non-S3 services and signs the session token", async () => {
+    const signed = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        sessionToken: "TOKEN==",
+        method: "POST",
+        url: "https://dynamodb.us-west-2.amazonaws.com//x//y?b=2&a=1&a=0&=empty",
+        headers: {
+          "Content-Type": "application/x-amz-json-1.0",
+          "X-Amz-Target": "DynamoDB_20120810.ListTables",
+          "user-agent": "ua",
+        },
+        body: new Uint8Array([1, 2, 3]),
+        service: "dynamodb",
+        region: "us-west-2",
+        datetime,
+      }),
+    );
+    expect(signed.headers["x-amz-security-token"]).toBe("TOKEN==");
+    expect(signed.headers["x-amz-content-sha256"]).toBeUndefined();
+    expect(signed.headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-west-2/dynamodb/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-amz-target, Signature=5ed05481b0774da674f77f2add0ae15d315f9f7b095ad026bb7d0e7bd9c6b35c",
+    );
+  });
+
+  test("honours an explicit x-amz-content-sha256 and normalises header whitespace", async () => {
+    const a = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        method: "PUT",
+        url: "https://s3-control.us-east-1.amazonaws.com/v20180820/accesspoint",
+        headers: { "X-Amz-Content-Sha256": "abc", "X-Weird": "  a   b  " },
+        body: "<x/>",
+        service: "s3",
+        region: "us-east-1",
+        datetime,
+      }),
+    );
+    const b = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        method: "PUT",
+        url: "https://s3-control.us-east-1.amazonaws.com/v20180820/accesspoint",
+        headers: { "x-amz-content-sha256": "abc", "x-weird": "a b" },
+        body: "<different/>",
+        service: "s3",
+        region: "us-east-1",
+        datetime,
+      }),
+    );
+    expect(a.headers.authorization).toBe(b.headers.authorization);
+  });
+
+  test("presigns into the query string with reserved characters encoded", async () => {
+    const signed = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        sessionToken: "TOK",
+        method: "GET",
+        url: "https://examplebucket.s3.amazonaws.com/a b/(x)!*'.txt?X-Amz-Expires=900&foo=bar&foo=baz",
+        headers: { "content-type": "image/png" },
+        allHeaders: true,
+        service: "s3",
+        region: "us-east-1",
+        datetime,
+        signQuery: true,
+      }),
+    );
+    const url = new URL(signed.url);
+    expect(url.pathname).toBe("/a%20b/(x)!*'.txt");
+    expect(url.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(url.searchParams.get("X-Amz-Credential")).toBe(
+      "AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request",
+    );
+    expect(url.searchParams.get("X-Amz-SignedHeaders")).toBe(
+      "content-type;host",
+    );
+    expect(url.searchParams.get("X-Amz-Security-Token")).toBe("TOK");
+    expect(url.searchParams.get("X-Amz-Expires")).toBe("900");
+    expect(url.searchParams.get("X-Amz-Signature")).toBe(
+      "8623d0f2477209accf78e1b704b10fecd0ffeb2398d9209e9ded51e313878a87",
+    );
+    expect(signed.headers.authorization).toBeUndefined();
+  });
+
+  test("iotdevicegateway appends the session token after the signature", async () => {
+    const signed = await Effect.runPromise(
+      SigV4.sign({
+        ...creds,
+        sessionToken: "TOK",
+        url: "https://data.iot.us-east-1.amazonaws.com/mqtt",
+        service: "iotdevicegateway",
+        region: "us-east-1",
+        datetime,
+        signQuery: true,
+      }),
+    );
+    const keys = [...new URL(signed.url).searchParams.keys()];
+    expect(keys.indexOf("X-Amz-Security-Token")).toBeGreaterThan(
+      keys.indexOf("X-Amz-Signature"),
+    );
+  });
+});
+
+describe("Presign", () => {
+  const layer = Layer.mergeAll(
+    Layer.succeed(
+      Credentials.Credentials,
+      Effect.succeed({
+        accessKeyId: Redacted.make(creds.accessKeyId),
+        secretAccessKey: Redacted.make(creds.secretAccessKey),
+        region: "us-east-1" as Region.RegionName,
+      }),
+    ),
+    Layer.succeed(
+      Region.Region,
+      Effect.succeed("us-east-1" as Region.RegionName),
+    ),
+  );
+
+  test("presignS3Url pins content-type into the signed headers", async () => {
+    const url = await Effect.runPromise(
+      Presign.presignS3Url({
+        method: "PUT",
+        bucket: "examplebucket",
+        key: "dir/a b.png",
+        contentType: "image/png",
+        expiresIn: 60,
+        datetime,
+      }).pipe(Effect.provide(layer)),
+    );
+    const parsed = new URL(url);
+    expect(parsed.host).toBe("examplebucket.s3.us-east-1.amazonaws.com");
+    expect(parsed.pathname).toBe("/dir/a%20b.png");
+    expect(parsed.searchParams.get("X-Amz-SignedHeaders")).toBe(
+      "content-type;host",
+    );
+    expect(parsed.searchParams.get("X-Amz-Expires")).toBe("60");
+    expect(parsed.searchParams.get("X-Amz-Signature")).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
+  });
+});

--- a/packages/aws/src/sigv4.test.ts
+++ b/packages/aws/src/sigv4.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import * as Cache from "effect/Cache";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as Credentials from "./credentials.browser.ts";
@@ -167,6 +170,49 @@ describe("SigV4.sign", () => {
       }).pipe(Effect.flip),
     );
     expect(error._tag).toBe("AWS::SigV4::InvalidSigningHeaders");
+  });
+
+  test("a failed key derivation is not retained by the cache", async () => {
+    let attempts = 0;
+    const defaultCache = Effect.runSync(SigV4.SigningKeyCache);
+    const flakyCache = Effect.runSync(
+      Cache.makeWith(
+        (scope: SigV4.SigningKeyScope) =>
+          Effect.suspend(() =>
+            attempts++ === 0
+              ? Effect.fail(
+                  new SigV4.CryptoError({ operation: "hmac", cause: "boom" }),
+                )
+              : Cache.get(defaultCache, scope),
+          ),
+        {
+          capacity: 4,
+          timeToLive: (exit) =>
+            Exit.isSuccess(exit) ? Duration.infinity : Duration.zero,
+        },
+      ),
+    );
+    const request = {
+      ...creds,
+      method: "GET",
+      url: "https://examplebucket.s3.amazonaws.com/test.txt",
+      headers: { Range: "bytes=0-9" },
+      service: "s3",
+      region: "us-east-1",
+      datetime,
+    } as const;
+    const withCache = Effect.provideService(SigV4.SigningKeyCache, flakyCache);
+
+    const first = await Effect.runPromise(
+      SigV4.sign(request).pipe(Effect.flip, withCache),
+    );
+    expect(first).toBeInstanceOf(SigV4.CryptoError);
+
+    const second = await Effect.runPromise(SigV4.sign(request).pipe(withCache));
+    expect(second.headers.authorization).toBe(
+      "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=5c0d4ff29e72b8f94c5b6720369921e587e39bf7a64e456887dec4b43a2d1b77",
+    );
+    expect(attempts).toBe(2);
   });
 
   test("iotdevicegateway appends the session token after the signature", async () => {

--- a/packages/aws/src/sigv4.ts
+++ b/packages/aws/src/sigv4.ts
@@ -31,7 +31,10 @@ const UNSIGNABLE_HEADERS: ReadonlySet<string> = new Set([
 /**
  * Derived signing keys, keyed on secret/date/region/service. Deriving the key
  * costs four HMACs; requests within one UTC day for the same scope share it.
+ * Bounded (LRU, insertion order) so long-lived processes rotating temporary
+ * credentials do not accumulate secret-derived material indefinitely.
  */
+const SIGNING_KEY_CACHE_MAX = 64;
 const signingKeyCache = new Map<string, ArrayBuffer>();
 
 export type SignableBody = string | ArrayBuffer | ArrayBufferView;
@@ -140,11 +143,19 @@ const signingKey = async (
 ): Promise<ArrayBuffer> => {
   const cacheKey = [secretAccessKey, date, region, service].join();
   const cached = signingKeyCache.get(cacheKey);
-  if (cached) return cached;
+  if (cached) {
+    // re-insert so the entry moves to the most-recently-used end
+    signingKeyCache.delete(cacheKey);
+    signingKeyCache.set(cacheKey, cached);
+    return cached;
+  }
   const kDate = await hmac("AWS4" + secretAccessKey, date);
   const kRegion = await hmac(kDate, region);
   const kService = await hmac(kRegion, service);
   const kCredentials = await hmac(kService, "aws4_request");
+  if (signingKeyCache.size >= SIGNING_KEY_CACHE_MAX) {
+    signingKeyCache.delete(signingKeyCache.keys().next().value!);
+  }
   signingKeyCache.set(cacheKey, kCredentials);
   return kCredentials;
 };

--- a/packages/aws/src/sigv4.ts
+++ b/packages/aws/src/sigv4.ts
@@ -8,9 +8,11 @@
  * region are always supplied by the callers here, so host-based guessing is
  * intentionally absent.
  */
+import * as Cache from "effect/Cache";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-
-const encoder = new TextEncoder();
+import * as Encoding from "effect/Encoding";
+import * as Redacted from "effect/Redacted";
 
 /**
  * Headers left out of the signature by default (matches aws4fetch). Callers
@@ -28,15 +30,6 @@ const UNSIGNABLE_HEADERS: ReadonlySet<string> = new Set([
   "connection",
 ]);
 
-/**
- * Derived signing keys, keyed on secret/date/region/service. Deriving the key
- * costs four HMACs; requests within one UTC day for the same scope share it.
- * Bounded (LRU, insertion order) so long-lived processes rotating temporary
- * credentials do not accumulate secret-derived material indefinitely.
- */
-const SIGNING_KEY_CACHE_MAX = 64;
-const signingKeyCache = new Map<string, ArrayBuffer>();
-
 export type SignableBody = string | ArrayBuffer | ArrayBufferView;
 
 export interface SignOptions {
@@ -51,9 +44,10 @@ export interface SignOptions {
    * `X-Amz-Content-Sha256` header yourself) or for bodiless requests.
    */
   readonly body?: SignableBody;
+  /** Public half of the key pair; it is written into the signed request. */
   readonly accessKeyId: string;
-  readonly secretAccessKey: string;
-  readonly sessionToken?: string;
+  readonly secretAccessKey: Redacted.Redacted<string>;
+  readonly sessionToken?: Redacted.Redacted<string> | undefined;
   /** SigV4 signing name (e.g. `s3`, `execute-api`). */
   readonly service: string;
   /** SigV4 signing region. */
@@ -74,45 +68,39 @@ export interface SignedRequest {
   readonly headers: Record<string, string>;
 }
 
-const hmac = async (
+const encoder = new TextEncoder();
+
+const toBytes = (data: SignableBody): Uint8Array<ArrayBuffer> =>
+  typeof data === "string"
+    ? encoder.encode(data)
+    : ArrayBuffer.isView(data)
+      ? // fresh ArrayBuffer-backed copy for the WebCrypto typings
+        new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice()
+      : new Uint8Array(data);
+
+const hmac = (
   key: string | ArrayBuffer,
   data: string,
-): Promise<ArrayBuffer> => {
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    typeof key === "string" ? encoder.encode(key) : key,
-    { name: "HMAC", hash: { name: "SHA-256" } },
-    false,
-    ["sign"],
-  );
-  return crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data));
-};
-
-const sha256 = (content: SignableBody): Promise<ArrayBuffer> =>
-  crypto.subtle.digest(
-    "SHA-256",
-    typeof content === "string"
-      ? encoder.encode(content)
-      : ArrayBuffer.isView(content)
-        ? // fresh ArrayBuffer-backed copy for the DOM typings
-          new Uint8Array(
-            content.buffer,
-            content.byteOffset,
-            content.byteLength,
-          ).slice()
-        : content,
+): Effect.Effect<ArrayBuffer> =>
+  Effect.promise(async () =>
+    crypto.subtle.sign(
+      "HMAC",
+      await crypto.subtle.importKey(
+        "raw",
+        typeof key === "string" ? encoder.encode(key) : key,
+        { name: "HMAC", hash: { name: "SHA-256" } },
+        false,
+        ["sign"],
+      ),
+      encoder.encode(data),
+    ),
   );
 
-const HEX = "0123456789abcdef";
-const toHex = (buffer: ArrayBuffer): string => {
-  const bytes = new Uint8Array(buffer);
-  let out = "";
-  for (let i = 0; i < bytes.length; i++) {
-    const n = bytes[i]!;
-    out += HEX[(n >>> 4) & 0xf]! + HEX[n & 0xf]!;
-  }
-  return out;
-};
+const sha256 = (content: SignableBody): Effect.Effect<ArrayBuffer> =>
+  Effect.promise(() => crypto.subtle.digest("SHA-256", toBytes(content)));
+
+const hex = (buffer: ArrayBuffer): string =>
+  Encoding.encodeHex(new Uint8Array(buffer));
 
 /** Percent-encode the characters `encodeURIComponent` leaves alone but RFC 3986 reserves. */
 const encodeRfc3986 = (encoded: string): string =>
@@ -121,201 +109,189 @@ const encodeRfc3986 = (encoded: string): string =>
     (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
   );
 
-/** `Headers`-style normalisation: lower-case names, trimmed values, duplicates joined. */
-const normalizeHeaders = (
-  headers: Record<string, string> | undefined,
-): Map<string, string> => {
-  const out = new Map<string, string>();
-  for (const [name, value] of Object.entries(headers ?? {})) {
-    const key = name.toLowerCase();
-    const trimmed = String(value).trim();
-    const existing = out.get(key);
-    out.set(key, existing === undefined ? trimmed : `${existing}, ${trimmed}`);
-  }
-  return out;
-};
+/**
+ * Scope of a derived signing key. `Redacted` hashes and compares by its
+ * underlying value, so the secret never has to be unwrapped into a cache key.
+ */
+interface SigningKeyScope {
+  readonly secretAccessKey: Redacted.Redacted<string>;
+  readonly date: string;
+  readonly region: string;
+  readonly service: string;
+}
 
-const signingKey = async (
-  secretAccessKey: string,
-  date: string,
-  region: string,
-  service: string,
-): Promise<ArrayBuffer> => {
-  const cacheKey = [secretAccessKey, date, region, service].join();
-  const cached = signingKeyCache.get(cacheKey);
-  if (cached) {
-    // re-insert so the entry moves to the most-recently-used end
-    signingKeyCache.delete(cacheKey);
-    signingKeyCache.set(cacheKey, cached);
-    return cached;
-  }
-  const kDate = await hmac("AWS4" + secretAccessKey, date);
-  const kRegion = await hmac(kDate, region);
-  const kService = await hmac(kRegion, service);
-  const kCredentials = await hmac(kService, "aws4_request");
-  if (signingKeyCache.size >= SIGNING_KEY_CACHE_MAX) {
-    signingKeyCache.delete(signingKeyCache.keys().next().value!);
-  }
-  signingKeyCache.set(cacheKey, kCredentials);
-  return kCredentials;
-};
-
-const signAsync = async (options: SignOptions): Promise<SignedRequest> => {
-  const {
-    accessKeyId,
-    secretAccessKey,
-    sessionToken,
-    service,
-    region,
-    signQuery,
-    allHeaders,
-    body,
-  } = options;
-  const method = options.method ?? (body ? "POST" : "GET");
-  const url = new URL(options.url);
-  const headers = normalizeHeaders(options.headers);
-  headers.delete("host");
-  const datetime =
-    options.datetime ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
-  const appendSessionToken = service === "iotdevicegateway";
-
-  if (service === "s3" && !signQuery && !headers.has("x-amz-content-sha256")) {
-    headers.set("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
-  }
-
-  const setParam = signQuery
-    ? (k: string, v: string) => url.searchParams.set(k, v)
-    : (k: string, v: string) => headers.set(k.toLowerCase(), v);
-  setParam("X-Amz-Date", datetime);
-  if (sessionToken && !appendSessionToken) {
-    setParam("X-Amz-Security-Token", sessionToken);
-  }
-
-  const signableHeaders = ["host", ...headers.keys()]
-    .filter((header) => allHeaders || !UNSIGNABLE_HEADERS.has(header))
-    .sort();
-  const signedHeaders = signableHeaders.join(";");
-  const canonicalHeaders = signableHeaders
-    .map(
-      (header) =>
-        header +
-        ":" +
-        (header === "host"
-          ? url.host
-          : (headers.get(header) ?? "").replace(/\s+/g, " ")),
-    )
-    .join("\n");
-  const credentialString = [
-    datetime.slice(0, 8),
-    region,
-    service,
-    "aws4_request",
-  ].join("/");
-
-  if (signQuery) {
-    if (service === "s3" && !url.searchParams.has("X-Amz-Expires")) {
-      url.searchParams.set("X-Amz-Expires", "86400");
-    }
-    url.searchParams.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
-    url.searchParams.set(
-      "X-Amz-Credential",
-      accessKeyId + "/" + credentialString,
-    );
-    url.searchParams.set("X-Amz-SignedHeaders", signedHeaders);
-  }
-
-  let encodedPath: string;
-  if (service === "s3") {
-    try {
-      encodedPath = decodeURIComponent(url.pathname.replace(/\+/g, " "));
-    } catch {
-      encodedPath = url.pathname;
-    }
-  } else {
-    encodedPath = url.pathname.replace(/\/+/g, "/");
-  }
-  encodedPath = encodeRfc3986(
-    encodeURIComponent(encodedPath).replace(/%2F/g, "/"),
+const deriveSigningKey = ({
+  secretAccessKey,
+  date,
+  region,
+  service,
+}: SigningKeyScope): Effect.Effect<ArrayBuffer> =>
+  hmac("AWS4" + Redacted.value(secretAccessKey), date).pipe(
+    Effect.flatMap((kDate) => hmac(kDate, region)),
+    Effect.flatMap((kRegion) => hmac(kRegion, service)),
+    Effect.flatMap((kService) => hmac(kService, "aws4_request")),
   );
 
-  const seenKeys = new Set<string>();
-  const encodedSearch = [...url.searchParams]
-    .filter(([k]) => {
-      if (!k) return false;
-      if (service === "s3") {
-        if (seenKeys.has(k)) return false;
-        seenKeys.add(k);
-      }
-      return true;
-    })
-    .map(
-      ([k, v]) =>
-        [
-          encodeRfc3986(encodeURIComponent(k)),
-          encodeRfc3986(encodeURIComponent(v)),
-        ] as const,
-    )
-    .sort(([k1, v1], [k2, v2]) =>
-      k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0,
-    )
-    .map((pair) => pair.join("="))
-    .join("&");
-
-  let payloadHash =
-    headers.get("x-amz-content-sha256") ??
-    (service === "s3" && signQuery ? "UNSIGNED-PAYLOAD" : undefined);
-  if (payloadHash === undefined) {
-    payloadHash = toHex(await sha256(body || ""));
-  }
-
-  const canonicalRequest = [
-    method.toUpperCase(),
-    encodedPath,
-    encodedSearch,
-    canonicalHeaders + "\n",
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    datetime,
-    credentialString,
-    toHex(await sha256(canonicalRequest)),
-  ].join("\n");
-  const key = await signingKey(
-    secretAccessKey,
-    datetime.slice(0, 8),
-    region,
-    service,
-  );
-  const signature = toHex(await hmac(key, stringToSign));
-
-  if (signQuery) {
-    url.searchParams.set("X-Amz-Signature", signature);
-    if (sessionToken && appendSessionToken) {
-      url.searchParams.set("X-Amz-Security-Token", sessionToken);
-    }
-  } else {
-    headers.set(
-      "authorization",
-      [
-        "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/" + credentialString,
-        "SignedHeaders=" + signedHeaders,
-        "Signature=" + signature,
-      ].join(", "),
-    );
-  }
-
-  return {
-    method,
-    url: url.toString(),
-    headers: Object.fromEntries(headers),
-  };
-};
+/**
+ * Derived signing keys, keyed on secret/date/region/service. Deriving one
+ * costs four HMACs; requests within a UTC day for the same scope share it.
+ * The cache is bounded (LRU) so long-lived processes rotating temporary
+ * credentials do not accumulate secret-derived material, and it is a context
+ * reference so a scope can substitute its own.
+ */
+export const SigningKeyCache = Context.Reference<
+  Cache.Cache<SigningKeyScope, ArrayBuffer>
+>("AWS::SigningKeyCache", {
+  defaultValue: () =>
+    Effect.runSync(Cache.make({ lookup: deriveSigningKey, capacity: 64 })),
+});
 
 /**
  * Sign a request with SigV4. Never fails: WebCrypto HMAC/SHA-256 over
  * in-memory data does not reject, so any throw is a defect.
  */
-export const sign = (options: SignOptions): Effect.Effect<SignedRequest> =>
-  Effect.promise(() => signAsync(options));
+export const sign: (options: SignOptions) => Effect.Effect<SignedRequest> =
+  Effect.fnUntraced(function* (options: SignOptions) {
+    const { accessKeyId, service, region, signQuery, allHeaders, body } =
+      options;
+    const sessionToken = options.sessionToken
+      ? Redacted.value(options.sessionToken)
+      : undefined;
+    const method = options.method ?? (body ? "POST" : "GET");
+    const url = new URL(options.url);
+    const headers = new Headers(options.headers);
+    headers.delete("host");
+    const datetime =
+      options.datetime ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
+    const appendSessionToken = service === "iotdevicegateway";
+
+    if (
+      service === "s3" &&
+      !signQuery &&
+      !headers.has("x-amz-content-sha256")
+    ) {
+      headers.set("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
+    }
+
+    const params = signQuery ? url.searchParams : headers;
+    params.set("X-Amz-Date", datetime);
+    if (sessionToken && !appendSessionToken) {
+      params.set("X-Amz-Security-Token", sessionToken);
+    }
+
+    const signableHeaders = ["host", ...headers.keys()]
+      .filter((header) => allHeaders || !UNSIGNABLE_HEADERS.has(header))
+      .sort();
+    const signedHeaders = signableHeaders.join(";");
+    const canonicalHeaders = signableHeaders
+      .map(
+        (header) =>
+          header +
+          ":" +
+          (header === "host"
+            ? url.host
+            : (headers.get(header) ?? "").replace(/\s+/g, " ")),
+      )
+      .join("\n");
+    const date = datetime.slice(0, 8);
+    const credentialString = [date, region, service, "aws4_request"].join("/");
+
+    if (signQuery) {
+      if (service === "s3" && !url.searchParams.has("X-Amz-Expires")) {
+        url.searchParams.set("X-Amz-Expires", "86400");
+      }
+      url.searchParams.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+      url.searchParams.set(
+        "X-Amz-Credential",
+        accessKeyId + "/" + credentialString,
+      );
+      url.searchParams.set("X-Amz-SignedHeaders", signedHeaders);
+    }
+
+    let encodedPath: string;
+    if (service === "s3") {
+      try {
+        encodedPath = decodeURIComponent(url.pathname.replace(/\+/g, " "));
+      } catch {
+        encodedPath = url.pathname;
+      }
+    } else {
+      encodedPath = url.pathname.replace(/\/+/g, "/");
+    }
+    encodedPath = encodeRfc3986(
+      encodeURIComponent(encodedPath).replace(/%2F/g, "/"),
+    );
+
+    const seenKeys = new Set<string>();
+    const encodedSearch = [...url.searchParams]
+      .filter(([k]) => {
+        if (!k) return false;
+        if (service === "s3") {
+          if (seenKeys.has(k)) return false;
+          seenKeys.add(k);
+        }
+        return true;
+      })
+      .map(
+        ([k, v]) =>
+          [
+            encodeRfc3986(encodeURIComponent(k)),
+            encodeRfc3986(encodeURIComponent(v)),
+          ] as const,
+      )
+      .sort(([k1, v1], [k2, v2]) =>
+        k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0,
+      )
+      .map((pair) => pair.join("="))
+      .join("&");
+
+    const payloadHash =
+      headers.get("x-amz-content-sha256") ??
+      (service === "s3" && signQuery
+        ? "UNSIGNED-PAYLOAD"
+        : hex(yield* sha256(body || "")));
+
+    const canonicalRequest = [
+      method.toUpperCase(),
+      encodedPath,
+      encodedSearch,
+      canonicalHeaders + "\n",
+      signedHeaders,
+      payloadHash,
+    ].join("\n");
+    const stringToSign = [
+      "AWS4-HMAC-SHA256",
+      datetime,
+      credentialString,
+      hex(yield* sha256(canonicalRequest)),
+    ].join("\n");
+    const signingKey = yield* Cache.get(yield* SigningKeyCache, {
+      secretAccessKey: options.secretAccessKey,
+      date,
+      region,
+      service,
+    });
+    const signature = hex(yield* hmac(signingKey, stringToSign));
+
+    if (signQuery) {
+      url.searchParams.set("X-Amz-Signature", signature);
+      if (sessionToken && appendSessionToken) {
+        url.searchParams.set("X-Amz-Security-Token", sessionToken);
+      }
+    } else {
+      headers.set(
+        "authorization",
+        [
+          "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/" + credentialString,
+          "SignedHeaders=" + signedHeaders,
+          "Signature=" + signature,
+        ].join(", "),
+      );
+    }
+
+    return {
+      method,
+      url: url.toString(),
+      headers: Object.fromEntries(headers),
+    };
+  });

--- a/packages/aws/src/sigv4.ts
+++ b/packages/aws/src/sigv4.ts
@@ -1,0 +1,310 @@
+/**
+ * SigV4 request signing (header `Authorization` and query-string presigning).
+ *
+ * Effect-native port of the signing core of `aws4fetch`'s `AwsV4Signer`,
+ * preserving its canonicalisation rules byte for byte: header/path/query
+ * encoding, the unsignable-header set, S3's UNSIGNED-PAYLOAD defaults and
+ * duplicate-query-key handling, and the derived-key cache. Service and
+ * region are always supplied by the callers here, so host-based guessing is
+ * intentionally absent.
+ */
+import * as Effect from "effect/Effect";
+
+const encoder = new TextEncoder();
+
+/**
+ * Headers left out of the signature by default (matches aws4fetch). Callers
+ * opt back in with `allHeaders`.
+ */
+const UNSIGNABLE_HEADERS: ReadonlySet<string> = new Set([
+  "authorization",
+  "content-type",
+  "content-length",
+  "user-agent",
+  "presigned-expires",
+  "expect",
+  "x-amzn-trace-id",
+  "range",
+  "connection",
+]);
+
+/**
+ * Derived signing keys, keyed on secret/date/region/service. Deriving the key
+ * costs four HMACs; requests within one UTC day for the same scope share it.
+ */
+const signingKeyCache = new Map<string, ArrayBuffer>();
+
+export type SignableBody = string | ArrayBuffer | ArrayBufferView;
+
+export interface SignOptions {
+  /** HTTP method. Defaults to `POST` when a body is present, else `GET`. */
+  readonly method?: string;
+  /** Absolute URL to sign. */
+  readonly url: string;
+  /** Request headers. Keys are case-insensitive; `Host` is derived from the URL. */
+  readonly headers?: Record<string, string>;
+  /**
+   * Request body used for the payload hash. Omit for UNSIGNED-PAYLOAD (set the
+   * `X-Amz-Content-Sha256` header yourself) or for bodiless requests.
+   */
+  readonly body?: SignableBody;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly sessionToken?: string;
+  /** SigV4 signing name (e.g. `s3`, `execute-api`). */
+  readonly service: string;
+  /** SigV4 signing region. */
+  readonly region: string;
+  /** Fixed `YYYYMMDDTHHMMSSZ` signing time; defaults to now. */
+  readonly datetime?: string;
+  /** Sign into the query string (presigned URL) instead of headers. */
+  readonly signQuery?: boolean;
+  /** Include the normally unsignable headers (content-type, range, …). */
+  readonly allHeaders?: boolean;
+}
+
+export interface SignedRequest {
+  readonly method: string;
+  /** Normalised URL; carries the `X-Amz-*` params when `signQuery` is set. */
+  readonly url: string;
+  /** Lower-cased header names, including the added `x-amz-*` / `authorization`. */
+  readonly headers: Record<string, string>;
+}
+
+const hmac = async (
+  key: string | ArrayBuffer,
+  data: string,
+): Promise<ArrayBuffer> => {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    typeof key === "string" ? encoder.encode(key) : key,
+    { name: "HMAC", hash: { name: "SHA-256" } },
+    false,
+    ["sign"],
+  );
+  return crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(data));
+};
+
+const sha256 = (content: SignableBody): Promise<ArrayBuffer> =>
+  crypto.subtle.digest(
+    "SHA-256",
+    typeof content === "string"
+      ? encoder.encode(content)
+      : ArrayBuffer.isView(content)
+        ? // fresh ArrayBuffer-backed copy for the DOM typings
+          new Uint8Array(
+            content.buffer,
+            content.byteOffset,
+            content.byteLength,
+          ).slice()
+        : content,
+  );
+
+const HEX = "0123456789abcdef";
+const toHex = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const n = bytes[i]!;
+    out += HEX[(n >>> 4) & 0xf]! + HEX[n & 0xf]!;
+  }
+  return out;
+};
+
+/** Percent-encode the characters `encodeURIComponent` leaves alone but RFC 3986 reserves. */
+const encodeRfc3986 = (encoded: string): string =>
+  encoded.replace(
+    /[!'()*]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+
+/** `Headers`-style normalisation: lower-case names, trimmed values, duplicates joined. */
+const normalizeHeaders = (
+  headers: Record<string, string> | undefined,
+): Map<string, string> => {
+  const out = new Map<string, string>();
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    const key = name.toLowerCase();
+    const trimmed = String(value).trim();
+    const existing = out.get(key);
+    out.set(key, existing === undefined ? trimmed : `${existing}, ${trimmed}`);
+  }
+  return out;
+};
+
+const signingKey = async (
+  secretAccessKey: string,
+  date: string,
+  region: string,
+  service: string,
+): Promise<ArrayBuffer> => {
+  const cacheKey = [secretAccessKey, date, region, service].join();
+  const cached = signingKeyCache.get(cacheKey);
+  if (cached) return cached;
+  const kDate = await hmac("AWS4" + secretAccessKey, date);
+  const kRegion = await hmac(kDate, region);
+  const kService = await hmac(kRegion, service);
+  const kCredentials = await hmac(kService, "aws4_request");
+  signingKeyCache.set(cacheKey, kCredentials);
+  return kCredentials;
+};
+
+const signAsync = async (options: SignOptions): Promise<SignedRequest> => {
+  const {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    service,
+    region,
+    signQuery,
+    allHeaders,
+    body,
+  } = options;
+  const method = options.method ?? (body ? "POST" : "GET");
+  const url = new URL(options.url);
+  const headers = normalizeHeaders(options.headers);
+  headers.delete("host");
+  const datetime =
+    options.datetime ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const appendSessionToken = service === "iotdevicegateway";
+
+  if (service === "s3" && !signQuery && !headers.has("x-amz-content-sha256")) {
+    headers.set("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
+  }
+
+  const setParam = signQuery
+    ? (k: string, v: string) => url.searchParams.set(k, v)
+    : (k: string, v: string) => headers.set(k.toLowerCase(), v);
+  setParam("X-Amz-Date", datetime);
+  if (sessionToken && !appendSessionToken) {
+    setParam("X-Amz-Security-Token", sessionToken);
+  }
+
+  const signableHeaders = ["host", ...headers.keys()]
+    .filter((header) => allHeaders || !UNSIGNABLE_HEADERS.has(header))
+    .sort();
+  const signedHeaders = signableHeaders.join(";");
+  const canonicalHeaders = signableHeaders
+    .map(
+      (header) =>
+        header +
+        ":" +
+        (header === "host"
+          ? url.host
+          : (headers.get(header) ?? "").replace(/\s+/g, " ")),
+    )
+    .join("\n");
+  const credentialString = [
+    datetime.slice(0, 8),
+    region,
+    service,
+    "aws4_request",
+  ].join("/");
+
+  if (signQuery) {
+    if (service === "s3" && !url.searchParams.has("X-Amz-Expires")) {
+      url.searchParams.set("X-Amz-Expires", "86400");
+    }
+    url.searchParams.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+    url.searchParams.set(
+      "X-Amz-Credential",
+      accessKeyId + "/" + credentialString,
+    );
+    url.searchParams.set("X-Amz-SignedHeaders", signedHeaders);
+  }
+
+  let encodedPath: string;
+  if (service === "s3") {
+    try {
+      encodedPath = decodeURIComponent(url.pathname.replace(/\+/g, " "));
+    } catch {
+      encodedPath = url.pathname;
+    }
+  } else {
+    encodedPath = url.pathname.replace(/\/+/g, "/");
+  }
+  encodedPath = encodeRfc3986(
+    encodeURIComponent(encodedPath).replace(/%2F/g, "/"),
+  );
+
+  const seenKeys = new Set<string>();
+  const encodedSearch = [...url.searchParams]
+    .filter(([k]) => {
+      if (!k) return false;
+      if (service === "s3") {
+        if (seenKeys.has(k)) return false;
+        seenKeys.add(k);
+      }
+      return true;
+    })
+    .map(
+      ([k, v]) =>
+        [
+          encodeRfc3986(encodeURIComponent(k)),
+          encodeRfc3986(encodeURIComponent(v)),
+        ] as const,
+    )
+    .sort(([k1, v1], [k2, v2]) =>
+      k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0,
+    )
+    .map((pair) => pair.join("="))
+    .join("&");
+
+  let payloadHash =
+    headers.get("x-amz-content-sha256") ??
+    (service === "s3" && signQuery ? "UNSIGNED-PAYLOAD" : undefined);
+  if (payloadHash === undefined) {
+    payloadHash = toHex(await sha256(body || ""));
+  }
+
+  const canonicalRequest = [
+    method.toUpperCase(),
+    encodedPath,
+    encodedSearch,
+    canonicalHeaders + "\n",
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    datetime,
+    credentialString,
+    toHex(await sha256(canonicalRequest)),
+  ].join("\n");
+  const key = await signingKey(
+    secretAccessKey,
+    datetime.slice(0, 8),
+    region,
+    service,
+  );
+  const signature = toHex(await hmac(key, stringToSign));
+
+  if (signQuery) {
+    url.searchParams.set("X-Amz-Signature", signature);
+    if (sessionToken && appendSessionToken) {
+      url.searchParams.set("X-Amz-Security-Token", sessionToken);
+    }
+  } else {
+    headers.set(
+      "authorization",
+      [
+        "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/" + credentialString,
+        "SignedHeaders=" + signedHeaders,
+        "Signature=" + signature,
+      ].join(", "),
+    );
+  }
+
+  return {
+    method,
+    url: url.toString(),
+    headers: Object.fromEntries(headers),
+  };
+};
+
+/**
+ * Sign a request with SigV4. Never fails: WebCrypto HMAC/SHA-256 over
+ * in-memory data does not reject, so any throw is a defect.
+ */
+export const sign = (options: SignOptions): Effect.Effect<SignedRequest> =>
+  Effect.promise(() => signAsync(options));

--- a/packages/aws/src/sigv4.ts
+++ b/packages/aws/src/sigv4.ts
@@ -10,8 +10,11 @@
  */
 import * as Cache from "effect/Cache";
 import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
+import * as Exit from "effect/Exit";
 import * as Redacted from "effect/Redacted";
 
 /**
@@ -68,6 +71,35 @@ export interface SignedRequest {
   readonly headers: Record<string, string>;
 }
 
+/** `options.url` is not an absolute URL the `URL` constructor accepts. */
+export class InvalidSigningUrl extends Data.TaggedError(
+  "AWS::SigV4::InvalidSigningUrl",
+)<{
+  readonly url: string;
+  readonly cause: unknown;
+}> {}
+
+/**
+ * A header name or value is not valid HTTP (the `Headers` constructor
+ * rejected it), so it cannot be canonicalised.
+ */
+export class InvalidSigningHeaders extends Data.TaggedError(
+  "AWS::SigV4::InvalidSigningHeaders",
+)<{
+  readonly cause: unknown;
+}> {}
+
+/** WebCrypto (`crypto.subtle`) rejected an HMAC or SHA-256 operation. */
+export class CryptoError extends Data.TaggedError("AWS::SigV4::CryptoError")<{
+  readonly operation: "hmac" | "sha256";
+  readonly cause: unknown;
+}> {}
+
+export type SigningError =
+  | InvalidSigningUrl
+  | InvalidSigningHeaders
+  | CryptoError;
+
 const encoder = new TextEncoder();
 
 const toBytes = (data: SignableBody): Uint8Array<ArrayBuffer> =>
@@ -81,23 +113,30 @@ const toBytes = (data: SignableBody): Uint8Array<ArrayBuffer> =>
 const hmac = (
   key: string | ArrayBuffer,
   data: string,
-): Effect.Effect<ArrayBuffer> =>
-  Effect.promise(async () =>
-    crypto.subtle.sign(
-      "HMAC",
-      await crypto.subtle.importKey(
-        "raw",
-        typeof key === "string" ? encoder.encode(key) : key,
-        { name: "HMAC", hash: { name: "SHA-256" } },
-        false,
-        ["sign"],
+): Effect.Effect<ArrayBuffer, CryptoError> =>
+  Effect.tryPromise({
+    try: async () =>
+      crypto.subtle.sign(
+        "HMAC",
+        await crypto.subtle.importKey(
+          "raw",
+          typeof key === "string" ? encoder.encode(key) : key,
+          { name: "HMAC", hash: { name: "SHA-256" } },
+          false,
+          ["sign"],
+        ),
+        encoder.encode(data),
       ),
-      encoder.encode(data),
-    ),
-  );
+    catch: (cause) => new CryptoError({ operation: "hmac", cause }),
+  });
 
-const sha256 = (content: SignableBody): Effect.Effect<ArrayBuffer> =>
-  Effect.promise(() => crypto.subtle.digest("SHA-256", toBytes(content)));
+const sha256 = (
+  content: SignableBody,
+): Effect.Effect<ArrayBuffer, CryptoError> =>
+  Effect.tryPromise({
+    try: () => crypto.subtle.digest("SHA-256", toBytes(content)),
+    catch: (cause) => new CryptoError({ operation: "sha256", cause }),
+  });
 
 const hex = (buffer: ArrayBuffer): string =>
   Encoding.encodeHex(new Uint8Array(buffer));
@@ -125,7 +164,7 @@ const deriveSigningKey = ({
   date,
   region,
   service,
-}: SigningKeyScope): Effect.Effect<ArrayBuffer> =>
+}: SigningKeyScope): Effect.Effect<ArrayBuffer, CryptoError> =>
   hmac("AWS4" + Redacted.value(secretAccessKey), date).pipe(
     Effect.flatMap((kDate) => hmac(kDate, region)),
     Effect.flatMap((kRegion) => hmac(kRegion, service)),
@@ -137,161 +176,172 @@ const deriveSigningKey = ({
  * costs four HMACs; requests within a UTC day for the same scope share it.
  * The cache is bounded (LRU) so long-lived processes rotating temporary
  * credentials do not accumulate secret-derived material, and it is a context
- * reference so a scope can substitute its own.
+ * reference so a scope can substitute its own. Failed derivations are not
+ * retained, so a transient WebCrypto failure is retried on the next request.
  */
 export const SigningKeyCache = Context.Reference<
-  Cache.Cache<SigningKeyScope, ArrayBuffer>
+  Cache.Cache<SigningKeyScope, ArrayBuffer, CryptoError>
 >("AWS::SigningKeyCache", {
   defaultValue: () =>
-    Effect.runSync(Cache.make({ lookup: deriveSigningKey, capacity: 64 })),
+    Effect.runSync(
+      Cache.makeWith(deriveSigningKey, {
+        capacity: 64,
+        timeToLive: (exit) =>
+          Exit.isSuccess(exit) ? Duration.infinity : Duration.zero,
+      }),
+    ),
 });
 
 /**
- * Sign a request with SigV4. Never fails: WebCrypto HMAC/SHA-256 over
- * in-memory data does not reject, so any throw is a defect.
+ * Sign a request with SigV4. Fails with a {@link SigningError} when the URL
+ * or headers cannot be canonicalised or WebCrypto rejects an operation.
  */
-export const sign: (options: SignOptions) => Effect.Effect<SignedRequest> =
-  Effect.fnUntraced(function* (options: SignOptions) {
-    const { accessKeyId, service, region, signQuery, allHeaders, body } =
-      options;
-    const sessionToken = options.sessionToken
-      ? Redacted.value(options.sessionToken)
-      : undefined;
-    const method = options.method ?? (body ? "POST" : "GET");
-    const url = new URL(options.url);
-    const headers = new Headers(options.headers);
-    headers.delete("host");
-    const datetime =
-      options.datetime ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
-    const appendSessionToken = service === "iotdevicegateway";
-
-    if (
-      service === "s3" &&
-      !signQuery &&
-      !headers.has("x-amz-content-sha256")
-    ) {
-      headers.set("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
-    }
-
-    const params = signQuery ? url.searchParams : headers;
-    params.set("X-Amz-Date", datetime);
-    if (sessionToken && !appendSessionToken) {
-      params.set("X-Amz-Security-Token", sessionToken);
-    }
-
-    const signableHeaders = ["host", ...headers.keys()]
-      .filter((header) => allHeaders || !UNSIGNABLE_HEADERS.has(header))
-      .sort();
-    const signedHeaders = signableHeaders.join(";");
-    const canonicalHeaders = signableHeaders
-      .map(
-        (header) =>
-          header +
-          ":" +
-          (header === "host"
-            ? url.host
-            : (headers.get(header) ?? "").replace(/\s+/g, " ")),
-      )
-      .join("\n");
-    const date = datetime.slice(0, 8);
-    const credentialString = [date, region, service, "aws4_request"].join("/");
-
-    if (signQuery) {
-      if (service === "s3" && !url.searchParams.has("X-Amz-Expires")) {
-        url.searchParams.set("X-Amz-Expires", "86400");
-      }
-      url.searchParams.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
-      url.searchParams.set(
-        "X-Amz-Credential",
-        accessKeyId + "/" + credentialString,
-      );
-      url.searchParams.set("X-Amz-SignedHeaders", signedHeaders);
-    }
-
-    let encodedPath: string;
-    if (service === "s3") {
-      try {
-        encodedPath = decodeURIComponent(url.pathname.replace(/\+/g, " "));
-      } catch {
-        encodedPath = url.pathname;
-      }
-    } else {
-      encodedPath = url.pathname.replace(/\/+/g, "/");
-    }
-    encodedPath = encodeRfc3986(
-      encodeURIComponent(encodedPath).replace(/%2F/g, "/"),
-    );
-
-    const seenKeys = new Set<string>();
-    const encodedSearch = [...url.searchParams]
-      .filter(([k]) => {
-        if (!k) return false;
-        if (service === "s3") {
-          if (seenKeys.has(k)) return false;
-          seenKeys.add(k);
-        }
-        return true;
-      })
-      .map(
-        ([k, v]) =>
-          [
-            encodeRfc3986(encodeURIComponent(k)),
-            encodeRfc3986(encodeURIComponent(v)),
-          ] as const,
-      )
-      .sort(([k1, v1], [k2, v2]) =>
-        k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0,
-      )
-      .map((pair) => pair.join("="))
-      .join("&");
-
-    const payloadHash =
-      headers.get("x-amz-content-sha256") ??
-      (service === "s3" && signQuery
-        ? "UNSIGNED-PAYLOAD"
-        : hex(yield* sha256(body || "")));
-
-    const canonicalRequest = [
-      method.toUpperCase(),
-      encodedPath,
-      encodedSearch,
-      canonicalHeaders + "\n",
-      signedHeaders,
-      payloadHash,
-    ].join("\n");
-    const stringToSign = [
-      "AWS4-HMAC-SHA256",
-      datetime,
-      credentialString,
-      hex(yield* sha256(canonicalRequest)),
-    ].join("\n");
-    const signingKey = yield* Cache.get(yield* SigningKeyCache, {
-      secretAccessKey: options.secretAccessKey,
-      date,
-      region,
-      service,
-    });
-    const signature = hex(yield* hmac(signingKey, stringToSign));
-
-    if (signQuery) {
-      url.searchParams.set("X-Amz-Signature", signature);
-      if (sessionToken && appendSessionToken) {
-        url.searchParams.set("X-Amz-Security-Token", sessionToken);
-      }
-    } else {
-      headers.set(
-        "authorization",
-        [
-          "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/" + credentialString,
-          "SignedHeaders=" + signedHeaders,
-          "Signature=" + signature,
-        ].join(", "),
-      );
-    }
-
-    return {
-      method,
-      url: url.toString(),
-      headers: Object.fromEntries(headers),
-    };
+export const sign: (
+  options: SignOptions,
+) => Effect.Effect<SignedRequest, SigningError> = Effect.fnUntraced(function* (
+  options: SignOptions,
+) {
+  const { accessKeyId, service, region, signQuery, allHeaders, body } = options;
+  const sessionToken = options.sessionToken
+    ? Redacted.value(options.sessionToken)
+    : undefined;
+  const method = options.method ?? (body ? "POST" : "GET");
+  const url = yield* Effect.try({
+    try: () => new URL(options.url),
+    catch: (cause) => new InvalidSigningUrl({ url: options.url, cause }),
   });
+  const headers = yield* Effect.try({
+    try: () => new Headers(options.headers),
+    catch: (cause) => new InvalidSigningHeaders({ cause }),
+  });
+  headers.delete("host");
+  const datetime =
+    options.datetime ?? new Date().toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const appendSessionToken = service === "iotdevicegateway";
+
+  if (service === "s3" && !signQuery && !headers.has("x-amz-content-sha256")) {
+    headers.set("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
+  }
+
+  const params = signQuery ? url.searchParams : headers;
+  params.set("X-Amz-Date", datetime);
+  if (sessionToken && !appendSessionToken) {
+    params.set("X-Amz-Security-Token", sessionToken);
+  }
+
+  const signableHeaders = ["host", ...headers.keys()]
+    .filter((header) => allHeaders || !UNSIGNABLE_HEADERS.has(header))
+    .sort();
+  const signedHeaders = signableHeaders.join(";");
+  const canonicalHeaders = signableHeaders
+    .map(
+      (header) =>
+        header +
+        ":" +
+        (header === "host"
+          ? url.host
+          : (headers.get(header) ?? "").replace(/\s+/g, " ")),
+    )
+    .join("\n");
+  const date = datetime.slice(0, 8);
+  const credentialString = [date, region, service, "aws4_request"].join("/");
+
+  if (signQuery) {
+    if (service === "s3" && !url.searchParams.has("X-Amz-Expires")) {
+      url.searchParams.set("X-Amz-Expires", "86400");
+    }
+    url.searchParams.set("X-Amz-Algorithm", "AWS4-HMAC-SHA256");
+    url.searchParams.set(
+      "X-Amz-Credential",
+      accessKeyId + "/" + credentialString,
+    );
+    url.searchParams.set("X-Amz-SignedHeaders", signedHeaders);
+  }
+
+  let encodedPath: string;
+  if (service === "s3") {
+    try {
+      encodedPath = decodeURIComponent(url.pathname.replace(/\+/g, " "));
+    } catch {
+      encodedPath = url.pathname;
+    }
+  } else {
+    encodedPath = url.pathname.replace(/\/+/g, "/");
+  }
+  encodedPath = encodeRfc3986(
+    encodeURIComponent(encodedPath).replace(/%2F/g, "/"),
+  );
+
+  const seenKeys = new Set<string>();
+  const encodedSearch = [...url.searchParams]
+    .filter(([k]) => {
+      if (!k) return false;
+      if (service === "s3") {
+        if (seenKeys.has(k)) return false;
+        seenKeys.add(k);
+      }
+      return true;
+    })
+    .map(
+      ([k, v]) =>
+        [
+          encodeRfc3986(encodeURIComponent(k)),
+          encodeRfc3986(encodeURIComponent(v)),
+        ] as const,
+    )
+    .sort(([k1, v1], [k2, v2]) =>
+      k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0,
+    )
+    .map((pair) => pair.join("="))
+    .join("&");
+
+  const payloadHash =
+    headers.get("x-amz-content-sha256") ??
+    (service === "s3" && signQuery
+      ? "UNSIGNED-PAYLOAD"
+      : hex(yield* sha256(body || "")));
+
+  const canonicalRequest = [
+    method.toUpperCase(),
+    encodedPath,
+    encodedSearch,
+    canonicalHeaders + "\n",
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    datetime,
+    credentialString,
+    hex(yield* sha256(canonicalRequest)),
+  ].join("\n");
+  const signingKey = yield* Cache.get(yield* SigningKeyCache, {
+    secretAccessKey: options.secretAccessKey,
+    date,
+    region,
+    service,
+  });
+  const signature = hex(yield* hmac(signingKey, stringToSign));
+
+  if (signQuery) {
+    url.searchParams.set("X-Amz-Signature", signature);
+    if (sessionToken && appendSessionToken) {
+      url.searchParams.set("X-Amz-Security-Token", sessionToken);
+    }
+  } else {
+    headers.set(
+      "authorization",
+      [
+        "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/" + credentialString,
+        "SignedHeaders=" + signedHeaders,
+        "Signature=" + signature,
+      ].join(", "),
+    );
+  }
+
+  return {
+    method,
+    url: url.toString(),
+    headers: Object.fromEntries(headers),
+  };
+});

--- a/packages/aws/src/sigv4.ts
+++ b/packages/aws/src/sigv4.ts
@@ -113,7 +113,7 @@ const encodeRfc3986 = (encoded: string): string =>
  * Scope of a derived signing key. `Redacted` hashes and compares by its
  * underlying value, so the secret never has to be unwrapped into a cache key.
  */
-interface SigningKeyScope {
+export interface SigningKeyScope {
   readonly secretAccessKey: Redacted.Redacted<string>;
   readonly date: string;
   readonly region: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ catalogs:
     '@smithy/util-base64':
       specifier: ^4.3.0
       version: 4.6.0
-    aws4fetch:
-      specifier: ^1.0.20
-      version: 1.0.20
   bench:
     mitata:
       specifier: ^1.0.34
@@ -287,9 +284,6 @@ importers:
       '@smithy/util-base64':
         specifier: catalog:aws
         version: 4.6.0
-      aws4fetch:
-        specifier: catalog:aws
-        version: 1.0.20
       effect:
         specifier: catalog:effect
         version: 4.0.0-rc.113

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,6 @@ catalogs:
     "@smithy/shared-ini-file-loader": ^4.4.3
     "@smithy/types": ^4.12.0
     "@smithy/util-base64": ^4.3.0
-    aws4fetch: ^1.0.20
   build:
     typescript: ^7.0.2
   effect:


### PR DESCRIPTION
## Summary
- Replaces the `aws4fetch` runtime dependency with a handwritten, Effect-native SigV4 signer at `packages/aws/src/sigv4.ts` (`SigV4.sign(options): Effect<SignedRequest>`), covering both `Authorization`-header signing and query-string presigning.
- Rewires the only two importers, `packages/aws/src/protocol.ts` and `packages/aws/src/presign.ts`. Nothing under `src/services/` referenced aws4fetch.
- Drops `aws4fetch` from `packages/aws/package.json`, the `aws` catalog in `pnpm-workspace.yaml`, and the corresponding importer hunks of `pnpm-lock.yaml`. (Remaining `aws4fetch` lockfile entries belong to the published `@distilled.cloud/aws` snapshots that `alchemy` pulls in.)

Signing semantics are preserved byte for byte: canonical path/query encoding, the unsignable-header set, S3 `UNSIGNED-PAYLOAD` defaults, S3 duplicate-query-key handling, `iotdevicegateway` token append, and the derived-key cache. Host-based service/region guessing is intentionally dropped — both callers always supply them.

## Verification
- Differential check against aws4fetch 1.0.20 on 8 fixtures (S3 GET with Range, PUT with reserved chars + duplicate query keys, DynamoDB with session token + `//` paths, S3 presign with `allHeaders`, execute-api presign, iotdevicegateway presign, explicit `x-amz-content-sha256`, defaulted method/datetime): identical URLs, headers, signatures.
- `bun test packages/aws/src/sigv4.test.ts packages/aws/src/auth.test.ts`: 14 pass / 0 fail.
- `pnpm --filter @distilled.cloud/aws typecheck` and root `pnpm typecheck`: green.
- `pnpm install --frozen-lockfile`: OK. `oxfmt --check` on touched files: clean.
- `pnpm typecheck:ci` not run: no shared/core or generator change; `encode()` shape unchanged.