### PR TITLE
fix(railway): type observed errors and paginate service instances

### DIFF
--- a/packages/cloudflare/.generated-specs/workers.json
+++ b/packages/cloudflare/.generated-specs/workers.json
@@ -120,7 +120,11 @@
       "workflowName": "workflow_name",
       "wranglerSessionConfig": "wrangler-session-config",
       "zoneId": "zone_id",
-      "zoneName": "zone_name"
+      "zoneName": "zone_name",
+      "previewId": "preview_id",
+      "previewName": "preview_name",
+      "workerName": "worker_name",
+      "ignoreBaseConfig": "ignore_base_config"
     },
     "distilled.finalized": true
   },
@@ -12871,6 +12875,12 @@
           "traits": {
             "smithy.api#documentation": "Name of the zone containing the domain hostname.",
             "smithy.api#required": {}
+          }
+        },
+        "previews_enabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
           }
         }
       }
@@ -42153,6 +42163,21 @@
         },
         {
           "target": "com.cloudflare.workers#CreateZoneEdgePreviewSession"
+        },
+        {
+          "target": "com.cloudflare.workers#GetPreview"
+        },
+        {
+          "target": "com.cloudflare.workers#CreatePreview"
+        },
+        {
+          "target": "com.cloudflare.workers#DeletePreview"
+        },
+        {
+          "target": "com.cloudflare.workers#CreatePreviewDeployment"
+        },
+        {
+          "target": "com.cloudflare.workers#GetPreviewDeployment"
         }
       ],
       "traits": {
@@ -45629,6 +45654,12 @@
             "smithy.api#documentation": "Name of the zone containing the domain hostname.",
             "smithy.api#required": {}
           }
+        },
+        "previews_enabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
+          }
         }
       },
       "traits": {
@@ -48318,6 +48349,12 @@
           "traits": {
             "smithy.api#documentation": "Name of the zone containing the domain hostname."
           }
+        },
+        "previews_enabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Serve Worker Previews on this custom domain as `<preview-name>.<hostname>`."
+          }
         }
       },
       "traits": {
@@ -48374,6 +48411,12 @@
           "traits": {
             "smithy.api#documentation": "Name of the zone containing the domain hostname.",
             "smithy.api#required": {}
+          }
+        },
+        "previews_enabled": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
           }
         }
       },
@@ -52176,6 +52219,560 @@
           "code": 200
         },
         "smithy.api#documentation": "Create an edge-preview session scoped to a zone (undocumented endpoint)."
