### PR TITLE
fix(core): preserve nullable OpenAPI collection values

### DIFF
--- a/packages/azure/.generated-specs/apicenter.json
+++ b/packages/azure/.generated-specs/apicenter.json
@@ -4359,7 +4359,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.apicenter#UserAssignedIdentity"
+        "target": "com.azure.apicenter#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4548,7 +4551,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.apicenter#UserAssignedIdentityInput"
+        "target": "com.azure.apicenter#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/app.json
+++ b/packages/azure/.generated-specs/app.json
@@ -180,7 +180,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1236,7 +1239,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentityInput"
+        "target": "com.azure.app#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -28949,7 +28955,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -29492,7 +29501,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -30419,7 +30431,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -30583,7 +30598,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentityInput"
+        "target": "com.azure.app#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -30715,7 +30733,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -30816,7 +30837,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentityInput"
+        "target": "com.azure.app#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -31019,7 +31043,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -31213,7 +31240,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -32088,7 +32118,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -32581,7 +32614,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentityInput"
+        "target": "com.azure.app#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -32713,7 +32749,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -32814,7 +32853,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentityInput"
+        "target": "com.azure.app#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -33046,7 +33088,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -33240,7 +33285,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.app#UserAssignedIdentity"
+        "target": "com.azure.app#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/applicationinsights.json
+++ b/packages/azure/.generated-specs/applicationinsights.json
@@ -155,7 +155,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.applicationinsights#UserAssignedIdentity"
+        "target": "com.azure.applicationinsights#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1112,7 +1115,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.applicationinsights#UserAssignedIdentityInput"
+        "target": "com.azure.applicationinsights#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/azuredatatransfer.json
+++ b/packages/azure/.generated-specs/azuredatatransfer.json
@@ -129,7 +129,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.azuredatatransfer#UserAssignedIdentity"
+        "target": "com.azure.azuredatatransfer#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2735,7 +2738,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.azuredatatransfer#UserAssignedIdentityInput"
+        "target": "com.azure.azuredatatransfer#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/azurefleet.json
+++ b/packages/azure/.generated-specs/azurefleet.json
@@ -498,7 +498,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.azurefleet#UserAssignedIdentity"
+        "target": "com.azure.azurefleet#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4964,7 +4967,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.azurefleet#UserAssignedIdentityInput"
+        "target": "com.azure.azurefleet#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/billingbenefits.json
+++ b/packages/azure/.generated-specs/billingbenefits.json
@@ -274,7 +274,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1818,7 +1821,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2018,7 +2024,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2263,7 +2272,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2558,7 +2570,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2683,7 +2698,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentityInput"
+        "target": "com.azure.billingbenefits#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2984,7 +3002,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3208,7 +3229,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3445,7 +3469,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3795,7 +3822,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3920,7 +3950,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentityInput"
+        "target": "com.azure.billingbenefits#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4132,7 +4165,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4355,7 +4391,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6067,7 +6106,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6381,7 +6423,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6514,7 +6559,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentityInput"
+        "target": "com.azure.billingbenefits#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6702,7 +6750,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6934,7 +6985,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -7185,7 +7239,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -7795,7 +7852,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -8048,7 +8108,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -8173,7 +8236,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentityInput"
+        "target": "com.azure.billingbenefits#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -8436,7 +8502,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -8660,7 +8729,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -9680,7 +9752,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10018,7 +10093,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10353,7 +10431,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10478,7 +10559,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentityInput"
+        "target": "com.azure.billingbenefits#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10709,7 +10793,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10933,7 +11020,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.billingbenefits#UserAssignedIdentity"
+        "target": "com.azure.billingbenefits#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/cdn.json
+++ b/packages/azure/.generated-specs/cdn.json
@@ -477,7 +477,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentity"
+        "target": "com.azure.cdn#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -16333,7 +16336,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentity"
+        "target": "com.azure.cdn#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -16447,7 +16453,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentityInput"
+        "target": "com.azure.cdn#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -16599,7 +16608,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentity"
+        "target": "com.azure.cdn#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -16707,7 +16719,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentityInput"
+        "target": "com.azure.cdn#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -16872,7 +16887,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentity"
+        "target": "com.azure.cdn#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -17079,7 +17097,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.cdn#UserAssignedIdentity"
+        "target": "com.azure.cdn#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/chaos.json
+++ b/packages/azure/.generated-specs/chaos.json
@@ -1261,7 +1261,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.chaos#UserAssignedIdentity"
+        "target": "com.azure.chaos#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1398,7 +1401,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.chaos#UserAssignedIdentityInput"
+        "target": "com.azure.chaos#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/communication.json
+++ b/packages/azure/.generated-specs/communication.json
@@ -4267,7 +4267,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentity"
+        "target": "com.azure.communication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4573,7 +4576,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentityInput"
+        "target": "com.azure.communication#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4764,7 +4770,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentity"
+        "target": "com.azure.communication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4865,7 +4874,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentityInput"
+        "target": "com.azure.communication#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5056,7 +5068,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentity"
+        "target": "com.azure.communication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5250,7 +5265,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.communication#UserAssignedIdentity"
+        "target": "com.azure.communication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/databricks.json
+++ b/packages/azure/.generated-specs/databricks.json
@@ -3493,7 +3493,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.databricks#UserAssignedIdentity"
+        "target": "com.azure.databricks#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3657,7 +3660,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.databricks#UserAssignedIdentityInput"
+        "target": "com.azure.databricks#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/datamigration.json
+++ b/packages/azure/.generated-specs/datamigration.json
@@ -9268,7 +9268,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.datamigration#UserAssignedIdentity"
+        "target": "com.azure.datamigration#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10016,7 +10019,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.datamigration#UserAssignedIdentityInput"
+        "target": "com.azure.datamigration#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/devopsinfrastructure.json
+++ b/packages/azure/.generated-specs/devopsinfrastructure.json
@@ -580,7 +580,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -998,7 +1001,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentityInput"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1125,7 +1131,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1226,7 +1235,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentityInput"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1358,7 +1370,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1552,7 +1567,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity"
+        "target": "com.azure.devopsinfrastructure#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/hardwaresecuritymodules.json
+++ b/packages/azure/.generated-specs/hardwaresecuritymodules.json
@@ -3028,7 +3028,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3390,7 +3393,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentityInput"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3535,7 +3541,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3642,7 +3651,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentityInput"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3800,7 +3812,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4000,7 +4015,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity"
+        "target": "com.azure.hardwaresecuritymodules#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/healthdataaiservices.json
+++ b/packages/azure/.generated-specs/healthdataaiservices.json
@@ -1081,7 +1081,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.healthdataaiservices#UserAssignedIdentity"
+        "target": "com.azure.healthdataaiservices#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1686,7 +1689,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.healthdataaiservices#UserAssignedIdentityInput"
+        "target": "com.azure.healthdataaiservices#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/hybridcompute.json
+++ b/packages/azure/.generated-specs/hybridcompute.json
@@ -7341,7 +7341,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentity"
+        "target": "com.azure.hybridcompute#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -9255,7 +9258,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentityInput"
+        "target": "com.azure.hybridcompute#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -9406,7 +9412,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentity"
+        "target": "com.azure.hybridcompute#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -9529,7 +9538,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentityInput"
+        "target": "com.azure.hybridcompute#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -9971,7 +9983,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentity"
+        "target": "com.azure.hybridcompute#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -10205,7 +10220,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.hybridcompute#UserAssignedIdentity"
+        "target": "com.azure.hybridcompute#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/iotoperations.json
+++ b/packages/azure/.generated-specs/iotoperations.json
@@ -11134,7 +11134,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.iotoperations#UserAssignedIdentity"
+        "target": "com.azure.iotoperations#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -11475,7 +11478,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.iotoperations#UserAssignedIdentityInput"
+        "target": "com.azure.iotoperations#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/keyvault.json
+++ b/packages/azure/.generated-specs/keyvault.json
@@ -5149,7 +5149,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.keyvault#UserAssignedIdentity"
+        "target": "com.azure.keyvault#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5848,7 +5851,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.keyvault#UserAssignedIdentityInput"
+        "target": "com.azure.keyvault#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/kubernetesconfiguration.json
+++ b/packages/azure/.generated-specs/kubernetesconfiguration.json
@@ -3920,7 +3920,10 @@
     "com.azure.kubernetesconfiguration#FluxConfigurationPropertiesStatusesList": {
       "type": "list",
       "member": {
-        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition"
+        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration."
@@ -4107,7 +4110,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition"
+        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
@@ -4211,7 +4217,10 @@
     "com.azure.kubernetesconfiguration#PostBuildDefinitionSubstituteFromList": {
       "type": "list",
       "member": {
-        "target": "com.azure.kubernetesconfiguration#SubstituteFromDefinition"
+        "target": "com.azure.kubernetesconfiguration#SubstituteFromDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization."
@@ -5078,7 +5087,10 @@
     "com.azure.kubernetesconfiguration#UpdateFluxConfigurationResponsePropertiesStatusesList": {
       "type": "list",
       "member": {
-        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition"
+        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration."
@@ -5102,7 +5114,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition"
+        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
@@ -5245,7 +5260,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationPatchDefinition"
+        "target": "com.azure.kubernetesconfiguration#KustomizationPatchDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
@@ -5936,7 +5954,10 @@
     "com.azure.kubernetesconfiguration#FluxConfigurationsCreateOrUpdateResponsePropertiesStatusesList": {
       "type": "list",
       "member": {
-        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition"
+        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration."
@@ -5960,7 +5981,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition"
+        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
@@ -6127,7 +6151,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationDefinitionInput"
+        "target": "com.azure.kubernetesconfiguration#KustomizationDefinitionInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."
@@ -6556,7 +6583,10 @@
     "com.azure.kubernetesconfiguration#GetFluxConfigurationResponsePropertiesStatusesList": {
       "type": "list",
       "member": {
-        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition"
+        "target": "com.azure.kubernetesconfiguration#ObjectStatusDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration."
@@ -6580,7 +6610,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition"
+        "target": "com.azure.kubernetesconfiguration#KustomizationDefinition",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster."

--- a/packages/azure/.generated-specs/liftrweightsandbiases.json
+++ b/packages/azure/.generated-specs/liftrweightsandbiases.json
@@ -180,7 +180,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.liftrweightsandbiases#UserAssignedIdentity"
+        "target": "com.azure.liftrweightsandbiases#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1053,7 +1056,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.liftrweightsandbiases#UserAssignedIdentityInput"
+        "target": "com.azure.liftrweightsandbiases#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/loadtestservice.json
+++ b/packages/azure/.generated-specs/loadtestservice.json
@@ -340,7 +340,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.loadtestservice#UserAssignedIdentity"
+        "target": "com.azure.loadtestservice#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -748,7 +751,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.loadtestservice#UserAssignedIdentityInput"
+        "target": "com.azure.loadtestservice#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/machinelearningservices.json
+++ b/packages/azure/.generated-specs/machinelearningservices.json
@@ -638,7 +638,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Specifies any required headers to target this serverless endpoint."
@@ -1081,7 +1084,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."
@@ -2210,7 +2216,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -2222,7 +2231,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -5841,7 +5853,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.machinelearningservices#Collection"
+        "target": "com.azure.machinelearningservices#Collection",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "[Required] The collection configuration. Each collection has it own configuration to collect model data and the name of collection can be arbitrary string.\nModel data collector can be used for either payload logging or custom logging or both of them. Collection request and response are reserved for payload logging, others are for custom logging."
@@ -5905,7 +5920,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -5917,7 +5935,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Environment variables configuration for the deployment."
@@ -6023,7 +6044,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."
@@ -7178,7 +7202,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -7280,7 +7307,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."
@@ -7702,7 +7732,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -8646,7 +8679,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.machinelearningservices#FlavorData"
+        "target": "com.azure.machinelearningservices#FlavorData",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Mapping of model flavors to their properties."
@@ -8671,7 +8707,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Model flavor-specific data."
@@ -8683,7 +8722,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -8695,7 +8737,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -9260,7 +9305,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -9272,7 +9320,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -9364,7 +9415,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -9376,7 +9430,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -10882,7 +10939,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.machinelearningservices#JobService"
+        "target": "com.azure.machinelearningservices#JobService",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of JobEndpoints.\nFor local jobs, a job endpoint will have an endpoint value of FileStreamObject."
@@ -10951,7 +11011,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Additional properties to set on the endpoint."
@@ -11021,7 +11084,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.machinelearningservices#Webhook"
+        "target": "com.azure.machinelearningservices#Webhook",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Send webhook callback to a service. Key is a user-provided name for the webhook."
@@ -11192,7 +11258,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -11204,7 +11273,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -11353,7 +11425,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.machinelearningservices#JobServiceInput"
+        "target": "com.azure.machinelearningservices#JobServiceInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of JobEndpoints.\nFor local jobs, a job endpoint will have an endpoint value of FileStreamObject."
@@ -11408,7 +11483,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Additional properties to set on the endpoint."
@@ -11420,7 +11498,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -11432,7 +11513,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -11993,7 +12077,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -12005,7 +12092,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -12565,7 +12655,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -12577,7 +12670,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -12671,7 +12767,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -12683,7 +12782,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -13142,7 +13244,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -13154,7 +13259,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -13570,7 +13678,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Specifies the tags"
@@ -13582,7 +13693,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Specifies the spark compute settings"
@@ -13609,7 +13723,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Specifies the properties"
@@ -13969,7 +14086,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Specifies the spark compute settings"
@@ -14202,7 +14322,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -14214,7 +14337,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -14774,7 +14900,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -14786,7 +14915,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -14880,7 +15012,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -14892,7 +15027,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -15743,7 +15881,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -15755,7 +15896,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -16280,7 +16424,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -16292,7 +16439,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -16386,7 +16536,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -16398,7 +16551,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -17438,7 +17594,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -17450,7 +17609,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -17559,7 +17721,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -17571,7 +17736,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -18151,7 +18319,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -18163,7 +18334,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -18696,7 +18870,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -18708,7 +18885,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -18809,7 +18989,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -18821,7 +19004,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -22890,7 +23076,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -22902,7 +23091,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -23427,7 +23619,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -23439,7 +23634,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -23533,7 +23731,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -23545,7 +23746,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -24280,7 +24484,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -24292,7 +24499,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -24800,7 +25010,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -24812,7 +25025,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -24906,7 +25122,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -24918,7 +25137,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -25472,7 +25694,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -25484,7 +25709,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -25677,7 +25905,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Tag dictionary. Tags can be added, removed, and updated."
@@ -25689,7 +25920,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The asset property dictionary."
@@ -26248,7 +26482,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#Document"
+        "target": "smithy.api#Document",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Additional properties bag."
@@ -26382,7 +26619,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -26394,7 +26634,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Environment variables configuration for the deployment."
@@ -26478,7 +26721,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."
@@ -27599,7 +27845,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -27675,7 +27924,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."
@@ -28033,7 +28285,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Property dictionary. Properties can be added, but not removed or altered."
@@ -35796,7 +36051,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Resource tags."

--- a/packages/azure/.generated-specs/managednetworkfabric.json
+++ b/packages/azure/.generated-specs/managednetworkfabric.json
@@ -2730,7 +2730,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.managednetworkfabric#UserAssignedIdentity"
+        "target": "com.azure.managednetworkfabric#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3472,7 +3475,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.managednetworkfabric#UserAssignedIdentityInput"
+        "target": "com.azure.managednetworkfabric#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/manufacturingplatform.json
+++ b/packages/azure/.generated-specs/manufacturingplatform.json
@@ -365,7 +365,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.manufacturingplatform#UserAssignedIdentity"
+        "target": "com.azure.manufacturingplatform#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1812,7 +1815,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.manufacturingplatform#UserAssignedIdentityInput"
+        "target": "com.azure.manufacturingplatform#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/mission.json
+++ b/packages/azure/.generated-specs/mission.json
@@ -2376,7 +2376,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.mission#UserAssignedIdentity"
+        "target": "com.azure.mission#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4383,7 +4386,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.mission#UserAssignedIdentityInput"
+        "target": "com.azure.mission#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/mongocluster.json
+++ b/packages/azure/.generated-specs/mongocluster.json
@@ -3173,7 +3173,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.mongocluster#UserAssignedIdentity"
+        "target": "com.azure.mongocluster#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3430,7 +3433,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.mongocluster#UserAssignedIdentityInput"
+        "target": "com.azure.mongocluster#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/monitoringservice.json
+++ b/packages/azure/.generated-specs/monitoringservice.json
@@ -2465,7 +2465,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentity"
+        "target": "com.azure.monitoringservice#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2968,7 +2971,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentityInput"
+        "target": "com.azure.monitoringservice#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3113,7 +3119,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentity"
+        "target": "com.azure.monitoringservice#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3214,7 +3223,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentityInput"
+        "target": "com.azure.monitoringservice#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3352,7 +3364,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentity"
+        "target": "com.azure.monitoringservice#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3552,7 +3567,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.monitoringservice#UserAssignedIdentity"
+        "target": "com.azure.monitoringservice#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/netapp.json
+++ b/packages/azure/.generated-specs/netapp.json
@@ -17039,7 +17039,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentity"
+        "target": "com.azure.netapp#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -17655,7 +17658,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentityInput"
+        "target": "com.azure.netapp#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -18093,7 +18099,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentity"
+        "target": "com.azure.netapp#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -18194,7 +18203,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentityInput"
+        "target": "com.azure.netapp#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -18332,7 +18344,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentity"
+        "target": "com.azure.netapp#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -18532,7 +18547,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.netapp#UserAssignedIdentity"
+        "target": "com.azure.netapp#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/networkcloud.json
+++ b/packages/azure/.generated-specs/networkcloud.json
@@ -2395,7 +2395,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3327,7 +3330,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3468,7 +3474,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -3577,7 +3586,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4010,7 +4022,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -4218,7 +4233,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -18242,7 +18260,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -20257,7 +20278,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -20397,7 +20421,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -20512,7 +20539,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -20913,7 +20943,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -21127,7 +21160,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -21452,7 +21488,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -21767,7 +21806,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -21900,7 +21942,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -22008,7 +22053,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentityInput"
+        "target": "com.azure.networkcloud#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -22201,7 +22249,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -22408,7 +22459,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.networkcloud#UserAssignedIdentity"
+        "target": "com.azure.networkcloud#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/operationalinsights.json
+++ b/packages/azure/.generated-specs/operationalinsights.json
@@ -11756,7 +11756,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.operationalinsights#UserAssignedIdentity"
+        "target": "com.azure.operationalinsights#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -12260,7 +12263,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.operationalinsights#UserAssignedIdentityInput"
+        "target": "com.azure.operationalinsights#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/orbitalplanetarycomputer.json
+++ b/packages/azure/.generated-specs/orbitalplanetarycomputer.json
@@ -180,7 +180,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.orbitalplanetarycomputer#UserAssignedIdentity"
+        "target": "com.azure.orbitalplanetarycomputer#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -810,7 +813,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.orbitalplanetarycomputer#UserAssignedIdentityInput"
+        "target": "com.azure.orbitalplanetarycomputer#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/recoveryservicesdatareplication.json
+++ b/packages/azure/.generated-specs/recoveryservicesdatareplication.json
@@ -5282,7 +5282,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity"
+        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5726,7 +5729,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity"
+        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5827,7 +5833,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentityInput"
+        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -5966,7 +5975,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity"
+        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6160,7 +6172,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity"
+        "target": "com.azure.recoveryservicesdatareplication#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/redhatopenshift.json
+++ b/packages/azure/.generated-specs/redhatopenshift.json
@@ -320,7 +320,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentity"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1191,7 +1194,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentityInput"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1593,7 +1599,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentity"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1694,7 +1703,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentityInput"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1826,7 +1838,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentity"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -2020,7 +2035,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.redhatopenshift#UserAssignedIdentity"
+        "target": "com.azure.redhatopenshift#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/storageactions.json
+++ b/packages/azure/.generated-specs/storageactions.json
@@ -708,7 +708,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.storageactions#UserAssignedIdentity"
+        "target": "com.azure.storageactions#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -1191,7 +1194,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.storageactions#UserAssignedIdentityInput"
+        "target": "com.azure.storageactions#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/.generated-specs/storagesync.json
+++ b/packages/azure/.generated-specs/storagesync.json
@@ -6176,7 +6176,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.storagesync#UserAssignedIdentity"
+        "target": "com.azure.storagesync#UserAssignedIdentity",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."
@@ -6462,7 +6465,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.azure.storagesync#UserAssignedIdentityInput"
+        "target": "com.azure.storagesync#UserAssignedIdentityInput",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests."

--- a/packages/azure/src/services/apicenter.ts
+++ b/packages/azure/src/services/apicenter.ts
@@ -1555,11 +1555,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2557,11 +2557,11 @@ export const UserAssignedIdentityInput = ServicePropertiesInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: ServicePropertiesInput | undefined;
+  [key: string]: ServicePropertiesInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  ServicePropertiesInput,
+  S.NullOr(ServicePropertiesInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/app.ts
+++ b/packages/azure/src/services/app.ts
@@ -441,12 +441,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const AgentsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<AgentsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -608,12 +608,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AgentsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AgentsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -940,11 +940,11 @@ export const AgentSpacePropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentSpacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const AgentSpacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<AgentSpacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1143,11 +1143,11 @@ export const AgentSpaceProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentSpacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const AgentSpacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AgentSpacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4362,11 +4362,11 @@ export const ContainerAppPropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4845,11 +4845,11 @@ export const ContainerAppProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7058,12 +7058,12 @@ export const GetAgentResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetAgentResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetAgentResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetAgentResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7210,12 +7210,12 @@ export const GetAgentSpaceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetAgentSpaceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetAgentSpaceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetAgentSpaceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -12428,11 +12428,11 @@ export const AgentTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AgentIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<AgentIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -12729,12 +12729,12 @@ export const AgentSpaceTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AgentSpaceIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AgentSpaceIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AgentSpaceIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -17107,12 +17107,12 @@ export const StartAgentResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type StartAgentResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const StartAgentResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<StartAgentResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -17393,12 +17393,12 @@ export const StopAgentResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type StopAgentResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const StopAgentResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<StopAgentResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -17679,12 +17679,12 @@ export const UpdateAgentRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAgentRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateAgentRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateAgentRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -17796,12 +17796,12 @@ export const UpdateAgentResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAgentResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateAgentResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateAgentResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -17871,12 +17871,12 @@ export const UpdateAgentSpaceRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAgentSpaceRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateAgentSpaceRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateAgentSpaceRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -18011,12 +18011,12 @@ export const UpdateAgentSpaceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAgentSpaceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateAgentSpaceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateAgentSpaceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/applicationinsights.ts
+++ b/packages/azure/src/services/applicationinsights.ts
@@ -196,11 +196,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -713,11 +713,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/azuredatatransfer.ts
+++ b/packages/azure/src/services/azuredatatransfer.ts
@@ -319,11 +319,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -480,11 +480,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/azurefleet.ts
+++ b/packages/azure/src/services/azurefleet.ts
@@ -1973,11 +1973,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2496,11 +2496,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/billingbenefits.ts
+++ b/packages/azure/src/services/billingbenefits.ts
@@ -229,12 +229,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CancelConditionalCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CancelConditionalCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CancelConditionalCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -623,12 +623,12 @@ export const CreditProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CancelCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CancelCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CancelCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1124,12 +1124,12 @@ export const MaccModelProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CancelMaccResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CancelMaccResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CancelMaccResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1263,11 +1263,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ConditionalCreditsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const ConditionalCreditsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<ConditionalCreditsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1350,11 +1350,11 @@ export const ConditionalCreditsCreateOrUpdateResponseTagsMap =
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ConditionalCreditsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const ConditionalCreditsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<ConditionalCreditsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1497,12 +1497,12 @@ export const CreditPropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateCreditRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateCreditRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateCreditRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1580,12 +1580,12 @@ export const CreateCreditResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1893,12 +1893,12 @@ export const FreeServicesPropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateFreeServiceRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateFreeServiceRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateFreeServiceRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2024,12 +2024,12 @@ export const FreeServicesProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateFreeServiceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateFreeServiceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateFreeServiceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2187,12 +2187,12 @@ export const MaccModelPropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateMaccRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateMaccRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateMaccRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2270,12 +2270,12 @@ export const CreateMaccResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateMaccResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateMaccResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateMaccResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2810,12 +2810,12 @@ export const CreditSourcePropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateSourceRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateSourceRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateSourceRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2918,12 +2918,12 @@ export const CreditSourceProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateSourceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateSourceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateSourceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3445,12 +3445,12 @@ export const GetConditionalCreditResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetConditionalCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetConditionalCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetConditionalCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3935,12 +3935,12 @@ export const GetCreditResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4182,12 +4182,12 @@ export const GetFreeServiceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetFreeServiceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetFreeServiceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetFreeServiceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4293,12 +4293,12 @@ export const GetMaccResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetMaccResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetMaccResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetMaccResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4969,12 +4969,12 @@ export const GetSourceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetSourceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetSourceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetSourceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -5286,12 +5286,12 @@ export const ConditionalCreditTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ConditionalCreditIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const ConditionalCreditIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<ConditionalCreditIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -5720,11 +5720,11 @@ export const CreditTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreditIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreditIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<CreditIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6072,12 +6072,12 @@ export const FreeServicesTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type FreeServicesIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const FreeServicesIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<FreeServicesIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6223,11 +6223,11 @@ export const MaccTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type MaccIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const MaccIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<MaccIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6819,12 +6819,12 @@ export const CreditSourceTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreditSourceIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreditSourceIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreditSourceIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6981,12 +6981,12 @@ export const MaccsChargeShortfallResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type MaccsChargeShortfallResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const MaccsChargeShortfallResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<MaccsChargeShortfallResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7097,12 +7097,12 @@ export const MaccsWriteOffResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type MaccsWriteOffResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const MaccsWriteOffResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<MaccsWriteOffResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7521,12 +7521,12 @@ export const UpdateConditionalCreditResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateConditionalCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateConditionalCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateConditionalCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7673,12 +7673,12 @@ export const UpdateCreditResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateCreditResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateCreditResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateCreditResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7929,12 +7929,12 @@ export const UpdateFreeServiceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateFreeServiceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateFreeServiceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateFreeServiceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8103,12 +8103,12 @@ export const UpdateMaccResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateMaccResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateMaccResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateMaccResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8281,12 +8281,12 @@ export const UpdateSourceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateSourceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateSourceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateSourceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/cdn.ts
+++ b/packages/azure/src/services/cdn.ts
@@ -337,12 +337,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AFDProfilesUpgradeResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AFDProfilesUpgradeResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AFDProfilesUpgradeResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2729,12 +2729,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateProfileRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateProfileRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateProfileRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2805,12 +2805,12 @@ export const CreateProfileResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateProfileResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateProfileResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateProfileResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6363,12 +6363,12 @@ export const GetProfileResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetProfileResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetProfileResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetProfileResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8142,11 +8142,11 @@ export const ProfileTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ProfileIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const ProfileIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<ProfileIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -10263,12 +10263,12 @@ export const UpdateProfileRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateProfileRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateProfileRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateProfileRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -10349,12 +10349,12 @@ export const UpdateProfileResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateProfileResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateProfileResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateProfileResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/chaos.ts
+++ b/packages/azure/src/services/chaos.ts
@@ -323,11 +323,11 @@ export const UserAssignedIdentityInput = CapabilityPropertiesInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: CapabilityPropertiesInput | undefined;
+  [key: string]: CapabilityPropertiesInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  CapabilityPropertiesInput,
+  S.NullOr(CapabilityPropertiesInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -541,11 +541,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/communication.ts
+++ b/packages/azure/src/services/communication.ts
@@ -175,11 +175,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CommunicationServicesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const CommunicationServicesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CommunicationServicesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -367,11 +367,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CommunicationServicesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const CommunicationServicesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CommunicationServicesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1169,12 +1169,12 @@ export const GetCommunicationServiceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetCommunicationServiceResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetCommunicationServiceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetCommunicationServiceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1721,12 +1721,12 @@ export const CommunicationServiceResourceTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CommunicationServiceResourceIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CommunicationServiceResourceIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CommunicationServiceResourceIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2858,11 +2858,11 @@ export const CommunicationServiceUpdateProperties = /*@__PURE__*/ S.suspend(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateCommunicationServiceRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const UpdateCommunicationServiceRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateCommunicationServiceRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2928,11 +2928,11 @@ export const UpdateCommunicationServiceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateCommunicationServiceResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const UpdateCommunicationServiceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateCommunicationServiceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/databricks.ts
+++ b/packages/azure/src/services/databricks.ts
@@ -43,11 +43,11 @@ export const UserAssignedIdentityInput = AccessConnectorPropertiesInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: AccessConnectorPropertiesInput | undefined;
+  [key: string]: AccessConnectorPropertiesInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  AccessConnectorPropertiesInput,
+  S.NullOr(AccessConnectorPropertiesInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -167,11 +167,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/datamigration.ts
+++ b/packages/azure/src/services/datamigration.ts
@@ -1401,12 +1401,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AzureBlobInputIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const AzureBlobInputIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<AzureBlobInputIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1779,12 +1779,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AzureBlobIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AzureBlobIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AzureBlobIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/devopsinfrastructure.ts
+++ b/packages/azure/src/services/devopsinfrastructure.ts
@@ -354,12 +354,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetPoolResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetPoolResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetPoolResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -620,11 +620,11 @@ export const PoolTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type PoolIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const PoolIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<PoolIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1114,12 +1114,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type PoolsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const PoolsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<PoolsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1187,12 +1187,12 @@ export const PoolsCreateOrUpdateResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type PoolsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const PoolsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<PoolsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1332,12 +1332,12 @@ export const PagedQuota = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdatePoolRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdatePoolRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdatePoolRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1438,12 +1438,12 @@ export const UpdatePoolResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdatePoolResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdatePoolResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdatePoolResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/hardwaresecuritymodules.ts
+++ b/packages/azure/src/services/hardwaresecuritymodules.ts
@@ -246,11 +246,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CloudHsmClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const CloudHsmClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CloudHsmClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -609,11 +609,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CloudHsmClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const CloudHsmClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CloudHsmClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1307,12 +1307,12 @@ export const GetCloudHsmClusterResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1600,12 +1600,12 @@ export const CloudHsmClusterTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CloudHsmClusterIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CloudHsmClusterIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CloudHsmClusterIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2247,12 +2247,12 @@ export const UpdateCloudHsmClusterRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateCloudHsmClusterRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateCloudHsmClusterRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateCloudHsmClusterRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2315,12 +2315,12 @@ export const UpdateCloudHsmClusterResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateCloudHsmClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/healthdataaiservices.ts
+++ b/packages/azure/src/services/healthdataaiservices.ts
@@ -56,11 +56,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -328,11 +328,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/hybridcompute.ts
+++ b/packages/azure/src/services/hybridcompute.ts
@@ -2318,12 +2318,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetMachineResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetMachineResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetMachineResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4800,11 +4800,11 @@ export const MachineResourcesList = /*@__PURE__*/ S.Array(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type MachineIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const MachineIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<MachineIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6128,12 +6128,13 @@ export const UserAssignedIdentityInput =
 export type MachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap = {
   [key: string]:
     | LicenseProfileArmProductProfilePropertiesInputError
+    | null
     | undefined;
 };
 export const MachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    LicenseProfileArmProductProfilePropertiesInputError,
+    S.NullOr(LicenseProfileArmProductProfilePropertiesInputError),
   ) as any as S.Schema<MachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6216,12 +6217,12 @@ export const MachinesCreateOrUpdateResponseResourcesList =
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type MachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const MachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<MachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7074,12 +7075,13 @@ export const UpdateMachineRequestTagsMap = /*@__PURE__*/ S.Record(
 export type UpdateMachineRequestIdentityUserAssignedIdentitiesMap = {
   [key: string]:
     | LicenseProfileArmProductProfilePropertiesInputError
+    | null
     | undefined;
 };
 export const UpdateMachineRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    LicenseProfileArmProductProfilePropertiesInputError,
+    S.NullOr(LicenseProfileArmProductProfilePropertiesInputError),
   ) as any as S.Schema<UpdateMachineRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -7195,12 +7197,12 @@ export const UpdateMachineResponseResourcesList = /*@__PURE__*/ S.Array(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateMachineResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateMachineResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateMachineResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/iotoperations.ts
+++ b/packages/azure/src/services/iotoperations.ts
@@ -5119,11 +5119,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -5365,11 +5365,11 @@ export const UserAssignedIdentityInput = AkriConnectorPropertiesInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: AkriConnectorPropertiesInput | undefined;
+  [key: string]: AkriConnectorPropertiesInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  AkriConnectorPropertiesInput,
+  S.NullOr(AkriConnectorPropertiesInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/keyvault.ts
+++ b/packages/azure/src/services/keyvault.ts
@@ -938,11 +938,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4104,11 +4104,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/kubernetesconfiguration.ts
+++ b/packages/azure/src/services/kubernetesconfiguration.ts
@@ -984,9 +984,9 @@ export const SubstituteFromDefinition = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of ConfigMaps/Secrets from which the variables are substituted for this Kustomization. */
 export type PostBuildDefinitionSubstituteFromList =
-  Array<SubstituteFromDefinition>;
+  Array<SubstituteFromDefinition | null>;
 export const PostBuildDefinitionSubstituteFromList = /*@__PURE__*/ S.Array(
-  SubstituteFromDefinition,
+  S.NullOr(SubstituteFromDefinition),
 ) as any as S.Schema<PostBuildDefinitionSubstituteFromList>;
 
 /** The postBuild definitions defining variable substitutions for this Kustomization after kustomize build. */
@@ -1044,11 +1044,11 @@ export const KustomizationDefinitionInput = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type FluxConfigurationsCreateOrUpdateRequestPropertiesKustomizationsMap =
-  { [key: string]: KustomizationDefinitionInput | undefined };
+  { [key: string]: KustomizationDefinitionInput | null | undefined };
 export const FluxConfigurationsCreateOrUpdateRequestPropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationDefinitionInput,
+    S.NullOr(KustomizationDefinitionInput),
   ) as any as S.Schema<FluxConfigurationsCreateOrUpdateRequestPropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -1198,11 +1198,11 @@ export const KustomizationDefinition = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type FluxConfigurationsCreateOrUpdateResponsePropertiesKustomizationsMap =
-  { [key: string]: KustomizationDefinition | undefined };
+  { [key: string]: KustomizationDefinition | null | undefined };
 export const FluxConfigurationsCreateOrUpdateResponsePropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationDefinition,
+    S.NullOr(KustomizationDefinition),
   ) as any as S.Schema<FluxConfigurationsCreateOrUpdateResponsePropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -1333,10 +1333,10 @@ export const ObjectStatusDefinition = /*@__PURE__*/ S.suspend(() =>
 
 /** Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration. */
 export type FluxConfigurationsCreateOrUpdateResponsePropertiesStatusesList =
-  Array<ObjectStatusDefinition>;
+  Array<ObjectStatusDefinition | null>;
 export const FluxConfigurationsCreateOrUpdateResponsePropertiesStatusesList =
   /*@__PURE__*/ S.Array(
-    ObjectStatusDefinition,
+    S.NullOr(ObjectStatusDefinition),
   ) as any as S.Schema<FluxConfigurationsCreateOrUpdateResponsePropertiesStatusesList>;
 
 /** The provisioning state of the resource. */
@@ -1984,12 +1984,12 @@ export const GetFluxConfigurationRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type GetFluxConfigurationResponsePropertiesKustomizationsMap = {
-  [key: string]: KustomizationDefinition | undefined;
+  [key: string]: KustomizationDefinition | null | undefined;
 };
 export const GetFluxConfigurationResponsePropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationDefinition,
+    S.NullOr(KustomizationDefinition),
   ) as any as S.Schema<GetFluxConfigurationResponsePropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -2003,10 +2003,10 @@ export const GetFluxConfigurationResponsePropertiesConfigurationProtectedSetting
 
 /** Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration. */
 export type GetFluxConfigurationResponsePropertiesStatusesList =
-  Array<ObjectStatusDefinition>;
+  Array<ObjectStatusDefinition | null>;
 export const GetFluxConfigurationResponsePropertiesStatusesList =
   /*@__PURE__*/ S.Array(
-    ObjectStatusDefinition,
+    S.NullOr(ObjectStatusDefinition),
   ) as any as S.Schema<GetFluxConfigurationResponsePropertiesStatusesList>;
 
 /** The provisioning state of the resource. */
@@ -2883,12 +2883,12 @@ export const ListFluxConfigurationsRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type FluxConfigurationPropertiesKustomizationsMap = {
-  [key: string]: KustomizationDefinition | undefined;
+  [key: string]: KustomizationDefinition | null | undefined;
 };
 export const FluxConfigurationPropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationDefinition,
+    S.NullOr(KustomizationDefinition),
   ) as any as S.Schema<FluxConfigurationPropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -2903,9 +2903,9 @@ export const FluxConfigurationPropertiesConfigurationProtectedSettingsMap =
 
 /** Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration. */
 export type FluxConfigurationPropertiesStatusesList =
-  Array<ObjectStatusDefinition>;
+  Array<ObjectStatusDefinition | null>;
 export const FluxConfigurationPropertiesStatusesList = /*@__PURE__*/ S.Array(
-  ObjectStatusDefinition,
+  S.NullOr(ObjectStatusDefinition),
 ) as any as S.Schema<FluxConfigurationPropertiesStatusesList>;
 
 /** The provisioning state of the resource. */
@@ -4178,12 +4178,12 @@ export const KustomizationPatchDefinition = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type UpdateFluxConfigurationRequestPropertiesKustomizationsMap = {
-  [key: string]: KustomizationPatchDefinition | undefined;
+  [key: string]: KustomizationPatchDefinition | null | undefined;
 };
 export const UpdateFluxConfigurationRequestPropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationPatchDefinition,
+    S.NullOr(KustomizationPatchDefinition),
   ) as any as S.Schema<UpdateFluxConfigurationRequestPropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -4272,12 +4272,12 @@ export const UpdateFluxConfigurationRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** Array of kustomizations used to reconcile the artifact pulled by the source type on the cluster. */
 export type UpdateFluxConfigurationResponsePropertiesKustomizationsMap = {
-  [key: string]: KustomizationDefinition | undefined;
+  [key: string]: KustomizationDefinition | null | undefined;
 };
 export const UpdateFluxConfigurationResponsePropertiesKustomizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    KustomizationDefinition,
+    S.NullOr(KustomizationDefinition),
   ) as any as S.Schema<UpdateFluxConfigurationResponsePropertiesKustomizationsMap>;
 
 /** Key-value pairs of protected configuration settings for the configuration */
@@ -4291,10 +4291,10 @@ export const UpdateFluxConfigurationResponsePropertiesConfigurationProtectedSett
 
 /** Statuses of the Flux Kubernetes resources created by the fluxConfiguration or created by the managed objects provisioned by the fluxConfiguration. */
 export type UpdateFluxConfigurationResponsePropertiesStatusesList =
-  Array<ObjectStatusDefinition>;
+  Array<ObjectStatusDefinition | null>;
 export const UpdateFluxConfigurationResponsePropertiesStatusesList =
   /*@__PURE__*/ S.Array(
-    ObjectStatusDefinition,
+    S.NullOr(ObjectStatusDefinition),
   ) as any as S.Schema<UpdateFluxConfigurationResponsePropertiesStatusesList>;
 
 /** The provisioning state of the resource. */

--- a/packages/azure/src/services/liftrweightsandbiases.ts
+++ b/packages/azure/src/services/liftrweightsandbiases.ts
@@ -324,11 +324,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -425,11 +425,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/loadtestservice.ts
+++ b/packages/azure/src/services/loadtestservice.ts
@@ -450,11 +450,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1531,11 +1531,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/machinelearningservices.ts
+++ b/packages/azure/src/services/machinelearningservices.ts
@@ -41,21 +41,21 @@ export const CodeConfiguration = /*@__PURE__*/ S.suspend(() =>
 
 /** Environment variables configuration for the deployment. */
 export type BatchDeploymentPropertiesEnvironmentVariablesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const BatchDeploymentPropertiesEnvironmentVariablesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<BatchDeploymentPropertiesEnvironmentVariablesMap>;
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type BatchDeploymentPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const BatchDeploymentPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<BatchDeploymentPropertiesPropertiesMap>;
 
 /** The enumerated property types for batch deployments. */
@@ -116,11 +116,11 @@ export const DeploymentProvisioningState = S.String;
 
 /** Additional properties bag. */
 export type ResourceConfigurationPropertiesMap = {
-  [key: string]: unknown | undefined;
+  [key: string]: unknown | null | undefined;
 };
 export const ResourceConfigurationPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.Unknown,
+  S.NullOr(S.Unknown),
 ) as any as S.Schema<ResourceConfigurationPropertiesMap>;
 
 export interface ResourceConfiguration {
@@ -534,11 +534,11 @@ export const EndpointAuthKeys = /*@__PURE__*/ S.suspend(() =>
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type BatchEndpointPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const BatchEndpointPropertiesInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<BatchEndpointPropertiesInputPropertiesMap>;
 
 /** Batch endpoint default values */
@@ -649,11 +649,11 @@ export const BatchEndpointsCreateOrUpdateResponseTagsMap =
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type BatchEndpointPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const BatchEndpointPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<BatchEndpointPropertiesPropertiesMap>;
 
 /** State of endpoint provisioning. */
@@ -789,21 +789,21 @@ export const CancelJobResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type CapabilityHostPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CapabilityHostPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CapabilityHostPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type CapabilityHostPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CapabilityHostPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CapabilityHostPropertiesInputTagsMap>;
 
 /** List of Aca Environment connections. */
@@ -938,20 +938,20 @@ export const CapabilityHostsCreateOrUpdateRequest = /*@__PURE__*/ S.suspend(
 
 /** The asset property dictionary. */
 export type CapabilityHostPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CapabilityHostPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CapabilityHostPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type CapabilityHostPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CapabilityHostPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CapabilityHostPropertiesTagsMap>;
 
 /** List of Aca Environment connections. */
@@ -1093,20 +1093,20 @@ export const CapabilityHostsCreateOrUpdateResponse = /*@__PURE__*/ S.suspend(
 
 /** The asset property dictionary. */
 export type CodeContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeContainerPropertiesInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type CodeContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeContainerPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeContainerPropertiesInputTagsMap>;
 
 /** Container for code asset versions. */
@@ -1164,20 +1164,20 @@ export const CodeContainersCreateOrUpdateRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type CodeContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeContainerPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type CodeContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeContainerPropertiesTagsMap>;
 
 /** Provisioning state of registry asset. */
@@ -1357,20 +1357,20 @@ export const PendingUploadResponseDto = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type CodeVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeVersionPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type CodeVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CodeVersionPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CodeVersionPropertiesTagsMap>;
 
 /** Code asset version details. */
@@ -1464,21 +1464,21 @@ export const CodeVersionsCreateOrUpdateResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type ComponentContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentContainerPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<ComponentContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ComponentContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentContainerPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ComponentContainerPropertiesInputTagsMap>;
 
 /** Component container definition. <see href="https://docs.microsoft.com/en-us/azure/machine-learning/reference-yaml-component-command" /> */
@@ -1539,20 +1539,20 @@ export const ComponentContainersCreateOrUpdateRequest = /*@__PURE__*/ S.suspend(
 
 /** The asset property dictionary. */
 export type ComponentContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentContainerPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ComponentContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ComponentContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ComponentContainerPropertiesTagsMap>;
 
 /** Component container definition. <see href="https://docs.microsoft.com/en-us/azure/machine-learning/reference-yaml-component-command" /> */
@@ -1613,20 +1613,20 @@ export const ComponentContainersCreateOrUpdateResponse =
 
 /** The asset property dictionary. */
 export type ComponentVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentVersionPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ComponentVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ComponentVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ComponentVersionPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ComponentVersionPropertiesTagsMap>;
 
 /** Definition of a component version: defines resources that span component types. */
@@ -2329,20 +2329,20 @@ export const CreateWorkspaceConnectionResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type DataContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataContainerPropertiesInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type DataContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataContainerPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataContainerPropertiesInputTagsMap>;
 
 /** Enum to determine the type of data. */
@@ -2407,20 +2407,20 @@ export const DataContainersCreateOrUpdateRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type DataContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataContainerPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type DataContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataContainerPropertiesTagsMap>;
 
 /** Container for data asset versions. */
@@ -2481,20 +2481,20 @@ export const DataContainersCreateOrUpdateResponse = /*@__PURE__*/ S.suspend(
 
 /** The asset property dictionary. */
 export type DatastorePropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DatastorePropertiesInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DatastorePropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type DatastorePropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DatastorePropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DatastorePropertiesInputTagsMap>;
 
 /** Enum to determine the datastore credentials type. */
@@ -2589,18 +2589,20 @@ export const DatastoresCreateOrUpdateRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type DatastorePropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DatastorePropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DatastorePropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
-export type DatastorePropertiesTagsMap = { [key: string]: string | undefined };
+export type DatastorePropertiesTagsMap = {
+  [key: string]: string | null | undefined;
+};
 export const DatastorePropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DatastorePropertiesTagsMap>;
 
 /** Base definition for datastore contents configuration. */
@@ -2657,20 +2659,20 @@ export const DatastoresCreateOrUpdateResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type DataVersionBasePropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataVersionBasePropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataVersionBasePropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type DataVersionBasePropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const DataVersionBasePropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<DataVersionBasePropertiesTagsMap>;
 
 /** Data version base definition */
@@ -4220,22 +4222,22 @@ export const DeleteWorkspaceConnectionResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type EnvironmentContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentContainerPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type EnvironmentContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentContainerPropertiesInputTagsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentContainerPropertiesInputTagsMap>;
 
 /** Container for environment specification versions. */
@@ -4296,21 +4298,21 @@ export const EnvironmentContainersCreateOrUpdateRequest =
 
 /** The asset property dictionary. */
 export type EnvironmentContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentContainerPropertiesPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type EnvironmentContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<EnvironmentContainerPropertiesTagsMap>;
 
 /** Container for environment specification versions. */
@@ -4373,20 +4375,20 @@ export const EnvironmentContainersCreateOrUpdateResponse =
 
 /** The asset property dictionary. */
 export type EnvironmentVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentVersionPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<EnvironmentVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type EnvironmentVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const EnvironmentVersionPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<EnvironmentVersionPropertiesTagsMap>;
 
 /** AutoRebuild setting for the derived image */
@@ -4565,21 +4567,21 @@ export const EnvironmentVersionsCreateOrUpdateResponse =
 
 /** The asset property dictionary. */
 export type FeaturesetContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetContainerPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturesetContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturesetContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetContainerPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturesetContainerPropertiesInputTagsMap>;
 
 /** DTO object representing feature set */
@@ -4640,21 +4642,21 @@ export const FeaturesetContainersCreateOrUpdateRequest =
 
 /** The asset property dictionary. */
 export type FeaturesetContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetContainerPropertiesPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturesetContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturesetContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturesetContainerPropertiesTagsMap>;
 
 /** DTO object representing feature set */
@@ -4747,12 +4749,12 @@ export const FeatureWindow = /*@__PURE__*/ S.suspend(() =>
 
 /** Specifies the properties */
 export type FeaturesetVersionsBackfillRequestPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetVersionsBackfillRequestPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturesetVersionsBackfillRequestPropertiesMap>;
 
 /** DTO object representing compute resource */
@@ -4770,21 +4772,21 @@ export const MaterializationComputeResource = /*@__PURE__*/ S.suspend(() =>
 
 /** Specifies the spark compute settings */
 export type FeaturesetVersionsBackfillRequestSparkConfigurationMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetVersionsBackfillRequestSparkConfigurationMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturesetVersionsBackfillRequestSparkConfigurationMap>;
 
 /** Specifies the tags */
 export type FeaturesetVersionsBackfillRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetVersionsBackfillRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturesetVersionsBackfillRequestTagsMap>;
 
 export interface FeaturesetVersionsBackfillRequest {
@@ -4871,20 +4873,20 @@ export const FeaturesetVersionBackfillResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type FeaturesetVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetVersionPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturesetVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturesetVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturesetVersionPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturesetVersionPropertiesTagsMap>;
 
 /** Specifies list of entities */
@@ -4934,11 +4936,11 @@ export const Webhook = /*@__PURE__*/ S.suspend(() =>
 
 /** Send webhook callback to a service. Key is a user-provided name for the webhook. */
 export type NotificationSettingWebhooksMap = {
-  [key: string]: Webhook | undefined;
+  [key: string]: Webhook | null | undefined;
 };
 export const NotificationSettingWebhooksMap = /*@__PURE__*/ S.Record(
   S.String,
-  Webhook,
+  S.NullOr(Webhook),
 ) as any as S.Schema<NotificationSettingWebhooksMap>;
 
 /** Configuration for notification. */
@@ -5055,12 +5057,12 @@ export const RecurrenceTrigger = /*@__PURE__*/ S.suspend(() =>
 
 /** Specifies the spark compute settings */
 export type MaterializationSettingsSparkConfigurationMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const MaterializationSettingsSparkConfigurationMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<MaterializationSettingsSparkConfigurationMap>;
 
 /** Specifies the stores to which materialization should happen */
@@ -5212,22 +5214,22 @@ export const FeaturesetVersionsCreateOrUpdateResponse = /*@__PURE__*/ S.suspend(
 
 /** The asset property dictionary. */
 export type FeaturestoreEntityContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityContainerPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturestoreEntityContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityContainerPropertiesInputTagsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityContainerPropertiesInputTagsMap>;
 
 /** DTO object representing feature entity */
@@ -5291,22 +5293,22 @@ export const FeaturestoreEntityContainersCreateOrUpdateRequest =
 
 /** The asset property dictionary. */
 export type FeaturestoreEntityContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityContainerPropertiesPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturestoreEntityContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityContainerPropertiesTagsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityContainerPropertiesTagsMap>;
 
 /** DTO object representing feature entity */
@@ -5370,22 +5372,22 @@ export const FeaturestoreEntityContainersCreateOrUpdateResponse =
 
 /** The asset property dictionary. */
 export type FeaturestoreEntityVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityVersionPropertiesPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type FeaturestoreEntityVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturestoreEntityVersionPropertiesTagsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<FeaturestoreEntityVersionPropertiesTagsMap>;
 
 /** Specifies the data type */
@@ -6348,18 +6350,20 @@ export const GetFeatureRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type FeaturePropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const FeaturePropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturePropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
-export type FeaturePropertiesTagsMap = { [key: string]: string | undefined };
+export type FeaturePropertiesTagsMap = {
+  [key: string]: string | null | undefined;
+};
 export const FeaturePropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FeaturePropertiesTagsMap>;
 
 /** Specifies type */
@@ -6669,18 +6673,20 @@ export const GetJobRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type JobBasePropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const JobBasePropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobBasePropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
-export type JobBasePropertiesTagsMap = { [key: string]: string | undefined };
+export type JobBasePropertiesTagsMap = {
+  [key: string]: string | null | undefined;
+};
 export const JobBasePropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobBasePropertiesTagsMap>;
 
 /** Enum to determine identity framework. */
@@ -6720,10 +6726,12 @@ export const Nodes = /*@__PURE__*/ S.suspend(() =>
 ).annotate({ identifier: "Nodes" }) as any as S.Schema<Nodes>;
 
 /** Additional properties to set on the endpoint. */
-export type JobServicePropertiesMap = { [key: string]: string | undefined };
+export type JobServicePropertiesMap = {
+  [key: string]: string | null | undefined;
+};
 export const JobServicePropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobServicePropertiesMap>;
 
 /** Job endpoint definition */
@@ -6757,11 +6765,11 @@ export const JobService = /*@__PURE__*/ S.suspend(() =>
 
 /** List of JobEndpoints. For local jobs, a job endpoint will have an endpoint value of FileStreamObject. */
 export type JobBasePropertiesServicesMap = {
-  [key: string]: JobService | undefined;
+  [key: string]: JobService | null | undefined;
 };
 export const JobBasePropertiesServicesMap = /*@__PURE__*/ S.Record(
   S.String,
-  JobService,
+  S.NullOr(JobService),
 ) as any as S.Schema<JobBasePropertiesServicesMap>;
 
 /** The status of a job. */
@@ -7091,20 +7099,20 @@ export const GetModelContainerRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type ModelContainerPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelContainerPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ModelContainerPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ModelContainerPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelContainerPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ModelContainerPropertiesTagsMap>;
 
 export interface ModelContainerProperties {
@@ -7194,27 +7202,27 @@ export const GetModelVersionRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type ModelVersionPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelVersionPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ModelVersionPropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ModelVersionPropertiesTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelVersionPropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ModelVersionPropertiesTagsMap>;
 
 /** Model flavor-specific data. */
-export type FlavorDataDataMap = { [key: string]: string | undefined };
+export type FlavorDataDataMap = { [key: string]: string | null | undefined };
 export const FlavorDataDataMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<FlavorDataDataMap>;
 
 export interface FlavorData {
@@ -7229,11 +7237,11 @@ export const FlavorData = /*@__PURE__*/ S.suspend(() =>
 
 /** Mapping of model flavors to their properties. */
 export type ModelVersionPropertiesFlavorsMap = {
-  [key: string]: FlavorData | undefined;
+  [key: string]: FlavorData | null | undefined;
 };
 export const ModelVersionPropertiesFlavorsMap = /*@__PURE__*/ S.Record(
   S.String,
-  FlavorData,
+  S.NullOr(FlavorData),
 ) as any as S.Schema<ModelVersionPropertiesFlavorsMap>;
 
 /** Dataset reference object. */
@@ -7370,21 +7378,21 @@ export const GetOnlineDeploymentResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** Environment variables configuration for the deployment. */
 export type OnlineDeploymentPropertiesEnvironmentVariablesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const OnlineDeploymentPropertiesEnvironmentVariablesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OnlineDeploymentPropertiesEnvironmentVariablesMap>;
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type OnlineDeploymentPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const OnlineDeploymentPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<OnlineDeploymentPropertiesPropertiesMap>;
 
 /** Enable or disable data collection. */
@@ -7412,11 +7420,11 @@ export const Collection = /*@__PURE__*/ S.suspend(() =>
 
 /** [Required] The collection configuration. Each collection has it own configuration to collect model data and the name of collection can be arbitrary string. Model data collector can be used for either payload logging or custom logging or both of them. Collection request and response are reserved for payload logging, others are for custom logging. */
 export type DataCollectorCollectionsMap = {
-  [key: string]: Collection | undefined;
+  [key: string]: Collection | null | undefined;
 };
 export const DataCollectorCollectionsMap = /*@__PURE__*/ S.Record(
   S.String,
-  Collection,
+  S.NullOr(Collection),
 ) as any as S.Schema<DataCollectorCollectionsMap>;
 
 /** For payload logging, we only collect payload by default. If customers also want to collect the specified headers, they can set them in captureHeaders so that backend will collect those headers along with payload. */
@@ -7740,11 +7748,11 @@ export const GetOnlineEndpointResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type OnlineEndpointPropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const OnlineEndpointPropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<OnlineEndpointPropertiesPropertiesMap>;
 
 /** Percentage of traffic to be mirrored to each deployment without using returned scoring. Traffic values need to sum to utmost 50. */
@@ -9116,18 +9124,20 @@ export const GetScheduleRequest = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type SchedulePropertiesPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const SchedulePropertiesPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<SchedulePropertiesPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
-export type SchedulePropertiesTagsMap = { [key: string]: string | undefined };
+export type SchedulePropertiesTagsMap = {
+  [key: string]: string | null | undefined;
+};
 export const SchedulePropertiesTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<SchedulePropertiesTagsMap>;
 
 export type ScheduleActionType =
@@ -9303,11 +9313,11 @@ export const ServerlessEndpointState = S.String;
 
 /** Specifies any required headers to target this serverless endpoint. */
 export type ServerlessInferenceEndpointHeadersMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ServerlessInferenceEndpointHeadersMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ServerlessInferenceEndpointHeadersMap>;
 
 export interface ServerlessInferenceEndpoint {
@@ -10045,29 +10055,29 @@ export const GetWorkspaceConnectionResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The asset property dictionary. */
 export type JobBasePropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const JobBasePropertiesInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobBasePropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type JobBasePropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const JobBasePropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobBasePropertiesInputTagsMap>;
 
 /** Additional properties to set on the endpoint. */
 export type JobServiceInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const JobServiceInputPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<JobServiceInputPropertiesMap>;
 
 /** Job endpoint definition */
@@ -10097,11 +10107,11 @@ export const JobServiceInput = /*@__PURE__*/ S.suspend(() =>
 
 /** List of JobEndpoints. For local jobs, a job endpoint will have an endpoint value of FileStreamObject. */
 export type JobBasePropertiesInputServicesMap = {
-  [key: string]: JobServiceInput | undefined;
+  [key: string]: JobServiceInput | null | undefined;
 };
 export const JobBasePropertiesInputServicesMap = /*@__PURE__*/ S.Record(
   S.String,
-  JobServiceInput,
+  S.NullOr(JobServiceInput),
 ) as any as S.Schema<JobBasePropertiesInputServicesMap>;
 
 /** Base definition for a job. */
@@ -15097,21 +15107,21 @@ export const MarketplaceSubscriptionsCreateOrUpdateResponse =
 
 /** The asset property dictionary. */
 export type ModelContainerPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelContainerPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<ModelContainerPropertiesInputPropertiesMap>;
 
 /** Tag dictionary. Tags can be added, removed, and updated. */
 export type ModelContainerPropertiesInputTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const ModelContainerPropertiesInputTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ModelContainerPropertiesInputTagsMap>;
 
 export interface ModelContainerPropertiesInput {
@@ -15398,12 +15408,12 @@ export const OnlineEndpointsCreateOrUpdateRequestTagsMap =
 
 /** Property dictionary. Properties can be added, but not removed or altered. */
 export type OnlineEndpointPropertiesInputPropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const OnlineEndpointPropertiesInputPropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OnlineEndpointPropertiesInputPropertiesMap>;
 
 /** Percentage of traffic to be mirrored to each deployment without using returned scoring. Traffic values need to sum to utmost 50. */
@@ -17508,11 +17518,11 @@ export const PartialBatchDeployment = /*@__PURE__*/ S.suspend(() =>
 
 /** Resource tags. */
 export type UpdateBatchDeploymentRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateBatchDeploymentRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateBatchDeploymentRequestTagsMap>;
 
 export interface UpdateBatchDeploymentRequest {
@@ -17614,11 +17624,11 @@ export const UpdateBatchDeploymentResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** Resource tags. */
 export type UpdateBatchEndpointRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateBatchEndpointRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateBatchEndpointRequestTagsMap>;
 
 /** Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed). */
@@ -17883,11 +17893,11 @@ export const UpdateComputeResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** Resource tags. */
 export type UpdateOnlineDeploymentRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateOnlineDeploymentRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateOnlineDeploymentRequestTagsMap>;
 
 /** This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT. */
@@ -18016,11 +18026,11 @@ export const UpdateOnlineDeploymentResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** Resource tags. */
 export type UpdateOnlineEndpointRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateOnlineEndpointRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateOnlineEndpointRequestTagsMap>;
 
 export interface UpdateOnlineEndpointRequest {
@@ -18237,11 +18247,11 @@ export const RegistryPartialManagedServiceIdentityInput =
 
 /** Resource tags. */
 export type UpdateRegistryRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateRegistryRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateRegistryRequestTagsMap>;
 
 export interface UpdateRegistryRequest {
@@ -18340,11 +18350,11 @@ export const UpdateRegistryResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** Resource tags. */
 export type UpdateServerlessEndpointRequestTagsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateServerlessEndpointRequestTagsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateServerlessEndpointRequestTagsMap>;
 
 export interface UpdateServerlessEndpointRequest {

--- a/packages/azure/src/services/managednetworkfabric.ts
+++ b/packages/azure/src/services/managednetworkfabric.ts
@@ -3984,11 +3984,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4114,11 +4114,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/manufacturingplatform.ts
+++ b/packages/azure/src/services/manufacturingplatform.ts
@@ -517,11 +517,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1009,11 +1009,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/mission.ts
+++ b/packages/azure/src/services/mission.ts
@@ -787,11 +787,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1134,11 +1134,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/mongocluster.ts
+++ b/packages/azure/src/services/mongocluster.ts
@@ -1053,11 +1053,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2084,11 +2084,11 @@ export const UserAssignedIdentityInput = PrivateEndpointInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: PrivateEndpointInput | undefined;
+  [key: string]: PrivateEndpointInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  PrivateEndpointInput,
+  S.NullOr(PrivateEndpointInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/monitoringservice.ts
+++ b/packages/azure/src/services/monitoringservice.ts
@@ -159,11 +159,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AzureMonitorWorkspacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const AzureMonitorWorkspacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<AzureMonitorWorkspacesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -498,11 +498,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AzureMonitorWorkspacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const AzureMonitorWorkspacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AzureMonitorWorkspacesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1016,11 +1016,11 @@ export const GetAzureMonitorWorkspaceResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const GetAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2112,12 +2112,12 @@ export const AzureMonitorWorkspaceResourceTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AzureMonitorWorkspaceResourceIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AzureMonitorWorkspaceResourceIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AzureMonitorWorkspaceResourceIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2945,11 +2945,11 @@ export const UpdateAzureMonitorWorkspaceRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAzureMonitorWorkspaceRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const UpdateAzureMonitorWorkspaceRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateAzureMonitorWorkspaceRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3016,11 +3016,11 @@ export const UpdateAzureMonitorWorkspaceResponseTagsMap =
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const UpdateAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateAzureMonitorWorkspaceResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/netapp.ts
+++ b/packages/azure/src/services/netapp.ts
@@ -306,12 +306,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AccountsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const AccountsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<AccountsCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -660,12 +660,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type AccountsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const AccountsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<AccountsCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4696,12 +4696,12 @@ export const GetAccountResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetAccountResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetAccountResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetAccountResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -6164,12 +6164,12 @@ export const NetAppAccountTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type NetAppAccountIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const NetAppAccountIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<NetAppAccountIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8714,12 +8714,12 @@ export const UpdateAccountRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAccountRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateAccountRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateAccountRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8787,12 +8787,12 @@ export const UpdateAccountResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateAccountResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateAccountResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateAccountResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/networkcloud.ts
+++ b/packages/azure/src/services/networkcloud.ts
@@ -2613,11 +2613,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClusterManagersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const ClusterManagersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<ClusterManagersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2824,11 +2824,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClusterManagersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const ClusterManagersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<ClusterManagersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3403,12 +3403,12 @@ export const ClusterPropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const ClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<ClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3823,12 +3823,12 @@ export const ClusterProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const ClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<ClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -5469,12 +5469,12 @@ export const GetClusterResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -5578,12 +5578,12 @@ export const GetClusterManagerResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetClusterManagerResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetClusterManagerResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetClusterManagerResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -8337,12 +8337,12 @@ export const VirtualMachineProperties = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetVirtualMachineResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetVirtualMachineResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetVirtualMachineResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -9840,11 +9840,11 @@ export const ClusterTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClusterIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const ClusterIdentityUserAssignedIdentitiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<ClusterIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -9994,12 +9994,12 @@ export const ClusterManagerTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type ClusterManagerIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const ClusterManagerIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<ClusterManagerIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -11418,12 +11418,12 @@ export const VirtualMachineTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type VirtualMachineIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const VirtualMachineIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<VirtualMachineIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -13389,12 +13389,12 @@ export const UpdateCloudServicesNetworkResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateClusterRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateClusterRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateClusterRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -13769,12 +13769,12 @@ export const UpdateClusterResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -13844,12 +13844,12 @@ export const UpdateClusterResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateClusterManagerRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateClusterManagerRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateClusterManagerRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -13920,12 +13920,12 @@ export const UpdateClusterManagerResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateClusterManagerResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateClusterManagerResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateClusterManagerResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -15090,12 +15090,12 @@ export const UpdateTrunkedNetworkResponse = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateVirtualMachineRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UpdateVirtualMachineRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<UpdateVirtualMachineRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -15201,12 +15201,12 @@ export const UpdateVirtualMachineResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateVirtualMachineResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateVirtualMachineResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateVirtualMachineResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -15511,11 +15511,11 @@ export const VirtualMachinePropertiesInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type VirtualMachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentityInput | undefined };
+  { [key: string]: UserAssignedIdentityInput | null | undefined };
 export const VirtualMachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<VirtualMachinesCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -15589,11 +15589,11 @@ export const VirtualMachinesCreateOrUpdateResponseTagsMap =
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type VirtualMachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const VirtualMachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<VirtualMachinesCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/operationalinsights.ts
+++ b/packages/azure/src/services/operationalinsights.ts
@@ -133,11 +133,11 @@ export const UserAssignedIdentityInput = AssociatedWorkspaceInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: AssociatedWorkspaceInput | undefined;
+  [key: string]: AssociatedWorkspaceInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  AssociatedWorkspaceInput,
+  S.NullOr(AssociatedWorkspaceInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -422,11 +422,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/orbitalplanetarycomputer.ts
+++ b/packages/azure/src/services/orbitalplanetarycomputer.ts
@@ -72,11 +72,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -246,11 +246,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/recoveryservicesdatareplication.ts
+++ b/packages/azure/src/services/recoveryservicesdatareplication.ts
@@ -1152,12 +1152,12 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateVaultRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const CreateVaultRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentityInput,
+    S.NullOr(UserAssignedIdentityInput),
   ) as any as S.Schema<CreateVaultRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1374,12 +1374,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type CreateVaultResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const CreateVaultResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<CreateVaultResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -2767,12 +2767,12 @@ export const GetVaultResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetVaultResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetVaultResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetVaultResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -3755,12 +3755,12 @@ export const VaultModelTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type VaultModelIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const VaultModelIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<VaultModelIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -4358,12 +4358,12 @@ export const UpdateVaultResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateVaultResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateVaultResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateVaultResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/redhatopenshift.ts
+++ b/packages/azure/src/services/redhatopenshift.ts
@@ -508,12 +508,12 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type GetOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const GetOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<GetOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -802,12 +802,12 @@ export const OpenShiftClusterTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type OpenShiftClusterIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const OpenShiftClusterIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<OpenShiftClusterIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1381,11 +1381,11 @@ export const UserAssignedIdentityInput = ConsoleProfileInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type OpenShiftClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
-  { [key: string]: ConsoleProfileInput | undefined };
+  { [key: string]: ConsoleProfileInput | null | undefined };
 export const OpenShiftClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ConsoleProfileInput,
+    S.NullOr(ConsoleProfileInput),
   ) as any as S.Schema<OpenShiftClustersCreateOrUpdateRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1456,11 +1456,11 @@ export const OpenShiftClustersCreateOrUpdateResponseTagsMap =
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type OpenShiftClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
-  { [key: string]: UserAssignedIdentity | undefined };
+  { [key: string]: UserAssignedIdentity | null | undefined };
 export const OpenShiftClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<OpenShiftClustersCreateOrUpdateResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1532,12 +1532,12 @@ export const UpdateOpenShiftClusterRequestTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateOpenShiftClusterRequestIdentityUserAssignedIdentitiesMap = {
-  [key: string]: ConsoleProfileInput | undefined;
+  [key: string]: ConsoleProfileInput | null | undefined;
 };
 export const UpdateOpenShiftClusterRequestIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ConsoleProfileInput,
+    S.NullOr(ConsoleProfileInput),
   ) as any as S.Schema<UpdateOpenShiftClusterRequestIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1603,12 +1603,12 @@ export const UpdateOpenShiftClusterResponseTagsMap = /*@__PURE__*/ S.Record(
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UpdateOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UpdateOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    UserAssignedIdentity,
+    S.NullOr(UserAssignedIdentity),
   ) as any as S.Schema<UpdateOpenShiftClusterResponseIdentityUserAssignedIdentitiesMap>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/storageactions.ts
+++ b/packages/azure/src/services/storageactions.ts
@@ -161,11 +161,11 @@ export const UserAssignedIdentityInput = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: UserAssignedIdentityInput | undefined;
+  [key: string]: UserAssignedIdentityInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentityInput,
+  S.NullOr(UserAssignedIdentityInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -328,11 +328,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/azure/src/services/storagesync.ts
+++ b/packages/azure/src/services/storagesync.ts
@@ -1779,11 +1779,11 @@ export const UserAssignedIdentityInput = PrivateEndpointInput;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentitiesInput = {
-  [key: string]: PrivateEndpointInput | undefined;
+  [key: string]: PrivateEndpointInput | null | undefined;
 };
 export const UserAssignedIdentitiesInput = /*@__PURE__*/ S.Record(
   S.String,
-  PrivateEndpointInput,
+  S.NullOr(PrivateEndpointInput),
 ) as any as S.Schema<UserAssignedIdentitiesInput>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */
@@ -1958,11 +1958,11 @@ export const UserAssignedIdentity = /*@__PURE__*/ S.suspend(() =>
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
 export type UserAssignedIdentities = {
-  [key: string]: UserAssignedIdentity | undefined;
+  [key: string]: UserAssignedIdentity | null | undefined;
 };
 export const UserAssignedIdentities = /*@__PURE__*/ S.Record(
   S.String,
-  UserAssignedIdentity,
+  S.NullOr(UserAssignedIdentity),
 ) as any as S.Schema<UserAssignedIdentities>;
 
 /** Managed service identity (system assigned and/or user assigned identities) */

--- a/packages/core/src/codegen/generator.ts
+++ b/packages/core/src/codegen/generator.ts
@@ -949,16 +949,26 @@ export const generateService = (
         );
       }
     } else if (d.type === "list") {
-      out.push(`export type ${name} = Array<${tsRefAt(d.member.target, id)}>;`);
+      const nullable =
+        spec.nullableTrait !== undefined &&
+        spec.nullableTrait in (d.member.traits ?? {});
+      const item = ref(d.member.target, i);
       out.push(
-        `export const ${name} = ${pure}S.Array(${ref(d.member.target, i)}) as any as S.Schema<${name}>;\n`,
+        `export type ${name} = Array<${tsRefAt(d.member.target, id)}${nullable ? " | null" : ""}>;`,
+      );
+      out.push(
+        `export const ${name} = ${pure}S.Array(${nullable ? `S.NullOr(${item})` : item}) as any as S.Schema<${name}>;\n`,
       );
     } else if (d.type === "map") {
+      const nullable =
+        spec.nullableTrait !== undefined &&
+        spec.nullableTrait in (d.value.traits ?? {});
+      const value = ref(d.value.target, i);
       out.push(
-        `export type ${name} = { [key: string]: ${tsRefAt(d.value.target, id)} | undefined };`,
+        `export type ${name} = { [key: string]: ${tsRefAt(d.value.target, id)}${nullable ? " | null" : ""} | undefined };`,
       );
       out.push(
-        `export const ${name} = ${pure}S.Record(S.String, ${ref(d.value.target, i)}) as any as S.Schema<${name}>;\n`,
+        `export const ${name} = ${pure}S.Record(S.String, ${nullable ? `S.NullOr(${value})` : value}) as any as S.Schema<${name}>;\n`,
       );
     } else if (d.type === "union") {
       // A union arm targeting the union itself carries no information

--- a/packages/core/src/codegen/openapi.ts
+++ b/packages/core/src/codegen/openapi.ts
@@ -852,7 +852,14 @@ const convertSchema = (
     const item = convertSchema(ctx, def.items, `${hint}Item`, depth + 1, dir);
     return {
       target: emit(
-        { type: "list", member: { target: item.target }, traits: docTraits },
+        {
+          type: "list",
+          member: {
+            target: item.target,
+            ...(item.nullable ? { traits: { [NULLABLE_TRAIT]: {} } } : {}),
+          },
+          traits: docTraits,
+        },
         reservedId !== undefined ? hint : `${hint}List`,
       ),
       nullable,
@@ -889,7 +896,10 @@ const convertSchema = (
           {
             type: "map",
             key: { target: PRELUDE.String },
-            value: { target: value.target },
+            value: {
+              target: value.target,
+              ...(value.nullable ? { traits: { [NULLABLE_TRAIT]: {} } } : {}),
+            },
             traits: docTraits,
           },
           reservedId !== undefined ? hint : `${hint}Map`,

--- a/packages/discord/.generated-specs/discord.json
+++ b/packages/discord/.generated-specs/discord.json
@@ -1537,7 +1537,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.discord.api#ApplicationIntegrationTypeConfiguration"
+        "target": "com.discord.api#ApplicationIntegrationTypeConfiguration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -1747,7 +1750,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.discord.api#ApplicationIntegrationTypeConfiguration"
+        "target": "com.discord.api#ApplicationIntegrationTypeConfiguration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -5655,7 +5661,10 @@
     "com.discord.api#GetEntitlementsRequestSkuIdsCase1List": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -7214,7 +7223,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -7224,7 +7236,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10247,7 +10262,10 @@
     "com.discord.api#ListChannelInvitesResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ListChannelInvitesResponseBodyItem"
+        "target": "com.discord.api#ListChannelInvitesResponseBodyItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -14671,21 +14689,30 @@
     "com.discord.api#MessageAllowedMentionsRequestParseList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#AllowedMentionTypes"
+        "target": "com.discord.api#AllowedMentionTypes",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
     "com.discord.api#MessageAllowedMentionsRequestUsersList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
     "com.discord.api#MessageAllowedMentionsRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20118,7 +20145,10 @@
     "com.discord.api#UpdateGuildRequestFeaturesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -22849,7 +22879,10 @@
     "com.discord.api#GuildAuditLogResponseAutoModerationRulesList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#GuildAuditLogResponseAutoModerationRulesItem"
+        "target": "com.discord.api#GuildAuditLogResponseAutoModerationRulesItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -22908,7 +22941,10 @@
     "com.discord.api#ListAutoModerationRulesResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ListAutoModerationRulesResponseBodyItem"
+        "target": "com.discord.api#ListAutoModerationRulesResponseBodyItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -24791,7 +24827,10 @@
     "com.discord.api#CreateGuildChannelRequestAvailableTagsList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#CreateOrUpdateThreadTagRequest"
+        "target": "com.discord.api#CreateOrUpdateThreadTagRequest",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -25072,7 +25111,10 @@
     "com.discord.api#CreateGuildEmojiRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -25166,7 +25208,10 @@
     "com.discord.api#UpdateGuildEmojiRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -25720,7 +25765,10 @@
     "com.discord.api#ListGuildInvitesResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ListGuildInvitesResponseBodyItem"
+        "target": "com.discord.api#ListGuildInvitesResponseBodyItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -26186,7 +26234,10 @@
     "com.discord.api#UpdateGuildMemberRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -28085,7 +28136,10 @@
     "com.discord.api#PreviewPruneGuildRequestIncludeRolesCase1List": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -32410,7 +32464,10 @@
     "com.discord.api#InteractionApplicationCommandAutocompleteCallbackIntegerDataChoicesList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ApplicationCommandOptionIntegerChoice"
+        "target": "com.discord.api#ApplicationCommandOptionIntegerChoice",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -32429,7 +32486,10 @@
     "com.discord.api#InteractionApplicationCommandAutocompleteCallbackNumberDataChoicesList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ApplicationCommandOptionNumberChoice"
+        "target": "com.discord.api#ApplicationCommandOptionNumberChoice",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -32448,7 +32508,10 @@
     "com.discord.api#InteractionApplicationCommandAutocompleteCallbackStringDataChoicesList": {
       "type": "list",
       "member": {
-        "target": "com.discord.api#ApplicationCommandOptionStringChoice"
+        "target": "com.discord.api#ApplicationCommandOptionStringChoice",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -36881,7 +36944,10 @@
     "com.discord.api#GetCurrentUserApplicationEntitlementsRequestSkuIdsCase1List": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -37124,7 +37190,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/discord/src/services/discord.ts
+++ b/packages/discord/src/services/discord.ts
@@ -5406,10 +5406,12 @@ export const CreateDmRequestAccessTokensList = /*@__PURE__*/ S.Array(
   S.String,
 ) as any as S.Schema<CreateDmRequestAccessTokensList>;
 
-export type CreateDmRequestNicksMap = { [key: string]: string | undefined };
+export type CreateDmRequestNicksMap = {
+  [key: string]: string | null | undefined;
+};
 export const CreateDmRequestNicksMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CreateDmRequestNicksMap>;
 
 export interface CreateDmRequest {
@@ -5836,9 +5838,9 @@ export const CreateOrUpdateThreadTagRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<CreateOrUpdateThreadTagRequest>;
 
 export type CreateGuildChannelRequestAvailableTagsList =
-  Array<CreateOrUpdateThreadTagRequest>;
+  Array<CreateOrUpdateThreadTagRequest | null>;
 export const CreateGuildChannelRequestAvailableTagsList = /*@__PURE__*/ S.Array(
-  CreateOrUpdateThreadTagRequest,
+  S.NullOr(CreateOrUpdateThreadTagRequest),
 ) as any as S.Schema<CreateGuildChannelRequestAvailableTagsList>;
 
 export interface CreateGuildChannelRequest {
@@ -6025,9 +6027,9 @@ export const GuildChannelResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "GuildChannelResponse",
 }) as any as S.Schema<GuildChannelResponse>;
 
-export type CreateGuildEmojiRequestRolesList = Array<string>;
+export type CreateGuildEmojiRequestRolesList = Array<string | null>;
 export const CreateGuildEmojiRequestRolesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CreateGuildEmojiRequestRolesList>;
 
 export interface CreateGuildEmojiRequest {
@@ -7021,10 +7023,10 @@ export type InteractionCallbackTypes = 1 | 4 | 5 | 6 | 7 | 8 | 9 | 12 | 13;
 export const InteractionCallbackTypes = S.Number;
 
 export type InteractionApplicationCommandAutocompleteCallbackIntegerDataChoicesList =
-  Array<ApplicationCommandOptionIntegerChoice>;
+  Array<ApplicationCommandOptionIntegerChoice | null>;
 export const InteractionApplicationCommandAutocompleteCallbackIntegerDataChoicesList =
   /*@__PURE__*/ S.Array(
-    ApplicationCommandOptionIntegerChoice,
+    S.NullOr(ApplicationCommandOptionIntegerChoice),
   ) as any as S.Schema<InteractionApplicationCommandAutocompleteCallbackIntegerDataChoicesList>;
 
 export interface InteractionApplicationCommandAutocompleteCallbackIntegerData {
@@ -7044,10 +7046,10 @@ export const InteractionApplicationCommandAutocompleteCallbackIntegerData =
   }) as any as S.Schema<InteractionApplicationCommandAutocompleteCallbackIntegerData>;
 
 export type InteractionApplicationCommandAutocompleteCallbackNumberDataChoicesList =
-  Array<ApplicationCommandOptionNumberChoice>;
+  Array<ApplicationCommandOptionNumberChoice | null>;
 export const InteractionApplicationCommandAutocompleteCallbackNumberDataChoicesList =
   /*@__PURE__*/ S.Array(
-    ApplicationCommandOptionNumberChoice,
+    S.NullOr(ApplicationCommandOptionNumberChoice),
   ) as any as S.Schema<InteractionApplicationCommandAutocompleteCallbackNumberDataChoicesList>;
 
 export interface InteractionApplicationCommandAutocompleteCallbackNumberData {
@@ -7067,10 +7069,10 @@ export const InteractionApplicationCommandAutocompleteCallbackNumberData =
   }) as any as S.Schema<InteractionApplicationCommandAutocompleteCallbackNumberData>;
 
 export type InteractionApplicationCommandAutocompleteCallbackStringDataChoicesList =
-  Array<ApplicationCommandOptionStringChoice>;
+  Array<ApplicationCommandOptionStringChoice | null>;
 export const InteractionApplicationCommandAutocompleteCallbackStringDataChoicesList =
   /*@__PURE__*/ S.Array(
-    ApplicationCommandOptionStringChoice,
+    S.NullOr(ApplicationCommandOptionStringChoice),
   ) as any as S.Schema<InteractionApplicationCommandAutocompleteCallbackStringDataChoicesList>;
 
 export interface InteractionApplicationCommandAutocompleteCallbackStringData {
@@ -7241,20 +7243,20 @@ export type AllowedMentionTypes = "users" | "roles" | "everyone";
 export const AllowedMentionTypes = S.String;
 
 export type MessageAllowedMentionsRequestParseList = Array<
-  AllowedMentionTypes | (string & {})
+  AllowedMentionTypes | (string & {}) | null
 >;
 export const MessageAllowedMentionsRequestParseList = /*@__PURE__*/ S.Array(
-  AllowedMentionTypes,
+  S.NullOr(AllowedMentionTypes),
 ) as any as S.Schema<MessageAllowedMentionsRequestParseList>;
 
-export type MessageAllowedMentionsRequestUsersList = Array<string>;
+export type MessageAllowedMentionsRequestUsersList = Array<string | null>;
 export const MessageAllowedMentionsRequestUsersList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<MessageAllowedMentionsRequestUsersList>;
 
-export type MessageAllowedMentionsRequestRolesList = Array<string>;
+export type MessageAllowedMentionsRequestRolesList = Array<string | null>;
 export const MessageAllowedMentionsRequestRolesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<MessageAllowedMentionsRequestRolesList>;
 
 export interface MessageAllowedMentionsRequest {
@@ -14614,11 +14616,12 @@ export const GetChannelResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "GetChannelResponse",
 }) as any as S.Schema<GetChannelResponse>;
 
-export type GetCurrentUserApplicationEntitlementsRequestSkuIdsCase1List =
-  Array<string>;
+export type GetCurrentUserApplicationEntitlementsRequestSkuIdsCase1List = Array<
+  string | null
+>;
 export const GetCurrentUserApplicationEntitlementsRequestSkuIdsCase1List =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<GetCurrentUserApplicationEntitlementsRequestSkuIdsCase1List>;
 
 export type GetCurrentUserApplicationEntitlementsRequestSkuIds =
@@ -14688,9 +14691,9 @@ export const GetEntitlementRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "GetEntitlementRequest",
 }) as any as S.Schema<GetEntitlementRequest>;
 
-export type GetEntitlementsRequestSkuIdsCase1List = Array<string>;
+export type GetEntitlementsRequestSkuIdsCase1List = Array<string | null>;
 export const GetEntitlementsRequestSkuIdsCase1List = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<GetEntitlementsRequestSkuIdsCase1List>;
 
 export type GetEntitlementsRequestSkuIds =
@@ -17461,9 +17464,9 @@ export const ListAutoModerationRulesResponseBodyItem =
   );
 
 export type ListAutoModerationRulesResponseBodyList =
-  Array<ListAutoModerationRulesResponseBodyItem>;
+  Array<ListAutoModerationRulesResponseBodyItem | null>;
 export const ListAutoModerationRulesResponseBodyList = /*@__PURE__*/ S.Array(
-  ListAutoModerationRulesResponseBodyItem,
+  S.NullOr(ListAutoModerationRulesResponseBodyItem),
 ) as any as S.Schema<ListAutoModerationRulesResponseBodyList>;
 
 export type ListAutoModerationRulesResponse =
@@ -17548,9 +17551,9 @@ export const ListChannelInvitesResponseBodyItem = /*@__PURE__*/ S.Unknown.pipe(
 );
 
 export type ListChannelInvitesResponseBodyList =
-  Array<ListChannelInvitesResponseBodyItem>;
+  Array<ListChannelInvitesResponseBodyItem | null>;
 export const ListChannelInvitesResponseBodyList = /*@__PURE__*/ S.Array(
-  ListChannelInvitesResponseBodyItem,
+  S.NullOr(ListChannelInvitesResponseBodyItem),
 ) as any as S.Schema<ListChannelInvitesResponseBodyList>;
 
 export type ListChannelInvitesResponse = ListChannelInvitesResponseBodyList;
@@ -18199,10 +18202,10 @@ export const GuildAuditLogResponseAutoModerationRulesItem =
   );
 
 export type GuildAuditLogResponseAutoModerationRulesList =
-  Array<GuildAuditLogResponseAutoModerationRulesItem>;
+  Array<GuildAuditLogResponseAutoModerationRulesItem | null>;
 export const GuildAuditLogResponseAutoModerationRulesList =
   /*@__PURE__*/ S.Array(
-    GuildAuditLogResponseAutoModerationRulesItem,
+    S.NullOr(GuildAuditLogResponseAutoModerationRulesItem),
   ) as any as S.Schema<GuildAuditLogResponseAutoModerationRulesList>;
 
 export interface GuildAuditLogResponse {
@@ -18630,9 +18633,9 @@ export const ListGuildInvitesResponseBodyItem = /*@__PURE__*/ S.Unknown.pipe(
 );
 
 export type ListGuildInvitesResponseBodyList =
-  Array<ListGuildInvitesResponseBodyItem>;
+  Array<ListGuildInvitesResponseBodyItem | null>;
 export const ListGuildInvitesResponseBodyList = /*@__PURE__*/ S.Array(
-  ListGuildInvitesResponseBodyItem,
+  S.NullOr(ListGuildInvitesResponseBodyItem),
 ) as any as S.Schema<ListGuildInvitesResponseBodyList>;
 
 export type ListGuildInvitesResponse = ListGuildInvitesResponseBodyList;
@@ -19556,10 +19559,12 @@ export const PollExpireRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "PollExpireRequest",
 }) as any as S.Schema<PollExpireRequest>;
 
-export type PreviewPruneGuildRequestIncludeRolesCase1List = Array<string>;
+export type PreviewPruneGuildRequestIncludeRolesCase1List = Array<
+  string | null
+>;
 export const PreviewPruneGuildRequestIncludeRolesCase1List =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<PreviewPruneGuildRequestIncludeRolesCase1List>;
 
 export type PreviewPruneGuildRequestIncludeRoles =
@@ -20671,12 +20676,12 @@ export const ApplicationIntegrationTypeConfiguration = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<ApplicationIntegrationTypeConfiguration>;
 
 export type UpdateApplicationRequestIntegrationTypesConfigMap = {
-  [key: string]: ApplicationIntegrationTypeConfiguration | undefined;
+  [key: string]: ApplicationIntegrationTypeConfiguration | null | undefined;
 };
 export const UpdateApplicationRequestIntegrationTypesConfigMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ApplicationIntegrationTypeConfiguration,
+    S.NullOr(ApplicationIntegrationTypeConfiguration),
   ) as any as S.Schema<UpdateApplicationRequestIntegrationTypesConfigMap>;
 
 export type UpdateApplicationRequestEventWebhooksTypesList = Array<
@@ -20978,19 +20983,19 @@ export const UpdateApplicationEmojiRequest = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<UpdateApplicationEmojiRequest>;
 
 export type ApplicationRoleConnectionsMetadataItemRequestNameLocalizationsMap =
-  { [key: string]: string | undefined };
+  { [key: string]: string | null | undefined };
 export const ApplicationRoleConnectionsMetadataItemRequestNameLocalizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<ApplicationRoleConnectionsMetadataItemRequestNameLocalizationsMap>;
 
 export type ApplicationRoleConnectionsMetadataItemRequestDescriptionLocalizationsMap =
-  { [key: string]: string | undefined };
+  { [key: string]: string | null | undefined };
 export const ApplicationRoleConnectionsMetadataItemRequestDescriptionLocalizationsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<ApplicationRoleConnectionsMetadataItemRequestDescriptionLocalizationsMap>;
 
 export interface ApplicationRoleConnectionsMetadataItemRequest {
@@ -21894,9 +21899,9 @@ export const UpdateChannelResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "UpdateChannelResponse",
 }) as any as S.Schema<UpdateChannelResponse>;
 
-export type UpdateGuildRequestFeaturesList = Array<string>;
+export type UpdateGuildRequestFeaturesList = Array<string | null>;
 export const UpdateGuildRequestFeaturesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateGuildRequestFeaturesList>;
 
 export interface UpdateGuildRequest {
@@ -22291,9 +22296,9 @@ export const UpdateGuildApplicationCommandRequest = /*@__PURE__*/ S.suspend(
   identifier: "UpdateGuildApplicationCommandRequest",
 }) as any as S.Schema<UpdateGuildApplicationCommandRequest>;
 
-export type UpdateGuildEmojiRequestRolesList = Array<string>;
+export type UpdateGuildEmojiRequestRolesList = Array<string | null>;
 export const UpdateGuildEmojiRequestRolesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateGuildEmojiRequestRolesList>;
 
 export interface UpdateGuildEmojiRequest {
@@ -22342,9 +22347,9 @@ export const UpdateGuildIncidentActionsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "UpdateGuildIncidentActionsRequest",
 }) as any as S.Schema<UpdateGuildIncidentActionsRequest>;
 
-export type UpdateGuildMemberRequestRolesList = Array<string>;
+export type UpdateGuildMemberRequestRolesList = Array<string | null>;
 export const UpdateGuildMemberRequestRolesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateGuildMemberRequestRolesList>;
 
 export interface UpdateGuildMemberRequest {
@@ -22982,12 +22987,12 @@ export const UpdateMyApplicationRequestTagsList = /*@__PURE__*/ S.Array(
 ) as any as S.Schema<UpdateMyApplicationRequestTagsList>;
 
 export type UpdateMyApplicationRequestIntegrationTypesConfigMap = {
-  [key: string]: ApplicationIntegrationTypeConfiguration | undefined;
+  [key: string]: ApplicationIntegrationTypeConfiguration | null | undefined;
 };
 export const UpdateMyApplicationRequestIntegrationTypesConfigMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ApplicationIntegrationTypeConfiguration,
+    S.NullOr(ApplicationIntegrationTypeConfiguration),
   ) as any as S.Schema<UpdateMyApplicationRequestIntegrationTypesConfigMap>;
 
 export type UpdateMyApplicationRequestEventWebhooksTypesList = Array<

--- a/packages/github/.generated-specs/code_scanning.json
+++ b/packages/github/.generated-specs/code_scanning.json
@@ -809,7 +809,10 @@
     "com.github.code_scanning#CodeScanningAlertInstanceClassificationsList": {
       "type": "list",
       "member": {
-        "target": "com.github.code_scanning#CodeScanningAlertClassification"
+        "target": "com.github.code_scanning#CodeScanningAlertClassification",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Classifications that have been applied to the file that triggered the alert.\nFor example identifying it as documentation, or a generated file."
@@ -4365,7 +4368,10 @@
     "com.github.code_scanning#CodeScanningAlertInstanceListClassificationsList": {
       "type": "list",
       "member": {
-        "target": "com.github.code_scanning#CodeScanningAlertClassification"
+        "target": "com.github.code_scanning#CodeScanningAlertClassification",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Classifications that have been applied to the file that triggered the alert.\nFor example identifying it as documentation, or a generated file."

--- a/packages/github/.generated-specs/dependabot.json
+++ b/packages/github/.generated-specs/dependabot.json
@@ -2148,7 +2148,10 @@
     "com.github.dependabot#DependabotRepositoryAccessDetailsAccessibleRepositoriesList": {
       "type": "list",
       "member": {
-        "target": "com.github.dependabot#NullableSimpleRepository"
+        "target": "com.github.dependabot#NullableSimpleRepository",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/github/.generated-specs/dependency_graph.json
+++ b/packages/github/.generated-specs/dependency_graph.json
@@ -441,7 +441,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.github.dependency_graph#MetadataValue"
+        "target": "com.github.dependency_graph#MetadataValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "User-defined metadata to store domain-specific information limited to 8 keys with scalar values."

--- a/packages/github/.generated-specs/gists.json
+++ b/packages/github/.generated-specs/gists.json
@@ -1251,7 +1251,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.github.gists#GistSimpleFilesValue"
+        "target": "com.github.gists#GistSimpleFilesValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -1498,7 +1501,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.github.gists#UpdateRequestFilesValue"
+        "target": "com.github.gists#UpdateRequestFilesValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The gist files to be updated, renamed, or deleted. Each `key` must match the current filename\n(including extension) of the targeted gist file. For example: `hello.py`.\n\nTo delete a file, set the whole file to null. For example: `hello.py : null`. The file will also be\ndeleted if the specified object does not contain at least one of `content` or `filename`."

--- a/packages/github/.generated-specs/orgs.json
+++ b/packages/github/.generated-specs/orgs.json
@@ -2281,7 +2281,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.github.orgs#ListAttestationsBulkResponseAttestationsSubjectDigestsValueList"
+        "target": "com.github.orgs#ListAttestationsBulkResponseAttestationsSubjectDigestsValueList",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Mapping of subject digest to bundles."
@@ -8539,7 +8542,10 @@
     "com.github.orgs#ListIssueFieldsResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.orgs#IssueField"
+        "target": "com.github.orgs#IssueField",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9197,7 +9203,10 @@
     "com.github.orgs#ListIssueTypesResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.orgs#IssueType"
+        "target": "com.github.orgs#IssueType",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/github/.generated-specs/repos.json
+++ b/packages/github/.generated-specs/repos.json
@@ -10272,7 +10272,10 @@
     "com.github.repos#ProtectedBranchPullRequestReviewDismissalRestrictionsAppsList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The list of apps with review dismissal access."
@@ -10332,7 +10335,10 @@
     "com.github.repos#ProtectedBranchPullRequestReviewBypassPullRequestAllowancesAppsList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "The list of apps allowed to bypass pull request requirements."
@@ -11854,7 +11860,10 @@
     "com.github.repos#ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsAppsList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -11914,7 +11923,10 @@
     "com.github.repos#ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowancesAppsList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13598,7 +13610,10 @@
     "com.github.repos#GetAppsWithAccessToProtectedBranchResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13690,7 +13705,10 @@
     "com.github.repos#AddAppAccessRestrictionsResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13782,7 +13800,10 @@
     "com.github.repos#SetAppAccessRestrictionsResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13874,7 +13895,10 @@
     "com.github.repos#RemoveAppAccessRestrictionsResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#Integration"
+        "target": "com.github.repos#Integration",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -24135,7 +24159,10 @@
     "com.github.repos#ListIssueTypesResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.github.repos#IssueType"
+        "target": "com.github.repos#IssueType",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/github/.generated-specs/users.json
+++ b/packages/github/.generated-specs/users.json
@@ -3180,7 +3180,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.github.users#ListAttestationsBulkResponseAttestationsSubjectDigestsValueList"
+        "target": "com.github.users#ListAttestationsBulkResponseAttestationsSubjectDigestsValueList",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Mapping of subject digest to bundles."

--- a/packages/github/src/services/code_scanning.ts
+++ b/packages/github/src/services/code_scanning.ts
@@ -853,10 +853,10 @@ export const CodeScanningAlertClassification = S.String;
 
 /** Classifications that have been applied to the file that triggered the alert. For example identifying it as documentation, or a generated file. */
 export type CodeScanningAlertInstanceClassificationsList =
-  Array<CodeScanningAlertClassification>;
+  Array<CodeScanningAlertClassification | null>;
 export const CodeScanningAlertInstanceClassificationsList =
   /*@__PURE__*/ S.Array(
-    CodeScanningAlertClassification,
+    S.NullOr(CodeScanningAlertClassification),
   ) as any as S.Schema<CodeScanningAlertInstanceClassificationsList>;
 
 export interface CodeScanningAlertInstance {
@@ -2152,10 +2152,10 @@ export const CodeScanningAlertInstanceListMessage = /*@__PURE__*/ S.suspend(
 
 /** Classifications that have been applied to the file that triggered the alert. For example identifying it as documentation, or a generated file. */
 export type CodeScanningAlertInstanceListClassificationsList =
-  Array<CodeScanningAlertClassification>;
+  Array<CodeScanningAlertClassification | null>;
 export const CodeScanningAlertInstanceListClassificationsList =
   /*@__PURE__*/ S.Array(
-    CodeScanningAlertClassification,
+    S.NullOr(CodeScanningAlertClassification),
   ) as any as S.Schema<CodeScanningAlertInstanceListClassificationsList>;
 
 export interface CodeScanningAlertInstanceList {

--- a/packages/github/src/services/dependabot.ts
+++ b/packages/github/src/services/dependabot.ts
@@ -2237,10 +2237,10 @@ export type NullableSimpleRepository = SimpleRepository;
 export const NullableSimpleRepository = SimpleRepository;
 
 export type DependabotRepositoryAccessDetailsAccessibleRepositoriesList =
-  Array<SimpleRepository>;
+  Array<SimpleRepository | null>;
 export const DependabotRepositoryAccessDetailsAccessibleRepositoriesList =
   /*@__PURE__*/ S.Array(
-    SimpleRepository,
+    S.NullOr(SimpleRepository),
   ) as any as S.Schema<DependabotRepositoryAccessDetailsAccessibleRepositoriesList>;
 
 /** Information about repositories that Dependabot is able to access in an organization */

--- a/packages/github/src/services/dependency_graph.ts
+++ b/packages/github/src/services/dependency_graph.ts
@@ -81,10 +81,10 @@ export type MetadataValue = string | number | boolean;
 export const MetadataValue = S.Unknown as any as S.Schema<MetadataValue>;
 
 /** User-defined metadata to store domain-specific information limited to 8 keys with scalar values. */
-export type Metadata = { [key: string]: MetadataValue | undefined };
+export type Metadata = { [key: string]: MetadataValue | null | undefined };
 export const Metadata = /*@__PURE__*/ S.Record(
   S.String,
-  MetadataValue,
+  S.NullOr(MetadataValue),
 ) as any as S.Schema<Metadata>;
 
 export interface ManifestFile {

--- a/packages/github/src/services/gists.ts
+++ b/packages/github/src/services/gists.ts
@@ -436,11 +436,11 @@ export const GistSimpleFilesValue = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<GistSimpleFilesValue>;
 
 export type GistSimpleFilesMap = {
-  [key: string]: GistSimpleFilesValue | undefined;
+  [key: string]: GistSimpleFilesValue | null | undefined;
 };
 export const GistSimpleFilesMap = /*@__PURE__*/ S.Record(
   S.String,
-  GistSimpleFilesValue,
+  S.NullOr(GistSimpleFilesValue),
 ) as any as S.Schema<GistSimpleFilesMap>;
 
 /** A GitHub user. */
@@ -1025,11 +1025,11 @@ export const UpdateRequestFilesValue = /*@__PURE__*/ S.suspend(() =>
 
 /** The gist files to be updated, renamed, or deleted. Each `key` must match the current filename (including extension) of the targeted gist file. For example: `hello.py`. To delete a file, set the whole file to null. For example: `hello.py : null`. The file will also be deleted if the specified object does not contain at least one of `content` or `filename`. */
 export type UpdateRequestFilesMap = {
-  [key: string]: UpdateRequestFilesValue | undefined;
+  [key: string]: UpdateRequestFilesValue | null | undefined;
 };
 export const UpdateRequestFilesMap = /*@__PURE__*/ S.Record(
   S.String,
-  UpdateRequestFilesValue,
+  S.NullOr(UpdateRequestFilesValue),
 ) as any as S.Schema<UpdateRequestFilesMap>;
 
 export interface UpdateRequest {

--- a/packages/github/src/services/orgs.ts
+++ b/packages/github/src/services/orgs.ts
@@ -4922,12 +4922,13 @@ export const ListAttestationsBulkResponseAttestationsSubjectDigestsValueList =
 export type ListAttestationsBulkResponseAttestationsSubjectDigestsMap = {
   [key: string]:
     | ListAttestationsBulkResponseAttestationsSubjectDigestsValueList
+    | null
     | undefined;
 };
 export const ListAttestationsBulkResponseAttestationsSubjectDigestsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ListAttestationsBulkResponseAttestationsSubjectDigestsValueList,
+    S.NullOr(ListAttestationsBulkResponseAttestationsSubjectDigestsValueList),
   ) as any as S.Schema<ListAttestationsBulkResponseAttestationsSubjectDigestsMap>;
 
 /** Information about the current page. */
@@ -5278,9 +5279,9 @@ export const ListIssueFieldsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListIssueFieldsRequest",
 }) as any as S.Schema<ListIssueFieldsRequest>;
 
-export type ListIssueFieldsResponseBodyList = Array<IssueField>;
+export type ListIssueFieldsResponseBodyList = Array<IssueField | null>;
 export const ListIssueFieldsResponseBodyList = /*@__PURE__*/ S.Array(
-  IssueField,
+  S.NullOr(IssueField),
 ) as any as S.Schema<ListIssueFieldsResponseBodyList>;
 
 export type ListIssueFieldsResponse = ListIssueFieldsResponseBodyList;
@@ -5302,9 +5303,9 @@ export const ListIssueTypesRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "ListIssueTypesRequest",
 }) as any as S.Schema<ListIssueTypesRequest>;
 
-export type ListIssueTypesResponseBodyList = Array<IssueType>;
+export type ListIssueTypesResponseBodyList = Array<IssueType | null>;
 export const ListIssueTypesResponseBodyList = /*@__PURE__*/ S.Array(
-  IssueType,
+  S.NullOr(IssueType),
 ) as any as S.Schema<ListIssueTypesResponseBodyList>;
 
 export type ListIssueTypesResponse = ListIssueTypesResponseBodyList;

--- a/packages/github/src/services/repos.ts
+++ b/packages/github/src/services/repos.ts
@@ -272,9 +272,10 @@ export const Integration = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "Integration" }) as any as S.Schema<Integration>;
 
-export type AddAppAccessRestrictionsResponseBodyList = Array<Integration>;
+export type AddAppAccessRestrictionsResponseBodyList =
+  Array<Integration | null>;
 export const AddAppAccessRestrictionsResponseBodyList = /*@__PURE__*/ S.Array(
-  Integration,
+  S.NullOr(Integration),
 ) as any as S.Schema<AddAppAccessRestrictionsResponseBodyList>;
 
 export type AddAppAccessRestrictionsResponse =
@@ -8042,10 +8043,10 @@ export const GetAppsWithAccessToProtectedBranchRequest =
   }) as any as S.Schema<GetAppsWithAccessToProtectedBranchRequest>;
 
 export type GetAppsWithAccessToProtectedBranchResponseBodyList =
-  Array<Integration>;
+  Array<Integration | null>;
 export const GetAppsWithAccessToProtectedBranchResponseBodyList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<GetAppsWithAccessToProtectedBranchResponseBodyList>;
 
 export type GetAppsWithAccessToProtectedBranchResponse =
@@ -8187,10 +8188,10 @@ export const ProtectedBranchPullRequestReviewDismissalRestrictionsTeamsList =
 
 /** The list of apps with review dismissal access. */
 export type ProtectedBranchPullRequestReviewDismissalRestrictionsAppsList =
-  Array<Integration>;
+  Array<Integration | null>;
 export const ProtectedBranchPullRequestReviewDismissalRestrictionsAppsList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<ProtectedBranchPullRequestReviewDismissalRestrictionsAppsList>;
 
 export interface ProtectedBranchPullRequestReviewDismissalRestrictions {
@@ -8242,10 +8243,10 @@ export const ProtectedBranchPullRequestReviewBypassPullRequestAllowancesTeamsLis
 
 /** The list of apps allowed to bypass pull request requirements. */
 export type ProtectedBranchPullRequestReviewBypassPullRequestAllowancesAppsList =
-  Array<Integration>;
+  Array<Integration | null>;
 export const ProtectedBranchPullRequestReviewBypassPullRequestAllowancesAppsList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<ProtectedBranchPullRequestReviewBypassPullRequestAllowancesAppsList>;
 
 /** Allow specific users, teams, or apps to bypass pull request requirements. */
@@ -13564,9 +13565,9 @@ export const IssueType = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "IssueType" }) as any as S.Schema<IssueType>;
 
-export type ListIssueTypesResponseBodyList = Array<IssueType>;
+export type ListIssueTypesResponseBodyList = Array<IssueType | null>;
 export const ListIssueTypesResponseBodyList = /*@__PURE__*/ S.Array(
-  IssueType,
+  S.NullOr(IssueType),
 ) as any as S.Schema<ListIssueTypesResponseBodyList>;
 
 export type ListIssueTypesResponse = ListIssueTypesResponseBodyList;
@@ -14479,10 +14480,11 @@ export const RemoveAppAccessRestrictionsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "RemoveAppAccessRestrictionsRequest",
 }) as any as S.Schema<RemoveAppAccessRestrictionsRequest>;
 
-export type RemoveAppAccessRestrictionsResponseBodyList = Array<Integration>;
+export type RemoveAppAccessRestrictionsResponseBodyList =
+  Array<Integration | null>;
 export const RemoveAppAccessRestrictionsResponseBodyList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<RemoveAppAccessRestrictionsResponseBodyList>;
 
 export type RemoveAppAccessRestrictionsResponse =
@@ -14897,9 +14899,10 @@ export const SetAppAccessRestrictionsRequest = /*@__PURE__*/ S.suspend(() =>
   identifier: "SetAppAccessRestrictionsRequest",
 }) as any as S.Schema<SetAppAccessRestrictionsRequest>;
 
-export type SetAppAccessRestrictionsResponseBodyList = Array<Integration>;
+export type SetAppAccessRestrictionsResponseBodyList =
+  Array<Integration | null>;
 export const SetAppAccessRestrictionsResponseBodyList = /*@__PURE__*/ S.Array(
-  Integration,
+  S.NullOr(Integration),
 ) as any as S.Schema<SetAppAccessRestrictionsResponseBodyList>;
 
 export type SetAppAccessRestrictionsResponse =
@@ -15791,10 +15794,10 @@ export const ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeams
   ) as any as S.Schema<ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsTeamsList>;
 
 export type ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsAppsList =
-  Array<Integration>;
+  Array<Integration | null>;
 export const ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsAppsList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<ProtectedBranchRequiredPullRequestReviewsDismissalRestrictionsAppsList>;
 
 export interface ProtectedBranchRequiredPullRequestReviewsDismissalRestrictions {
@@ -15839,10 +15842,10 @@ export const ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowance
   ) as any as S.Schema<ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowancesTeamsList>;
 
 export type ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowancesAppsList =
-  Array<Integration>;
+  Array<Integration | null>;
 export const ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowancesAppsList =
   /*@__PURE__*/ S.Array(
-    Integration,
+    S.NullOr(Integration),
   ) as any as S.Schema<ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowancesAppsList>;
 
 export interface ProtectedBranchRequiredPullRequestReviewsBypassPullRequestAllowances {

--- a/packages/github/src/services/users.ts
+++ b/packages/github/src/services/users.ts
@@ -1418,12 +1418,13 @@ export const ListAttestationsBulkResponseAttestationsSubjectDigestsValueList =
 export type ListAttestationsBulkResponseAttestationsSubjectDigestsMap = {
   [key: string]:
     | ListAttestationsBulkResponseAttestationsSubjectDigestsValueList
+    | null
     | undefined;
 };
 export const ListAttestationsBulkResponseAttestationsSubjectDigestsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    ListAttestationsBulkResponseAttestationsSubjectDigestsValueList,
+    S.NullOr(ListAttestationsBulkResponseAttestationsSubjectDigestsValueList),
   ) as any as S.Schema<ListAttestationsBulkResponseAttestationsSubjectDigestsMap>;
 
 /** Information about the current page. */

--- a/packages/mongodb-atlas/.generated-specs/atlas.json
+++ b/packages/mongodb-atlas/.generated-specs/atlas.json
@@ -1206,7 +1206,10 @@
     "com.mongodbatlas.api#ConnectedOrgConfigPostAuthRoleGrantsList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#ConnectedOrgConfigPostAuthRoleGrantsItem"
+        "target": "com.mongodbatlas.api#ConnectedOrgConfigPostAuthRoleGrantsItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Atlas roles that are granted to a user in this organization after authenticating. Roles are a human-readable label that identifies the collection of privileges that MongoDB Cloud grants a specific MongoDB Cloud user. These roles can only be organization specific roles."
@@ -1500,7 +1503,10 @@
     "com.mongodbatlas.api#UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsItem"
+        "target": "com.mongodbatlas.api#UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Atlas roles that are granted to a user in this organization after authenticating. Roles are a human-readable label that identifies the collection of privileges that MongoDB Cloud grants a specific MongoDB Cloud user. These roles can only be organization specific roles."
@@ -108206,7 +108212,10 @@
     "com.mongodbatlas.api#MeasurementsIndexesIndexIdsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List that contains the Atlas Search index identifiers."
@@ -135627,7 +135636,10 @@
     "com.mongodbatlas.api#CreateAtlasOrganizationApiKeyRolesList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#CreateAtlasOrganizationApiKeyRolesItem"
+        "target": "com.mongodbatlas.api#CreateAtlasOrganizationApiKeyRolesItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization."
@@ -138636,7 +138648,10 @@
     "com.mongodbatlas.api#CreateOrgApiKeyRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#CreateOrgApiKeyRequestRolesItem"
+        "target": "com.mongodbatlas.api#CreateOrgApiKeyRequestRolesItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization."
@@ -138827,7 +138842,10 @@
     "com.mongodbatlas.api#UpdateOrgApiKeyRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#UpdateOrgApiKeyRequestRolesItem"
+        "target": "com.mongodbatlas.api#UpdateOrgApiKeyRequestRolesItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization."
@@ -146661,7 +146679,10 @@
     "com.mongodbatlas.api#UpdateOrgMcpConfigRequestRolesList": {
       "type": "list",
       "member": {
-        "target": "com.mongodbatlas.api#UpdateOrgMcpConfigRequestRolesItem"
+        "target": "com.mongodbatlas.api#UpdateOrgMcpConfigRequestRolesItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "List of organization roles associated with this MCP configuration. If provided, replaces the existing list of roles."

--- a/packages/mongodb-atlas/src/services/atlas.ts
+++ b/packages/mongodb-atlas/src/services/atlas.ts
@@ -2275,9 +2275,9 @@ export const ConnectedOrgConfigPostAuthRoleGrantsItem = S.String;
 
 /** Atlas roles that are granted to a user in this organization after authenticating. Roles are a human-readable label that identifies the collection of privileges that MongoDB Cloud grants a specific MongoDB Cloud user. These roles can only be organization specific roles. */
 export type ConnectedOrgConfigPostAuthRoleGrantsList =
-  Array<ConnectedOrgConfigPostAuthRoleGrantsItem>;
+  Array<ConnectedOrgConfigPostAuthRoleGrantsItem | null>;
 export const ConnectedOrgConfigPostAuthRoleGrantsList = /*@__PURE__*/ S.Array(
-  ConnectedOrgConfigPostAuthRoleGrantsItem,
+  S.NullOr(ConnectedOrgConfigPostAuthRoleGrantsItem),
 ) as any as S.Schema<ConnectedOrgConfigPostAuthRoleGrantsList>;
 
 /** Role mappings that are configured in this organization. */
@@ -28529,10 +28529,10 @@ export const CreateAtlasOrganizationApiKeyRolesItem = S.String;
 
 /** List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization. */
 export type CreateAtlasOrganizationApiKeyRolesList = Array<
-  CreateAtlasOrganizationApiKeyRolesItem | (string & {})
+  CreateAtlasOrganizationApiKeyRolesItem | (string & {}) | null
 >;
 export const CreateAtlasOrganizationApiKeyRolesList = /*@__PURE__*/ S.Array(
-  CreateAtlasOrganizationApiKeyRolesItem,
+  S.NullOr(CreateAtlasOrganizationApiKeyRolesItem),
 ) as any as S.Schema<CreateAtlasOrganizationApiKeyRolesList>;
 
 /** Organization Service Account that Atlas creates for this organization. If omitted, Atlas doesn't create an organization Service Account for this organization. If specified, this object requires all body parameters. Note that API Keys cannot be specified in the same request. */
@@ -28748,10 +28748,10 @@ export const CreateOrgApiKeyRequestRolesItem = S.String;
 
 /** List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization. */
 export type CreateOrgApiKeyRequestRolesList = Array<
-  CreateOrgApiKeyRequestRolesItem | (string & {})
+  CreateOrgApiKeyRequestRolesItem | (string & {}) | null
 >;
 export const CreateOrgApiKeyRequestRolesList = /*@__PURE__*/ S.Array(
-  CreateOrgApiKeyRequestRolesItem,
+  S.NullOr(CreateOrgApiKeyRequestRolesItem),
 ) as any as S.Schema<CreateOrgApiKeyRequestRolesList>;
 
 export interface CreateOrgApiKeyRequest {
@@ -40186,9 +40186,9 @@ export type MeasurementsIndexesGranularity = "PT1M" | "PT5M" | "PT1H" | "P1D";
 export const MeasurementsIndexesGranularity = S.String;
 
 /** List that contains the Atlas Search index identifiers. */
-export type MeasurementsIndexesIndexIdsList = Array<string>;
+export type MeasurementsIndexesIndexIdsList = Array<string | null>;
 export const MeasurementsIndexesIndexIdsList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<MeasurementsIndexesIndexIdsList>;
 
 /** Value of, and metadata provided for, one data point generated at a particular moment in time. If no data point exists for a particular moment in time, the `value` parameter returns `null`. */
@@ -55477,10 +55477,13 @@ export type UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsLi
   Array<
     | UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsItem
     | (string & {})
+    | null
   >;
 export const UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsList =
   /*@__PURE__*/ S.Array(
-    UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsItem,
+    S.NullOr(
+      UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsItem,
+    ),
   ) as any as S.Schema<UpdateFederationSettingConnectedOrgConfigRequestPostAuthRoleGrantsList>;
 
 /** Atlas roles and the unique identifiers of the groups and organizations associated with each role. The array must include at least one element with an Organization role and its respective `orgId`. Each element in the array can have a value for `orgId` or `groupId`, but not both. */
@@ -59060,10 +59063,10 @@ export const UpdateOrgApiKeyRequestRolesItem = S.String;
 
 /** List of roles to grant this API key. If you provide this list, provide a minimum of one role and ensure each role applies to this organization. */
 export type UpdateOrgApiKeyRequestRolesList = Array<
-  UpdateOrgApiKeyRequestRolesItem | (string & {})
+  UpdateOrgApiKeyRequestRolesItem | (string & {}) | null
 >;
 export const UpdateOrgApiKeyRequestRolesList = /*@__PURE__*/ S.Array(
-  UpdateOrgApiKeyRequestRolesItem,
+  S.NullOr(UpdateOrgApiKeyRequestRolesItem),
 ) as any as S.Schema<UpdateOrgApiKeyRequestRolesList>;
 
 export interface UpdateOrgApiKeyRequest {
@@ -59181,10 +59184,10 @@ export const UpdateOrgMcpConfigRequestRolesItem = S.String;
 
 /** List of organization roles associated with this MCP configuration. If provided, replaces the existing list of roles. */
 export type UpdateOrgMcpConfigRequestRolesList = Array<
-  UpdateOrgMcpConfigRequestRolesItem | (string & {})
+  UpdateOrgMcpConfigRequestRolesItem | (string & {}) | null
 >;
 export const UpdateOrgMcpConfigRequestRolesList = /*@__PURE__*/ S.Array(
-  UpdateOrgMcpConfigRequestRolesItem,
+  S.NullOr(UpdateOrgMcpConfigRequestRolesItem),
 ) as any as S.Schema<UpdateOrgMcpConfigRequestRolesList>;
 
 export interface UpdateOrgMcpConfigRequest {

--- a/packages/posthog/.generated-specs/alerts.json
+++ b/packages/posthog/.generated-specs/alerts.json
@@ -2519,7 +2519,10 @@
     "com.posthog.alerts#AlertSimulateResponseScoresList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Anomaly score for each point (null if insufficient data)."
@@ -2643,7 +2646,10 @@
     "com.posthog.alerts#BreakdownSimulationResultScoresList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Anomaly score for each point."

--- a/packages/posthog/.generated-specs/dashboards.json
+++ b/packages/posthog/.generated-specs/dashboards.json
@@ -23336,7 +23336,10 @@
     "com.posthog.dashboards#Response22MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -23488,7 +23491,10 @@
     "com.posthog.dashboards#Response23MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -23571,7 +23577,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Requested direct Account fields, keyed by their typed field reference."
@@ -23598,7 +23607,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.posthog.dashboards#AccountsTableRowCustomPropertiesValue"
+        "target": "com.posthog.dashboards#AccountsTableRowCustomPropertiesValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Current values keyed by requested custom property definition ID."
@@ -36636,7 +36648,10 @@
     "com.posthog.dashboards#AccountsQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -37730,7 +37745,10 @@
     "com.posthog.dashboards#AccountsTableQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/.generated-specs/environments.json
+++ b/packages/posthog/.generated-specs/environments.json
@@ -70,7 +70,10 @@
     "com.posthog.environments#EnvironmentsAddProductIntentPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -3682,7 +3685,10 @@
     "com.posthog.environments#EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -3748,7 +3754,10 @@
     "com.posthog.environments#EnvironmentsAddProductIntentPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8154,7 +8163,10 @@
     "com.posthog.environments#UpdateEnvironmentsCompleteProductOnboardingPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8182,7 +8194,10 @@
     "com.posthog.environments#UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8196,7 +8211,10 @@
     "com.posthog.environments#UpdateEnvironmentsCompleteProductOnboardingPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8581,7 +8599,10 @@
     "com.posthog.environments#EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8609,7 +8630,10 @@
     "com.posthog.environments#EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8623,7 +8647,10 @@
     "com.posthog.environments#EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9421,7 +9448,10 @@
     "com.posthog.environments#UpdateEnvironmentsExperimentsConfigPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9449,7 +9479,10 @@
     "com.posthog.environments#UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9463,7 +9496,10 @@
     "com.posthog.environments#UpdateEnvironmentsExperimentsConfigPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9848,7 +9884,10 @@
     "com.posthog.environments#EnvironmentsGenerateConversationsPublicTokenCreateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9876,7 +9915,10 @@
     "com.posthog.environments#EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -9890,7 +9932,10 @@
     "com.posthog.environments#EnvironmentsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10365,7 +10410,10 @@
     "com.posthog.environments#UpdateEnvironmentsLogsConfigPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10393,7 +10441,10 @@
     "com.posthog.environments#UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10407,7 +10458,10 @@
     "com.posthog.environments#UpdateEnvironmentsLogsConfigPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10781,7 +10835,10 @@
     "com.posthog.environments#EnvironmentsResetTokenPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10809,7 +10866,10 @@
     "com.posthog.environments#EnvironmentsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -10823,7 +10883,10 @@
     "com.posthog.environments#EnvironmentsResetTokenPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -11208,7 +11271,10 @@
     "com.posthog.environments#EnvironmentsRotateSecretTokenPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -11236,7 +11302,10 @@
     "com.posthog.environments#EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -11250,7 +11319,10 @@
     "com.posthog.environments#EnvironmentsRotateSecretTokenPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/.generated-specs/insights.json
+++ b/packages/posthog/.generated-specs/insights.json
@@ -19987,7 +19987,10 @@
     "com.posthog.insights#Response22MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20139,7 +20142,10 @@
     "com.posthog.insights#Response23MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20222,7 +20228,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Requested direct Account fields, keyed by their typed field reference."
@@ -20249,7 +20258,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.posthog.insights#AccountsTableRowCustomPropertiesValue"
+        "target": "com.posthog.insights#AccountsTableRowCustomPropertiesValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Current values keyed by requested custom property definition ID."
@@ -33287,7 +33299,10 @@
     "com.posthog.insights#AccountsQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -34381,7 +34396,10 @@
     "com.posthog.insights#AccountsTableQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/.generated-specs/mcp_analytics.json
+++ b/packages/posthog/.generated-specs/mcp_analytics.json
@@ -695,7 +695,10 @@
     "com.posthog.mcp_analytics#MCPIntentClusterJourneyPathStepsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step."

--- a/packages/posthog/.generated-specs/organizations.json
+++ b/packages/posthog/.generated-specs/organizations.json
@@ -8666,7 +8666,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8696,7 +8699,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -8762,7 +8768,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -13671,7 +13680,10 @@
     "com.posthog.organizations#ProjectBackwardCompatAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13701,7 +13713,10 @@
     "com.posthog.organizations#ProjectBackwardCompatSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13715,7 +13730,10 @@
     "com.posthog.organizations#ProjectBackwardCompatRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -14283,7 +14301,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -14313,7 +14334,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -14327,7 +14351,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -14774,7 +14801,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -14804,7 +14834,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -14818,7 +14851,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -15363,7 +15399,10 @@
     "com.posthog.organizations#OrganizationsProjectsAddProductIntentPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -15393,7 +15432,10 @@
     "com.posthog.organizations#OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -15407,7 +15449,10 @@
     "com.posthog.organizations#OrganizationsProjectsAddProductIntentPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -15854,7 +15899,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsChangeOrganizationRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -15884,7 +15932,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -15898,7 +15949,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsChangeOrganizationRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -16345,7 +16399,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -16375,7 +16432,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -16389,7 +16449,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -16877,7 +16940,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsDefaultEvaluationContextRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -16907,7 +16973,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -16921,7 +16990,10 @@
     "com.posthog.organizations#CreateOrganizationsProjectsDefaultEvaluationContextRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -17439,7 +17511,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsDefaultReleaseConditionRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -17469,7 +17544,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -17483,7 +17561,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsDefaultReleaseConditionRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -17919,7 +18000,10 @@
     "com.posthog.organizations#OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -17949,7 +18033,10 @@
     "com.posthog.organizations#OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -17963,7 +18050,10 @@
     "com.posthog.organizations#OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -18814,7 +18904,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsExperimentsConfigPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -18844,7 +18937,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -18858,7 +18954,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsExperimentsConfigPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -19294,7 +19393,10 @@
     "com.posthog.organizations#OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -19324,7 +19426,10 @@
     "com.posthog.organizations#OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -19338,7 +19443,10 @@
     "com.posthog.organizations#OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -19875,7 +19983,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsLogsConfigPartialRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -19905,7 +20016,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -19919,7 +20033,10 @@
     "com.posthog.organizations#UpdateOrganizationsProjectsLogsConfigPartialRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -20355,7 +20472,10 @@
     "com.posthog.organizations#OrganizationsProjectsResetTokenPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20385,7 +20505,10 @@
     "com.posthog.organizations#OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20399,7 +20522,10 @@
     "com.posthog.organizations#OrganizationsProjectsResetTokenPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."
@@ -20846,7 +20972,10 @@
     "com.posthog.organizations#OrganizationsProjectsRotateSecretTokenPartialUpdateRequestAppUrlsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20876,7 +21005,10 @@
     "com.posthog.organizations#OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -20890,7 +21022,10 @@
     "com.posthog.organizations#OrganizationsProjectsRotateSecretTokenPartialUpdateRequestRecordingDomainsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Origins permitted to record session replays and heatmaps. Empty list allows all origins."

--- a/packages/posthog/.generated-specs/persons.json
+++ b/packages/posthog/.generated-specs/persons.json
@@ -2437,7 +2437,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Person properties as they existed at the specified time"

--- a/packages/posthog/.generated-specs/query.json
+++ b/packages/posthog/.generated-specs/query.json
@@ -37689,7 +37689,10 @@
     "com.posthog.query#AccountsQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -38783,7 +38786,10 @@
     "com.posthog.query#AccountsTableQueryResponseMetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -38866,7 +38872,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Requested direct Account fields, keyed by their typed field reference."
@@ -38893,7 +38902,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.posthog.query#AccountsTableRowCustomPropertiesValue"
+        "target": "com.posthog.query#AccountsTableRowCustomPropertiesValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Current values keyed by requested custom property definition ID."
@@ -49967,7 +49979,10 @@
     "com.posthog.query#Response22MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -50119,7 +50134,10 @@
     "com.posthog.query#Response23MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -62119,7 +62137,10 @@
     "com.posthog.query#QueryResponseAlternative61MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -62271,7 +62292,10 @@
     "com.posthog.query#QueryResponseAlternative62MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -65304,7 +65328,10 @@
     "com.posthog.query#QueryResponseAlternative91MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -65468,7 +65495,10 @@
     "com.posthog.query#QueryResponseAlternative92MetricsResultsList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#Double"
+        "target": "smithy.api#Double",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/.generated-specs/replay.json
+++ b/packages/posthog/.generated-specs/replay.json
@@ -326,7 +326,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.posthog.replay#SessionRecordingPlaylistOutputRecordingsCountsValueValue"
+        "target": "com.posthog.replay#SessionRecordingPlaylistOutputRecordingsCountsValueValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/.generated-specs/surveys.json
+++ b/packages/posthog/.generated-specs/surveys.json
@@ -700,7 +700,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -714,7 +717,10 @@
     "com.posthog.surveys#SurveyIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -2566,7 +2572,10 @@
     "com.posthog.surveys#CreateSurveyRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -2950,7 +2959,10 @@
     "com.posthog.surveys#SurveySerializerCreateUpdateOnlyOutputIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -3053,7 +3065,10 @@
     "com.posthog.surveys#UpdateSurveyRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -3325,7 +3340,10 @@
     "com.posthog.surveys#UpdateSurveysPartialRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -3733,7 +3751,10 @@
     "com.posthog.surveys#SurveysDuplicateToProjectsCreateRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -4562,7 +4583,10 @@
     "com.posthog.surveys#SurveysResponsesArchiveCreateRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -4796,7 +4820,10 @@
     "com.posthog.surveys#SurveysResponsesUnarchiveCreateRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -5293,7 +5320,10 @@
     "com.posthog.surveys#CreateSurveysSummaryHeadlineRequestIterationStartDatesList": {
       "type": "list",
       "member": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/posthog/src/services/alerts.ts
+++ b/packages/posthog/src/services/alerts.ts
@@ -970,9 +970,9 @@ export const AlertSimulateResponseDatesList = /*@__PURE__*/ S.Array(
 ) as any as S.Schema<AlertSimulateResponseDatesList>;
 
 /** Anomaly score for each point (null if insufficient data). */
-export type AlertSimulateResponseScoresList = Array<number>;
+export type AlertSimulateResponseScoresList = Array<number | null>;
 export const AlertSimulateResponseScoresList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<AlertSimulateResponseScoresList>;
 
 /** Indices of points flagged as anomalies. */
@@ -1016,9 +1016,9 @@ export const BreakdownSimulationResultDatesList = /*@__PURE__*/ S.Array(
 ) as any as S.Schema<BreakdownSimulationResultDatesList>;
 
 /** Anomaly score for each point. */
-export type BreakdownSimulationResultScoresList = Array<number>;
+export type BreakdownSimulationResultScoresList = Array<number | null>;
 export const BreakdownSimulationResultScoresList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<BreakdownSimulationResultScoresList>;
 
 /** Indices of points flagged as anomalies. */

--- a/packages/posthog/src/services/dashboards.ts
+++ b/packages/posthog/src/services/dashboards.ts
@@ -9986,9 +9986,9 @@ export const Response22ColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<Response22ColumnsList>;
 
-export type Response22MetricsResultsList = Array<number>;
+export type Response22MetricsResultsList = Array<number | null>;
 export const Response22MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response22MetricsResultsList>;
 
 export type Response22ResultsItemList = Array<unknown>;
@@ -10083,18 +10083,18 @@ export const Response22 = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "Response22" }) as any as S.Schema<Response22>;
 
-export type Response23MetricsResultsList = Array<number>;
+export type Response23MetricsResultsList = Array<number | null>;
 export const Response23MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response23MetricsResultsList>;
 
 /** Requested direct Account fields, keyed by their typed field reference. */
 export type AccountsTableRowAccountFieldsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const AccountsTableRowAccountFieldsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<AccountsTableRowAccountFieldsMap>;
 
 export type AccountsTableRowCustomPropertiesValue = string | number | boolean;
@@ -10103,11 +10103,11 @@ export const AccountsTableRowCustomPropertiesValue =
 
 /** Current values keyed by requested custom property definition ID. */
 export type AccountsTableRowCustomPropertiesMap = {
-  [key: string]: AccountsTableRowCustomPropertiesValue | undefined;
+  [key: string]: AccountsTableRowCustomPropertiesValue | null | undefined;
 };
 export const AccountsTableRowCustomPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  AccountsTableRowCustomPropertiesValue,
+  S.NullOr(AccountsTableRowCustomPropertiesValue),
 ) as any as S.Schema<AccountsTableRowCustomPropertiesMap>;
 
 export interface AccountsTableCustomPropertyHistoryPoint {
@@ -16772,9 +16772,9 @@ export const AccountsQueryResponseColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<AccountsQueryResponseColumnsList>;
 
-export type AccountsQueryResponseMetricsResultsList = Array<number>;
+export type AccountsQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsQueryResponseMetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<AccountsQueryResponseMetricsResultsList>;
 
 export type AccountsQueryResponseResultsItemList = Array<unknown>;
@@ -17305,10 +17305,10 @@ export const AccountsTableQueryMetricsList = /*@__PURE__*/ S.Array(
   AccountsTableQueryMetricsItem,
 ) as any as S.Schema<AccountsTableQueryMetricsList>;
 
-export type AccountsTableQueryResponseMetricsResultsList = Array<number>;
+export type AccountsTableQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsTableQueryResponseMetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<AccountsTableQueryResponseMetricsResultsList>;
 
 export type AccountsTableQueryResponseResultsList = Array<AccountsTableRow>;

--- a/packages/posthog/src/services/environments.ts
+++ b/packages/posthog/src/services/environments.ts
@@ -82,11 +82,12 @@ export const EvaluationContextSuggestionResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "EvaluationContextSuggestionResponse",
 }) as any as S.Schema<EvaluationContextSuggestionResponse>;
 
-export type EnvironmentsAddProductIntentPartialUpdateRequestAppUrlsList =
-  Array<string>;
+export type EnvironmentsAddProductIntentPartialUpdateRequestAppUrlsList = Array<
+  string | null
+>;
 export const EnvironmentsAddProductIntentPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateRequestAppUrlsList>;
 
 /** * `Africa/Abidjan` - Africa/Abidjan * `Africa/Accra` - Africa/Accra * `Africa/Addis_Ababa` - Africa/Addis_Ababa * `Africa/Algiers` - Africa/Algiers * `Africa/Asmara` - Africa/Asmara * `Africa/Asmera` - Africa/Asmera * `Africa/Bamako` - Africa/Bamako * `Africa/Bangui` - Africa/Bangui * `Africa/Banjul` - Africa/Banjul * `Africa/Bissau` - Africa/Bissau * `Africa/Blantyre` - Africa/Blantyre * `Africa/Brazzaville` - Africa/Brazzaville * `Africa/Bujumbura` - Africa/Bujumbura * `Africa/Cairo` - Africa/Cairo * `Africa/Casablanca` - Africa/Casablanca * `Africa/Ceuta` - Africa/Ceuta * `Africa/Conakry` - Africa/Conakry * `Africa/Dakar` - Africa/Dakar * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam * `Africa/Djibouti` - Africa/Djibouti * `Africa/Douala` - Africa/Douala * `Africa/El_Aaiun` - Africa/El_Aaiun * `Africa/Freetown` - Africa/Freetown * `Africa/Gaborone` - Africa/Gaborone * `Africa/Harare` - Africa/Harare * `Africa/Johannesburg` - Africa/Johannesburg * `Africa/Juba` - Africa/Juba * `Africa/Kampala` - Africa/Kampala * `Africa/Khartoum` - Africa/Khartoum * `Africa/Kigali` - Africa/Kigali * `Africa/Kinshasa` - Africa/Kinshasa * `Africa/Lagos` - Africa/Lagos * `Africa/Libreville` - Africa/Libreville * `Africa/Lome` - Africa/Lome * `Africa/Luanda` - Africa/Luanda * `Africa/Lubumbashi` - Africa/Lubumbashi * `Africa/Lusaka` - Africa/Lusaka * `Africa/Malabo` - Africa/Malabo * `Africa/Maputo` - Africa/Maputo * `Africa/Maseru` - Africa/Maseru * `Africa/Mbabane` - Africa/Mbabane * `Africa/Mogadishu` - Africa/Mogadishu * `Africa/Monrovia` - Africa/Monrovia * `Africa/Nairobi` - Africa/Nairobi * `Africa/Ndjamena` - Africa/Ndjamena * `Africa/Niamey` - Africa/Niamey * `Africa/Nouakchott` - Africa/Nouakchott * `Africa/Ouagadougou` - Africa/Ouagadougou * `Africa/Porto-Novo` - Africa/Porto-Novo * `Africa/Sao_Tome` - Africa/Sao_Tome * `Africa/Timbuktu` - Africa/Timbuktu * `Africa/Tripoli` - Africa/Tripoli * `Africa/Tunis` - Africa/Tunis * `Africa/Windhoek` - Africa/Windhoek * `America/Adak` - America/Adak * `America/Anchorage` - America/Anchorage * `America/Anguilla` - America/Anguilla * `America/Antigua` - America/Antigua * `America/Araguaina` - America/Araguaina * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires * `America/Argentina/Catamarca` - America/Argentina/Catamarca * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia * `America/Argentina/Cordoba` - America/Argentina/Cordoba * `America/Argentina/Jujuy` - America/Argentina/Jujuy * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja * `America/Argentina/Mendoza` - America/Argentina/Mendoza * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos * `America/Argentina/Salta` - America/Argentina/Salta * `America/Argentina/San_Juan` - America/Argentina/San_Juan * `America/Argentina/San_Luis` - America/Argentina/San_Luis * `America/Argentina/Tucuman` - America/Argentina/Tucuman * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia * `America/Aruba` - America/Aruba * `America/Asuncion` - America/Asuncion * `America/Atikokan` - America/Atikokan * `America/Atka` - America/Atka * `America/Bahia` - America/Bahia * `America/Bahia_Banderas` - America/Bahia_Banderas * `America/Barbados` - America/Barbados * `America/Belem` - America/Belem * `America/Belize` - America/Belize * `America/Blanc-Sablon` - America/Blanc-Sablon * `America/Boa_Vista` - America/Boa_Vista * `America/Bogota` - America/Bogota * `America/Boise` - America/Boise * `America/Buenos_Aires` - America/Buenos_Aires * `America/Cambridge_Bay` - America/Cambridge_Bay * `America/Campo_Grande` - America/Campo_Grande * `America/Cancun` - America/Cancun * `America/Caracas` - America/Caracas * `America/Catamarca` - America/Catamarca * `America/Cayenne` - America/Cayenne * `America/Cayman` - America/Cayman * `America/Chicago` - America/Chicago * `America/Chihuahua` - America/Chihuahua * `America/Ciudad_Juarez` - America/Ciudad_Juarez * `America/Coral_Harbour` - America/Coral_Harbour * `America/Cordoba` - America/Cordoba * `America/Costa_Rica` - America/Costa_Rica * `America/Creston` - America/Creston * `America/Cuiaba` - America/Cuiaba * `America/Curacao` - America/Curacao * `America/Danmarkshavn` - America/Danmarkshavn * `America/Dawson` - America/Dawson * `America/Dawson_Creek` - America/Dawson_Creek * `America/Denver` - America/Denver * `America/Detroit` - America/Detroit * `America/Dominica` - America/Dominica * `America/Edmonton` - America/Edmonton * `America/Eirunepe` - America/Eirunepe * `America/El_Salvador` - America/El_Salvador * `America/Ensenada` - America/Ensenada * `America/Fort_Nelson` - America/Fort_Nelson * `America/Fort_Wayne` - America/Fort_Wayne * `America/Fortaleza` - America/Fortaleza * `America/Glace_Bay` - America/Glace_Bay * `America/Godthab` - America/Godthab * `America/Goose_Bay` - America/Goose_Bay * `America/Grand_Turk` - America/Grand_Turk * `America/Grenada` - America/Grenada * `America/Guadeloupe` - America/Guadeloupe * `America/Guatemala` - America/Guatemala * `America/Guayaquil` - America/Guayaquil * `America/Guyana` - America/Guyana * `America/Halifax` - America/Halifax * `America/Havana` - America/Havana * `America/Hermosillo` - America/Hermosillo * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis * `America/Indiana/Knox` - America/Indiana/Knox * `America/Indiana/Marengo` - America/Indiana/Marengo * `America/Indiana/Petersburg` - America/Indiana/Petersburg * `America/Indiana/Tell_City` - America/Indiana/Tell_City * `America/Indiana/Vevay` - America/Indiana/Vevay * `America/Indiana/Vincennes` - America/Indiana/Vincennes * `America/Indiana/Winamac` - America/Indiana/Winamac * `America/Indianapolis` - America/Indianapolis * `America/Inuvik` - America/Inuvik * `America/Iqaluit` - America/Iqaluit * `America/Jamaica` - America/Jamaica * `America/Jujuy` - America/Jujuy * `America/Juneau` - America/Juneau * `America/Kentucky/Louisville` - America/Kentucky/Louisville * `America/Kentucky/Monticello` - America/Kentucky/Monticello * `America/Knox_IN` - America/Knox_IN * `America/Kralendijk` - America/Kralendijk * `America/La_Paz` - America/La_Paz * `America/Lima` - America/Lima * `America/Los_Angeles` - America/Los_Angeles * `America/Louisville` - America/Louisville * `America/Lower_Princes` - America/Lower_Princes * `America/Maceio` - America/Maceio * `America/Managua` - America/Managua * `America/Manaus` - America/Manaus * `America/Marigot` - America/Marigot * `America/Martinique` - America/Martinique * `America/Matamoros` - America/Matamoros * `America/Mazatlan` - America/Mazatlan * `America/Mendoza` - America/Mendoza * `America/Menominee` - America/Menominee * `America/Merida` - America/Merida * `America/Metlakatla` - America/Metlakatla * `America/Mexico_City` - America/Mexico_City * `America/Miquelon` - America/Miquelon * `America/Moncton` - America/Moncton * `America/Monterrey` - America/Monterrey * `America/Montevideo` - America/Montevideo * `America/Montreal` - America/Montreal * `America/Montserrat` - America/Montserrat * `America/Nassau` - America/Nassau * `America/New_York` - America/New_York * `America/Nipigon` - America/Nipigon * `America/Nome` - America/Nome * `America/Noronha` - America/Noronha * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah * `America/North_Dakota/Center` - America/North_Dakota/Center * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem * `America/Nuuk` - America/Nuuk * `America/Ojinaga` - America/Ojinaga * `America/Panama` - America/Panama * `America/Pangnirtung` - America/Pangnirtung * `America/Paramaribo` - America/Paramaribo * `America/Phoenix` - America/Phoenix * `America/Port-au-Prince` - America/Port-au-Prince * `America/Port_of_Spain` - America/Port_of_Spain * `America/Porto_Acre` - America/Porto_Acre * `America/Porto_Velho` - America/Porto_Velho * `America/Puerto_Rico` - America/Puerto_Rico * `America/Punta_Arenas` - America/Punta_Arenas * `America/Rainy_River` - America/Rainy_River * `America/Rankin_Inlet` - America/Rankin_Inlet * `America/Recife` - America/Recife * `America/Regina` - America/Regina * `America/Resolute` - America/Resolute * `America/Rio_Branco` - America/Rio_Branco * `America/Rosario` - America/Rosario * `America/Santa_Isabel` - America/Santa_Isabel * `America/Santarem` - America/Santarem * `America/Santiago` - America/Santiago * `America/Santo_Domingo` - America/Santo_Domingo * `America/Sao_Paulo` - America/Sao_Paulo * `America/Scoresbysund` - America/Scoresbysund * `America/Shiprock` - America/Shiprock * `America/Sitka` - America/Sitka * `America/St_Barthelemy` - America/St_Barthelemy * `America/St_Johns` - America/St_Johns * `America/St_Kitts` - America/St_Kitts * `America/St_Lucia` - America/St_Lucia * `America/St_Thomas` - America/St_Thomas * `America/St_Vincent` - America/St_Vincent * `America/Swift_Current` - America/Swift_Current * `America/Tegucigalpa` - America/Tegucigalpa * `America/Thule` - America/Thule * `America/Thunder_Bay` - America/Thunder_Bay * `America/Tijuana` - America/Tijuana * `America/Toronto` - America/Toronto * `America/Tortola` - America/Tortola * `America/Vancouver` - America/Vancouver * `America/Virgin` - America/Virgin * `America/Whitehorse` - America/Whitehorse * `America/Winnipeg` - America/Winnipeg * `America/Yakutat` - America/Yakutat * `America/Yellowknife` - America/Yellowknife * `Antarctica/Casey` - Antarctica/Casey * `Antarctica/Davis` - Antarctica/Davis * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville * `Antarctica/Macquarie` - Antarctica/Macquarie * `Antarctica/Mawson` - Antarctica/Mawson * `Antarctica/McMurdo` - Antarctica/McMurdo * `Antarctica/Palmer` - Antarctica/Palmer * `Antarctica/Rothera` - Antarctica/Rothera * `Antarctica/South_Pole` - Antarctica/South_Pole * `Antarctica/Syowa` - Antarctica/Syowa * `Antarctica/Troll` - Antarctica/Troll * `Antarctica/Vostok` - Antarctica/Vostok * `Arctic/Longyearbyen` - Arctic/Longyearbyen * `Asia/Aden` - Asia/Aden * `Asia/Almaty` - Asia/Almaty * `Asia/Amman` - Asia/Amman * `Asia/Anadyr` - Asia/Anadyr * `Asia/Aqtau` - Asia/Aqtau * `Asia/Aqtobe` - Asia/Aqtobe * `Asia/Ashgabat` - Asia/Ashgabat * `Asia/Ashkhabad` - Asia/Ashkhabad * `Asia/Atyrau` - Asia/Atyrau * `Asia/Baghdad` - Asia/Baghdad * `Asia/Bahrain` - Asia/Bahrain * `Asia/Baku` - Asia/Baku * `Asia/Bangkok` - Asia/Bangkok * `Asia/Barnaul` - Asia/Barnaul * `Asia/Beirut` - Asia/Beirut * `Asia/Bishkek` - Asia/Bishkek * `Asia/Brunei` - Asia/Brunei * `Asia/Calcutta` - Asia/Calcutta * `Asia/Chita` - Asia/Chita * `Asia/Choibalsan` - Asia/Choibalsan * `Asia/Chongqing` - Asia/Chongqing * `Asia/Chungking` - Asia/Chungking * `Asia/Colombo` - Asia/Colombo * `Asia/Dacca` - Asia/Dacca * `Asia/Damascus` - Asia/Damascus * `Asia/Dhaka` - Asia/Dhaka * `Asia/Dili` - Asia/Dili * `Asia/Dubai` - Asia/Dubai * `Asia/Dushanbe` - Asia/Dushanbe * `Asia/Famagusta` - Asia/Famagusta * `Asia/Gaza` - Asia/Gaza * `Asia/Harbin` - Asia/Harbin * `Asia/Hebron` - Asia/Hebron * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh * `Asia/Hong_Kong` - Asia/Hong_Kong * `Asia/Hovd` - Asia/Hovd * `Asia/Irkutsk` - Asia/Irkutsk * `Asia/Istanbul` - Asia/Istanbul * `Asia/Jakarta` - Asia/Jakarta * `Asia/Jayapura` - Asia/Jayapura * `Asia/Jerusalem` - Asia/Jerusalem * `Asia/Kabul` - Asia/Kabul * `Asia/Kamchatka` - Asia/Kamchatka * `Asia/Karachi` - Asia/Karachi * `Asia/Kashgar` - Asia/Kashgar * `Asia/Kathmandu` - Asia/Kathmandu * `Asia/Katmandu` - Asia/Katmandu * `Asia/Khandyga` - Asia/Khandyga * `Asia/Kolkata` - Asia/Kolkata * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur * `Asia/Kuching` - Asia/Kuching * `Asia/Kuwait` - Asia/Kuwait * `Asia/Macao` - Asia/Macao * `Asia/Macau` - Asia/Macau * `Asia/Magadan` - Asia/Magadan * `Asia/Makassar` - Asia/Makassar * `Asia/Manila` - Asia/Manila * `Asia/Muscat` - Asia/Muscat * `Asia/Nicosia` - Asia/Nicosia * `Asia/Novokuznetsk` - Asia/Novokuznetsk * `Asia/Novosibirsk` - Asia/Novosibirsk * `Asia/Omsk` - Asia/Omsk * `Asia/Oral` - Asia/Oral * `Asia/Phnom_Penh` - Asia/Phnom_Penh * `Asia/Pontianak` - Asia/Pontianak * `Asia/Pyongyang` - Asia/Pyongyang * `Asia/Qatar` - Asia/Qatar * `Asia/Qostanay` - Asia/Qostanay * `Asia/Qyzylorda` - Asia/Qyzylorda * `Asia/Rangoon` - Asia/Rangoon * `Asia/Riyadh` - Asia/Riyadh * `Asia/Saigon` - Asia/Saigon * `Asia/Sakhalin` - Asia/Sakhalin * `Asia/Samarkand` - Asia/Samarkand * `Asia/Seoul` - Asia/Seoul * `Asia/Shanghai` - Asia/Shanghai * `Asia/Singapore` - Asia/Singapore * `Asia/Srednekolymsk` - Asia/Srednekolymsk * `Asia/Taipei` - Asia/Taipei * `Asia/Tashkent` - Asia/Tashkent * `Asia/Tbilisi` - Asia/Tbilisi * `Asia/Tehran` - Asia/Tehran * `Asia/Tel_Aviv` - Asia/Tel_Aviv * `Asia/Thimbu` - Asia/Thimbu * `Asia/Thimphu` - Asia/Thimphu * `Asia/Tokyo` - Asia/Tokyo * `Asia/Tomsk` - Asia/Tomsk * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar * `Asia/Ulan_Bator` - Asia/Ulan_Bator * `Asia/Urumqi` - Asia/Urumqi * `Asia/Ust-Nera` - Asia/Ust-Nera * `Asia/Vientiane` - Asia/Vientiane * `Asia/Vladivostok` - Asia/Vladivostok * `Asia/Yakutsk` - Asia/Yakutsk * `Asia/Yangon` - Asia/Yangon * `Asia/Yekaterinburg` - Asia/Yekaterinburg * `Asia/Yerevan` - Asia/Yerevan * `Atlantic/Azores` - Atlantic/Azores * `Atlantic/Bermuda` - Atlantic/Bermuda * `Atlantic/Canary` - Atlantic/Canary * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde * `Atlantic/Faeroe` - Atlantic/Faeroe * `Atlantic/Faroe` - Atlantic/Faroe * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen * `Atlantic/Madeira` - Atlantic/Madeira * `Atlantic/Reykjavik` - Atlantic/Reykjavik * `Atlantic/South_Georgia` - Atlantic/South_Georgia * `Atlantic/St_Helena` - Atlantic/St_Helena * `Atlantic/Stanley` - Atlantic/Stanley * `Australia/ACT` - Australia/ACT * `Australia/Adelaide` - Australia/Adelaide * `Australia/Brisbane` - Australia/Brisbane * `Australia/Broken_Hill` - Australia/Broken_Hill * `Australia/Canberra` - Australia/Canberra * `Australia/Currie` - Australia/Currie * `Australia/Darwin` - Australia/Darwin * `Australia/Eucla` - Australia/Eucla * `Australia/Hobart` - Australia/Hobart * `Australia/LHI` - Australia/LHI * `Australia/Lindeman` - Australia/Lindeman * `Australia/Lord_Howe` - Australia/Lord_Howe * `Australia/Melbourne` - Australia/Melbourne * `Australia/NSW` - Australia/NSW * `Australia/North` - Australia/North * `Australia/Perth` - Australia/Perth * `Australia/Queensland` - Australia/Queensland * `Australia/South` - Australia/South * `Australia/Sydney` - Australia/Sydney * `Australia/Tasmania` - Australia/Tasmania * `Australia/Victoria` - Australia/Victoria * `Australia/West` - Australia/West * `Australia/Yancowinna` - Australia/Yancowinna * `Brazil/Acre` - Brazil/Acre * `Brazil/DeNoronha` - Brazil/DeNoronha * `Brazil/East` - Brazil/East * `Brazil/West` - Brazil/West * `CET` - CET * `CST6CDT` - CST6CDT * `Canada/Atlantic` - Canada/Atlantic * `Canada/Central` - Canada/Central * `Canada/Eastern` - Canada/Eastern * `Canada/Mountain` - Canada/Mountain * `Canada/Newfoundland` - Canada/Newfoundland * `Canada/Pacific` - Canada/Pacific * `Canada/Saskatchewan` - Canada/Saskatchewan * `Canada/Yukon` - Canada/Yukon * `Chile/Continental` - Chile/Continental * `Chile/EasterIsland` - Chile/EasterIsland * `Cuba` - Cuba * `EET` - EET * `EST` - EST * `EST5EDT` - EST5EDT * `Egypt` - Egypt * `Eire` - Eire * `Etc/GMT` - Etc/GMT * `Etc/GMT+0` - Etc/GMT+0 * `Etc/GMT+1` - Etc/GMT+1 * `Etc/GMT+10` - Etc/GMT+10 * `Etc/GMT+11` - Etc/GMT+11 * `Etc/GMT+12` - Etc/GMT+12 * `Etc/GMT+2` - Etc/GMT+2 * `Etc/GMT+3` - Etc/GMT+3 * `Etc/GMT+4` - Etc/GMT+4 * `Etc/GMT+5` - Etc/GMT+5 * `Etc/GMT+6` - Etc/GMT+6 * `Etc/GMT+7` - Etc/GMT+7 * `Etc/GMT+8` - Etc/GMT+8 * `Etc/GMT+9` - Etc/GMT+9 * `Etc/GMT-0` - Etc/GMT-0 * `Etc/GMT-1` - Etc/GMT-1 * `Etc/GMT-10` - Etc/GMT-10 * `Etc/GMT-11` - Etc/GMT-11 * `Etc/GMT-12` - Etc/GMT-12 * `Etc/GMT-13` - Etc/GMT-13 * `Etc/GMT-14` - Etc/GMT-14 * `Etc/GMT-2` - Etc/GMT-2 * `Etc/GMT-3` - Etc/GMT-3 * `Etc/GMT-4` - Etc/GMT-4 * `Etc/GMT-5` - Etc/GMT-5 * `Etc/GMT-6` - Etc/GMT-6 * `Etc/GMT-7` - Etc/GMT-7 * `Etc/GMT-8` - Etc/GMT-8 * `Etc/GMT-9` - Etc/GMT-9 * `Etc/GMT0` - Etc/GMT0 * `Etc/Greenwich` - Etc/Greenwich * `Etc/UCT` - Etc/UCT * `Etc/UTC` - Etc/UTC * `Etc/Universal` - Etc/Universal * `Etc/Zulu` - Etc/Zulu * `Europe/Amsterdam` - Europe/Amsterdam * `Europe/Andorra` - Europe/Andorra * `Europe/Astrakhan` - Europe/Astrakhan * `Europe/Athens` - Europe/Athens * `Europe/Belfast` - Europe/Belfast * `Europe/Belgrade` - Europe/Belgrade * `Europe/Berlin` - Europe/Berlin * `Europe/Bratislava` - Europe/Bratislava * `Europe/Brussels` - Europe/Brussels * `Europe/Bucharest` - Europe/Bucharest * `Europe/Budapest` - Europe/Budapest * `Europe/Busingen` - Europe/Busingen * `Europe/Chisinau` - Europe/Chisinau * `Europe/Copenhagen` - Europe/Copenhagen * `Europe/Dublin` - Europe/Dublin * `Europe/Gibraltar` - Europe/Gibraltar * `Europe/Guernsey` - Europe/Guernsey * `Europe/Helsinki` - Europe/Helsinki * `Europe/Isle_of_Man` - Europe/Isle_of_Man * `Europe/Istanbul` - Europe/Istanbul * `Europe/Jersey` - Europe/Jersey * `Europe/Kaliningrad` - Europe/Kaliningrad * `Europe/Kiev` - Europe/Kiev * `Europe/Kirov` - Europe/Kirov * `Europe/Kyiv` - Europe/Kyiv * `Europe/Lisbon` - Europe/Lisbon * `Europe/Ljubljana` - Europe/Ljubljana * `Europe/London` - Europe/London * `Europe/Luxembourg` - Europe/Luxembourg * `Europe/Madrid` - Europe/Madrid * `Europe/Malta` - Europe/Malta * `Europe/Mariehamn` - Europe/Mariehamn * `Europe/Minsk` - Europe/Minsk * `Europe/Monaco` - Europe/Monaco * `Europe/Moscow` - Europe/Moscow * `Europe/Nicosia` - Europe/Nicosia * `Europe/Oslo` - Europe/Oslo * `Europe/Paris` - Europe/Paris * `Europe/Podgorica` - Europe/Podgorica * `Europe/Prague` - Europe/Prague * `Europe/Riga` - Europe/Riga * `Europe/Rome` - Europe/Rome * `Europe/Samara` - Europe/Samara * `Europe/San_Marino` - Europe/San_Marino * `Europe/Sarajevo` - Europe/Sarajevo * `Europe/Saratov` - Europe/Saratov * `Europe/Simferopol` - Europe/Simferopol * `Europe/Skopje` - Europe/Skopje * `Europe/Sofia` - Europe/Sofia * `Europe/Stockholm` - Europe/Stockholm * `Europe/Tallinn` - Europe/Tallinn * `Europe/Tirane` - Europe/Tirane * `Europe/Tiraspol` - Europe/Tiraspol * `Europe/Ulyanovsk` - Europe/Ulyanovsk * `Europe/Uzhgorod` - Europe/Uzhgorod * `Europe/Vaduz` - Europe/Vaduz * `Europe/Vatican` - Europe/Vatican * `Europe/Vienna` - Europe/Vienna * `Europe/Vilnius` - Europe/Vilnius * `Europe/Volgograd` - Europe/Volgograd * `Europe/Warsaw` - Europe/Warsaw * `Europe/Zagreb` - Europe/Zagreb * `Europe/Zaporozhye` - Europe/Zaporozhye * `Europe/Zurich` - Europe/Zurich * `GB` - GB * `GB-Eire` - GB-Eire * `GMT` - GMT * `GMT+0` - GMT+0 * `GMT-0` - GMT-0 * `GMT0` - GMT0 * `Greenwich` - Greenwich * `HST` - HST * `Hongkong` - Hongkong * `Iceland` - Iceland * `Indian/Antananarivo` - Indian/Antananarivo * `Indian/Chagos` - Indian/Chagos * `Indian/Christmas` - Indian/Christmas * `Indian/Cocos` - Indian/Cocos * `Indian/Comoro` - Indian/Comoro * `Indian/Kerguelen` - Indian/Kerguelen * `Indian/Mahe` - Indian/Mahe * `Indian/Maldives` - Indian/Maldives * `Indian/Mauritius` - Indian/Mauritius * `Indian/Mayotte` - Indian/Mayotte * `Indian/Reunion` - Indian/Reunion * `Iran` - Iran * `Israel` - Israel * `Jamaica` - Jamaica * `Japan` - Japan * `Kwajalein` - Kwajalein * `Libya` - Libya * `MET` - MET * `MST` - MST * `MST7MDT` - MST7MDT * `Mexico/BajaNorte` - Mexico/BajaNorte * `Mexico/BajaSur` - Mexico/BajaSur * `Mexico/General` - Mexico/General * `NZ` - NZ * `NZ-CHAT` - NZ-CHAT * `Navajo` - Navajo * `PRC` - PRC * `PST8PDT` - PST8PDT * `Pacific/Apia` - Pacific/Apia * `Pacific/Auckland` - Pacific/Auckland * `Pacific/Bougainville` - Pacific/Bougainville * `Pacific/Chatham` - Pacific/Chatham * `Pacific/Chuuk` - Pacific/Chuuk * `Pacific/Easter` - Pacific/Easter * `Pacific/Efate` - Pacific/Efate * `Pacific/Enderbury` - Pacific/Enderbury * `Pacific/Fakaofo` - Pacific/Fakaofo * `Pacific/Fiji` - Pacific/Fiji * `Pacific/Funafuti` - Pacific/Funafuti * `Pacific/Galapagos` - Pacific/Galapagos * `Pacific/Gambier` - Pacific/Gambier * `Pacific/Guadalcanal` - Pacific/Guadalcanal * `Pacific/Guam` - Pacific/Guam * `Pacific/Honolulu` - Pacific/Honolulu * `Pacific/Johnston` - Pacific/Johnston * `Pacific/Kanton` - Pacific/Kanton * `Pacific/Kiritimati` - Pacific/Kiritimati * `Pacific/Kosrae` - Pacific/Kosrae * `Pacific/Kwajalein` - Pacific/Kwajalein * `Pacific/Majuro` - Pacific/Majuro * `Pacific/Marquesas` - Pacific/Marquesas * `Pacific/Midway` - Pacific/Midway * `Pacific/Nauru` - Pacific/Nauru * `Pacific/Niue` - Pacific/Niue * `Pacific/Norfolk` - Pacific/Norfolk * `Pacific/Noumea` - Pacific/Noumea * `Pacific/Pago_Pago` - Pacific/Pago_Pago * `Pacific/Palau` - Pacific/Palau * `Pacific/Pitcairn` - Pacific/Pitcairn * `Pacific/Pohnpei` - Pacific/Pohnpei * `Pacific/Ponape` - Pacific/Ponape * `Pacific/Port_Moresby` - Pacific/Port_Moresby * `Pacific/Rarotonga` - Pacific/Rarotonga * `Pacific/Saipan` - Pacific/Saipan * `Pacific/Samoa` - Pacific/Samoa * `Pacific/Tahiti` - Pacific/Tahiti * `Pacific/Tarawa` - Pacific/Tarawa * `Pacific/Tongatapu` - Pacific/Tongatapu * `Pacific/Truk` - Pacific/Truk * `Pacific/Wake` - Pacific/Wake * `Pacific/Wallis` - Pacific/Wallis * `Pacific/Yap` - Pacific/Yap * `Poland` - Poland * `Portugal` - Portugal * `ROC` - ROC * `ROK` - ROK * `Singapore` - Singapore * `Turkey` - Turkey * `UCT` - UCT * `US/Alaska` - US/Alaska * `US/Aleutian` - US/Aleutian * `US/Arizona` - US/Arizona * `US/Central` - US/Central * `US/East-Indiana` - US/East-Indiana * `US/Eastern` - US/Eastern * `US/Hawaii` - US/Hawaii * `US/Indiana-Starke` - US/Indiana-Starke * `US/Michigan` - US/Michigan * `US/Mountain` - US/Mountain * `US/Pacific` - US/Pacific * `US/Samoa` - US/Samoa * `UTC` - UTC * `Universal` - Universal * `W-SU` - W-SU * `WET` - WET * `Zulu` - Zulu */
@@ -711,10 +712,10 @@ export const EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingUrl
   ) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 /** * `30d` - 30 Days * `90d` - 90 Days * `1y` - 1 Year * `5y` - 5 Years */
@@ -733,10 +734,10 @@ export const EnvironmentsAddProductIntentPartialUpdateRequestLiveEventsColumnsLi
   ) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateRequestLiveEventsColumnsList>;
 
 export type EnvironmentsAddProductIntentPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsAddProductIntentPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateRequestRecordingDomainsList>;
 
 /** * `0` - Disabled * `1` - Stateless * `2` - Stateful */
@@ -2215,10 +2216,10 @@ export const EnvironmentsAddProductIntentPartialUpdateResponse =
   }) as any as S.Schema<EnvironmentsAddProductIntentPartialUpdateResponse>;
 
 export type EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList>;
 
 export type EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestPersonDisplayNamePropertiesList =
@@ -2243,10 +2244,10 @@ export const EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecor
   ) as any as S.Schema<EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestLiveEventsColumnsList =
@@ -2257,10 +2258,10 @@ export const EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestLiveEventsCo
   ) as any as S.Schema<EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestLiveEventsColumnsList>;
 
 export type EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -2508,10 +2509,10 @@ export const EnvironmentsEvaluationContextSuggestionsDestroyRequest =
   }) as any as S.Schema<EnvironmentsEvaluationContextSuggestionsDestroyRequest>;
 
 export type EnvironmentsGenerateConversationsPublicTokenCreateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsGenerateConversationsPublicTokenCreateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateRequestAppUrlsList>;
 
 export type EnvironmentsGenerateConversationsPublicTokenCreateRequestPersonDisplayNamePropertiesList =
@@ -2536,10 +2537,10 @@ export const EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRec
   ) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList>;
 
 export type EnvironmentsGenerateConversationsPublicTokenCreateRequestLiveEventsColumnsList =
@@ -2550,10 +2551,10 @@ export const EnvironmentsGenerateConversationsPublicTokenCreateRequestLiveEvents
   ) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateRequestLiveEventsColumnsList>;
 
 export type EnvironmentsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -2775,11 +2776,12 @@ export const EnvironmentsGenerateConversationsPublicTokenCreateResponse =
     identifier: "EnvironmentsGenerateConversationsPublicTokenCreateResponse",
   }) as any as S.Schema<EnvironmentsGenerateConversationsPublicTokenCreateResponse>;
 
-export type EnvironmentsResetTokenPartialUpdateRequestAppUrlsList =
-  Array<string>;
+export type EnvironmentsResetTokenPartialUpdateRequestAppUrlsList = Array<
+  string | null
+>;
 export const EnvironmentsResetTokenPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsResetTokenPartialUpdateRequestAppUrlsList>;
 
 export type EnvironmentsResetTokenPartialUpdateRequestPersonDisplayNamePropertiesList =
@@ -2804,10 +2806,10 @@ export const EnvironmentsResetTokenPartialUpdateRequestSessionRecordingUrlBlockl
   ) as any as S.Schema<EnvironmentsResetTokenPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type EnvironmentsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type EnvironmentsResetTokenPartialUpdateRequestLiveEventsColumnsList =
@@ -2818,10 +2820,10 @@ export const EnvironmentsResetTokenPartialUpdateRequestLiveEventsColumnsList =
   ) as any as S.Schema<EnvironmentsResetTokenPartialUpdateRequestLiveEventsColumnsList>;
 
 export type EnvironmentsResetTokenPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsResetTokenPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsResetTokenPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -3042,10 +3044,10 @@ export const EnvironmentsResetTokenPartialUpdateResponse =
   }) as any as S.Schema<EnvironmentsResetTokenPartialUpdateResponse>;
 
 export type EnvironmentsRotateSecretTokenPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsRotateSecretTokenPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsRotateSecretTokenPartialUpdateRequestAppUrlsList>;
 
 export type EnvironmentsRotateSecretTokenPartialUpdateRequestPersonDisplayNamePropertiesList =
@@ -3070,10 +3072,10 @@ export const EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingUr
   ) as any as S.Schema<EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type EnvironmentsRotateSecretTokenPartialUpdateRequestLiveEventsColumnsList =
@@ -3084,10 +3086,10 @@ export const EnvironmentsRotateSecretTokenPartialUpdateRequestLiveEventsColumnsL
   ) as any as S.Schema<EnvironmentsRotateSecretTokenPartialUpdateRequestLiveEventsColumnsList>;
 
 export type EnvironmentsRotateSecretTokenPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const EnvironmentsRotateSecretTokenPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<EnvironmentsRotateSecretTokenPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -3567,10 +3569,10 @@ export const ListEnvironmentsEventIngestionRestrictionsResponse =
   }) as any as S.Schema<ListEnvironmentsEventIngestionRestrictionsResponse>;
 
 export type UpdateEnvironmentsCompleteProductOnboardingPartialRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsCompleteProductOnboardingPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialRequestAppUrlsList>;
 
 export type UpdateEnvironmentsCompleteProductOnboardingPartialRequestPersonDisplayNamePropertiesList =
@@ -3595,10 +3597,10 @@ export const UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRec
   ) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateEnvironmentsCompleteProductOnboardingPartialRequestLiveEventsColumnsList =
@@ -3609,10 +3611,10 @@ export const UpdateEnvironmentsCompleteProductOnboardingPartialRequestLiveEvents
   ) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialRequestLiveEventsColumnsList>;
 
 export type UpdateEnvironmentsCompleteProductOnboardingPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsCompleteProductOnboardingPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -3835,10 +3837,10 @@ export const UpdateEnvironmentsCompleteProductOnboardingPartialResponse =
   }) as any as S.Schema<UpdateEnvironmentsCompleteProductOnboardingPartialResponse>;
 
 export type UpdateEnvironmentsExperimentsConfigPartialRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsExperimentsConfigPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialRequestAppUrlsList>;
 
 export type UpdateEnvironmentsExperimentsConfigPartialRequestPersonDisplayNamePropertiesList =
@@ -3863,10 +3865,10 @@ export const UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingUr
   ) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateEnvironmentsExperimentsConfigPartialRequestLiveEventsColumnsList =
@@ -3877,10 +3879,10 @@ export const UpdateEnvironmentsExperimentsConfigPartialRequestLiveEventsColumnsL
   ) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialRequestLiveEventsColumnsList>;
 
 export type UpdateEnvironmentsExperimentsConfigPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsExperimentsConfigPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -4102,11 +4104,12 @@ export const UpdateEnvironmentsExperimentsConfigPartialResponse =
     identifier: "UpdateEnvironmentsExperimentsConfigPartialResponse",
   }) as any as S.Schema<UpdateEnvironmentsExperimentsConfigPartialResponse>;
 
-export type UpdateEnvironmentsLogsConfigPartialRequestAppUrlsList =
-  Array<string>;
+export type UpdateEnvironmentsLogsConfigPartialRequestAppUrlsList = Array<
+  string | null
+>;
 export const UpdateEnvironmentsLogsConfigPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsLogsConfigPartialRequestAppUrlsList>;
 
 export type UpdateEnvironmentsLogsConfigPartialRequestPersonDisplayNamePropertiesList =
@@ -4131,10 +4134,10 @@ export const UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingUrlBlockl
   ) as any as S.Schema<UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateEnvironmentsLogsConfigPartialRequestLiveEventsColumnsList =
@@ -4145,10 +4148,10 @@ export const UpdateEnvironmentsLogsConfigPartialRequestLiveEventsColumnsList =
   ) as any as S.Schema<UpdateEnvironmentsLogsConfigPartialRequestLiveEventsColumnsList>;
 
 export type UpdateEnvironmentsLogsConfigPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateEnvironmentsLogsConfigPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateEnvironmentsLogsConfigPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers, used to optimize the UI layout. * `b2b` - B2B * `b2c` - B2C * `other` - Other */

--- a/packages/posthog/src/services/insights.ts
+++ b/packages/posthog/src/services/insights.ts
@@ -8686,9 +8686,9 @@ export const Response22ColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<Response22ColumnsList>;
 
-export type Response22MetricsResultsList = Array<number>;
+export type Response22MetricsResultsList = Array<number | null>;
 export const Response22MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response22MetricsResultsList>;
 
 export type Response22ResultsItemList = Array<unknown>;
@@ -8783,18 +8783,18 @@ export const Response22 = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "Response22" }) as any as S.Schema<Response22>;
 
