### PR TITLE
chore: update CI actions and align alchemy platform dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       - name: Run Typecheck
         run: pnpm typecheck:ci
@@ -57,17 +52,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       # A recursive filter rather than a matrix, so a new stack is covered the
       # day it is added. Each stack's own `typecheck` script decides what that
@@ -91,17 +81,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       - name: Check formatting
         run: pnpm format:check

--- a/.github/workflows/deploy-submodules-stack.yml
+++ b/.github/workflows/deploy-submodules-stack.yml
@@ -38,19 +38,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      # Only the stack's own subtree — a deploy has no use for 20 SDK packages
-      # and their generators.
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --filter "./stacks/distilled-submodules..."
+          install: true
+          require-lockfile: true
 
       - name: Deploy the spec-mirror repositories
         working-directory: stacks/distilled-submodules

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -28,20 +28,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       - name: Build packages
-        run: bun run build
+        run: pnpm run build
 
       - name: Publish packages
         id: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,17 +58,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.bot-token.outputs.token }}
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       - id: release
         name: Prepare release
@@ -128,17 +123,12 @@ jobs:
           ref: ${{ needs.build.outputs.sha }}
           fetch-depth: 0
 
-      - name: Setup pnpm & Bun
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      - name: Setup pnpm, Node.js, Bun and install dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           cache: true
-          install: false
-
-      - name: Install Node 24
-        run: pnpm runtime set node 24 -g
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          install: true
+          require-lockfile: true
 
       - run: sed -i '/always-auth/d' ~/.npmrc 2>/dev/null || true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,10 @@ catalogs:
       specifier: ^2.9.0
       version: 2.9.0
 
+overrides:
+  '@effect/platform-bun@4.0.0-rc.112>@effect/platform-node-shared': 4.0.0-rc.112
+  '@effect/platform-node@4.0.0-rc.112>@effect/platform-node-shared': 4.0.0-rc.112
+
 importers:
 
   .:
@@ -1992,6 +1996,12 @@ packages:
     resolution: {integrity: sha512-ilTFcs66ghInP8WHCJYa4bx/yzohYM9dRR//qjmVBBpSKu1hrCTiRWpEcc1N6zrnOEPk2kyVaKg5ykSMgiBMqQ==}
     peerDependencies:
       effect: ^4.0.0-rc.115
+
+  '@effect/platform-node-shared@4.0.0-rc.112':
+    resolution: {integrity: sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-rc.112
 
   '@effect/platform-node-shared@4.0.0-rc.115':
     resolution: {integrity: sha512-rcBwhDIfb82akJoTv7Vwh8K5x9vC/XfuePS7JjOr+z+dORXzsmKqI1BUQF27ARCN9fTAbDh7I6YvBlWhLjnqNg==}
@@ -4542,7 +4552,7 @@ snapshots:
 
   '@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-rc.115(effect@4.0.0-rc.112)
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
       effect: 4.0.0-rc.112
     transitivePeerDependencies:
       - bufferutil
@@ -4556,7 +4566,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-rc.115(effect@4.0.0-rc.112)':
+  '@effect/platform-node-shared@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
       '@types/ws': 8.18.1
       effect: 4.0.0-rc.112
@@ -4576,7 +4586,7 @@ snapshots:
 
   '@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-rc.115(effect@4.0.0-rc.112)
+      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
       effect: 4.0.0-rc.112
       mime: 4.1.0
       redis: 6.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,10 @@ catalog:
   rolldown: "1.2.5"
   typescript: "^7.0.2"
   yaml: "^2.9.0"
+overrides:
+  "@effect/platform-bun@4.0.0-rc.112>@effect/platform-node-shared": "4.0.0-rc.112"
+  "@effect/platform-node@4.0.0-rc.112>@effect/platform-node-shared": "4.0.0-rc.112"
+
 catalogs:
   # Compatibility line used by the deployment-stack fixtures.
   alchemy:


### PR DESCRIPTION
Update CI workflows to pnpm/setup v2.1.0 with dependency installation and lockfile enforcement, removing the separate Node setup and install steps. Use pnpm for the PR package build as well.

Fix Alchemy CLI startup by pinning the transitive @effect/platform-node-shared dependency to rc.112 for the rc.112 Node and Bun platform packages. Previously, the lockfile resolved it to rc.115, which imports effect/ByteSize unavailable in the stack's pinned Effect rc.112. Regenerate the lockfile with these scoped overrides.

Validation: dependency installation, formatting checks, git diff --check, and pnpm exec alchemy deploy --help pass. No deployment performed; workflow execution remains for CI.