+      }
+    },
+    "com.cloudflare.workers#PreviewNotFound": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "smithy.api#Integer"
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "com.cloudflare.protocols#errorMatchers": [
+          {
+            "code": 10025
+          },
+          {
+            "status": 404,
+            "message": {
+              "includes": "preview"
+            }
+          }
+        ]
+      }
+    },
+    "com.cloudflare.workers#PreviewDeploymentNotFound": {
+      "type": "structure",
+      "members": {
+        "code": {
+          "target": "smithy.api#Integer"
+        },
+        "message": {
+          "target": "smithy.api#String"
+        }
+      },
+      "traits": {
+        "smithy.api#error": "client",
+        "com.cloudflare.protocols#errorMatchers": [
+          {
+            "code": 10222
+          }
+        ]
+      }
+    },
+    "com.cloudflare.workers#PreviewUrlsList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "com.cloudflare.workers#PreviewTailConsumer": {
+      "type": "structure",
+      "members": {
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.cloudflare.workers#PreviewTailConsumersList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.workers#PreviewTailConsumer"
+      }
+    },
+    "com.cloudflare.workers#PreviewResource": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "Immutable Preview id."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "Preview name as created (e.g. a git branch)."
+          }
+        },
+        "slug": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "DNS-safe slug used in Preview URLs."
+          }
+        },
+        "worker_name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "Parent Worker script name this Preview belongs to."
+          }
+        },
+        "urls": {
+          "target": "com.cloudflare.workers#PreviewUrlsList",
+          "traits": {
+            "smithy.api#documentation": "Stable Preview URLs (always the latest deployment)."
+          }
+        },
+        "tags": {
+          "target": "com.cloudflare.workers#PreviewUrlsList"
+        },
+        "logpush": {
+          "target": "smithy.api#Boolean"
+        },
+        "tail_consumers": {
+          "target": "com.cloudflare.workers#PreviewTailConsumersList"
+        },
+        "created_on": {
+          "target": "smithy.api#String"
+        },
+        "updated_on": {
+          "target": "smithy.api#String"
+        }
+      }
+    },
+    "com.cloudflare.workers#GetPreviewRequest": {
+      "type": "structure",
+      "members": {
+        "account_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "worker_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Parent Worker id or script name.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "preview_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Preview id or name.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.cloudflare.workers#GetPreview": {
+      "type": "operation",
+      "input": {
+        "target": "com.cloudflare.workers#GetPreviewRequest"
+      },
+      "output": {
+        "target": "com.cloudflare.workers#PreviewResource"
+      },
+      "errors": [
+        {
+          "target": "com.cloudflare.workers#PreviewNotFound"
+        },
+        {
+          "target": "com.cloudflare.workers#WorkerNotFound"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+          "code": 200
+        },
+        "smithy.api#documentation": "Get a Worker Preview by id or name."
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewRequest": {
+      "type": "structure",
+      "members": {
+        "account_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "worker_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Parent Worker id or script name.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "ignore_base_config": {
+          "target": "smithy.api#Boolean",
+          "traits": {
+            "smithy.api#httpQuery": "ignore_base_config",
+            "smithy.api#documentation": "Do not copy the parent's Previews Base configuration onto this Preview."
+          }
+        },
+        "name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "Preview name. Defaults to the git branch in wrangler; Alchemy defaults to the stage."
+          }
+        },
+        "logpush": {
+          "target": "smithy.api#Boolean"
+        },
+        "tail_consumers": {
+          "target": "com.cloudflare.workers#PreviewTailConsumersList"
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.cloudflare.workers#CreatePreview": {
+      "type": "operation",
+      "input": {
+        "target": "com.cloudflare.workers#CreatePreviewRequest"
+      },
+      "output": {
+        "target": "com.cloudflare.workers#PreviewResource"
+      },
+      "errors": [
+        {
+          "target": "com.cloudflare.workers#WorkerNotFound"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews",
+          "code": 200
+        },
+        "smithy.api#documentation": "Create a Worker Preview. Does not deploy code; follow with createPreviewDeployment."
+      }
+    },
+    "com.cloudflare.workers#DeletePreviewRequest": {
+      "type": "structure",
+      "members": {
+        "account_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "worker_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "preview_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.cloudflare.workers#DeletePreviewResponse": {
+      "type": "structure",
+      "members": {},
+      "traits": {
+        "smithy.api#output": {}
+      }
+    },
+    "com.cloudflare.workers#DeletePreview": {
+      "type": "operation",
+      "input": {
+        "target": "com.cloudflare.workers#DeletePreviewRequest"
+      },
+      "output": {
+        "target": "com.cloudflare.workers#DeletePreviewResponse"
+      },
+      "errors": [
+        {
+          "target": "com.cloudflare.workers#PreviewNotFound"
+        },
+        {
+          "target": "com.cloudflare.workers#WorkerNotFound"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "DELETE",
+          "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+          "code": 200
+        },
+        "smithy.api#documentation": "Delete a Worker Preview and all its deployments."
+      }
+    },
+    "com.cloudflare.workers#PreviewDeploymentResource": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "preview_id": {
+          "target": "smithy.api#String"
+        },
+        "preview_name": {
+          "target": "smithy.api#String"
+        },
+        "migration_tag": {
+          "target": "smithy.api#String"
+        },
+        "urls": {
+          "target": "com.cloudflare.workers#PreviewUrlsList",
+          "traits": {
+            "smithy.api#documentation": "Pinned deployment URLs for this exact deploy."
+          }
+        },
+        "compatibility_date": {
+          "target": "smithy.api#String"
+        },
+        "created_on": {
+          "target": "smithy.api#String"
+        }
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentMetadataAssets": {
+      "type": "structure",
+      "members": {
+        "jwt": {
+          "target": "smithy.api#String"
+        },
+        "config": {
+          "target": "smithy.api#Document"
+        }
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentMetadataCompatibilityFlagsList": {
+      "type": "list",
+      "member": {
+        "target": "smithy.api#String"
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainer": {
+      "type": "structure",
+      "members": {
+        "class_name": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainersList": {
+      "type": "list",
+      "member": {
+        "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainer"
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentMetadata": {
+      "type": "structure",
+      "members": {
+        "main_module": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Entrypoint module filename."
+          }
+        },
+        "assets": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataAssets"
+        },
+        "compatibility_date": {
+          "target": "smithy.api#String"
+        },
+        "compatibility_flags": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataCompatibilityFlagsList"
+        },
+        "annotations": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "smithy.api#documentation": "Version annotations (workers/message, workers/tag, …)."
+          }
+        },
+        "migrations": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "smithy.api#documentation": "Durable Object class migrations for this Preview's isolated namespaces."
+          }
+        },
+        "limits": {
+          "target": "smithy.api#Document"
+        },
+        "placement": {
+          "target": "smithy.api#Document"
+        },
+        "cache_options": {
+          "target": "smithy.api#Document"
+        },
+        "env": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "smithy.api#documentation": "Binding map keyed by runtime name (wrangler `env` format)."
+          }
+        },
+        "containers": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainersList"
+        }
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "account_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "worker_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "preview_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Preview id (not name) — wrangler uses the resource id returned by createPreview.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "metadata": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadata",
+          "traits": {
+            "smithy.api#required": {},
+            "smithy.api#documentation": "JSON-encoded multipart `metadata` part."
+          }
+        },
+        "files": {
+          "target": "smithy.api#Document",
+          "traits": {
+            "com.cloudflare.protocols#formDataFile": {},
+            "smithy.api#documentation": "Module files comprising the Worker script, appended under their own filenames."
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.cloudflare.workers#CreatePreviewDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.cloudflare.workers#CreatePreviewDeploymentRequest"
+      },
+      "output": {
+        "target": "com.cloudflare.workers#PreviewDeploymentResource"
+      },
+      "errors": [
+        {
+          "target": "com.cloudflare.workers#PreviewNotFound"
+        },
+        {
+          "target": "com.cloudflare.workers#WorkerNotFound"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments",
+          "code": 200,
+          "contentType": "multipart"
+        },
+        "smithy.api#documentation": "Upload code, bindings, and assets as a new deployment of a Preview."
+      }
+    },
+    "com.cloudflare.workers#GetPreviewDeploymentRequest": {
+      "type": "structure",
+      "members": {
+        "account_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "worker_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "preview_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        },
+        "deployment_id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#documentation": "Deployment id, or `latest`.",
+            "smithy.api#httpLabel": {},
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#input": {}
+      }
+    },
+    "com.cloudflare.workers#GetPreviewDeployment": {
+      "type": "operation",
+      "input": {
+        "target": "com.cloudflare.workers#GetPreviewDeploymentRequest"
+      },
+      "output": {
+        "target": "com.cloudflare.workers#PreviewDeploymentResource"
+      },
+      "errors": [
+        {
+          "target": "com.cloudflare.workers#PreviewNotFound"
+        },
+        {
+          "target": "com.cloudflare.workers#PreviewDeploymentNotFound"
+        },
+        {
+          "target": "com.cloudflare.workers#WorkerNotFound"
+        }
+      ],
+      "traits": {
+        "smithy.api#http": {
+          "method": "GET",
+          "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments/{deployment_id}",
+          "code": 200
+        },
+        "smithy.api#documentation": "Get a Preview deployment by id, or `latest`."
       }
     },
     "com.cloudflare.workers#PutScriptMetadataStringList": {

--- a/packages/cloudflare/patches/workers/previews.manual.json
+++ b/packages/cloudflare/patches/workers/previews.manual.json
@@ -1,0 +1,606 @@
+{
+  "description": "Worker Previews (private beta, docs-absent): first-class named Previews of a Worker with isolated DO/container state, Preview URLs, and per-Preview deployments. Transcribed from wrangler's @cloudflare/deploy-helpers preview API. Also adds previews_enabled on custom-domain attach so Preview URLs can be served as <preview-name>.<hostname>.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/metadata/keyDictionary/previewId",
+      "value": "preview_id"
+    },
+    {
+      "op": "add",
+      "path": "/metadata/keyDictionary/previewName",
+      "value": "preview_name"
+    },
+    {
+      "op": "add",
+      "path": "/metadata/keyDictionary/workerName",
+      "value": "worker_name"
+    },
+    {
+      "op": "add",
+      "path": "/metadata/keyDictionary/ignoreBaseConfig",
+      "value": "ignore_base_config"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewNotFound",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": { "target": "smithy.api#Integer" },
+          "message": { "target": "smithy.api#String" }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [
+            { "code": 10025 },
+            { "status": 404, "message": { "includes": "preview" } }
+          ]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewDeploymentNotFound",
+      "value": {
+        "type": "structure",
+        "members": {
+          "code": { "target": "smithy.api#Integer" },
+          "message": { "target": "smithy.api#String" }
+        },
+        "traits": {
+          "smithy.api#error": "client",
+          "com.cloudflare.protocols#errorMatchers": [{ "code": 10222 }]
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewUrlsList",
+      "value": {
+        "type": "list",
+        "member": { "target": "smithy.api#String" }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewTailConsumer",
+      "value": {
+        "type": "structure",
+        "members": {
+          "name": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewTailConsumersList",
+      "value": {
+        "type": "list",
+        "member": {
+          "target": "com.cloudflare.workers#PreviewTailConsumer"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewResource",
+      "value": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "Immutable Preview id."
+            }
+          },
+          "name": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "Preview name as created (e.g. a git branch)."
+            }
+          },
+          "slug": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "DNS-safe slug used in Preview URLs."
+            }
+          },
+          "worker_name": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "Parent Worker script name this Preview belongs to."
+            }
+          },
+          "urls": {
+            "target": "com.cloudflare.workers#PreviewUrlsList",
+            "traits": {
+              "smithy.api#documentation": "Stable Preview URLs (always the latest deployment)."
+            }
+          },
+          "tags": {
+            "target": "com.cloudflare.workers#PreviewUrlsList"
+          },
+          "logpush": { "target": "smithy.api#Boolean" },
+          "tail_consumers": {
+            "target": "com.cloudflare.workers#PreviewTailConsumersList"
+          },
+          "created_on": { "target": "smithy.api#String" },
+          "updated_on": { "target": "smithy.api#String" }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#GetPreviewRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "account_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "worker_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Parent Worker id or script name.",
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "preview_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Preview id or name.",
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          }
+        },
+        "traits": { "smithy.api#input": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#GetPreview",
+      "value": {
+        "type": "operation",
+        "input": { "target": "com.cloudflare.workers#GetPreviewRequest" },
+        "output": { "target": "com.cloudflare.workers#PreviewResource" },
+        "errors": [
+          { "target": "com.cloudflare.workers#PreviewNotFound" },
+          { "target": "com.cloudflare.workers#WorkerNotFound" }
+        ],
+        "traits": {
+          "smithy.api#http": {
+            "method": "GET",
+            "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+            "code": 200
+          },
+          "smithy.api#documentation": "Get a Worker Preview by id or name."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "account_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "worker_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Parent Worker id or script name.",
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "ignore_base_config": {
+            "target": "smithy.api#Boolean",
+            "traits": {
+              "smithy.api#httpQuery": "ignore_base_config",
+              "smithy.api#documentation": "Do not copy the parent's Previews Base configuration onto this Preview."
+            }
+          },
+          "name": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "Preview name. Defaults to the git branch in wrangler; Alchemy defaults to the stage."
+            }
+          },
+          "logpush": { "target": "smithy.api#Boolean" },
+          "tail_consumers": {
+            "target": "com.cloudflare.workers#PreviewTailConsumersList"
+          }
+        },
+        "traits": { "smithy.api#input": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreview",
+      "value": {
+        "type": "operation",
+        "input": { "target": "com.cloudflare.workers#CreatePreviewRequest" },
+        "output": { "target": "com.cloudflare.workers#PreviewResource" },
+        "errors": [{ "target": "com.cloudflare.workers#WorkerNotFound" }],
+        "traits": {
+          "smithy.api#http": {
+            "method": "POST",
+            "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews",
+            "code": 200
+          },
+          "smithy.api#documentation": "Create a Worker Preview. Does not deploy code; follow with createPreviewDeployment."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#DeletePreviewRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "account_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "worker_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "preview_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          }
+        },
+        "traits": { "smithy.api#input": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#DeletePreviewResponse",
+      "value": {
+        "type": "structure",
+        "members": {},
+        "traits": { "smithy.api#output": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#DeletePreview",
+      "value": {
+        "type": "operation",
+        "input": { "target": "com.cloudflare.workers#DeletePreviewRequest" },
+        "output": { "target": "com.cloudflare.workers#DeletePreviewResponse" },
+        "errors": [
+          { "target": "com.cloudflare.workers#PreviewNotFound" },
+          { "target": "com.cloudflare.workers#WorkerNotFound" }
+        ],
+        "traits": {
+          "smithy.api#http": {
+            "method": "DELETE",
+            "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+            "code": 200
+          },
+          "smithy.api#documentation": "Delete a Worker Preview and all its deployments."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PreviewDeploymentResource",
+      "value": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "preview_id": { "target": "smithy.api#String" },
+          "preview_name": { "target": "smithy.api#String" },
+          "migration_tag": { "target": "smithy.api#String" },
+          "urls": {
+            "target": "com.cloudflare.workers#PreviewUrlsList",
+            "traits": {
+              "smithy.api#documentation": "Pinned deployment URLs for this exact deploy."
+            }
+          },
+          "compatibility_date": { "target": "smithy.api#String" },
+          "created_on": { "target": "smithy.api#String" }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentMetadataAssets",
+      "value": {
+        "type": "structure",
+        "members": {
+          "jwt": { "target": "smithy.api#String" },
+          "config": { "target": "smithy.api#Document" }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentMetadataCompatibilityFlagsList",
+      "value": {
+        "type": "list",
+        "member": { "target": "smithy.api#String" }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentMetadataContainer",
+      "value": {
+        "type": "structure",
+        "members": {
+          "class_name": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentMetadataContainersList",
+      "value": {
+        "type": "list",
+        "member": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainer"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentMetadata",
+      "value": {
+        "type": "structure",
+        "members": {
+          "main_module": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Entrypoint module filename."
+            }
+          },
+          "assets": {
+            "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataAssets"
+          },
+          "compatibility_date": { "target": "smithy.api#String" },
+          "compatibility_flags": {
+            "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataCompatibilityFlagsList"
+          },
+          "annotations": {
+            "target": "smithy.api#Document",
+            "traits": {
+              "smithy.api#documentation": "Version annotations (workers/message, workers/tag, …)."
+            }
+          },
+          "migrations": {
+            "target": "smithy.api#Document",
+            "traits": {
+              "smithy.api#documentation": "Durable Object class migrations for this Preview's isolated namespaces."
+            }
+          },
+          "limits": { "target": "smithy.api#Document" },
+          "placement": { "target": "smithy.api#Document" },
+          "cache_options": { "target": "smithy.api#Document" },
+          "env": {
+            "target": "smithy.api#Document",
+            "traits": {
+              "smithy.api#documentation": "Binding map keyed by runtime name (wrangler `env` format)."
+            }
+          },
+          "containers": {
+            "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadataContainersList"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeploymentRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "account_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "worker_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "preview_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Preview id (not name) — wrangler uses the resource id returned by createPreview.",
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "metadata": {
+            "target": "com.cloudflare.workers#CreatePreviewDeploymentMetadata",
+            "traits": {
+              "smithy.api#required": {},
+              "smithy.api#documentation": "JSON-encoded multipart `metadata` part."
+            }
+          },
+          "files": {
+            "target": "smithy.api#Document",
+            "traits": {
+              "com.cloudflare.protocols#formDataFile": {},
+              "smithy.api#documentation": "Module files comprising the Worker script, appended under their own filenames."
+            }
+          }
+        },
+        "traits": { "smithy.api#input": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#CreatePreviewDeployment",
+      "value": {
+        "type": "operation",
+        "input": {
+          "target": "com.cloudflare.workers#CreatePreviewDeploymentRequest"
+        },
+        "output": {
+          "target": "com.cloudflare.workers#PreviewDeploymentResource"
+        },
+        "errors": [
+          { "target": "com.cloudflare.workers#PreviewNotFound" },
+          { "target": "com.cloudflare.workers#WorkerNotFound" }
+        ],
+        "traits": {
+          "smithy.api#http": {
+            "method": "POST",
+            "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments",
+            "code": 200,
+            "contentType": "multipart"
+          },
+          "smithy.api#documentation": "Upload code, bindings, and assets as a new deployment of a Preview."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#GetPreviewDeploymentRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "account_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "worker_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "preview_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          },
+          "deployment_id": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#documentation": "Deployment id, or `latest`.",
+              "smithy.api#httpLabel": {},
+              "smithy.api#required": {}
+            }
+          }
+        },
+        "traits": { "smithy.api#input": {} }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#GetPreviewDeployment",
+      "value": {
+        "type": "operation",
+        "input": {
+          "target": "com.cloudflare.workers#GetPreviewDeploymentRequest"
+        },
+        "output": {
+          "target": "com.cloudflare.workers#PreviewDeploymentResource"
+        },
+        "errors": [
+          { "target": "com.cloudflare.workers#PreviewNotFound" },
+          { "target": "com.cloudflare.workers#PreviewDeploymentNotFound" },
+          { "target": "com.cloudflare.workers#WorkerNotFound" }
+        ],
+        "traits": {
+          "smithy.api#http": {
+            "method": "GET",
+            "uri": "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments/{deployment_id}",
+            "code": 200
+          },
+          "smithy.api#documentation": "Get a Preview deployment by id, or `latest`."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PutDomainRequest/members/previews_enabled",
+      "value": {
+        "target": "smithy.api#Boolean",
+        "traits": {
+          "smithy.api#documentation": "Serve Worker Previews on this custom domain as `<preview-name>.<hostname>`."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#PutDomainResponse/members/previews_enabled",
+      "value": {
+        "target": "smithy.api#Boolean",
+        "traits": {
+          "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#DomainsListResultItem/members/previews_enabled",
+      "value": {
+        "target": "smithy.api#Boolean",
+        "traits": {
+          "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.cloudflare.workers#GetDomainResponse/members/previews_enabled",
+      "value": {
+        "target": "smithy.api#Boolean",
+        "traits": {
+          "smithy.api#documentation": "Whether Worker Previews are served on this custom domain."
+        }
+      }
+    }
+  ]
+}

--- a/packages/cloudflare/src/services/workers.ts
+++ b/packages/cloudflare/src/services/workers.ts
@@ -121,6 +121,10 @@ const KEY_DICTIONARY: Record<string, string | ReadonlyArray<string>> = {
   wranglerSessionConfig: "wrangler-session-config",
   zoneId: "zone_id",
   zoneName: "zone_name",
+  previewId: "preview_id",
+  previewName: "preview_name",
+  workerName: "worker_name",
+  ignoreBaseConfig: "ignore_base_config",
 };
 
 export class ContentTypeRequired
@@ -329,6 +333,27 @@ export class ObservabilityDestinationPreflightFailed
       },
     ),
     [{ status: 400, message: "Bad Request" }],
+  ) {}
+
+export class PreviewDeploymentNotFound
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<PreviewDeploymentNotFound>()(
+      "PreviewDeploymentNotFound",
+      {
+        code: S.Number,
+        message: S.String,
+      },
+    ),
+    [{ code: 10222 }],
+  ) {}
+
+export class PreviewNotFound
+  extends /*@__PURE__*/ T.applyErrorMatchers(
+    /*@__PURE__*/ S.TaggedError<PreviewNotFound>()("PreviewNotFound", {
+      code: S.Number,
+      message: S.String,
+    }),
+    [{ code: 10025 }, { status: 404, message: { includes: "preview" } }],
   ) {}
 
 export class QueueConsumerConflict
@@ -6756,6 +6781,233 @@ export const CreateObservabilitySharedQueryResponse = /*@__PURE__*/ S.suspend(
   identifier: "CreateObservabilitySharedQueryResponse",
 }) as any as S.Schema<CreateObservabilitySharedQueryResponse>;
 
+export interface PreviewTailConsumer {
+  name: string;
+}
+export const PreviewTailConsumer = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    name: S.String,
+  }),
+).annotate({
+  identifier: "PreviewTailConsumer",
+}) as any as S.Schema<PreviewTailConsumer>;
+
+export type PreviewTailConsumersList = Array<PreviewTailConsumer>;
+export const PreviewTailConsumersList = /*@__PURE__*/ S.Array(
+  PreviewTailConsumer,
+) as any as S.Schema<PreviewTailConsumersList>;
+
+export interface CreatePreviewRequest {
+  accountId: string;
+  /** Parent Worker id or script name. */
+  workerId: string;
+  /** Do not copy the parent's Previews Base configuration onto this Preview. */
+  ignoreBaseConfig?: boolean;
+  /** Preview name. Defaults to the git branch in wrangler; Alchemy defaults to the stage. */
+  name: string;
+  logpush?: boolean;
+  tailConsumers?: PreviewTailConsumersList;
+}
+export const CreatePreviewRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    accountId: S.String.pipe(T.Label("account_id")),
+    workerId: S.String.pipe(T.Label("worker_id")),
+    ignoreBaseConfig: S.optional(S.Boolean.pipe(T.Query("ignore_base_config"))),
+    name: S.String,
+    logpush: S.optional(S.Boolean),
+    tailConsumers: S.optional(
+      PreviewTailConsumersList.pipe(T.Body("tail_consumers")),
+    ),
+  })
+    .pipe(
+      T.Http({
+        method: "POST",
+        uri: "/accounts/{account_id}/workers/workers/{worker_id}/previews",
+        code: 200,
+      }),
+    )
+    .pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "CreatePreviewRequest",
+}) as any as S.Schema<CreatePreviewRequest>;
+
+export type PreviewUrlsList = Array<string>;
+export const PreviewUrlsList = /*@__PURE__*/ S.Array(
+  S.String,
+) as any as S.Schema<PreviewUrlsList>;
+
+export interface PreviewResource {
+  /** Immutable Preview id. */
+  id: string;
+  /** Preview name as created (e.g. a git branch). */
+  name: string;
+  /** DNS-safe slug used in Preview URLs. */
+  slug: string;
+  /** Parent Worker script name this Preview belongs to. */
+  workerName: string;
+  /** Stable Preview URLs (always the latest deployment). */
+  urls?: PreviewUrlsList | null;
+  tags?: PreviewUrlsList | null;
+  logpush?: boolean | null;
+  tailConsumers?: PreviewTailConsumersList | null;
+  createdOn?: string | null;
+  updatedOn?: string | null;
+}
+export const PreviewResource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.String,
+    name: S.String,
+    slug: S.String,
+    workerName: S.String.pipe(T.Body("worker_name")),
+    urls: S.optional(S.NullOr(PreviewUrlsList)),
+    tags: S.optional(S.NullOr(PreviewUrlsList)),
+    logpush: S.optional(S.NullOr(S.Boolean)),
+    tailConsumers: S.optional(
+      S.NullOr(PreviewTailConsumersList).pipe(T.Body("tail_consumers")),
+    ),
+    createdOn: S.optional(S.NullOr(S.String).pipe(T.Body("created_on"))),
+    updatedOn: S.optional(S.NullOr(S.String).pipe(T.Body("updated_on"))),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "PreviewResource",
+}) as any as S.Schema<PreviewResource>;
+
+export interface CreatePreviewDeploymentMetadataAssets {
+  jwt?: string;
+  config?: unknown;
+}
+export const CreatePreviewDeploymentMetadataAssets = /*@__PURE__*/ S.suspend(
+  () =>
+    S.Struct({
+      jwt: S.optional(S.String),
+      config: S.optional(S.Unknown),
+    }),
+).annotate({
+  identifier: "CreatePreviewDeploymentMetadataAssets",
+}) as any as S.Schema<CreatePreviewDeploymentMetadataAssets>;
+
+export type CreatePreviewDeploymentMetadataCompatibilityFlagsList =
+  Array<string>;
+export const CreatePreviewDeploymentMetadataCompatibilityFlagsList =
+  /*@__PURE__*/ S.Array(
+    S.String,
+  ) as any as S.Schema<CreatePreviewDeploymentMetadataCompatibilityFlagsList>;
+
+export interface CreatePreviewDeploymentMetadataContainer {
+  className: string;
+}
+export const CreatePreviewDeploymentMetadataContainer = /*@__PURE__*/ S.suspend(
+  () =>
+    S.Struct({
+      className: S.String.pipe(T.Body("class_name")),
+    }),
+).annotate({
+  identifier: "CreatePreviewDeploymentMetadataContainer",
+}) as any as S.Schema<CreatePreviewDeploymentMetadataContainer>;
+
+export type CreatePreviewDeploymentMetadataContainersList =
+  Array<CreatePreviewDeploymentMetadataContainer>;
+export const CreatePreviewDeploymentMetadataContainersList =
+  /*@__PURE__*/ S.Array(
+    CreatePreviewDeploymentMetadataContainer,
+  ) as any as S.Schema<CreatePreviewDeploymentMetadataContainersList>;
+
+export interface CreatePreviewDeploymentMetadata {
+  /** Entrypoint module filename. */
+  mainModule?: string;
+  assets?: CreatePreviewDeploymentMetadataAssets;
+  compatibilityDate?: string;
+  compatibilityFlags?: CreatePreviewDeploymentMetadataCompatibilityFlagsList;
+  /** Version annotations (workers/message, workers/tag, …). */
+  annotations?: unknown;
+  /** Durable Object class migrations for this Preview's isolated namespaces. */
+  migrations?: unknown;
+  limits?: unknown;
+  placement?: unknown;
+  cacheOptions?: unknown;
+  /** Binding map keyed by runtime name (wrangler `env` format). */
+  env?: unknown;
+  containers?: CreatePreviewDeploymentMetadataContainersList;
+}
+export const CreatePreviewDeploymentMetadata = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    mainModule: S.optional(S.String.pipe(T.Body("main_module"))),
+    assets: S.optional(CreatePreviewDeploymentMetadataAssets),
+    compatibilityDate: S.optional(S.String.pipe(T.Body("compatibility_date"))),
+    compatibilityFlags: S.optional(
+      CreatePreviewDeploymentMetadataCompatibilityFlagsList.pipe(
+        T.Body("compatibility_flags"),
+      ),
+    ),
+    annotations: S.optional(S.Unknown),
+    migrations: S.optional(S.Unknown),
+    limits: S.optional(S.Unknown),
+    placement: S.optional(S.Unknown),
+    cacheOptions: S.optional(S.Unknown.pipe(T.Body("cache_options"))),
+    env: S.optional(S.Unknown),
+    containers: S.optional(CreatePreviewDeploymentMetadataContainersList),
+  }),
+).annotate({
+  identifier: "CreatePreviewDeploymentMetadata",
+}) as any as S.Schema<CreatePreviewDeploymentMetadata>;
+
+export interface CreatePreviewDeploymentRequest {
+  accountId: string;
+  workerId: string;
+  /** Preview id (not name) — wrangler uses the resource id returned by createPreview. */
+  previewId: string;
+  /** JSON-encoded multipart `metadata` part. */
+  metadata: CreatePreviewDeploymentMetadata;
+  /** Module files comprising the Worker script, appended under their own filenames. */
+  files?: File | Blob | (File | Blob)[];
+}
+export const CreatePreviewDeploymentRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    accountId: S.String.pipe(T.Label("account_id")),
+    workerId: S.String.pipe(T.Label("worker_id")),
+    previewId: S.String.pipe(T.Label("preview_id")),
+    metadata: CreatePreviewDeploymentMetadata,
+    files: S.optional(S.Unknown.pipe(T.FormDataFile())),
+  })
+    .pipe(
+      T.Http({
+        method: "POST",
+        uri: "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments",
+        code: 200,
+        contentType: "multipart",
+      }),
+    )
+    .pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "CreatePreviewDeploymentRequest",
+}) as any as S.Schema<CreatePreviewDeploymentRequest>;
+
+export interface PreviewDeploymentResource {
+  id: string;
+  previewId?: string | null;
+  previewName?: string | null;
+  migrationTag?: string | null;
+  /** Pinned deployment URLs for this exact deploy. */
+  urls?: PreviewUrlsList | null;
+  compatibilityDate?: string | null;
+  createdOn?: string | null;
+}
+export const PreviewDeploymentResource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.String,
+    previewId: S.optional(S.NullOr(S.String).pipe(T.Body("preview_id"))),
+    previewName: S.optional(S.NullOr(S.String).pipe(T.Body("preview_name"))),
+    migrationTag: S.optional(S.NullOr(S.String).pipe(T.Body("migration_tag"))),
+    urls: S.optional(S.NullOr(PreviewUrlsList)),
+    compatibilityDate: S.optional(
+      S.NullOr(S.String).pipe(T.Body("compatibility_date")),
+    ),
+    createdOn: S.optional(S.NullOr(S.String).pipe(T.Body("created_on"))),
+  }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "PreviewDeploymentResource",
+}) as any as S.Schema<PreviewDeploymentResource>;
+
 export interface CreateRouteRequest {
   /** Identifier. */
   zoneId: string;
@@ -7459,24 +7711,16 @@ export const CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundWork
       "CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundWorker",
   }) as any as S.Schema<CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundWorker>;
 