-export type Response23MetricsResultsList = Array<number>;
+export type Response23MetricsResultsList = Array<number | null>;
 export const Response23MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response23MetricsResultsList>;
 
 /** Requested direct Account fields, keyed by their typed field reference. */
 export type AccountsTableRowAccountFieldsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const AccountsTableRowAccountFieldsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<AccountsTableRowAccountFieldsMap>;
 
 export type AccountsTableRowCustomPropertiesValue = string | number | boolean;
@@ -8803,11 +8803,11 @@ export const AccountsTableRowCustomPropertiesValue =
 
 /** Current values keyed by requested custom property definition ID. */
 export type AccountsTableRowCustomPropertiesMap = {
-  [key: string]: AccountsTableRowCustomPropertiesValue | undefined;
+  [key: string]: AccountsTableRowCustomPropertiesValue | null | undefined;
 };
 export const AccountsTableRowCustomPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  AccountsTableRowCustomPropertiesValue,
+  S.NullOr(AccountsTableRowCustomPropertiesValue),
 ) as any as S.Schema<AccountsTableRowCustomPropertiesMap>;
 
 export interface AccountsTableCustomPropertyHistoryPoint {
@@ -15489,9 +15489,9 @@ export const AccountsQueryResponseColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<AccountsQueryResponseColumnsList>;
 
-export type AccountsQueryResponseMetricsResultsList = Array<number>;
+export type AccountsQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsQueryResponseMetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<AccountsQueryResponseMetricsResultsList>;
 
 export type AccountsQueryResponseResultsItemList = Array<unknown>;
@@ -16022,10 +16022,10 @@ export const AccountsTableQueryMetricsList = /*@__PURE__*/ S.Array(
   AccountsTableQueryMetricsItem,
 ) as any as S.Schema<AccountsTableQueryMetricsList>;
 
-export type AccountsTableQueryResponseMetricsResultsList = Array<number>;
+export type AccountsTableQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsTableQueryResponseMetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<AccountsTableQueryResponseMetricsResultsList>;
 
 export type AccountsTableQueryResponseResultsList = Array<AccountsTableRow>;

--- a/packages/posthog/src/services/mcp_analytics.ts
+++ b/packages/posthog/src/services/mcp_analytics.ts
@@ -278,9 +278,9 @@ export const MCPIntentClusterSampleIntentsList = /*@__PURE__*/ S.Array(
 ) as any as S.Schema<MCPIntentClusterSampleIntentsList>;
 
 /** Ordered tool names called during the path. Length is fixed; null entries indicate the session ended before this step. */
-export type MCPIntentClusterJourneyPathStepsList = Array<string>;
+export type MCPIntentClusterJourneyPathStepsList = Array<string | null>;
 export const MCPIntentClusterJourneyPathStepsList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<MCPIntentClusterJourneyPathStepsList>;
 
 /** * `completed` - Completed * `error` - Error */

--- a/packages/posthog/src/services/organizations.ts
+++ b/packages/posthog/src/services/organizations.ts
@@ -856,10 +856,10 @@ export const CreateOrganizationsProjectRequestTagsList = /*@__PURE__*/ S.Array(
   S.String,
 ) as any as S.Schema<CreateOrganizationsProjectRequestTagsList>;
 
-export type CreateOrganizationsProjectRequestAppUrlsList = Array<string>;
+export type CreateOrganizationsProjectRequestAppUrlsList = Array<string | null>;
 export const CreateOrganizationsProjectRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectRequestAppUrlsList>;
 
 /** * `Africa/Abidjan` - Africa/Abidjan * `Africa/Accra` - Africa/Accra * `Africa/Addis_Ababa` - Africa/Addis_Ababa * `Africa/Algiers` - Africa/Algiers * `Africa/Asmara` - Africa/Asmara * `Africa/Asmera` - Africa/Asmera * `Africa/Bamako` - Africa/Bamako * `Africa/Bangui` - Africa/Bangui * `Africa/Banjul` - Africa/Banjul * `Africa/Bissau` - Africa/Bissau * `Africa/Blantyre` - Africa/Blantyre * `Africa/Brazzaville` - Africa/Brazzaville * `Africa/Bujumbura` - Africa/Bujumbura * `Africa/Cairo` - Africa/Cairo * `Africa/Casablanca` - Africa/Casablanca * `Africa/Ceuta` - Africa/Ceuta * `Africa/Conakry` - Africa/Conakry * `Africa/Dakar` - Africa/Dakar * `Africa/Dar_es_Salaam` - Africa/Dar_es_Salaam * `Africa/Djibouti` - Africa/Djibouti * `Africa/Douala` - Africa/Douala * `Africa/El_Aaiun` - Africa/El_Aaiun * `Africa/Freetown` - Africa/Freetown * `Africa/Gaborone` - Africa/Gaborone * `Africa/Harare` - Africa/Harare * `Africa/Johannesburg` - Africa/Johannesburg * `Africa/Juba` - Africa/Juba * `Africa/Kampala` - Africa/Kampala * `Africa/Khartoum` - Africa/Khartoum * `Africa/Kigali` - Africa/Kigali * `Africa/Kinshasa` - Africa/Kinshasa * `Africa/Lagos` - Africa/Lagos * `Africa/Libreville` - Africa/Libreville * `Africa/Lome` - Africa/Lome * `Africa/Luanda` - Africa/Luanda * `Africa/Lubumbashi` - Africa/Lubumbashi * `Africa/Lusaka` - Africa/Lusaka * `Africa/Malabo` - Africa/Malabo * `Africa/Maputo` - Africa/Maputo * `Africa/Maseru` - Africa/Maseru * `Africa/Mbabane` - Africa/Mbabane * `Africa/Mogadishu` - Africa/Mogadishu * `Africa/Monrovia` - Africa/Monrovia * `Africa/Nairobi` - Africa/Nairobi * `Africa/Ndjamena` - Africa/Ndjamena * `Africa/Niamey` - Africa/Niamey * `Africa/Nouakchott` - Africa/Nouakchott * `Africa/Ouagadougou` - Africa/Ouagadougou * `Africa/Porto-Novo` - Africa/Porto-Novo * `Africa/Sao_Tome` - Africa/Sao_Tome * `Africa/Timbuktu` - Africa/Timbuktu * `Africa/Tripoli` - Africa/Tripoli * `Africa/Tunis` - Africa/Tunis * `Africa/Windhoek` - Africa/Windhoek * `America/Adak` - America/Adak * `America/Anchorage` - America/Anchorage * `America/Anguilla` - America/Anguilla * `America/Antigua` - America/Antigua * `America/Araguaina` - America/Araguaina * `America/Argentina/Buenos_Aires` - America/Argentina/Buenos_Aires * `America/Argentina/Catamarca` - America/Argentina/Catamarca * `America/Argentina/ComodRivadavia` - America/Argentina/ComodRivadavia * `America/Argentina/Cordoba` - America/Argentina/Cordoba * `America/Argentina/Jujuy` - America/Argentina/Jujuy * `America/Argentina/La_Rioja` - America/Argentina/La_Rioja * `America/Argentina/Mendoza` - America/Argentina/Mendoza * `America/Argentina/Rio_Gallegos` - America/Argentina/Rio_Gallegos * `America/Argentina/Salta` - America/Argentina/Salta * `America/Argentina/San_Juan` - America/Argentina/San_Juan * `America/Argentina/San_Luis` - America/Argentina/San_Luis * `America/Argentina/Tucuman` - America/Argentina/Tucuman * `America/Argentina/Ushuaia` - America/Argentina/Ushuaia * `America/Aruba` - America/Aruba * `America/Asuncion` - America/Asuncion * `America/Atikokan` - America/Atikokan * `America/Atka` - America/Atka * `America/Bahia` - America/Bahia * `America/Bahia_Banderas` - America/Bahia_Banderas * `America/Barbados` - America/Barbados * `America/Belem` - America/Belem * `America/Belize` - America/Belize * `America/Blanc-Sablon` - America/Blanc-Sablon * `America/Boa_Vista` - America/Boa_Vista * `America/Bogota` - America/Bogota * `America/Boise` - America/Boise * `America/Buenos_Aires` - America/Buenos_Aires * `America/Cambridge_Bay` - America/Cambridge_Bay * `America/Campo_Grande` - America/Campo_Grande * `America/Cancun` - America/Cancun * `America/Caracas` - America/Caracas * `America/Catamarca` - America/Catamarca * `America/Cayenne` - America/Cayenne * `America/Cayman` - America/Cayman * `America/Chicago` - America/Chicago * `America/Chihuahua` - America/Chihuahua * `America/Ciudad_Juarez` - America/Ciudad_Juarez * `America/Coral_Harbour` - America/Coral_Harbour * `America/Cordoba` - America/Cordoba * `America/Costa_Rica` - America/Costa_Rica * `America/Creston` - America/Creston * `America/Cuiaba` - America/Cuiaba * `America/Curacao` - America/Curacao * `America/Danmarkshavn` - America/Danmarkshavn * `America/Dawson` - America/Dawson * `America/Dawson_Creek` - America/Dawson_Creek * `America/Denver` - America/Denver * `America/Detroit` - America/Detroit * `America/Dominica` - America/Dominica * `America/Edmonton` - America/Edmonton * `America/Eirunepe` - America/Eirunepe * `America/El_Salvador` - America/El_Salvador * `America/Ensenada` - America/Ensenada * `America/Fort_Nelson` - America/Fort_Nelson * `America/Fort_Wayne` - America/Fort_Wayne * `America/Fortaleza` - America/Fortaleza * `America/Glace_Bay` - America/Glace_Bay * `America/Godthab` - America/Godthab * `America/Goose_Bay` - America/Goose_Bay * `America/Grand_Turk` - America/Grand_Turk * `America/Grenada` - America/Grenada * `America/Guadeloupe` - America/Guadeloupe * `America/Guatemala` - America/Guatemala * `America/Guayaquil` - America/Guayaquil * `America/Guyana` - America/Guyana * `America/Halifax` - America/Halifax * `America/Havana` - America/Havana * `America/Hermosillo` - America/Hermosillo * `America/Indiana/Indianapolis` - America/Indiana/Indianapolis * `America/Indiana/Knox` - America/Indiana/Knox * `America/Indiana/Marengo` - America/Indiana/Marengo * `America/Indiana/Petersburg` - America/Indiana/Petersburg * `America/Indiana/Tell_City` - America/Indiana/Tell_City * `America/Indiana/Vevay` - America/Indiana/Vevay * `America/Indiana/Vincennes` - America/Indiana/Vincennes * `America/Indiana/Winamac` - America/Indiana/Winamac * `America/Indianapolis` - America/Indianapolis * `America/Inuvik` - America/Inuvik * `America/Iqaluit` - America/Iqaluit * `America/Jamaica` - America/Jamaica * `America/Jujuy` - America/Jujuy * `America/Juneau` - America/Juneau * `America/Kentucky/Louisville` - America/Kentucky/Louisville * `America/Kentucky/Monticello` - America/Kentucky/Monticello * `America/Knox_IN` - America/Knox_IN * `America/Kralendijk` - America/Kralendijk * `America/La_Paz` - America/La_Paz * `America/Lima` - America/Lima * `America/Los_Angeles` - America/Los_Angeles * `America/Louisville` - America/Louisville * `America/Lower_Princes` - America/Lower_Princes * `America/Maceio` - America/Maceio * `America/Managua` - America/Managua * `America/Manaus` - America/Manaus * `America/Marigot` - America/Marigot * `America/Martinique` - America/Martinique * `America/Matamoros` - America/Matamoros * `America/Mazatlan` - America/Mazatlan * `America/Mendoza` - America/Mendoza * `America/Menominee` - America/Menominee * `America/Merida` - America/Merida * `America/Metlakatla` - America/Metlakatla * `America/Mexico_City` - America/Mexico_City * `America/Miquelon` - America/Miquelon * `America/Moncton` - America/Moncton * `America/Monterrey` - America/Monterrey * `America/Montevideo` - America/Montevideo * `America/Montreal` - America/Montreal * `America/Montserrat` - America/Montserrat * `America/Nassau` - America/Nassau * `America/New_York` - America/New_York * `America/Nipigon` - America/Nipigon * `America/Nome` - America/Nome * `America/Noronha` - America/Noronha * `America/North_Dakota/Beulah` - America/North_Dakota/Beulah * `America/North_Dakota/Center` - America/North_Dakota/Center * `America/North_Dakota/New_Salem` - America/North_Dakota/New_Salem * `America/Nuuk` - America/Nuuk * `America/Ojinaga` - America/Ojinaga * `America/Panama` - America/Panama * `America/Pangnirtung` - America/Pangnirtung * `America/Paramaribo` - America/Paramaribo * `America/Phoenix` - America/Phoenix * `America/Port-au-Prince` - America/Port-au-Prince * `America/Port_of_Spain` - America/Port_of_Spain * `America/Porto_Acre` - America/Porto_Acre * `America/Porto_Velho` - America/Porto_Velho * `America/Puerto_Rico` - America/Puerto_Rico * `America/Punta_Arenas` - America/Punta_Arenas * `America/Rainy_River` - America/Rainy_River * `America/Rankin_Inlet` - America/Rankin_Inlet * `America/Recife` - America/Recife * `America/Regina` - America/Regina * `America/Resolute` - America/Resolute * `America/Rio_Branco` - America/Rio_Branco * `America/Rosario` - America/Rosario * `America/Santa_Isabel` - America/Santa_Isabel * `America/Santarem` - America/Santarem * `America/Santiago` - America/Santiago * `America/Santo_Domingo` - America/Santo_Domingo * `America/Sao_Paulo` - America/Sao_Paulo * `America/Scoresbysund` - America/Scoresbysund * `America/Shiprock` - America/Shiprock * `America/Sitka` - America/Sitka * `America/St_Barthelemy` - America/St_Barthelemy * `America/St_Johns` - America/St_Johns * `America/St_Kitts` - America/St_Kitts * `America/St_Lucia` - America/St_Lucia * `America/St_Thomas` - America/St_Thomas * `America/St_Vincent` - America/St_Vincent * `America/Swift_Current` - America/Swift_Current * `America/Tegucigalpa` - America/Tegucigalpa * `America/Thule` - America/Thule * `America/Thunder_Bay` - America/Thunder_Bay * `America/Tijuana` - America/Tijuana * `America/Toronto` - America/Toronto * `America/Tortola` - America/Tortola * `America/Vancouver` - America/Vancouver * `America/Virgin` - America/Virgin * `America/Whitehorse` - America/Whitehorse * `America/Winnipeg` - America/Winnipeg * `America/Yakutat` - America/Yakutat * `America/Yellowknife` - America/Yellowknife * `Antarctica/Casey` - Antarctica/Casey * `Antarctica/Davis` - Antarctica/Davis * `Antarctica/DumontDUrville` - Antarctica/DumontDUrville * `Antarctica/Macquarie` - Antarctica/Macquarie * `Antarctica/Mawson` - Antarctica/Mawson * `Antarctica/McMurdo` - Antarctica/McMurdo * `Antarctica/Palmer` - Antarctica/Palmer * `Antarctica/Rothera` - Antarctica/Rothera * `Antarctica/South_Pole` - Antarctica/South_Pole * `Antarctica/Syowa` - Antarctica/Syowa * `Antarctica/Troll` - Antarctica/Troll * `Antarctica/Vostok` - Antarctica/Vostok * `Arctic/Longyearbyen` - Arctic/Longyearbyen * `Asia/Aden` - Asia/Aden * `Asia/Almaty` - Asia/Almaty * `Asia/Amman` - Asia/Amman * `Asia/Anadyr` - Asia/Anadyr * `Asia/Aqtau` - Asia/Aqtau * `Asia/Aqtobe` - Asia/Aqtobe * `Asia/Ashgabat` - Asia/Ashgabat * `Asia/Ashkhabad` - Asia/Ashkhabad * `Asia/Atyrau` - Asia/Atyrau * `Asia/Baghdad` - Asia/Baghdad * `Asia/Bahrain` - Asia/Bahrain * `Asia/Baku` - Asia/Baku * `Asia/Bangkok` - Asia/Bangkok * `Asia/Barnaul` - Asia/Barnaul * `Asia/Beirut` - Asia/Beirut * `Asia/Bishkek` - Asia/Bishkek * `Asia/Brunei` - Asia/Brunei * `Asia/Calcutta` - Asia/Calcutta * `Asia/Chita` - Asia/Chita * `Asia/Choibalsan` - Asia/Choibalsan * `Asia/Chongqing` - Asia/Chongqing * `Asia/Chungking` - Asia/Chungking * `Asia/Colombo` - Asia/Colombo * `Asia/Dacca` - Asia/Dacca * `Asia/Damascus` - Asia/Damascus * `Asia/Dhaka` - Asia/Dhaka * `Asia/Dili` - Asia/Dili * `Asia/Dubai` - Asia/Dubai * `Asia/Dushanbe` - Asia/Dushanbe * `Asia/Famagusta` - Asia/Famagusta * `Asia/Gaza` - Asia/Gaza * `Asia/Harbin` - Asia/Harbin * `Asia/Hebron` - Asia/Hebron * `Asia/Ho_Chi_Minh` - Asia/Ho_Chi_Minh * `Asia/Hong_Kong` - Asia/Hong_Kong * `Asia/Hovd` - Asia/Hovd * `Asia/Irkutsk` - Asia/Irkutsk * `Asia/Istanbul` - Asia/Istanbul * `Asia/Jakarta` - Asia/Jakarta * `Asia/Jayapura` - Asia/Jayapura * `Asia/Jerusalem` - Asia/Jerusalem * `Asia/Kabul` - Asia/Kabul * `Asia/Kamchatka` - Asia/Kamchatka * `Asia/Karachi` - Asia/Karachi * `Asia/Kashgar` - Asia/Kashgar * `Asia/Kathmandu` - Asia/Kathmandu * `Asia/Katmandu` - Asia/Katmandu * `Asia/Khandyga` - Asia/Khandyga * `Asia/Kolkata` - Asia/Kolkata * `Asia/Krasnoyarsk` - Asia/Krasnoyarsk * `Asia/Kuala_Lumpur` - Asia/Kuala_Lumpur * `Asia/Kuching` - Asia/Kuching * `Asia/Kuwait` - Asia/Kuwait * `Asia/Macao` - Asia/Macao * `Asia/Macau` - Asia/Macau * `Asia/Magadan` - Asia/Magadan * `Asia/Makassar` - Asia/Makassar * `Asia/Manila` - Asia/Manila * `Asia/Muscat` - Asia/Muscat * `Asia/Nicosia` - Asia/Nicosia * `Asia/Novokuznetsk` - Asia/Novokuznetsk * `Asia/Novosibirsk` - Asia/Novosibirsk * `Asia/Omsk` - Asia/Omsk * `Asia/Oral` - Asia/Oral * `Asia/Phnom_Penh` - Asia/Phnom_Penh * `Asia/Pontianak` - Asia/Pontianak * `Asia/Pyongyang` - Asia/Pyongyang * `Asia/Qatar` - Asia/Qatar * `Asia/Qostanay` - Asia/Qostanay * `Asia/Qyzylorda` - Asia/Qyzylorda * `Asia/Rangoon` - Asia/Rangoon * `Asia/Riyadh` - Asia/Riyadh * `Asia/Saigon` - Asia/Saigon * `Asia/Sakhalin` - Asia/Sakhalin * `Asia/Samarkand` - Asia/Samarkand * `Asia/Seoul` - Asia/Seoul * `Asia/Shanghai` - Asia/Shanghai * `Asia/Singapore` - Asia/Singapore * `Asia/Srednekolymsk` - Asia/Srednekolymsk * `Asia/Taipei` - Asia/Taipei * `Asia/Tashkent` - Asia/Tashkent * `Asia/Tbilisi` - Asia/Tbilisi * `Asia/Tehran` - Asia/Tehran * `Asia/Tel_Aviv` - Asia/Tel_Aviv * `Asia/Thimbu` - Asia/Thimbu * `Asia/Thimphu` - Asia/Thimphu * `Asia/Tokyo` - Asia/Tokyo * `Asia/Tomsk` - Asia/Tomsk * `Asia/Ujung_Pandang` - Asia/Ujung_Pandang * `Asia/Ulaanbaatar` - Asia/Ulaanbaatar * `Asia/Ulan_Bator` - Asia/Ulan_Bator * `Asia/Urumqi` - Asia/Urumqi * `Asia/Ust-Nera` - Asia/Ust-Nera * `Asia/Vientiane` - Asia/Vientiane * `Asia/Vladivostok` - Asia/Vladivostok * `Asia/Yakutsk` - Asia/Yakutsk * `Asia/Yangon` - Asia/Yangon * `Asia/Yekaterinburg` - Asia/Yekaterinburg * `Asia/Yerevan` - Asia/Yerevan * `Atlantic/Azores` - Atlantic/Azores * `Atlantic/Bermuda` - Atlantic/Bermuda * `Atlantic/Canary` - Atlantic/Canary * `Atlantic/Cape_Verde` - Atlantic/Cape_Verde * `Atlantic/Faeroe` - Atlantic/Faeroe * `Atlantic/Faroe` - Atlantic/Faroe * `Atlantic/Jan_Mayen` - Atlantic/Jan_Mayen * `Atlantic/Madeira` - Atlantic/Madeira * `Atlantic/Reykjavik` - Atlantic/Reykjavik * `Atlantic/South_Georgia` - Atlantic/South_Georgia * `Atlantic/St_Helena` - Atlantic/St_Helena * `Atlantic/Stanley` - Atlantic/Stanley * `Australia/ACT` - Australia/ACT * `Australia/Adelaide` - Australia/Adelaide * `Australia/Brisbane` - Australia/Brisbane * `Australia/Broken_Hill` - Australia/Broken_Hill * `Australia/Canberra` - Australia/Canberra * `Australia/Currie` - Australia/Currie * `Australia/Darwin` - Australia/Darwin * `Australia/Eucla` - Australia/Eucla * `Australia/Hobart` - Australia/Hobart * `Australia/LHI` - Australia/LHI * `Australia/Lindeman` - Australia/Lindeman * `Australia/Lord_Howe` - Australia/Lord_Howe * `Australia/Melbourne` - Australia/Melbourne * `Australia/NSW` - Australia/NSW * `Australia/North` - Australia/North * `Australia/Perth` - Australia/Perth * `Australia/Queensland` - Australia/Queensland * `Australia/South` - Australia/South * `Australia/Sydney` - Australia/Sydney * `Australia/Tasmania` - Australia/Tasmania * `Australia/Victoria` - Australia/Victoria * `Australia/West` - Australia/West * `Australia/Yancowinna` - Australia/Yancowinna * `Brazil/Acre` - Brazil/Acre * `Brazil/DeNoronha` - Brazil/DeNoronha * `Brazil/East` - Brazil/East * `Brazil/West` - Brazil/West * `CET` - CET * `CST6CDT` - CST6CDT * `Canada/Atlantic` - Canada/Atlantic * `Canada/Central` - Canada/Central * `Canada/Eastern` - Canada/Eastern * `Canada/Mountain` - Canada/Mountain * `Canada/Newfoundland` - Canada/Newfoundland * `Canada/Pacific` - Canada/Pacific * `Canada/Saskatchewan` - Canada/Saskatchewan * `Canada/Yukon` - Canada/Yukon * `Chile/Continental` - Chile/Continental * `Chile/EasterIsland` - Chile/EasterIsland * `Cuba` - Cuba * `EET` - EET * `EST` - EST * `EST5EDT` - EST5EDT * `Egypt` - Egypt * `Eire` - Eire * `Etc/GMT` - Etc/GMT * `Etc/GMT+0` - Etc/GMT+0 * `Etc/GMT+1` - Etc/GMT+1 * `Etc/GMT+10` - Etc/GMT+10 * `Etc/GMT+11` - Etc/GMT+11 * `Etc/GMT+12` - Etc/GMT+12 * `Etc/GMT+2` - Etc/GMT+2 * `Etc/GMT+3` - Etc/GMT+3 * `Etc/GMT+4` - Etc/GMT+4 * `Etc/GMT+5` - Etc/GMT+5 * `Etc/GMT+6` - Etc/GMT+6 * `Etc/GMT+7` - Etc/GMT+7 * `Etc/GMT+8` - Etc/GMT+8 * `Etc/GMT+9` - Etc/GMT+9 * `Etc/GMT-0` - Etc/GMT-0 * `Etc/GMT-1` - Etc/GMT-1 * `Etc/GMT-10` - Etc/GMT-10 * `Etc/GMT-11` - Etc/GMT-11 * `Etc/GMT-12` - Etc/GMT-12 * `Etc/GMT-13` - Etc/GMT-13 * `Etc/GMT-14` - Etc/GMT-14 * `Etc/GMT-2` - Etc/GMT-2 * `Etc/GMT-3` - Etc/GMT-3 * `Etc/GMT-4` - Etc/GMT-4 * `Etc/GMT-5` - Etc/GMT-5 * `Etc/GMT-6` - Etc/GMT-6 * `Etc/GMT-7` - Etc/GMT-7 * `Etc/GMT-8` - Etc/GMT-8 * `Etc/GMT-9` - Etc/GMT-9 * `Etc/GMT0` - Etc/GMT0 * `Etc/Greenwich` - Etc/Greenwich * `Etc/UCT` - Etc/UCT * `Etc/UTC` - Etc/UTC * `Etc/Universal` - Etc/Universal * `Etc/Zulu` - Etc/Zulu * `Europe/Amsterdam` - Europe/Amsterdam * `Europe/Andorra` - Europe/Andorra * `Europe/Astrakhan` - Europe/Astrakhan * `Europe/Athens` - Europe/Athens * `Europe/Belfast` - Europe/Belfast * `Europe/Belgrade` - Europe/Belgrade * `Europe/Berlin` - Europe/Berlin * `Europe/Bratislava` - Europe/Bratislava * `Europe/Brussels` - Europe/Brussels * `Europe/Bucharest` - Europe/Bucharest * `Europe/Budapest` - Europe/Budapest * `Europe/Busingen` - Europe/Busingen * `Europe/Chisinau` - Europe/Chisinau * `Europe/Copenhagen` - Europe/Copenhagen * `Europe/Dublin` - Europe/Dublin * `Europe/Gibraltar` - Europe/Gibraltar * `Europe/Guernsey` - Europe/Guernsey * `Europe/Helsinki` - Europe/Helsinki * `Europe/Isle_of_Man` - Europe/Isle_of_Man * `Europe/Istanbul` - Europe/Istanbul * `Europe/Jersey` - Europe/Jersey * `Europe/Kaliningrad` - Europe/Kaliningrad * `Europe/Kiev` - Europe/Kiev * `Europe/Kirov` - Europe/Kirov * `Europe/Kyiv` - Europe/Kyiv * `Europe/Lisbon` - Europe/Lisbon * `Europe/Ljubljana` - Europe/Ljubljana * `Europe/London` - Europe/London * `Europe/Luxembourg` - Europe/Luxembourg * `Europe/Madrid` - Europe/Madrid * `Europe/Malta` - Europe/Malta * `Europe/Mariehamn` - Europe/Mariehamn * `Europe/Minsk` - Europe/Minsk * `Europe/Monaco` - Europe/Monaco * `Europe/Moscow` - Europe/Moscow * `Europe/Nicosia` - Europe/Nicosia * `Europe/Oslo` - Europe/Oslo * `Europe/Paris` - Europe/Paris * `Europe/Podgorica` - Europe/Podgorica * `Europe/Prague` - Europe/Prague * `Europe/Riga` - Europe/Riga * `Europe/Rome` - Europe/Rome * `Europe/Samara` - Europe/Samara * `Europe/San_Marino` - Europe/San_Marino * `Europe/Sarajevo` - Europe/Sarajevo * `Europe/Saratov` - Europe/Saratov * `Europe/Simferopol` - Europe/Simferopol * `Europe/Skopje` - Europe/Skopje * `Europe/Sofia` - Europe/Sofia * `Europe/Stockholm` - Europe/Stockholm * `Europe/Tallinn` - Europe/Tallinn * `Europe/Tirane` - Europe/Tirane * `Europe/Tiraspol` - Europe/Tiraspol * `Europe/Ulyanovsk` - Europe/Ulyanovsk * `Europe/Uzhgorod` - Europe/Uzhgorod * `Europe/Vaduz` - Europe/Vaduz * `Europe/Vatican` - Europe/Vatican * `Europe/Vienna` - Europe/Vienna * `Europe/Vilnius` - Europe/Vilnius * `Europe/Volgograd` - Europe/Volgograd * `Europe/Warsaw` - Europe/Warsaw * `Europe/Zagreb` - Europe/Zagreb * `Europe/Zaporozhye` - Europe/Zaporozhye * `Europe/Zurich` - Europe/Zurich * `GB` - GB * `GB-Eire` - GB-Eire * `GMT` - GMT * `GMT+0` - GMT+0 * `GMT-0` - GMT-0 * `GMT0` - GMT0 * `Greenwich` - Greenwich * `HST` - HST * `Hongkong` - Hongkong * `Iceland` - Iceland * `Indian/Antananarivo` - Indian/Antananarivo * `Indian/Chagos` - Indian/Chagos * `Indian/Christmas` - Indian/Christmas * `Indian/Cocos` - Indian/Cocos * `Indian/Comoro` - Indian/Comoro * `Indian/Kerguelen` - Indian/Kerguelen * `Indian/Mahe` - Indian/Mahe * `Indian/Maldives` - Indian/Maldives * `Indian/Mauritius` - Indian/Mauritius * `Indian/Mayotte` - Indian/Mayotte * `Indian/Reunion` - Indian/Reunion * `Iran` - Iran * `Israel` - Israel * `Jamaica` - Jamaica * `Japan` - Japan * `Kwajalein` - Kwajalein * `Libya` - Libya * `MET` - MET * `MST` - MST * `MST7MDT` - MST7MDT * `Mexico/BajaNorte` - Mexico/BajaNorte * `Mexico/BajaSur` - Mexico/BajaSur * `Mexico/General` - Mexico/General * `NZ` - NZ * `NZ-CHAT` - NZ-CHAT * `Navajo` - Navajo * `PRC` - PRC * `PST8PDT` - PST8PDT * `Pacific/Apia` - Pacific/Apia * `Pacific/Auckland` - Pacific/Auckland * `Pacific/Bougainville` - Pacific/Bougainville * `Pacific/Chatham` - Pacific/Chatham * `Pacific/Chuuk` - Pacific/Chuuk * `Pacific/Easter` - Pacific/Easter * `Pacific/Efate` - Pacific/Efate * `Pacific/Enderbury` - Pacific/Enderbury * `Pacific/Fakaofo` - Pacific/Fakaofo * `Pacific/Fiji` - Pacific/Fiji * `Pacific/Funafuti` - Pacific/Funafuti * `Pacific/Galapagos` - Pacific/Galapagos * `Pacific/Gambier` - Pacific/Gambier * `Pacific/Guadalcanal` - Pacific/Guadalcanal * `Pacific/Guam` - Pacific/Guam * `Pacific/Honolulu` - Pacific/Honolulu * `Pacific/Johnston` - Pacific/Johnston * `Pacific/Kanton` - Pacific/Kanton * `Pacific/Kiritimati` - Pacific/Kiritimati * `Pacific/Kosrae` - Pacific/Kosrae * `Pacific/Kwajalein` - Pacific/Kwajalein * `Pacific/Majuro` - Pacific/Majuro * `Pacific/Marquesas` - Pacific/Marquesas * `Pacific/Midway` - Pacific/Midway * `Pacific/Nauru` - Pacific/Nauru * `Pacific/Niue` - Pacific/Niue * `Pacific/Norfolk` - Pacific/Norfolk * `Pacific/Noumea` - Pacific/Noumea * `Pacific/Pago_Pago` - Pacific/Pago_Pago * `Pacific/Palau` - Pacific/Palau * `Pacific/Pitcairn` - Pacific/Pitcairn * `Pacific/Pohnpei` - Pacific/Pohnpei * `Pacific/Ponape` - Pacific/Ponape * `Pacific/Port_Moresby` - Pacific/Port_Moresby * `Pacific/Rarotonga` - Pacific/Rarotonga * `Pacific/Saipan` - Pacific/Saipan * `Pacific/Samoa` - Pacific/Samoa * `Pacific/Tahiti` - Pacific/Tahiti * `Pacific/Tarawa` - Pacific/Tarawa * `Pacific/Tongatapu` - Pacific/Tongatapu * `Pacific/Truk` - Pacific/Truk * `Pacific/Wake` - Pacific/Wake * `Pacific/Wallis` - Pacific/Wallis * `Pacific/Yap` - Pacific/Yap * `Poland` - Poland * `Portugal` - Portugal * `ROC` - ROC * `ROK` - ROK * `Singapore` - Singapore * `Turkey` - Turkey * `UCT` - UCT * `US/Alaska` - US/Alaska * `US/Aleutian` - US/Aleutian * `US/Arizona` - US/Arizona * `US/Central` - US/Central * `US/East-Indiana` - US/East-Indiana * `US/Eastern` - US/Eastern * `US/Hawaii` - US/Hawaii * `US/Indiana-Starke` - US/Indiana-Starke * `US/Michigan` - US/Michigan * `US/Mountain` - US/Mountain * `US/Pacific` - US/Pacific * `US/Samoa` - US/Samoa * `UTC` - UTC * `Universal` - Universal * `W-SU` - W-SU * `WET` - WET * `Zulu` - Zulu */
@@ -1485,10 +1485,10 @@ export const CreateOrganizationsProjectRequestSessionRecordingUrlBlocklistConfig
   ) as any as S.Schema<CreateOrganizationsProjectRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type CreateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList>;
 
 /** * `30d` - 30 Days * `90d` - 90 Days * `1y` - 1 Year * `5y` - 5 Years */
@@ -1507,11 +1507,12 @@ export const CreateOrganizationsProjectRequestLiveEventsColumnsList =
   ) as any as S.Schema<CreateOrganizationsProjectRequestLiveEventsColumnsList>;
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
-export type CreateOrganizationsProjectRequestRecordingDomainsList =
-  Array<string>;
+export type CreateOrganizationsProjectRequestRecordingDomainsList = Array<
+  string | null
+>;
 export const CreateOrganizationsProjectRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectRequestRecordingDomainsList>;
 
 /** * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -3018,9 +3019,9 @@ export const ProjectBackwardCompatGroupTypesList = /*@__PURE__*/ S.Array(
   ProjectBackwardCompatGroupTypesItemMap,
 ) as any as S.Schema<ProjectBackwardCompatGroupTypesList>;
 
-export type ProjectBackwardCompatAppUrlsList = Array<string>;
+export type ProjectBackwardCompatAppUrlsList = Array<string | null>;
 export const ProjectBackwardCompatAppUrlsList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ProjectBackwardCompatAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -3045,11 +3046,12 @@ export const ProjectBackwardCompatSessionRecordingUrlBlocklistConfigList =
     S.Unknown,
   ) as any as S.Schema<ProjectBackwardCompatSessionRecordingUrlBlocklistConfigList>;
 