-export interface CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam {
-  name: string;
-}
+export type CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam =
+  PreviewTailConsumer;
 export const CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam =
-  /*@__PURE__*/ S.suspend(() =>
-    S.Struct({
-      name: S.String,
-    }),
-  ).annotate({
-    identifier:
-      "CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam",
-  }) as any as S.Schema<CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam>;
+  PreviewTailConsumer;
 
 export type CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParamsList =
-  Array<CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam>;
+  Array<PreviewTailConsumer>;
 export const CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParamsList =
   /*@__PURE__*/ S.Array(
-    CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam,
+    PreviewTailConsumer,
   ) as any as S.Schema<CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParamsList>;
 
 export interface CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutbound {
@@ -8391,23 +8635,16 @@ export const CreateScriptEdgePreviewMetadataObservability =
     identifier: "CreateScriptEdgePreviewMetadataObservability",
   }) as any as S.Schema<CreateScriptEdgePreviewMetadataObservability>;
 
-export interface CreateScriptEdgePreviewMetadataContainer {
-  className: string;
-}
-export const CreateScriptEdgePreviewMetadataContainer = /*@__PURE__*/ S.suspend(
-  () =>
-    S.Struct({
-      className: S.String.pipe(T.Body("class_name")),
-    }),
-).annotate({
-  identifier: "CreateScriptEdgePreviewMetadataContainer",
-}) as any as S.Schema<CreateScriptEdgePreviewMetadataContainer>;
+export type CreateScriptEdgePreviewMetadataContainer =
+  CreatePreviewDeploymentMetadataContainer;
+export const CreateScriptEdgePreviewMetadataContainer =
+  CreatePreviewDeploymentMetadataContainer;
 
 export type CreateScriptEdgePreviewMetadataContainersList =