-export type ProjectBackwardCompatSessionRecordingEventTriggerConfigList =
-  Array<string>;
+export type ProjectBackwardCompatSessionRecordingEventTriggerConfigList = Array<
+  string | null
+>;
 export const ProjectBackwardCompatSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<ProjectBackwardCompatSessionRecordingEventTriggerConfigList>;
 
 export type ProjectBackwardCompatLiveEventsColumnsList = Array<string>;
@@ -3058,9 +3060,9 @@ export const ProjectBackwardCompatLiveEventsColumnsList = /*@__PURE__*/ S.Array(
 ) as any as S.Schema<ProjectBackwardCompatLiveEventsColumnsList>;
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
-export type ProjectBackwardCompatRecordingDomainsList = Array<string>;
+export type ProjectBackwardCompatRecordingDomainsList = Array<string | null>;
 export const ProjectBackwardCompatRecordingDomainsList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<ProjectBackwardCompatRecordingDomainsList>;
 
 export type ProjectBackwardCompatDefaultModifiersMap = {
@@ -3446,10 +3448,10 @@ export const CreateOrganizationsProjectsChangeOrganizationRequestTagsList =
   ) as any as S.Schema<CreateOrganizationsProjectsChangeOrganizationRequestTagsList>;
 
 export type CreateOrganizationsProjectsChangeOrganizationRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsChangeOrganizationRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsChangeOrganizationRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -3475,10 +3477,10 @@ export const CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordin
   ) as any as S.Schema<CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsChangeOrganizationRequestSessionRecordingEventTriggerConfigList>;
 
 export type CreateOrganizationsProjectsChangeOrganizationRequestLiveEventsColumnsList =
@@ -3490,10 +3492,10 @@ export const CreateOrganizationsProjectsChangeOrganizationRequestLiveEventsColum
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type CreateOrganizationsProjectsChangeOrganizationRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsChangeOrganizationRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsChangeOrganizationRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -3750,10 +3752,10 @@ export const CreateOrganizationsProjectsDefaultEvaluationContextRequestTagsList 
   ) as any as S.Schema<CreateOrganizationsProjectsDefaultEvaluationContextRequestTagsList>;
 
 export type CreateOrganizationsProjectsDefaultEvaluationContextRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsDefaultEvaluationContextRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsDefaultEvaluationContextRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -3779,10 +3781,10 @@ export const CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRe
   ) as any as S.Schema<CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsDefaultEvaluationContextRequestSessionRecordingEventTriggerConfigList>;
 
 export type CreateOrganizationsProjectsDefaultEvaluationContextRequestLiveEventsColumnsList =
@@ -3794,10 +3796,10 @@ export const CreateOrganizationsProjectsDefaultEvaluationContextRequestLiveEvent
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type CreateOrganizationsProjectsDefaultEvaluationContextRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const CreateOrganizationsProjectsDefaultEvaluationContextRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateOrganizationsProjectsDefaultEvaluationContextRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -6211,10 +6213,10 @@ export const OrganizationsProjectsAddProductIntentPartialUpdateRequestTagsList =
   ) as any as S.Schema<OrganizationsProjectsAddProductIntentPartialUpdateRequestTagsList>;
 
 export type OrganizationsProjectsAddProductIntentPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsAddProductIntentPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsAddProductIntentPartialUpdateRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -6240,10 +6242,10 @@ export const OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRec
   ) as any as S.Schema<OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsAddProductIntentPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type OrganizationsProjectsAddProductIntentPartialUpdateRequestLiveEventsColumnsList =