-  Array<CreateScriptEdgePreviewMetadataContainer>;
+  Array<CreatePreviewDeploymentMetadataContainer>;
 export const CreateScriptEdgePreviewMetadataContainersList =
   /*@__PURE__*/ S.Array(
-    CreateScriptEdgePreviewMetadataContainer,
+    CreatePreviewDeploymentMetadataContainer,
   ) as any as S.Schema<CreateScriptEdgePreviewMetadataContainersList>;
 
 export interface CreateScriptEdgePreviewMetadata {
@@ -8853,15 +9090,15 @@ export const PutScriptBindingDataBlob = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<PutScriptBindingDataBlob>;
 
 export type PutScriptBindingDispatchNamespaceOutboundParam =
-  CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam;
+  PreviewTailConsumer;
 export const PutScriptBindingDispatchNamespaceOutboundParam =
-  CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam;
+  PreviewTailConsumer;
 
 export type PutScriptBindingDispatchNamespaceOutboundParamsList =
-  Array<CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam>;
+  Array<PreviewTailConsumer>;
 export const PutScriptBindingDispatchNamespaceOutboundParamsList =
   /*@__PURE__*/ S.Array(
-    CreateScriptEdgePreviewMetadataBindingDispatchNamespaceOutboundParam,
+    PreviewTailConsumer,
   ) as any as S.Schema<PutScriptBindingDispatchNamespaceOutboundParamsList>;
 
 export interface PutScriptBindingDispatchNamespaceOutboundWorker {
@@ -9618,13 +9855,13 @@ export const PutScriptMetadataBindingsList = /*@__PURE__*/ S.Array(
   PutScriptBinding,
 ) as any as S.Schema<PutScriptMetadataBindingsList>;
 
-export type PutScriptContainer = CreateScriptEdgePreviewMetadataContainer;
-export const PutScriptContainer = CreateScriptEdgePreviewMetadataContainer;
+export type PutScriptContainer = CreatePreviewDeploymentMetadataContainer;
+export const PutScriptContainer = CreatePreviewDeploymentMetadataContainer;
 
 export type PutScriptMetadataContainersList =
-  Array<CreateScriptEdgePreviewMetadataContainer>;
+  Array<CreatePreviewDeploymentMetadataContainer>;
 export const PutScriptMetadataContainersList = /*@__PURE__*/ S.Array(
-  CreateScriptEdgePreviewMetadataContainer,
+  CreatePreviewDeploymentMetadataContainer,
 ) as any as S.Schema<PutScriptMetadataContainersList>;
 
 export type PutScriptMetadataLimits = CreateScriptEdgePreviewMetadataLimits;
@@ -11856,6 +12093,36 @@ export const DeleteObservabilityDestinationResponse = /*@__PURE__*/ S.suspend(
 ).annotate({
   identifier: "DeleteObservabilityDestinationResponse",
 }) as any as S.Schema<DeleteObservabilityDestinationResponse>;
+
+export interface DeletePreviewRequest {
+  accountId: string;
+  workerId: string;
+  previewId: string;
+}
+export const DeletePreviewRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    accountId: S.String.pipe(T.Label("account_id")),
+    workerId: S.String.pipe(T.Label("worker_id")),
+    previewId: S.String.pipe(T.Label("preview_id")),
+  })
+    .pipe(
+      T.Http({
+        method: "DELETE",
+        uri: "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+        code: 200,
+      }),
+    )
+    .pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "DeletePreviewRequest",
+}) as any as S.Schema<DeletePreviewRequest>;
+
+export interface DeletePreviewResponse {}
+export const DeletePreviewResponse = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({}).pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "DeletePreviewResponse",
+}) as any as S.Schema<DeletePreviewResponse>;
 
 export interface DeleteRouteRequest {
   /** Identifier. */
@@ -14216,6 +14483,8 @@ export interface GetDomainResponse {
   zoneId: string;
   /** Name of the zone containing the domain hostname. */
   zoneName: string;
+  /** Whether Worker Previews are served on this custom domain. */
+  previewsEnabled?: boolean | null;
 }
 export const GetDomainResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -14226,6 +14495,9 @@ export const GetDomainResponse = /*@__PURE__*/ S.suspend(() =>
     service: S.String,
     zoneId: S.String.pipe(T.Body("zone_id")),
     zoneName: S.String.pipe(T.Body("zone_name")),
+    previewsEnabled: S.optional(
+      S.NullOr(S.Boolean).pipe(T.Body("previews_enabled")),
+    ),
   }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "GetDomainResponse",
@@ -16228,6 +16500,57 @@ export const GetObservabilitySharedQueryResponse = /*@__PURE__*/ S.suspend(() =>
 ).annotate({
   identifier: "GetObservabilitySharedQueryResponse",
 }) as any as S.Schema<GetObservabilitySharedQueryResponse>;
+
+export interface GetPreviewRequest {
+  accountId: string;
+  /** Parent Worker id or script name. */
+  workerId: string;
+  /** Preview id or name. */
+  previewId: string;
+}
+export const GetPreviewRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    accountId: S.String.pipe(T.Label("account_id")),
+    workerId: S.String.pipe(T.Label("worker_id")),
+    previewId: S.String.pipe(T.Label("preview_id")),
+  })
+    .pipe(
+      T.Http({
+        method: "GET",
+        uri: "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}",
+        code: 200,
+      }),
+    )
+    .pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "GetPreviewRequest",
+}) as any as S.Schema<GetPreviewRequest>;
+
+export interface GetPreviewDeploymentRequest {
+  accountId: string;
+  workerId: string;
+  previewId: string;
+  /** Deployment id, or `latest`. */
+  deploymentId: string;
+}
+export const GetPreviewDeploymentRequest = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    accountId: S.String.pipe(T.Label("account_id")),
+    workerId: S.String.pipe(T.Label("worker_id")),
+    previewId: S.String.pipe(T.Label("preview_id")),
+    deploymentId: S.String.pipe(T.Label("deployment_id")),
+  })
+    .pipe(
+      T.Http({
+        method: "GET",
+        uri: "/accounts/{account_id}/workers/workers/{worker_id}/previews/{preview_id}/deployments/{deployment_id}",
+        code: 200,
+      }),
+    )
+    .pipe(T.KeyDictionary(KEY_DICTIONARY)),
+).annotate({
+  identifier: "GetPreviewDeploymentRequest",
+}) as any as S.Schema<GetPreviewDeploymentRequest>;
 
 export interface GetRouteRequest {
   /** Identifier. */
@@ -22718,6 +23041,8 @@ export interface DomainsListResultItem {
   zoneId: string;
   /** Name of the zone containing the domain hostname. */
   zoneName: string;
+  /** Whether Worker Previews are served on this custom domain. */
+  previewsEnabled?: boolean | null;
 }
 export const DomainsListResultItem = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -22728,6 +23053,9 @@ export const DomainsListResultItem = /*@__PURE__*/ S.suspend(() =>
     service: S.String,
     zoneId: S.String.pipe(T.Body("zone_id")),
     zoneName: S.String.pipe(T.Body("zone_name")),
+    previewsEnabled: S.optional(
+      S.NullOr(S.Boolean).pipe(T.Body("previews_enabled")),
+    ),
   }),
 ).annotate({
   identifier: "DomainsListResultItem",
@@ -27564,6 +27892,8 @@ export interface PutDomainRequest {
   zoneId?: string;
   /** Name of the zone containing the domain hostname. */
   zoneName?: string;
+  /** Serve Worker Previews on this custom domain as `<preview-name>.<hostname>`. */
+  previewsEnabled?: boolean;
 }
 export const PutDomainRequest = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -27573,6 +27903,7 @@ export const PutDomainRequest = /*@__PURE__*/ S.suspend(() =>
     environment: S.optional(S.String),
     zoneId: S.optional(S.String.pipe(T.Body("zone_id"))),
     zoneName: S.optional(S.String.pipe(T.Body("zone_name"))),
+    previewsEnabled: S.optional(S.Boolean.pipe(T.Body("previews_enabled"))),
   })
     .pipe(
       T.Http({
@@ -27602,6 +27933,8 @@ export interface PutDomainResponse {
   zoneId: string;
   /** Name of the zone containing the domain hostname. */
   zoneName: string;
+  /** Whether Worker Previews are served on this custom domain. */
+  previewsEnabled?: boolean | null;
 }
 export const PutDomainResponse = /*@__PURE__*/ S.suspend(() =>
   S.Struct({
@@ -27612,6 +27945,9 @@ export const PutDomainResponse = /*@__PURE__*/ S.suspend(() =>
     service: S.String,
     zoneId: S.String.pipe(T.Body("zone_id")),
     zoneName: S.String.pipe(T.Body("zone_name")),
+    previewsEnabled: S.optional(
+      S.NullOr(S.Boolean).pipe(T.Body("previews_enabled")),
+    ),
   }).pipe(T.KeyDictionary(KEY_DICTIONARY)),
 ).annotate({
   identifier: "PutDomainResponse",
@@ -32805,6 +33141,44 @@ export const createObservabilitySharedQuery: API.OperationMethod<
   retry: Retry.Retry,
 }));
 
+export type CreatePreviewError = WorkerNotFound | CloudflareOpError;
+/** Create a Worker Preview. Does not deploy code; follow with createPreviewDeployment. */
+export const createPreview: API.OperationMethod<
+  CreatePreviewRequest,
+  PreviewResource,
+  CreatePreviewError,
+  CloudflareOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: CreatePreviewRequest,
+  output: PreviewResource,
+  errors: [WorkerNotFound, CloudflareRateLimited, CloudflareError],
+  protocol: CloudflareProtocol,
+  retry: Retry.Retry,
+}));
+
+export type CreatePreviewDeploymentError =
+  | PreviewNotFound
+  | WorkerNotFound
+  | CloudflareOpError;
+/** Upload code, bindings, and assets as a new deployment of a Preview. */
+export const createPreviewDeployment: API.OperationMethod<
+  CreatePreviewDeploymentRequest,
+  PreviewDeploymentResource,
+  CreatePreviewDeploymentError,
+  CloudflareOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: CreatePreviewDeploymentRequest,
+  output: PreviewDeploymentResource,
+  errors: [
+    PreviewNotFound,
+    WorkerNotFound,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
+  protocol: CloudflareProtocol,
+  retry: Retry.Retry,
+}));
+
 export type CreateRouteError =
   | InvalidRoutePattern
   | InvalidRoute