@@ -6255,10 +6257,10 @@ export const OrganizationsProjectsAddProductIntentPartialUpdateRequestLiveEvents
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type OrganizationsProjectsAddProductIntentPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsAddProductIntentPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsAddProductIntentPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -6543,10 +6545,10 @@ export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestTag
   ) as any as S.Schema<OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestTagsList>;
 
 export type OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -6572,10 +6574,10 @@ export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSes
   ) as any as S.Schema<OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestLiveEventsColumnsList =
@@ -6587,10 +6589,10 @@ export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestLiv
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsDeleteSecretTokenBackupPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -6902,10 +6904,10 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestT
   ) as any as S.Schema<OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestTagsList>;
 
 export type OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -6931,10 +6933,10 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestS
   ) as any as S.Schema<OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestSessionRecordingEventTriggerConfigList>;
 
 export type OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestLiveEventsColumnsList =
@@ -6946,10 +6948,10 @@ export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestL
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsGenerateConversationsPublicTokenCreateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -7207,10 +7209,10 @@ export const OrganizationsProjectsResetTokenPartialUpdateRequestTagsList =
   ) as any as S.Schema<OrganizationsProjectsResetTokenPartialUpdateRequestTagsList>;
 
 export type OrganizationsProjectsResetTokenPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsResetTokenPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsResetTokenPartialUpdateRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -7236,10 +7238,10 @@ export const OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecording
   ) as any as S.Schema<OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsResetTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type OrganizationsProjectsResetTokenPartialUpdateRequestLiveEventsColumnsList =
@@ -7251,10 +7253,10 @@ export const OrganizationsProjectsResetTokenPartialUpdateRequestLiveEventsColumn
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type OrganizationsProjectsResetTokenPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsResetTokenPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsResetTokenPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -7511,10 +7513,10 @@ export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestTagsList 
   ) as any as S.Schema<OrganizationsProjectsRotateSecretTokenPartialUpdateRequestTagsList>;
 
 export type OrganizationsProjectsRotateSecretTokenPartialUpdateRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsRotateSecretTokenPartialUpdateRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -7540,10 +7542,10 @@ export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRe
   ) as any as S.Schema<OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsRotateSecretTokenPartialUpdateRequestSessionRecordingEventTriggerConfigList>;
 
 export type OrganizationsProjectsRotateSecretTokenPartialUpdateRequestLiveEventsColumnsList =
@@ -7555,10 +7557,10 @@ export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestLiveEvent
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type OrganizationsProjectsRotateSecretTokenPartialUpdateRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const OrganizationsProjectsRotateSecretTokenPartialUpdateRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<OrganizationsProjectsRotateSecretTokenPartialUpdateRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -8351,10 +8353,10 @@ export const UpdateOrganizationsProjectRequestTagsList = /*@__PURE__*/ S.Array(
   S.String,
 ) as any as S.Schema<UpdateOrganizationsProjectRequestTagsList>;
 
-export type UpdateOrganizationsProjectRequestAppUrlsList = Array<string>;
+export type UpdateOrganizationsProjectRequestAppUrlsList = Array<string | null>;
 export const UpdateOrganizationsProjectRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -8380,10 +8382,10 @@ export const UpdateOrganizationsProjectRequestSessionRecordingUrlBlocklistConfig
   ) as any as S.Schema<UpdateOrganizationsProjectRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectRequestLiveEventsColumnsList =
@@ -8394,11 +8396,12 @@ export const UpdateOrganizationsProjectRequestLiveEventsColumnsList =
   ) as any as S.Schema<UpdateOrganizationsProjectRequestLiveEventsColumnsList>;
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
-export type UpdateOrganizationsProjectRequestRecordingDomainsList =
-  Array<string>;
+export type UpdateOrganizationsProjectRequestRecordingDomainsList = Array<
+  string | null
+>;
 export const UpdateOrganizationsProjectRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -8642,10 +8645,10 @@ export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestT
   ) as any as S.Schema<UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestTagsList>;
 
 export type UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -8671,10 +8674,10 @@ export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestS
   ) as any as S.Schema<UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestLiveEventsColumnsList =
@@ -8686,10 +8689,10 @@ export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestL
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsCompleteProductOnboardingPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -8947,10 +8950,10 @@ export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestTagsList =
   ) as any as S.Schema<UpdateOrganizationsProjectsDefaultReleaseConditionRequestTagsList>;
 
 export type UpdateOrganizationsProjectsDefaultReleaseConditionRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsDefaultReleaseConditionRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -8976,10 +8979,10 @@ export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRec
   ) as any as S.Schema<UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsDefaultReleaseConditionRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectsDefaultReleaseConditionRequestLiveEventsColumnsList =
@@ -8991,10 +8994,10 @@ export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestLiveEvents
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type UpdateOrganizationsProjectsDefaultReleaseConditionRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsDefaultReleaseConditionRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsDefaultReleaseConditionRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -9251,10 +9254,10 @@ export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestTagsList 
   ) as any as S.Schema<UpdateOrganizationsProjectsExperimentsConfigPartialRequestTagsList>;
 
 export type UpdateOrganizationsProjectsExperimentsConfigPartialRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsExperimentsConfigPartialRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -9280,10 +9283,10 @@ export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRe
   ) as any as S.Schema<UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsExperimentsConfigPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectsExperimentsConfigPartialRequestLiveEventsColumnsList =
@@ -9295,10 +9298,10 @@ export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestLiveEvent
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type UpdateOrganizationsProjectsExperimentsConfigPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsExperimentsConfigPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsExperimentsConfigPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -9555,10 +9558,10 @@ export const UpdateOrganizationsProjectsLogsConfigPartialRequestTagsList =
   ) as any as S.Schema<UpdateOrganizationsProjectsLogsConfigPartialRequestTagsList>;
 
 export type UpdateOrganizationsProjectsLogsConfigPartialRequestAppUrlsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsLogsConfigPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsLogsConfigPartialRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -9584,10 +9587,10 @@ export const UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecording
   ) as any as S.Schema<UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsLogsConfigPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectsLogsConfigPartialRequestLiveEventsColumnsList =
@@ -9599,10 +9602,10 @@ export const UpdateOrganizationsProjectsLogsConfigPartialRequestLiveEventsColumn
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type UpdateOrganizationsProjectsLogsConfigPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsLogsConfigPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsLogsConfigPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */
@@ -9857,11 +9860,12 @@ export const UpdateOrganizationsProjectsPartialRequestTagsList =
     S.String,
   ) as any as S.Schema<UpdateOrganizationsProjectsPartialRequestTagsList>;
 
-export type UpdateOrganizationsProjectsPartialRequestAppUrlsList =
-  Array<string>;
+export type UpdateOrganizationsProjectsPartialRequestAppUrlsList = Array<
+  string | null
+>;
 export const UpdateOrganizationsProjectsPartialRequestAppUrlsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsPartialRequestAppUrlsList>;
 
 /** Ordered list of person properties used to render a human-friendly display name in the UI. */
@@ -9887,10 +9891,10 @@ export const UpdateOrganizationsProjectsPartialRequestSessionRecordingUrlBlockli
   ) as any as S.Schema<UpdateOrganizationsProjectsPartialRequestSessionRecordingUrlBlocklistConfigList>;
 
 export type UpdateOrganizationsProjectsPartialRequestSessionRecordingEventTriggerConfigList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsPartialRequestSessionRecordingEventTriggerConfigList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsPartialRequestSessionRecordingEventTriggerConfigList>;
 
 export type UpdateOrganizationsProjectsPartialRequestLiveEventsColumnsList =
@@ -9902,10 +9906,10 @@ export const UpdateOrganizationsProjectsPartialRequestLiveEventsColumnsList =
 
 /** Origins permitted to record session replays and heatmaps. Empty list allows all origins. */
 export type UpdateOrganizationsProjectsPartialRequestRecordingDomainsList =
-  Array<string>;
+  Array<string | null>;
 export const UpdateOrganizationsProjectsPartialRequestRecordingDomainsList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateOrganizationsProjectsPartialRequestRecordingDomainsList>;
 
 /** Whether this project serves B2B or B2C customers. Used to optimize default UI layouts. * `b2b` - B2B * `b2c` - B2C * `other` - Other */

--- a/packages/posthog/src/services/persons.ts
+++ b/packages/posthog/src/services/persons.ts
@@ -359,12 +359,12 @@ export const PersonPropertiesAtTimeResponseDistinctIdsList =
 
 /** Person properties as they existed at the specified time */
 export type PersonPropertiesAtTimeResponsePropertiesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const PersonPropertiesAtTimeResponsePropertiesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<PersonPropertiesAtTimeResponsePropertiesMap>;
 
 /** All distinct_ids that were queried for this person */

--- a/packages/posthog/src/services/query.ts
+++ b/packages/posthog/src/services/query.ts
@@ -18191,9 +18191,9 @@ export const AccountsQueryResponseColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<AccountsQueryResponseColumnsList>;
 
-export type AccountsQueryResponseMetricsResultsList = Array<number>;
+export type AccountsQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsQueryResponseMetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<AccountsQueryResponseMetricsResultsList>;
 
 export type AccountsQueryResponseResultsItemList = Array<unknown>;
@@ -18724,19 +18724,19 @@ export const AccountsTableQueryMetricsList = /*@__PURE__*/ S.Array(
   AccountsTableQueryMetricsItem,
 ) as any as S.Schema<AccountsTableQueryMetricsList>;
 
-export type AccountsTableQueryResponseMetricsResultsList = Array<number>;
+export type AccountsTableQueryResponseMetricsResultsList = Array<number | null>;
 export const AccountsTableQueryResponseMetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<AccountsTableQueryResponseMetricsResultsList>;
 
 /** Requested direct Account fields, keyed by their typed field reference. */
 export type AccountsTableRowAccountFieldsMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const AccountsTableRowAccountFieldsMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<AccountsTableRowAccountFieldsMap>;
 
 export type AccountsTableRowCustomPropertiesValue = string | number | boolean;
@@ -18745,11 +18745,11 @@ export const AccountsTableRowCustomPropertiesValue =
 
 /** Current values keyed by requested custom property definition ID. */
 export type AccountsTableRowCustomPropertiesMap = {
-  [key: string]: AccountsTableRowCustomPropertiesValue | undefined;
+  [key: string]: AccountsTableRowCustomPropertiesValue | null | undefined;
 };
 export const AccountsTableRowCustomPropertiesMap = /*@__PURE__*/ S.Record(
   S.String,
-  AccountsTableRowCustomPropertiesValue,
+  S.NullOr(AccountsTableRowCustomPropertiesValue),
 ) as any as S.Schema<AccountsTableRowCustomPropertiesMap>;
 
 export interface AccountsTableCustomPropertyHistoryPoint {
@@ -24803,9 +24803,9 @@ export const Response22ColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<Response22ColumnsList>;
 
-export type Response22MetricsResultsList = Array<number>;
+export type Response22MetricsResultsList = Array<number | null>;
 export const Response22MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response22MetricsResultsList>;
 
 export type Response22ResultsItemList = Array<unknown>;
@@ -24900,9 +24900,9 @@ export const Response22 = /*@__PURE__*/ S.suspend(() =>
   }),
 ).annotate({ identifier: "Response22" }) as any as S.Schema<Response22>;
 
-export type Response23MetricsResultsList = Array<number>;
+export type Response23MetricsResultsList = Array<number | null>;
 export const Response23MetricsResultsList = /*@__PURE__*/ S.Array(
-  S.Number,
+  S.NullOr(S.Number),
 ) as any as S.Schema<Response23MetricsResultsList>;
 
 export type Response23ResultsList = Array<AccountsTableRow>;
@@ -31701,10 +31701,10 @@ export const QueryResponseAlternative61ColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<QueryResponseAlternative61ColumnsList>;
 
-export type QueryResponseAlternative61MetricsResultsList = Array<number>;
+export type QueryResponseAlternative61MetricsResultsList = Array<number | null>;
 export const QueryResponseAlternative61MetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<QueryResponseAlternative61MetricsResultsList>;
 
 export type QueryResponseAlternative61ResultsItemList = Array<unknown>;
@@ -31806,10 +31806,10 @@ export const QueryResponseAlternative61 = /*@__PURE__*/ S.suspend(() =>
   identifier: "QueryResponseAlternative61",
 }) as any as S.Schema<QueryResponseAlternative61>;
 
-export type QueryResponseAlternative62MetricsResultsList = Array<number>;
+export type QueryResponseAlternative62MetricsResultsList = Array<number | null>;
 export const QueryResponseAlternative62MetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<QueryResponseAlternative62MetricsResultsList>;
 
 export type QueryResponseAlternative62ResultsList = Array<AccountsTableRow>;