@@ -33040,6 +33414,29 @@ export const deleteObservabilityDestination: API.OperationMethod<
   errors: [
     ObservabilityDestinationNotFound,
     Forbidden,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
+  protocol: CloudflareProtocol,
+  retry: Retry.Retry,
+}));
+
+export type DeletePreviewError =
+  | PreviewNotFound
+  | WorkerNotFound
+  | CloudflareOpError;
+/** Delete a Worker Preview and all its deployments. */
+export const deletePreview: API.OperationMethod<
+  DeletePreviewRequest,
+  DeletePreviewResponse,
+  DeletePreviewError,
+  CloudflareOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: DeletePreviewRequest,
+  output: DeletePreviewResponse,
+  errors: [
+    PreviewNotFound,
+    WorkerNotFound,
     CloudflareRateLimited,
     CloudflareError,
   ],
@@ -33283,6 +33680,54 @@ export const getObservabilitySharedQuery: API.OperationMethod<
   input: GetObservabilitySharedQueryRequest,
   output: GetObservabilitySharedQueryResponse,
   errors: [CloudflareRateLimited, CloudflareError],
+  protocol: CloudflareProtocol,
+  retry: Retry.Retry,
+}));
+
+export type GetPreviewError =
+  | PreviewNotFound
+  | WorkerNotFound
+  | CloudflareOpError;
+/** Get a Worker Preview by id or name. */
+export const getPreview: API.OperationMethod<
+  GetPreviewRequest,
+  PreviewResource,
+  GetPreviewError,
+  CloudflareOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: GetPreviewRequest,
+  output: PreviewResource,
+  errors: [
+    PreviewNotFound,
+    WorkerNotFound,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
+  protocol: CloudflareProtocol,
+  retry: Retry.Retry,
+}));
+
+export type GetPreviewDeploymentError =
+  | PreviewNotFound
+  | PreviewDeploymentNotFound
+  | WorkerNotFound
+  | CloudflareOpError;
+/** Get a Preview deployment by id, or `latest`. */
+export const getPreviewDeployment: API.OperationMethod<
+  GetPreviewDeploymentRequest,
+  PreviewDeploymentResource,
+  GetPreviewDeploymentError,
+  CloudflareOpContext
+> = /*@__PURE__*/ API.make(() => ({
+  input: GetPreviewDeploymentRequest,
+  output: PreviewDeploymentResource,
+  errors: [
+    PreviewNotFound,
+    PreviewDeploymentNotFound,
+    WorkerNotFound,
+    CloudflareRateLimited,
+    CloudflareError,
+  ],
   protocol: CloudflareProtocol,
   retry: Retry.Retry,
 }));

--- a/packages/railway/.generated-specs/railway.json
+++ b/packages/railway/.generated-specs/railway.json
@@ -38563,7 +38563,7 @@
       "traits": {
         "smithy.api#input": {},
         "com.railway.graphql#operation": {
-          "query": "mutation disableServiceCdn($input: DisableServiceCdnInput!) {\n  disableServiceCdn(input: $input) {\n    __typename\n  }\n}",
+          "query": "mutation disableServiceCdn($input: DisableServiceCdnInput!) {\n  disableServiceCdn(input: $input)\n}",
           "operationName": "disableServiceCdn",
           "type": "mutation"
         }

--- a/packages/railway/.generated-specs/railway.json
+++ b/packages/railway/.generated-specs/railway.json
@@ -63736,6 +63736,9 @@
         },
         {
           "target": "com.railway.api#CreateTcpProxy"
+        },
+        {
+          "target": "com.railway.api#ListEnvironmentServiceInstances"
         }
       ],
       "traits": {
@@ -63987,6 +63990,154 @@
           "traits": {
             "smithy.api#required": {}
           }
+        }
+      }
+    },
+    "com.railway.api#ListEnvironmentServiceInstancesRequest": {
+      "type": "structure",
+      "members": {
+        "environmentId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "after": {
+          "target": "smithy.api#String"
+        },
+        "first": {
+          "target": "smithy.api#Integer"
+        }
+      },
+      "traits": {
+        "smithy.api#input": {},
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/graphql/v2",
+          "code": 200
+        },
+        "com.railway.graphql#operation": {
+          "query": "query listEnvironmentServiceInstances($environmentId: String!, $after: String, $first: Int) { environment(id: $environmentId) { serviceInstances(after: $after, first: $first) { edges { cursor node { id serviceId environmentId deletedAt source { image } } } pageInfo { endCursor hasNextPage hasPreviousPage startCursor } } } }",
+          "operationName": "listEnvironmentServiceInstances",
+          "type": "query"
+        }
+      }
+    },
+    "com.railway.api#ListedServiceInstanceSource": {
+      "type": "structure",
+      "members": {
+        "image": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "com.railway.graphql#nullable": {}
+          }
+        }
+      }
+    },
+    "com.railway.api#ListedServiceInstance": {
+      "type": "structure",
+      "members": {
+        "id": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "serviceId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "environmentId": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "deletedAt": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {},
+            "com.railway.graphql#nullable": {}
+          }
+        },
+        "source": {
+          "target": "com.railway.api#ListedServiceInstanceSource",
+          "traits": {
+            "smithy.api#required": {},
+            "com.railway.graphql#nullable": {}
+          }
+        }
+      }
+    },
+    "com.railway.api#ListedServiceInstanceEdge": {
+      "type": "structure",
+      "members": {
+        "cursor": {
+          "target": "smithy.api#String",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "node": {
+          "target": "com.railway.api#ListedServiceInstance",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.railway.api#ListedServiceInstanceEdges": {
+      "type": "list",
+      "member": {
+        "target": "com.railway.api#ListedServiceInstanceEdge"
+      }
+    },
+    "com.railway.api#ListEnvironmentServiceInstancesResponse": {
+      "type": "structure",
+      "members": {
+        "edges": {
+          "target": "com.railway.api#ListedServiceInstanceEdges",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        },
+        "pageInfo": {
+          "target": "com.railway.api#EnvironmentsResponsePageInfo",
+          "traits": {
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#output": {},
+        "com.railway.graphql#responsePath": "environment.serviceInstances"
+      }
+    },
+    "com.railway.api#ListEnvironmentServiceInstances": {
+      "type": "operation",
+      "input": {
+        "target": "com.railway.api#ListEnvironmentServiceInstancesRequest"
+      },
+      "output": {
+        "target": "com.railway.api#ListEnvironmentServiceInstancesResponse"
+      },
+      "traits": {
+        "smithy.api#http": {
+          "method": "POST",
+          "uri": "/graphql/v2",
+          "code": 200
+        },
+        "smithy.api#readonly": {},
+        "smithy.api#paginated": {
+          "mode": "relay",
+          "inputToken": "after",
+          "outputToken": "pageInfo.endCursor",
+          "hasNextPage": "pageInfo.hasNextPage",
+          "items": "edges.node",
+          "pageSize": "first"
         }
       }
     },

--- a/packages/railway/patches/railway/disableServiceCdn.json
+++ b/packages/railway/patches/railway/disableServiceCdn.json
@@ -1,0 +1,10 @@
+{
+  "description": "disableServiceCdn returns Boolean! so the baked document must not select subfields. Observed live: every call failed with `Field \"disableServiceCdn\" must not have a selection since type \"Boolean!\" has no subfields.`",
+  "patches": [
+    {
+      "op": "replace",
+      "path": "/shapes/com.railway.api#DisableServiceCdnRequest/traits/com.railway.graphql#operation/query",
+      "value": "mutation disableServiceCdn($input: DisableServiceCdnInput!) {\n  disableServiceCdn(input: $input)\n}"
+    }
+  ]
+}

--- a/packages/railway/patches/railway/listEnvironmentServiceInstances.json
+++ b/packages/railway/patches/railway/listEnvironmentServiceInstances.json
@@ -1,0 +1,164 @@
+{
+  "description": "Expose the paginated environment.serviceInstances connection for service discovery without querying every service/environment combination.",
+  "patches": [
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListEnvironmentServiceInstancesRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "environmentId": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "after": { "target": "smithy.api#String" },
+          "first": { "target": "smithy.api#Integer" }
+        },
+        "traits": {
+          "smithy.api#input": {},
+          "smithy.api#http": {
+            "method": "POST",
+            "uri": "/graphql/v2",
+            "code": 200
+          },
+          "com.railway.graphql#operation": {
+            "query": "query listEnvironmentServiceInstances($environmentId: String!, $after: String, $first: Int) { environment(id: $environmentId) { serviceInstances(after: $after, first: $first) { edges { cursor node { id serviceId environmentId deletedAt source { image } } } pageInfo { endCursor hasNextPage hasPreviousPage startCursor } } } }",
+            "operationName": "listEnvironmentServiceInstances",
+            "type": "query"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListedServiceInstanceSource",
+      "value": {
+        "type": "structure",
+        "members": {
+          "image": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "com.railway.graphql#nullable": {}
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListedServiceInstance",
+      "value": {
+        "type": "structure",
+        "members": {
+          "id": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "serviceId": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "environmentId": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "deletedAt": {
+            "target": "smithy.api#String",
+            "traits": {
+              "smithy.api#required": {},
+              "com.railway.graphql#nullable": {}
+            }
+          },
+          "source": {
+            "target": "com.railway.api#ListedServiceInstanceSource",
+            "traits": {
+              "smithy.api#required": {},
+              "com.railway.graphql#nullable": {}
+            }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListedServiceInstanceEdge",
+      "value": {
+        "type": "structure",
+        "members": {
+          "cursor": {
+            "target": "smithy.api#String",
+            "traits": { "smithy.api#required": {} }
+          },
+          "node": {
+            "target": "com.railway.api#ListedServiceInstance",
+            "traits": { "smithy.api#required": {} }
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListedServiceInstanceEdges",
+      "value": {
+        "type": "list",
+        "member": { "target": "com.railway.api#ListedServiceInstanceEdge" }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListEnvironmentServiceInstancesResponse",
+      "value": {
+        "type": "structure",
+        "members": {
+          "edges": {
+            "target": "com.railway.api#ListedServiceInstanceEdges",
+            "traits": { "smithy.api#required": {} }
+          },
+          "pageInfo": {
+            "target": "com.railway.api#EnvironmentsResponsePageInfo",
+            "traits": { "smithy.api#required": {} }
+          }
+        },
+        "traits": {
+          "smithy.api#output": {},
+          "com.railway.graphql#responsePath": "environment.serviceInstances"
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#ListEnvironmentServiceInstances",
+      "value": {
+        "type": "operation",
+        "input": {
+          "target": "com.railway.api#ListEnvironmentServiceInstancesRequest"
+        },
+        "output": {
+          "target": "com.railway.api#ListEnvironmentServiceInstancesResponse"
+        },
+        "traits": {
+          "smithy.api#http": {
+            "method": "POST",
+            "uri": "/graphql/v2",
+            "code": 200
+          },
+          "smithy.api#readonly": {},
+          "smithy.api#paginated": {
+            "mode": "relay",
+            "inputToken": "after",
+            "outputToken": "pageInfo.endCursor",
+            "hasNextPage": "pageInfo.hasNextPage",
+            "items": "edges.node",
+            "pageSize": "first"
+          }
+        }
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/com.railway.api#Railway/operations/-",
+      "value": { "target": "com.railway.api#ListEnvironmentServiceInstances" }
+    }
+  ]
+}

--- a/packages/railway/src/errors.ts
+++ b/packages/railway/src/errors.ts
@@ -30,14 +30,13 @@ export {
 } from "@distilled.cloud/core/errors";
 // `retryAfter` is a parsed Duration, not a number of seconds — same shape as
 // core's TooManyRequests, so throttling handling is uniform across SDKs.
-import { DurationSchema } from "@distilled.cloud/core/errors";
+import { DurationSchema, NotFound } from "@distilled.cloud/core/errors";
 import type {
   BadRequest,
   Conflict,
   DefaultErrors as CoreDefaultErrors,
   Forbidden,
   Locked,
-  NotFound,
   UnprocessableEntity,
 } from "@distilled.cloud/core/errors";
 
@@ -89,14 +88,6 @@ export class RailwayForbidden extends Schema.TaggedError<RailwayForbidden>()(
     message: Schema.String,
   },
 ).pipe(Category.withAuthError) {}
-
-/** The addressed resource does not exist (`NOT_FOUND`). */
-export class RailwayNotFound extends Schema.TaggedError<RailwayNotFound>()(
-  "RailwayNotFound",
-  {
-    message: Schema.String,
-  },
-).pipe(Category.withNotFoundError) {}
 
 /**
  * The variables failed validation before the resolver ran
@@ -195,13 +186,13 @@ export const RAILWAY_ERROR_CODE_MAP: Record<string, any> = {
   UNAUTHENTICATED: RailwayUnauthenticated,
   UNAUTHORIZED: RailwayUnauthenticated,
   FORBIDDEN: RailwayForbidden,
-  NOT_FOUND: RailwayNotFound,
-  PROJECT_NOT_FOUND: RailwayNotFound,
-  SERVICE_NOT_FOUND: RailwayNotFound,
-  ENVIRONMENT_NOT_FOUND: RailwayNotFound,
-  VOLUME_NOT_FOUND: RailwayNotFound,
-  BUCKET_NOT_FOUND: RailwayNotFound,
-  RESOURCE_NOT_FOUND: RailwayNotFound,
+  NOT_FOUND: NotFound,
+  PROJECT_NOT_FOUND: NotFound,
+  SERVICE_NOT_FOUND: NotFound,
+  ENVIRONMENT_NOT_FOUND: NotFound,
+  VOLUME_NOT_FOUND: NotFound,
+  BUCKET_NOT_FOUND: NotFound,
+  RESOURCE_NOT_FOUND: NotFound,
   BAD_USER_INPUT: RailwayValidationError,
   GRAPHQL_VALIDATION_FAILED: RailwayValidationError,
   BAD_REQUEST: RailwayValidationError,
@@ -266,32 +257,32 @@ export const RAILWAY_ERROR_MATCHERS: ReadonlyArray<{
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "Project not found",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "ServiceInstance not found",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "BucketInstance not found",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "VolumeInstance not found",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "Source canvas view not found",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "Login session",
-    error: RailwayNotFound,
+    error: NotFound,
   },
   {
     code: "INTERNAL_SERVER_ERROR",
@@ -311,11 +302,16 @@ export const RAILWAY_ERROR_MATCHERS: ReadonlyArray<{
   },
 ];
 
-/** Union of the Railway-specific tagged error classes above. */
+/**
+ * Union of the Railway-specific tagged error classes above.
+ *
+ * Not-found is deliberately NOT Railway-specific: all `*_NOT_FOUND`
+ * GraphQL codes map to core's wide `NotFound`, the same class the HTTP
+ * 404 fallback constructs, so consumers catch exactly one tag.
+ */
 export type RailwayTypedErrors =
   | RailwayUnauthenticated
   | RailwayForbidden
-  | RailwayNotFound
   | RailwayValidationError
   | RailwayRateLimited
   | RailwayServiceDomainCreateFailed

--- a/packages/railway/src/errors.ts
+++ b/packages/railway/src/errors.ts
@@ -166,14 +166,15 @@ export class RailwayAlreadyExists extends Schema.TaggedError<RailwayAlreadyExist
 
 /**
  * Railway's gateway failed to process the request
- * (`Problem processing request` with a `traceId` and **no**
- * `extensions.code`). Observed transiently on `deployments` for a
- * freshly-created service before the instance fans out. Retryable.
+ * (`Problem processing request`, sometimes with no `extensions.code`).
+ * Preserve the response and trace ID for Railway support diagnostics.
  */
 export class RailwayRequestProcessingFailed extends Schema.TaggedError<RailwayRequestProcessingFailed>()(
   "RailwayRequestProcessingFailed",
   {
     message: Schema.String,
+    traceId: Schema.optional(Schema.String),
+    body: Schema.optional(Schema.Unknown),
   },
 ).pipe(Category.withServerError, Category.withRetryable()) {}
 
@@ -282,6 +283,11 @@ export const RAILWAY_ERROR_MATCHERS: ReadonlyArray<{
   {
     code: "INTERNAL_SERVER_ERROR",
     messageIncludes: "Login session",
+    error: NotFound,
+  },
+  {
+    code: "INTERNAL_SERVER_ERROR",
+    messageIncludes: "Deployment not found",
     error: NotFound,
   },
   {

--- a/packages/railway/src/errors.ts
+++ b/packages/railway/src/errors.ts
@@ -160,6 +160,33 @@ export class RailwayInternalError extends Schema.TaggedError<RailwayInternalErro
 ).pipe(Category.withServerError) {}
 
 /**
+ * A resource with the requested name already exists
+ * (`INTERNAL_SERVER_ERROR` + `... already exists in this project`).
+ * Railway reports create-name collisions through the internal-error code,
+ * e.g. `A service named "x" already exists in this project`. Reconcilers
+ * catch this as the create race and re-read the existing resource.
+ */
+export class RailwayAlreadyExists extends Schema.TaggedError<RailwayAlreadyExists>()(
+  "RailwayAlreadyExists",
+  {
+    message: Schema.String,
+  },
+).pipe(Category.withAlreadyExistsError) {}
+
+/**
+ * Railway's gateway failed to process the request
+ * (`Problem processing request` with a `traceId` and **no**
+ * `extensions.code`). Observed transiently on `deployments` for a
+ * freshly-created service before the instance fans out. Retryable.
+ */
+export class RailwayRequestProcessingFailed extends Schema.TaggedError<RailwayRequestProcessingFailed>()(
+  "RailwayRequestProcessingFailed",
+  {
+    message: Schema.String,
+  },
+).pipe(Category.withServerError, Category.withRetryable()) {}
+
+/**
  * Map from Railway GraphQL `extensions.code` → typed error class. Consulted
  * by the protocol's error matcher before any HTTP-status fallback.
  */
@@ -266,6 +293,22 @@ export const RAILWAY_ERROR_MATCHERS: ReadonlyArray<{
     messageIncludes: "Login session",
     error: RailwayNotFound,
   },
+  {
+    code: "INTERNAL_SERVER_ERROR",
+    messageIncludes: "already exists",
+    error: RailwayAlreadyExists,
+  },
+  {
+    code: "INTERNAL_SERVER_ERROR",
+    messageIncludes: "already in use",
+    error: RailwayAlreadyExists,
+  },
+  // No extensions.code at all — the gateway's generic processing failure
+  // (`{ message: "Problem processing request", traceId }`).
+  {
+    messageIncludes: "Problem processing request",
+    error: RailwayRequestProcessingFailed,
+  },
 ];
 
 /** Union of the Railway-specific tagged error classes above. */
@@ -277,7 +320,9 @@ export type RailwayTypedErrors =
   | RailwayRateLimited
   | RailwayServiceDomainCreateFailed
   | RailwayPlanLimitExceeded
-  | RailwayInternalError;
+  | RailwayInternalError
+  | RailwayAlreadyExists
+  | RailwayRequestProcessingFailed;
 
 /**
  * Errors any Railway operation may surface beyond the core default classes:

--- a/packages/railway/src/protocol.test.ts
+++ b/packages/railway/src/protocol.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { CredentialsFromToken } from "./credentials.ts";
+import {
+  cancelDeployment,
+  listEnvironmentServiceInstances,
+} from "./services/railway.ts";
+import * as Stream from "effect/Stream";
+import * as Retry from "./retry.ts";
+
+test("environment instance discovery follows Relay pages and unwraps the nested connection", () => {
+  let calls = 0;
+  return listEnvironmentServiceInstances
+    .items({ environmentId: "env", first: 1 })
+    .pipe(
+      Stream.runCollect,
+      Effect.provide(CredentialsFromToken({ token: "test-token" })),
+      Effect.provideService(
+        HttpClient.HttpClient,
+        HttpClient.make((request) =>
+          Effect.sync(() => {
+            calls++;
+            return HttpClientResponse.fromWeb(
+              request,
+              Response.json({
+                data: {
+                  environment: {
+                    serviceInstances: {
+                      edges: [
+                        {
+                          cursor: `cursor-${calls}`,
+                          node: {
+                            id: `instance-${calls}`,
+                            serviceId: `service-${calls}`,
+                            environmentId: "env",
+                            deletedAt: null,
+                            source: { image: "redis" },
+                          },
+                        },
+                      ],
+                      pageInfo: {
+                        startCursor: `cursor-${calls}`,
+                        endCursor: `cursor-${calls}`,
+                        hasPreviousPage: calls > 1,
+                        hasNextPage: calls < 2,
+                      },
+                    },
+                  },
+                },
+              }),
+            );
+          }),
+        ),
+      ),
+      Retry.none,
+      Effect.tap((rows) =>
+        Effect.sync(() => {
+          expect(calls).toBe(2);
+          expect(rows.map((row) => row.serviceId)).toEqual([
+            "service-1",
+            "service-2",
+          ]);
+        }),
+      ),
+      Effect.runPromise,
+    );
+});
+
+const responseError = (body: unknown, status = 200, invalidJson = false) =>
+  cancelDeployment({ id: "missing-deployment" }).pipe(
+    Effect.provide(CredentialsFromToken({ token: "test-token" })),
+    Effect.provideService(
+      HttpClient.HttpClient,
+      HttpClient.make((request) =>
+        Effect.sync(() =>
+          HttpClientResponse.fromWeb(
+            request,
+            invalidJson
+              ? new Response("invalid JSON", { status })
+              : Response.json(body, { status }),
+          ),
+        ),
+      ),
+    ),
+    Retry.none,
+    Effect.result,
+    Effect.runPromise,
+  );
+
+for (const code of [
+  "NOT_FOUND",
+  "PROJECT_NOT_FOUND",
+  "SERVICE_NOT_FOUND",
+  "ENVIRONMENT_NOT_FOUND",
+  "VOLUME_NOT_FOUND",
+  "BUCKET_NOT_FOUND",
+  "RESOURCE_NOT_FOUND",
+]) {
+  test(`${code} uses core NotFound`, () =>
+    responseError({
+      errors: [{ message: "Resource missing", extensions: { code } }],
+    }).then((result) => {
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result))
+        expect(result.failure._tag).toBe("NotFound");
+    }));
+}
+
+test("HTTP 404 uses the same NotFound as GraphQL", () =>
+  responseError({ message: "Resource missing" }, 404).then((result) => {
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result)) expect(result.failure._tag).toBe("NotFound");
+  }));
+
+for (const [message, tag] of [
+  ["Deployment not found", "NotFound"],
+  [
+    'A service named "api" already exists in this project',
+    "RailwayAlreadyExists",
+  ],
+  ["Not Authorized", "RailwayForbidden"],
+  ["Unexpected resolver failure", "RailwayInternalError"],
+] as const) {
+  test(`classifies observed internal error: ${message}`, () =>
+    responseError({
+      errors: [{ message, extensions: { code: "INTERNAL_SERVER_ERROR" } }],
+    }).then((result) => {
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) expect(result.failure._tag).toBe(tag);
+    }));
+}
+
+test("processing failures retain Railway's trace ID and response", () => {
+  const body = {
+    data: null,
+    errors: [
+      {
+        message: "Problem processing request",
+        traceId: "12589155908218604820",
+      },
+    ],
+  };
+  return responseError(body).then((result) => {
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result)) {
+      expect(result.failure._tag).toBe("RailwayRequestProcessingFailed");
+      if (result.failure._tag === "RailwayRequestProcessingFailed") {
+        expect(result.failure.traceId).toBe(body.errors[0]!.traceId);
+        expect(result.failure.body).toEqual(body);
+      }
+    }
+  });
+});
+
+test("invalid JSON responses remain parse failures", () =>
+  responseError(undefined, 200, true).then((result) => {
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result))
+      expect(result.failure._tag).toBe("RailwayParseError");
+  }));
+
+test("unmatched errors remain failures with their original response", () => {
+  const body = {
+    errors: [
+      { message: "New upstream failure", extensions: { code: "NEW_ERROR" } },
+    ],
+  };
+  return responseError(body).then((result) => {
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result)) {
+      expect(result.failure._tag).toBe("UnknownRailwayError");
+      if (result.failure._tag === "UnknownRailwayError")
+        expect(result.failure.body).toEqual(body);
+    }
+  });
+});

--- a/packages/railway/src/protocol.ts
+++ b/packages/railway/src/protocol.ts
@@ -45,6 +45,7 @@ import {
   RAILWAY_ERROR_MATCHERS,
   RailwayParseError,
   RailwayRateLimited,
+  RailwayRequestProcessingFailed,
   UnknownRailwayError,
 } from "./errors.ts";
 import {
@@ -84,6 +85,7 @@ const fail = (e: unknown): Effect.Effect<never> =>
 /** Single GraphQL error in the `errors[]` array of a response envelope. */
 const GraphQLError = Schema.Struct({
   message: Schema.String,
+  traceId: Schema.optional(Schema.String),
   path: Schema.optional(Schema.Array(Schema.Unknown)),
   locations: Schema.optional(Schema.Array(Schema.Unknown)),
   extensions: Schema.optional(
@@ -158,6 +160,15 @@ const matchError = (
       return true;
     });
     if (matcher) {
+      if (matcher.error === RailwayRequestProcessingFailed) {
+        return fail(
+          new RailwayRequestProcessingFailed({
+            message,
+            traceId: first.traceId,
+            body: errorBody,
+          }),
+        );
+      }
       if (matcher.error === RailwayRateLimited) {
         const retryAfter = retryAfterForRateLimit(message, headers);
         return fail(new RailwayRateLimited({ message, retryAfter }));

--- a/packages/railway/src/services/railway.ts
+++ b/packages/railway/src/services/railway.ts
@@ -12694,6 +12694,93 @@ export const LeaveWorkspaceResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "LeaveWorkspaceResponse",
 }) as any as S.Schema<LeaveWorkspaceResponse>;
 
+export interface ListEnvironmentServiceInstancesRequest {
+  environmentId: string;
+  after?: string;
+  first?: number;
+}
+export const ListEnvironmentServiceInstancesRequest = /*@__PURE__*/ S.suspend(
+  () =>
+    S.Struct({
+      environmentId: S.String,
+      after: S.optional(S.String),
+      first: S.optional(S.Number),
+    })
+      .pipe(T.Http({ method: "POST", uri: "/graphql/v2", code: 200 }))
+      .pipe(
+        T.GraphQLOp({
+          query:
+            "query listEnvironmentServiceInstances($environmentId: String!, $after: String, $first: Int) { environment(id: $environmentId) { serviceInstances(after: $after, first: $first) { edges { cursor node { id serviceId environmentId deletedAt source { image } } } pageInfo { endCursor hasNextPage hasPreviousPage startCursor } } } }",
+          operationName: "listEnvironmentServiceInstances",
+          type: "query",
+        }),
+      ),
+).annotate({
+  identifier: "ListEnvironmentServiceInstancesRequest",
+}) as any as S.Schema<ListEnvironmentServiceInstancesRequest>;
+
+export interface ListedServiceInstanceSource {
+  image: string | null;
+}
+export const ListedServiceInstanceSource = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    image: S.NullOr(S.String),
+  }),
+).annotate({
+  identifier: "ListedServiceInstanceSource",
+}) as any as S.Schema<ListedServiceInstanceSource>;
+
+export interface ListedServiceInstance {
+  id: string;
+  serviceId: string;
+  environmentId: string;
+  deletedAt: string | null;
+  source: ListedServiceInstanceSource | null;
+}
+export const ListedServiceInstance = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    id: S.String,
+    serviceId: S.String,
+    environmentId: S.String,
+    deletedAt: S.NullOr(S.String),
+    source: S.NullOr(ListedServiceInstanceSource),
+  }),
+).annotate({
+  identifier: "ListedServiceInstance",
+}) as any as S.Schema<ListedServiceInstance>;
+
+export interface ListedServiceInstanceEdge {
+  cursor: string;
+  node: ListedServiceInstance;
+}
+export const ListedServiceInstanceEdge = /*@__PURE__*/ S.suspend(() =>
+  S.Struct({
+    cursor: S.String,
+    node: ListedServiceInstance,
+  }),
+).annotate({
+  identifier: "ListedServiceInstanceEdge",
+}) as any as S.Schema<ListedServiceInstanceEdge>;
+
+export type ListedServiceInstanceEdges = Array<ListedServiceInstanceEdge>;
+export const ListedServiceInstanceEdges = /*@__PURE__*/ S.Array(
+  ListedServiceInstanceEdge,
+) as any as S.Schema<ListedServiceInstanceEdges>;
+
+export interface ListEnvironmentServiceInstancesResponse {
+  edges: ListedServiceInstanceEdges;
+  pageInfo: ApiTokensResponsePageInfo;
+}
+export const ListEnvironmentServiceInstancesResponse = /*@__PURE__*/ S.suspend(
+  () =>
+    S.Struct({
+      edges: ListedServiceInstanceEdges,
+      pageInfo: ApiTokensResponsePageInfo,
+    }).pipe(T.ResponsePath("environment.serviceInstances")),
+).annotate({
+  identifier: "ListEnvironmentServiceInstancesResponse",
+}) as any as S.Schema<ListEnvironmentServiceInstancesResponse>;
+
 export interface ListVolumeInstanceBackupRequest {
   /** The id of the volume instance to list the backups of */
   volumeInstanceId: string;
@@ -30093,6 +30180,32 @@ export const leaveWorkspace: API.OperationMethod<
   protocol: RailwayGraphqlProtocol,
   retry: Retry.Retry,
 }));
+
+export type ListEnvironmentServiceInstancesError = RailwayOpError;
+export const listEnvironmentServiceInstances: API.PaginatedOperationMethod<
+  ListEnvironmentServiceInstancesRequest,
+  ListEnvironmentServiceInstancesResponse,
+  ListEnvironmentServiceInstancesError,
+  RailwayOpContext,
+  ListedServiceInstance
+> = /*@__PURE__*/ API.makePaginated(
+  () => ({
+    input: ListEnvironmentServiceInstancesRequest,
+    output: ListEnvironmentServiceInstancesResponse,
+    errors: [UnknownRailwayError, RailwayParseError],
+    protocol: RailwayGraphqlProtocol,
+    retry: Retry.Retry,
+    pagination: {
+      mode: "relay",
+      inputToken: "after",
+      outputToken: "pageInfo.endCursor",
+      hasNextPage: "pageInfo.hasNextPage",
+      items: "edges.node",
+      pageSize: "first",
+    } as const,
+  }),
+  paginateRelay,
+) as any;
 
 export type ListVolumeInstanceBackupError = RailwayOpError;
 /** List backups of a volume instance */

--- a/packages/railway/src/services/railway.ts
+++ b/packages/railway/src/services/railway.ts
@@ -8630,7 +8630,7 @@ export const DisableServiceCdnRequest = /*@__PURE__*/ S.suspend(() =>
     .pipe(
       T.GraphQLOp({
         query:
-          "mutation disableServiceCdn($input: DisableServiceCdnInput!) {\n  disableServiceCdn(input: $input) {\n    __typename\n  }\n}",
+          "mutation disableServiceCdn($input: DisableServiceCdnInput!) {\n  disableServiceCdn(input: $input)\n}",
         operationName: "disableServiceCdn",
         type: "mutation",
       }),


### PR DESCRIPTION
Type Railway errors observed by Alchemy's live lifecycle suites and add paginated environment service-instance discovery.

- Classify duplicate-name failures as `RailwayAlreadyExists`.
- Map not-found responses, including `Deployment not found`, to the shared `NotFound` error instead of a second Railway-specific tag.
- Preserve the trace ID and response body on `RailwayRequestProcessingFailed`.
- Correct the CDN-disable GraphQL selection.
- Add `listEnvironmentServiceInstances` with Relay pagination.

```ts
railway.listEnvironmentServiceInstances.items({
  environmentId,
  first: 50,
})
```

Companion Alchemy changes: https://github.com/alchemy-run/alchemy/pull/1603.