@@ -33683,10 +33683,10 @@ export const QueryResponseAlternative91ColumnsList = /*@__PURE__*/ S.Array(
   S.Unknown,
 ) as any as S.Schema<QueryResponseAlternative91ColumnsList>;
 
-export type QueryResponseAlternative91MetricsResultsList = Array<number>;
+export type QueryResponseAlternative91MetricsResultsList = Array<number | null>;
 export const QueryResponseAlternative91MetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<QueryResponseAlternative91MetricsResultsList>;
 
 export type QueryResponseAlternative91ResultsItemList = Array<unknown>;
@@ -33788,10 +33788,10 @@ export const QueryResponseAlternative91 = /*@__PURE__*/ S.suspend(() =>
   identifier: "QueryResponseAlternative91",
 }) as any as S.Schema<QueryResponseAlternative91>;
 
-export type QueryResponseAlternative92MetricsResultsList = Array<number>;
+export type QueryResponseAlternative92MetricsResultsList = Array<number | null>;
 export const QueryResponseAlternative92MetricsResultsList =
   /*@__PURE__*/ S.Array(
-    S.Number,
+    S.NullOr(S.Number),
   ) as any as S.Schema<QueryResponseAlternative92MetricsResultsList>;
 
 export type QueryResponseAlternative92ResultsList = Array<AccountsTableRow>;

--- a/packages/posthog/src/services/replay.ts
+++ b/packages/posthog/src/services/replay.ts
@@ -144,12 +144,13 @@ export const SessionRecordingPlaylistOutputRecordingsCountsValueValue =
 export type SessionRecordingPlaylistOutputRecordingsCountsValueMap = {
   [key: string]:
     | SessionRecordingPlaylistOutputRecordingsCountsValueValue
+    | null
     | undefined;
 };
 export const SessionRecordingPlaylistOutputRecordingsCountsValueMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    SessionRecordingPlaylistOutputRecordingsCountsValueValue,
+    S.NullOr(SessionRecordingPlaylistOutputRecordingsCountsValueValue),
   ) as any as S.Schema<SessionRecordingPlaylistOutputRecordingsCountsValueMap>;
 
 export type SessionRecordingPlaylistOutputRecordingsCountsMap = {

--- a/packages/posthog/src/services/surveys.ts
+++ b/packages/posthog/src/services/surveys.ts
@@ -957,9 +957,9 @@ export const SurveyAppearanceSchema = /*@__PURE__*/ S.suspend(() =>
   identifier: "SurveyAppearanceSchema",
 }) as any as S.Schema<SurveyAppearanceSchema>;
 
-export type CreateSurveyRequestIterationStartDatesList = Array<string>;
+export type CreateSurveyRequestIterationStartDatesList = Array<string | null>;
 export const CreateSurveyRequestIterationStartDatesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<CreateSurveyRequestIterationStartDatesList>;
 
 /** * `day` - day * `week` - week * `month` - month */
@@ -1203,10 +1203,10 @@ export const UserBasic = /*@__PURE__*/ S.suspend(() =>
 ).annotate({ identifier: "UserBasic" }) as any as S.Schema<UserBasic>;
 
 export type SurveySerializerCreateUpdateOnlyOutputIterationStartDatesList =
-  Array<string>;
+  Array<string | null>;
 export const SurveySerializerCreateUpdateOnlyOutputIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<SurveySerializerCreateUpdateOnlyOutputIterationStartDatesList>;
 
 export type SurveySerializerCreateUpdateOnlyOutputResponseSamplingIntervalType =
@@ -1335,11 +1335,12 @@ export const CreateSurveysSummarizeResponseResponse = /*@__PURE__*/ S.suspend(
   identifier: "CreateSurveysSummarizeResponseResponse",
 }) as any as S.Schema<CreateSurveysSummarizeResponseResponse>;
 
-export type CreateSurveysSummaryHeadlineRequestIterationStartDatesList =
-  Array<string>;
+export type CreateSurveysSummaryHeadlineRequestIterationStartDatesList = Array<
+  string | null
+>;
 export const CreateSurveysSummaryHeadlineRequestIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateSurveysSummaryHeadlineRequestIterationStartDatesList>;
 
 export type CreateSurveysSummaryHeadlineRequestResponseSamplingIntervalType =
@@ -1474,11 +1475,11 @@ export const SurveyConditionsMap = /*@__PURE__*/ S.Record(
 ) as any as S.Schema<SurveyConditionsMap>;
 
 export type SurveyFeatureFlagKeysItemMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const SurveyFeatureFlagKeysItemMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<SurveyFeatureFlagKeysItemMap>;
 
 export type SurveyFeatureFlagKeysList = Array<SurveyFeatureFlagKeysItemMap>;
@@ -1486,9 +1487,9 @@ export const SurveyFeatureFlagKeysList = /*@__PURE__*/ S.Array(
   SurveyFeatureFlagKeysItemMap,
 ) as any as S.Schema<SurveyFeatureFlagKeysList>;
 
-export type SurveyIterationStartDatesList = Array<string>;
+export type SurveyIterationStartDatesList = Array<string | null>;
 export const SurveyIterationStartDatesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<SurveyIterationStartDatesList>;
 
 export type SurveyResponseSamplingIntervalType =
@@ -2123,10 +2124,10 @@ export const SurveysDestroyResponse = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<SurveysDestroyResponse>;
 
 export type SurveysDuplicateToProjectsCreateRequestIterationStartDatesList =
-  Array<string>;
+  Array<string | null>;
 export const SurveysDuplicateToProjectsCreateRequestIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<SurveysDuplicateToProjectsCreateRequestIterationStartDatesList>;
 
 export type SurveysDuplicateToProjectsCreateRequestResponseSamplingIntervalType =
@@ -2495,11 +2496,12 @@ export const SurveyQuestionLabelsResponse = /*@__PURE__*/ S.suspend(() =>
   identifier: "SurveyQuestionLabelsResponse",
 }) as any as S.Schema<SurveyQuestionLabelsResponse>;
 
-export type SurveysResponsesArchiveCreateRequestIterationStartDatesList =
-  Array<string>;
+export type SurveysResponsesArchiveCreateRequestIterationStartDatesList = Array<
+  string | null
+>;
 export const SurveysResponsesArchiveCreateRequestIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<SurveysResponsesArchiveCreateRequestIterationStartDatesList>;
 
 export type SurveysResponsesArchiveCreateRequestResponseSamplingIntervalType =
@@ -2612,10 +2614,10 @@ export const SurveysResponsesArchiveCreateResponse = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<SurveysResponsesArchiveCreateResponse>;
 
 export type SurveysResponsesUnarchiveCreateRequestIterationStartDatesList =
-  Array<string>;
+  Array<string | null>;
 export const SurveysResponsesUnarchiveCreateRequestIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<SurveysResponsesUnarchiveCreateRequestIterationStartDatesList>;
 
 export type SurveysResponsesUnarchiveCreateRequestResponseSamplingIntervalType =
@@ -2733,9 +2735,9 @@ export const UpdateSurveyRequestQuestionsList = /*@__PURE__*/ S.Array(
   SurveyQuestionInputSchema,
 ) as any as S.Schema<UpdateSurveyRequestQuestionsList>;
 
-export type UpdateSurveyRequestIterationStartDatesList = Array<string>;
+export type UpdateSurveyRequestIterationStartDatesList = Array<string | null>;
 export const UpdateSurveyRequestIterationStartDatesList = /*@__PURE__*/ S.Array(
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateSurveyRequestIterationStartDatesList>;
 
 export type UpdateSurveyRequestResponseSamplingIntervalType =
@@ -2859,10 +2861,12 @@ export const UpdateSurveysPartialRequestQuestionsList = /*@__PURE__*/ S.Array(
   SurveyQuestionInputSchema,
 ) as any as S.Schema<UpdateSurveysPartialRequestQuestionsList>;
 
-export type UpdateSurveysPartialRequestIterationStartDatesList = Array<string>;
+export type UpdateSurveysPartialRequestIterationStartDatesList = Array<
+  string | null
+>;
 export const UpdateSurveysPartialRequestIterationStartDatesList =
   /*@__PURE__*/ S.Array(
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateSurveysPartialRequestIterationStartDatesList>;
 
 export type UpdateSurveysPartialRequestResponseSamplingIntervalType =

--- a/packages/stripe/.generated-specs/stripe.json
+++ b/packages/stripe/.generated-specs/stripe.json
@@ -370788,7 +370788,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format."
@@ -394898,7 +394901,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format."
@@ -399601,7 +399607,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format."
@@ -405872,7 +405881,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format."
@@ -406336,7 +406348,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format."
@@ -407419,7 +407434,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Metadata."

--- a/packages/stripe/src/services/stripe.ts
+++ b/packages/stripe/src/services/stripe.ts
@@ -53877,12 +53877,12 @@ export const CreateCoreAccountPersonTokenRequestLegalGender = S.String;
 
 /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
 export type CreateCoreAccountPersonTokenRequestMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CreateCoreAccountPersonTokenRequestMetadataMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateCoreAccountPersonTokenRequestMetadataMap>;
 
 /** The nationalities (countries) this person is associated with. */
@@ -55444,12 +55444,12 @@ export const CreateCoreAccountTokenRequestIdentityIndividualLegalGender =
 
 /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
 export type CreateCoreAccountTokenRequestIdentityIndividualMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const CreateCoreAccountTokenRequestIdentityIndividualMetadataMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<CreateCoreAccountTokenRequestIdentityIndividualMetadataMap>;
 
 /** The countries where the individual is a national. Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
@@ -155078,12 +155078,12 @@ export const UpdateCoreAccountRequestIdentityIndividualLegalGender = S.String;
 
 /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
 export type UpdateCoreAccountRequestIdentityIndividualMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateCoreAccountRequestIdentityIndividualMetadataMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateCoreAccountRequestIdentityIndividualMetadataMap>;
 
 /** The countries where the individual is a national. Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)). */
@@ -155278,11 +155278,11 @@ export const UpdateCoreAccountRequestIncludeList = /*@__PURE__*/ S.Array(
 
 /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
 export type UpdateCoreAccountRequestMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateCoreAccountRequestMetadataMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateCoreAccountRequestMetadataMap>;
 
 export interface UpdateCoreAccountRequest {
@@ -155739,11 +155739,11 @@ export const UpdateCoreAccountPersonRequestLegalGender = S.String;
 
 /** Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. */
 export type UpdateCoreAccountPersonRequestMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateCoreAccountPersonRequestMetadataMap = /*@__PURE__*/ S.Record(
   S.String,
-  S.String,
+  S.NullOr(S.String),
 ) as any as S.Schema<UpdateCoreAccountPersonRequestMetadataMap>;
 
 /** The nationalities (countries) this person is associated with. */
@@ -155915,12 +155915,12 @@ export const UpdateCoreEventDestinationRequestIncludeList =
 
 /** Metadata. */
 export type UpdateCoreEventDestinationRequestMetadataMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const UpdateCoreEventDestinationRequestMetadataMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<UpdateCoreEventDestinationRequestMetadataMap>;
 
 /** Webhook endpoint configuration. */

--- a/packages/vercel/.generated-specs/api_ai_gateway.json
+++ b/packages/vercel/.generated-specs/api_ai_gateway.json
@@ -366,7 +366,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.api_ai_gateway#AiGatewayVirtualModelConfigInferenceRegionProvidersValue"
+        "target": "com.vercel.api_ai_gateway#AiGatewayVirtualModelConfigInferenceRegionProvidersValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Per-provider region overrides keyed by provider slug."

--- a/packages/vercel/.generated-specs/artifacts.json
+++ b/packages/vercel/.generated-specs/artifacts.json
@@ -697,7 +697,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.artifacts#ArtifactQueryResponseBodyValue"
+        "target": "com.vercel.artifacts#ArtifactQueryResponseBodyValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/vercel/.generated-specs/billing.json
+++ b/packages/vercel/.generated-specs/billing.json
@@ -729,7 +729,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "Optional metadata to associate with the subscription"

--- a/packages/vercel/.generated-specs/deployments.json
+++ b/packages/vercel/.generated-specs/deployments.json
@@ -1383,7 +1383,10 @@
     "com.vercel.deployments#GetDeploymentEventsResponseBodyList": {
       "type": "list",
       "member": {
-        "target": "com.vercel.deployments#GetDeploymentEventsResponseBodyItem"
+        "target": "com.vercel.deployments#GetDeploymentEventsResponseBodyItem",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/vercel/.generated-specs/marketplace.json
+++ b/packages/vercel/.generated-specs/marketplace.json
@@ -4313,7 +4313,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.marketplace#GlobalConfigItemValue"
+        "target": "com.vercel.marketplace#GlobalConfigItemValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -4436,7 +4439,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.marketplace#GlobalConfigItemValue"
+        "target": "com.vercel.marketplace#GlobalConfigItemValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/vercel/.generated-specs/microfrontends.json
+++ b/packages/vercel/.generated-specs/microfrontends.json
@@ -7246,7 +7246,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.microfrontends#GetMicrofrontendsInGroupResponseProjectsItemTargetsValue"
+        "target": "com.vercel.microfrontends#GetMicrofrontendsInGroupResponseProjectsItemTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/vercel/.generated-specs/projects.json
+++ b/packages/vercel/.generated-specs/projects.json
@@ -5392,7 +5392,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#GetProjectsResponseBodyCase0ItemTargetsValue"
+        "target": "com.vercel.projects#GetProjectsResponseBodyCase0ItemTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -13742,7 +13745,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#GetProjectsResponseBodyCase1ProjectsItemTargetsValue"
+        "target": "com.vercel.projects#GetProjectsResponseBodyCase1ProjectsItemTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -24145,7 +24151,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#GetProjectsResponseBodyCase2ProjectsItemTargetsValue"
+        "target": "com.vercel.projects#GetProjectsResponseBodyCase2ProjectsItemTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -39696,7 +39705,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#CreateProjectResponseTargetsValue"
+        "target": "com.vercel.projects#CreateProjectResponseTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -53558,7 +53570,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#GetProjectResponseTargetsValue"
+        "target": "com.vercel.projects#GetProjectResponseTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -69652,7 +69667,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#UpdateProjectResponseTargetsValue"
+        "target": "com.vercel.projects#UpdateProjectResponseTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -83377,7 +83395,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#UploadProjectAvatarResponseTargetsValue"
+        "target": "com.vercel.projects#UploadProjectAvatarResponseTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -100393,7 +100414,10 @@
     "com.vercel.projects#RemoveProjectEnvResponseBodyCase0List": {
       "type": "list",
       "member": {
-        "target": "com.vercel.projects#RemoveProjectEnvResponseBodyCase0Item"
+        "target": "com.vercel.projects#RemoveProjectEnvResponseBodyCase0Item",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },
@@ -110271,7 +110295,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "com.vercel.projects#UpdateMicrofrontendsResponseTargetsValue"
+        "target": "com.vercel.projects#UpdateMicrofrontendsResponseTargetsValue",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {}
     },

--- a/packages/vercel/src/services/api_ai_gateway.ts
+++ b/packages/vercel/src/services/api_ai_gateway.ts
@@ -135,12 +135,13 @@ export const AiGatewayVirtualModelConfigInferenceRegionProvidersValue =
 export type AiGatewayVirtualModelConfigInferenceRegionProvidersMap = {
   [key: string]:
     | AiGatewayVirtualModelConfigInferenceRegionProvidersValue
+    | null
     | undefined;
 };
 export const AiGatewayVirtualModelConfigInferenceRegionProvidersMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    AiGatewayVirtualModelConfigInferenceRegionProvidersValue,
+    S.NullOr(AiGatewayVirtualModelConfigInferenceRegionProvidersValue),
   ) as any as S.Schema<AiGatewayVirtualModelConfigInferenceRegionProvidersMap>;
 
 /** Pin scope: `specific` (one provider region), `zone` (geo zone), or `global`. */

--- a/packages/vercel/src/services/artifacts.ts
+++ b/packages/vercel/src/services/artifacts.ts
@@ -146,11 +146,11 @@ export const ArtifactQueryResponseBodyValue =
   S.Unknown as any as S.Schema<ArtifactQueryResponseBodyValue>;
 
 export type ArtifactQueryResponseBodyMap = {
-  [key: string]: ArtifactQueryResponseBodyValue | undefined;
+  [key: string]: ArtifactQueryResponseBodyValue | null | undefined;
 };
 export const ArtifactQueryResponseBodyMap = /*@__PURE__*/ S.Record(
   S.String,
-  ArtifactQueryResponseBodyValue,
+  S.NullOr(ArtifactQueryResponseBodyValue),
 ) as any as S.Schema<ArtifactQueryResponseBodyMap>;
 
 export type ArtifactQueryResponse = ArtifactQueryResponseBodyMap;

--- a/packages/vercel/src/services/billing.ts
+++ b/packages/vercel/src/services/billing.ts
@@ -411,11 +411,11 @@ export const BuyCreditsResponseBodyCase1PurchaseIntentConfigurationCase4OptionsA
 
 /** Optional metadata to associate with the subscription */
 export type BuyCreditsResponseBodyCase1PurchaseIntentConfigurationCase4OptionsMetadataMap =
-  { [key: string]: string | undefined };
+  { [key: string]: string | null | undefined };
 export const BuyCreditsResponseBodyCase1PurchaseIntentConfigurationCase4OptionsMetadataMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<BuyCreditsResponseBodyCase1PurchaseIntentConfigurationCase4OptionsMetadataMap>;
 
 /** The prices to remove in the subscription */

--- a/packages/vercel/src/services/deployments.ts
+++ b/packages/vercel/src/services/deployments.ts
@@ -23289,9 +23289,9 @@ export const GetDeploymentEventsResponseBodyItem =
   S.Unknown as any as S.Schema<GetDeploymentEventsResponseBodyItem>;
 
 export type GetDeploymentEventsResponseBodyList =
-  Array<GetDeploymentEventsResponseBodyItem>;
+  Array<GetDeploymentEventsResponseBodyItem | null>;
 export const GetDeploymentEventsResponseBodyList = /*@__PURE__*/ S.Array(
-  GetDeploymentEventsResponseBodyItem,
+  S.NullOr(GetDeploymentEventsResponseBodyItem),
 ) as any as S.Schema<GetDeploymentEventsResponseBodyList>;
 
 export type GetDeploymentEventsResponse = GetDeploymentEventsResponseBodyList;

--- a/packages/vercel/src/services/marketplace.ts
+++ b/packages/vercel/src/services/marketplace.ts
@@ -374,11 +374,11 @@ export const GlobalConfigItemValue =
   S.Unknown as any as S.Schema<GlobalConfigItemValue>;
 
 export type GetInstallationResourceExperimentationGlobalConfigResponseItemsMap =
-  { [key: string]: GlobalConfigItemValue | undefined };
+  { [key: string]: GlobalConfigItemValue | null | undefined };
 export const GetInstallationResourceExperimentationGlobalConfigResponseItemsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GlobalConfigItemValue,
+    S.NullOr(GlobalConfigItemValue),
   ) as any as S.Schema<GetInstallationResourceExperimentationGlobalConfigResponseItemsMap>;
 
 export type GetInstallationResourceExperimentationGlobalConfigResponsePurpose =
@@ -1349,11 +1349,11 @@ export const ReplaceInstallationsByIntegrationConfigurationIdResourcesByResource
   }) as any as S.Schema<ReplaceInstallationsByIntegrationConfigurationIdResourcesByResourceIdExperimentationGlobalConfigRequest>;
 
 export type ReplaceInstallationsByIntegrationConfigurationIdResourcesByResourceIdExperimentationGlobalConfigResponseItemsMap =
-  { [key: string]: GlobalConfigItemValue | undefined };
+  { [key: string]: GlobalConfigItemValue | null | undefined };
 export const ReplaceInstallationsByIntegrationConfigurationIdResourcesByResourceIdExperimentationGlobalConfigResponseItemsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GlobalConfigItemValue,
+    S.NullOr(GlobalConfigItemValue),
   ) as any as S.Schema<ReplaceInstallationsByIntegrationConfigurationIdResourcesByResourceIdExperimentationGlobalConfigResponseItemsMap>;
 
 export type ReplaceInstallationsByIntegrationConfigurationIdResourcesByResourceIdExperimentationGlobalConfigResponsePurpose =

--- a/packages/vercel/src/services/microfrontends.ts
+++ b/packages/vercel/src/services/microfrontends.ts
@@ -4250,12 +4250,13 @@ export const GetMicrofrontendsInGroupResponseProjectsItemTargetsValue =
 export type GetMicrofrontendsInGroupResponseProjectsItemTargetsMap = {
   [key: string]:
     | GetMicrofrontendsInGroupResponseProjectsItemTargetsValue
+    | null
     | undefined;
 };
 export const GetMicrofrontendsInGroupResponseProjectsItemTargetsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GetMicrofrontendsInGroupResponseProjectsItemTargetsValue,
+    S.NullOr(GetMicrofrontendsInGroupResponseProjectsItemTargetsValue),
   ) as any as S.Schema<GetMicrofrontendsInGroupResponseProjectsItemTargetsMap>;
 
 /** Enum containing the actions that can be performed against a resource. Group operations are included. */

--- a/packages/vercel/src/services/projects.ts
+++ b/packages/vercel/src/services/projects.ts
@@ -4164,11 +4164,11 @@ export const CreateProjectResponseTargetsValue = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<CreateProjectResponseTargetsValue>;
 
 export type CreateProjectResponseTargetsMap = {
-  [key: string]: CreateProjectResponseTargetsValue | undefined;
+  [key: string]: CreateProjectResponseTargetsValue | null | undefined;
 };
 export const CreateProjectResponseTargetsMap = /*@__PURE__*/ S.Record(
   S.String,
-  CreateProjectResponseTargetsValue,
+  S.NullOr(CreateProjectResponseTargetsValue),
 ) as any as S.Schema<CreateProjectResponseTargetsMap>;
 
 /** Enum containing the actions that can be performed against a resource. Group operations are included. */
@@ -15585,11 +15585,11 @@ export const GetProjectResponseTargetsValue = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<GetProjectResponseTargetsValue>;
 
 export type GetProjectResponseTargetsMap = {
-  [key: string]: GetProjectResponseTargetsValue | undefined;
+  [key: string]: GetProjectResponseTargetsValue | null | undefined;
 };
 export const GetProjectResponseTargetsMap = /*@__PURE__*/ S.Record(
   S.String,
-  GetProjectResponseTargetsValue,
+  S.NullOr(GetProjectResponseTargetsValue),
 ) as any as S.Schema<GetProjectResponseTargetsMap>;
 
 export type GetProjectResponsePermissionsOauth2ConnectionList =
@@ -24063,12 +24063,15 @@ export const GetProjectsResponseBodyCase0ItemTargetsValue =
   }) as any as S.Schema<GetProjectsResponseBodyCase0ItemTargetsValue>;
 
 export type GetProjectsResponseBodyCase0ItemTargetsMap = {
-  [key: string]: GetProjectsResponseBodyCase0ItemTargetsValue | undefined;
+  [key: string]:
+    | GetProjectsResponseBodyCase0ItemTargetsValue
+    | null
+    | undefined;
 };
 export const GetProjectsResponseBodyCase0ItemTargetsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GetProjectsResponseBodyCase0ItemTargetsValue,
+    S.NullOr(GetProjectsResponseBodyCase0ItemTargetsValue),
   ) as any as S.Schema<GetProjectsResponseBodyCase0ItemTargetsMap>;
 
 /** System environment slugs (`production`, `preview`) and/or custom environment slugs defined on the referenced project. */
@@ -28429,12 +28432,13 @@ export const GetProjectsResponseBodyCase1ProjectsItemTargetsValue =
 export type GetProjectsResponseBodyCase1ProjectsItemTargetsMap = {
   [key: string]:
     | GetProjectsResponseBodyCase1ProjectsItemTargetsValue
+    | null
     | undefined;
 };
 export const GetProjectsResponseBodyCase1ProjectsItemTargetsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GetProjectsResponseBodyCase1ProjectsItemTargetsValue,
+    S.NullOr(GetProjectsResponseBodyCase1ProjectsItemTargetsValue),
   ) as any as S.Schema<GetProjectsResponseBodyCase1ProjectsItemTargetsMap>;
 
 /** System environment slugs (`production`, `preview`) and/or custom environment slugs defined on the referenced project. */
@@ -33752,12 +33756,13 @@ export const GetProjectsResponseBodyCase2ProjectsItemTargetsValue =
 export type GetProjectsResponseBodyCase2ProjectsItemTargetsMap = {
   [key: string]:
     | GetProjectsResponseBodyCase2ProjectsItemTargetsValue
+    | null
     | undefined;
 };
 export const GetProjectsResponseBodyCase2ProjectsItemTargetsMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    GetProjectsResponseBodyCase2ProjectsItemTargetsValue,
+    S.NullOr(GetProjectsResponseBodyCase2ProjectsItemTargetsValue),
   ) as any as S.Schema<GetProjectsResponseBodyCase2ProjectsItemTargetsMap>;
 
 export type GetProjectsResponseBodyCase2ProjectsItemPermissionsOauth2ConnectionList =
@@ -40222,9 +40227,9 @@ export const RemoveProjectEnvResponseBodyCase0Item = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<RemoveProjectEnvResponseBodyCase0Item>;
 
 export type RemoveProjectEnvResponseBodyCase0List =
-  Array<RemoveProjectEnvResponseBodyCase0Item>;
+  Array<RemoveProjectEnvResponseBodyCase0Item | null>;
 export const RemoveProjectEnvResponseBodyCase0List = /*@__PURE__*/ S.Array(
-  RemoveProjectEnvResponseBodyCase0Item,
+  S.NullOr(RemoveProjectEnvResponseBodyCase0Item),
 ) as any as S.Schema<RemoveProjectEnvResponseBodyCase0List>;
 
 export type RemoveProjectEnvResponseBodyCase1Type =
@@ -44430,11 +44435,11 @@ export const UpdateMicrofrontendsResponseTargetsValue = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<UpdateMicrofrontendsResponseTargetsValue>;
 
 export type UpdateMicrofrontendsResponseTargetsMap = {
-  [key: string]: UpdateMicrofrontendsResponseTargetsValue | undefined;
+  [key: string]: UpdateMicrofrontendsResponseTargetsValue | null | undefined;
 };
 export const UpdateMicrofrontendsResponseTargetsMap = /*@__PURE__*/ S.Record(
   S.String,
-  UpdateMicrofrontendsResponseTargetsValue,
+  S.NullOr(UpdateMicrofrontendsResponseTargetsValue),
 ) as any as S.Schema<UpdateMicrofrontendsResponseTargetsMap>;
 
 export type UpdateMicrofrontendsResponsePermissionsOauth2ConnectionList =
@@ -53873,11 +53878,11 @@ export const UpdateProjectResponseTargetsValue = /*@__PURE__*/ S.suspend(() =>
 }) as any as S.Schema<UpdateProjectResponseTargetsValue>;
 
 export type UpdateProjectResponseTargetsMap = {
-  [key: string]: UpdateProjectResponseTargetsValue | undefined;
+  [key: string]: UpdateProjectResponseTargetsValue | null | undefined;
 };
 export const UpdateProjectResponseTargetsMap = /*@__PURE__*/ S.Record(
   S.String,
-  UpdateProjectResponseTargetsValue,
+  S.NullOr(UpdateProjectResponseTargetsValue),
 ) as any as S.Schema<UpdateProjectResponseTargetsMap>;
 
 export type UpdateProjectResponsePermissionsOauth2ConnectionList =
@@ -62283,11 +62288,11 @@ export const UploadProjectAvatarResponseTargetsValue = /*@__PURE__*/ S.suspend(
 }) as any as S.Schema<UploadProjectAvatarResponseTargetsValue>;
 
 export type UploadProjectAvatarResponseTargetsMap = {
-  [key: string]: UploadProjectAvatarResponseTargetsValue | undefined;
+  [key: string]: UploadProjectAvatarResponseTargetsValue | null | undefined;
 };
 export const UploadProjectAvatarResponseTargetsMap = /*@__PURE__*/ S.Record(
   S.String,
-  UploadProjectAvatarResponseTargetsValue,
+  S.NullOr(UploadProjectAvatarResponseTargetsValue),
 ) as any as S.Schema<UploadProjectAvatarResponseTargetsMap>;
 
 export type UploadProjectAvatarResponsePermissionsOauth2ConnectionList =

--- a/packages/workos/.generated-specs/workos.json
+++ b/packages/workos/.generated-specs/workos.json
@@ -12996,7 +12996,10 @@
         "target": "smithy.api#String"
       },
       "value": {
-        "target": "smithy.api#String"
+        "target": "smithy.api#String",
+        "traits": {
+          "com.distilled.openapi#nullable": {}
+        }
       },
       "traits": {
         "smithy.api#documentation": "How IdP attributes or claims map onto custom attributes, keyed by custom attribute name. Custom attributes must already be defined in the WorkOS dashboard. Only the provided keys are updated; a `null` value unsets that mapping."

--- a/packages/workos/src/services/workos.ts
+++ b/packages/workos/src/services/workos.ts
@@ -12749,12 +12749,12 @@ export const PatchConnectionStandardAttributesDto = /*@__PURE__*/ S.suspend(
 
 /** How IdP attributes or claims map onto custom attributes, keyed by custom attribute name. Custom attributes must already be defined in the WorkOS dashboard. Only the provided keys are updated; a `null` value unsets that mapping. */
 export type PatchConnectionAttributeMapsDtoCustomAttributesMap = {
-  [key: string]: string | undefined;
+  [key: string]: string | null | undefined;
 };
 export const PatchConnectionAttributeMapsDtoCustomAttributesMap =
   /*@__PURE__*/ S.Record(
     S.String,
-    S.String,
+    S.NullOr(S.String),
   ) as any as S.Schema<PatchConnectionAttributeMapsDtoCustomAttributesMap>;
 
 export interface PatchConnectionAttributeMapsDto {


### PR DESCRIPTION
The OpenAPI converter dropped nullability from array items and map values, so generated codecs rejected null entries allowed by the source schema. Preserve that information on collection members and emit `| null` types with `S.NullOr` codecs.

Regenerated all 79 SDK packages and isolated changes attributable to this fix by comparing regeneration with and without it against the same inputs. The PR changes 126 files (+2,668 / −1,305), covering core plus Azure, Discord, GitHub, MongoDB Atlas, PostHog, Stripe, Vercel, and WorkOS. Unrelated regeneration drift is excluded.

Spec inputs and coverage:
- 28 packages completed conversion and generation using pinned mirror commits or committed source specs. No mirror pointers changed.
- 51 packages have no pinned source mirror in this revision. Their generators ran successfully against the committed Smithy models. Recovering nullability lost during their earlier conversion requires pinned source specs to be added first.
- No output from live or newly fetched upstream specs is included.
- Webhook regeneration remains in the integration checkout for #583 to rebase onto this fix.

Validation: full distilled `typecheck:ci` passed for the full regeneration and the final isolated diff; formatting and `git diff --check` passed. An end-to-end converter/generator probe accepts nullable arrays and maps while rejecting incorrect types and nulls in non-nullable arrays. All 540 ordinary webhook samples pass in the integration checkout. No test files added.

Nullable union branches and `allOf` merging are separate follow-ups.
