### PR TITLE
chore: expose more public SDK modules and signature types

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -89,6 +89,252 @@
       "bun": "./src/traits.ts",
       "worker": "./src/traits.ts",
       "default": "./lib/traits.js"
+    },
+    "./client/generate-idempotency-tokens": {
+      "types": "./lib/client/generate-idempotency-tokens.d.ts",
+      "bun": "./src/client/generate-idempotency-tokens.ts",
+      "worker": "./src/client/generate-idempotency-tokens.ts",
+      "default": "./lib/client/generate-idempotency-tokens.js"
+    },
+    "./client/operation": {
+      "types": "./lib/client/operation.d.ts",
+      "bun": "./src/client/operation.ts",
+      "worker": "./src/client/operation.ts",
+      "default": "./lib/client/operation.js"
+    },
+    "./client/protocol": {
+      "types": "./lib/client/protocol.d.ts",
+      "bun": "./src/client/protocol.ts",
+      "worker": "./src/client/protocol.ts",
+      "default": "./lib/client/protocol.js"
+    },
+    "./client/request-builder": {
+      "types": "./lib/client/request-builder.d.ts",
+      "bun": "./src/client/request-builder.ts",
+      "worker": "./src/client/request-builder.ts",
+      "default": "./lib/client/request-builder.js"
+    },
+    "./client/request": {
+      "types": "./lib/client/request.d.ts",
+      "bun": "./src/client/request.ts",
+      "worker": "./src/client/request.ts",
+      "default": "./lib/client/request.js"
+    },
+    "./client/response-parser": {
+      "types": "./lib/client/response-parser.d.ts",
+      "bun": "./src/client/response-parser.ts",
+      "worker": "./src/client/response-parser.ts",
+      "default": "./lib/client/response-parser.js"
+    },
+    "./client/response": {
+      "types": "./lib/client/response.d.ts",
+      "bun": "./src/client/response.ts",
+      "worker": "./src/client/response.ts",
+      "default": "./lib/client/response.js"
+    },
+    "./client/stream-parser": {
+      "types": "./lib/client/stream-parser.d.ts",
+      "bun": "./src/client/stream-parser.ts",
+      "worker": "./src/client/stream-parser.ts",
+      "default": "./lib/client/stream-parser.js"
+    },
+    "./customizations/api-gateway": {
+      "types": "./lib/customizations/api-gateway.d.ts",
+      "bun": "./src/customizations/api-gateway.ts",
+      "worker": "./src/customizations/api-gateway.ts",
+      "default": "./lib/customizations/api-gateway.js"
+    },
+    "./customizations/glacier": {
+      "types": "./lib/customizations/glacier.d.ts",
+      "bun": "./src/customizations/glacier.ts",
+      "worker": "./src/customizations/glacier.ts",
+      "default": "./lib/customizations/glacier.js"
+    },
+    "./ErrorMessage": {
+      "types": "./lib/error-message.d.ts",
+      "bun": "./src/error-message.ts",
+      "worker": "./src/error-message.ts",
+      "default": "./lib/error-message.js"
+    },
+    "./eventstream/codec": {
+      "types": "./lib/eventstream/codec.d.ts",
+      "bun": "./src/eventstream/codec.ts",
+      "worker": "./src/eventstream/codec.ts",
+      "default": "./lib/eventstream/codec.js"
+    },
+    "./eventstream/parser": {
+      "types": "./lib/eventstream/parser.d.ts",
+      "bun": "./src/eventstream/parser.ts",
+      "worker": "./src/eventstream/parser.ts",
+      "default": "./lib/eventstream/parser.js"
+    },
+    "./eventstream/serializer": {
+      "types": "./lib/eventstream/serializer.d.ts",
+      "bun": "./src/eventstream/serializer.ts",
+      "worker": "./src/eventstream/serializer.ts",
+      "default": "./lib/eventstream/serializer.js"
+    },
+    "./hash/crc32": {
+      "types": "./lib/hash/crc32.d.ts",
+      "bun": "./src/hash/crc32.ts",
+      "worker": "./src/hash/crc32.ts",
+      "default": "./lib/hash/crc32.js"
+    },
+    "./hash/md5": {
+      "types": "./lib/hash/md5.d.ts",
+      "bun": "./src/hash/md5.ts",
+      "worker": "./src/hash/md5.ts",
+      "default": "./lib/hash/md5.js"
+    },
+    "./hash/utf8": {
+      "types": "./lib/hash/utf8.d.ts",
+      "bun": "./src/hash/utf8.ts",
+      "worker": "./src/hash/utf8.ts",
+      "default": "./lib/hash/utf8.js"
+    },
+    "./middleware/checksum": {
+      "types": "./lib/middleware/checksum.d.ts",
+      "bun": "./src/middleware/checksum.ts",
+      "worker": "./src/middleware/checksum.ts",
+      "default": "./lib/middleware/checksum.js"
+    },
+    "./middleware/index": {
+      "types": "./lib/middleware/index.d.ts",
+      "bun": "./src/middleware/index.ts",
+      "worker": "./src/middleware/index.ts",
+      "default": "./lib/middleware/index.js"
+    },
+    "./middleware/middleware": {
+      "types": "./lib/middleware/middleware.d.ts",
+      "bun": "./src/middleware/middleware.ts",
+      "worker": "./src/middleware/middleware.ts",
+      "default": "./lib/middleware/middleware.js"
+    },
+    "./middleware/streaming-body": {
+      "types": "./lib/middleware/streaming-body.d.ts",
+      "bun": "./src/middleware/streaming-body.ts",
+      "worker": "./src/middleware/streaming-body.ts",
+      "default": "./lib/middleware/streaming-body.js"
+    },
+    "./patch/spec-schema": {
+      "types": "./lib/patch/spec-schema.d.ts",
+      "bun": "./src/patch/spec-schema.ts",
+      "worker": "./src/patch/spec-schema.ts",
+      "default": "./lib/patch/spec-schema.js"
+    },
+    "./Protocol": {
+      "types": "./lib/protocol.d.ts",
+      "bun": "./src/protocol.ts",
+      "worker": "./src/protocol.ts",
+      "default": "./lib/protocol.js"
+    },
+    "./protocols/aws-json": {
+      "types": "./lib/protocols/aws-json.d.ts",
+      "bun": "./src/protocols/aws-json.ts",
+      "worker": "./src/protocols/aws-json.ts",
+      "default": "./lib/protocols/aws-json.js"
+    },
+    "./protocols/aws-query": {
+      "types": "./lib/protocols/aws-query.d.ts",
+      "bun": "./src/protocols/aws-query.ts",
+      "worker": "./src/protocols/aws-query.ts",
+      "default": "./lib/protocols/aws-query.js"
+    },
+    "./protocols/ec2-query": {
+      "types": "./lib/protocols/ec2-query.d.ts",
+      "bun": "./src/protocols/ec2-query.ts",
+      "worker": "./src/protocols/ec2-query.ts",
+      "default": "./lib/protocols/ec2-query.js"
+    },
+    "./protocols/rest-json": {
+      "types": "./lib/protocols/rest-json.d.ts",
+      "bun": "./src/protocols/rest-json.ts",
+      "worker": "./src/protocols/rest-json.ts",
+      "default": "./lib/protocols/rest-json.js"
+    },
+    "./protocols/rest-xml": {
+      "types": "./lib/protocols/rest-xml.d.ts",
+      "bun": "./src/protocols/rest-xml.ts",
+      "worker": "./src/protocols/rest-xml.ts",
+      "default": "./lib/protocols/rest-xml.js"
+    },
+    "./rules-engine/aws-functions": {
+      "types": "./lib/rules-engine/aws-functions.d.ts",
+      "bun": "./src/rules-engine/aws-functions.ts",
+      "worker": "./src/rules-engine/aws-functions.ts",
+      "default": "./lib/rules-engine/aws-functions.js"
+    },
+    "./rules-engine/endpoint-resolver": {
+      "types": "./lib/rules-engine/endpoint-resolver.d.ts",
+      "bun": "./src/rules-engine/endpoint-resolver.ts",
+      "worker": "./src/rules-engine/endpoint-resolver.ts",
+      "default": "./lib/rules-engine/endpoint-resolver.js"
+    },
+    "./rules-engine/expression": {
+      "types": "./lib/rules-engine/expression.d.ts",
+      "bun": "./src/rules-engine/expression.ts",
+      "worker": "./src/rules-engine/expression.ts",
+      "default": "./lib/rules-engine/expression.js"
+    },
+    "./rules-engine/standard-functions": {
+      "types": "./lib/rules-engine/standard-functions.d.ts",
+      "bun": "./src/rules-engine/standard-functions.ts",
+      "worker": "./src/rules-engine/standard-functions.ts",
+      "default": "./lib/rules-engine/standard-functions.js"
+    },
+    "./util/ast": {
+      "types": "./lib/util/ast.d.ts",
+      "bun": "./src/util/ast.ts",
+      "worker": "./src/util/ast.ts",
+      "default": "./lib/util/ast.js"
+    },
+    "./util/error": {
+      "types": "./lib/util/error.d.ts",
+      "bun": "./src/util/error.ts",
+      "worker": "./src/util/error.ts",
+      "default": "./lib/util/error.js"
+    },
+    "./util/parse-ini": {
+      "types": "./lib/util/parse-ini.d.ts",
+      "bun": "./src/util/parse-ini.ts",
+      "worker": "./src/util/parse-ini.ts",
+      "default": "./lib/util/parse-ini.js"
+    },
+    "./util/query-params": {
+      "types": "./lib/util/query-params.d.ts",
+      "bun": "./src/util/query-params.ts",
+      "worker": "./src/util/query-params.ts",
+      "default": "./lib/util/query-params.js"
+    },
+    "./util/serialize-input": {
+      "types": "./lib/util/serialize-input.d.ts",
+      "bun": "./src/util/serialize-input.ts",
+      "worker": "./src/util/serialize-input.ts",
+      "default": "./lib/util/serialize-input.js"
+    },
+    "./util/stream": {
+      "types": "./lib/util/stream.d.ts",
+      "bun": "./src/util/stream.ts",
+      "worker": "./src/util/stream.ts",
+      "default": "./lib/util/stream.js"
+    },
+    "./util/timestamp": {
+      "types": "./lib/util/timestamp.d.ts",
+      "bun": "./src/util/timestamp.ts",
+      "worker": "./src/util/timestamp.ts",
+      "default": "./lib/util/timestamp.js"
+    },
+    "./util/xml": {
+      "types": "./lib/util/xml.d.ts",
+      "bun": "./src/util/xml.ts",
+      "worker": "./src/util/xml.ts",
+      "default": "./lib/util/xml.js"
+    },
+    "./SigV4": {
+      "types": "./lib/sigv4.d.ts",
+      "bun": "./src/sigv4.ts",
+      "worker": "./src/sigv4.ts",
+      "default": "./lib/sigv4.js"
     }
   },
   "scripts": {

--- a/packages/aws/src/client/operation.ts
+++ b/packages/aws/src/client/operation.ts
@@ -7,7 +7,7 @@ export declare namespace Operation {
   export type Error<Op extends Operation> = Instance<Op["errors"][number]>;
 }
 
-type Instance<T> = T extends new (...args: any) => infer U ? U : T;
+export type Instance<T> = T extends new (...args: any) => infer U ? U : T;
 
 export interface Operation<
   Input extends S.Top = S.Any,

--- a/packages/aws/src/credentials.browser.ts
+++ b/packages/aws/src/credentials.browser.ts
@@ -126,7 +126,7 @@ export const regionFromEnv = regionFromEnvironment.pipe(
   ),
 );
 
-type ProviderName =
+export type ProviderName =
   | "env"
   | "ini"
   | "chain"

--- a/packages/aws/src/index.browser.ts
+++ b/packages/aws/src/index.browser.ts
@@ -61,3 +61,6 @@ export * as Sensitive from "./sensitive.ts";
  * @since 0.0.0
  */
 export * as Traits from "./traits.ts";
+
+/** SigV4 signing options, results, and errors. */
+export * as SigV4 from "./sigv4.ts";

--- a/packages/aws/src/index.ts
+++ b/packages/aws/src/index.ts
@@ -61,3 +61,6 @@ export * as Sensitive from "./sensitive.ts";
  * @since 0.0.0
  */
 export * as Traits from "./traits.ts";
+
+/** SigV4 signing options, results, and errors. */
+export * as SigV4 from "./sigv4.ts";

--- a/packages/aws/src/presign.ts
+++ b/packages/aws/src/presign.ts
@@ -7,6 +7,12 @@ import * as Endpoint from "./endpoint.ts";
 import * as Region from "./region.ts";
 import * as SigV4 from "./sigv4.ts";
 
+/** Errors returned when resolving credentials or signing a URL. */
+export type PresignError = Credentials.CredentialsError | SigV4.SigningError;
+
+/** Services required by the presigning helpers. */
+export type PresignContext = Credentials.Credentials | Region.Region;
+
 /**
  * Options for {@link presignUrl}.
  */
@@ -58,37 +64,35 @@ export interface PresignUrlOptions {
  */
 export const presignUrl: (
   options: PresignUrlOptions,
-) => Effect.Effect<
-  string,
-  Credentials.CredentialsError | SigV4.SigningError,
-  Credentials.Credentials | Region.Region
-> = Effect.fnUntraced(function* (options: PresignUrlOptions) {
-  const credentials = yield* yield* Credentials.Credentials;
-  const region = options.region ?? (yield* yield* Region.Region);
+) => Effect.Effect<string, PresignError, PresignContext> = Effect.fnUntraced(
+  function* (options: PresignUrlOptions) {
+    const credentials = yield* yield* Credentials.Credentials;
+    const region = options.region ?? (yield* yield* Region.Region);
 
-  const url = new URL(options.url);
-  url.searchParams.set("X-Amz-Expires", String(options.expiresIn ?? 900));
+    const url = new URL(options.url);
+    url.searchParams.set("X-Amz-Expires", String(options.expiresIn ?? 900));
 
-  const signed = yield* SigV4.sign({
-    method: options.method ?? "GET",
-    url: url.toString(),
-    headers: options.headers,
-    accessKeyId: Redacted.value(credentials.accessKeyId),
-    secretAccessKey: credentials.secretAccessKey,
-    sessionToken: credentials.sessionToken,
-    service: options.service,
-    region,
-    signQuery: true,
-    datetime: options.datetime,
-    // The signer excludes `content-type` (among others) from the signature by
-    // default (UNSIGNABLE_HEADERS). Callers passing headers here explicitly
-    // want them pinned into the signature — e.g. the AWS SDK's getSignedUrl
-    // signs `content-type` when a ContentType is given, which is what pins an
-    // uploader to the declared type — so opt back in.
-    allHeaders: options.headers !== undefined,
-  });
-  return signed.url;
-});
+    const signed = yield* SigV4.sign({
+      method: options.method ?? "GET",
+      url: url.toString(),
+      headers: options.headers,
+      accessKeyId: Redacted.value(credentials.accessKeyId),
+      secretAccessKey: credentials.secretAccessKey,
+      sessionToken: credentials.sessionToken,
+      service: options.service,
+      region,
+      signQuery: true,
+      datetime: options.datetime,
+      // The signer excludes `content-type` (among others) from the signature by
+      // default (UNSIGNABLE_HEADERS). Callers passing headers here explicitly
+      // want them pinned into the signature — e.g. the AWS SDK's getSignedUrl
+      // signs `content-type` when a ContentType is given, which is what pins an
+      // uploader to the declared type — so opt back in.
+      allHeaders: options.headers !== undefined,
+    });
+    return signed.url;
+  },
+);
 
 /**
  * Options for {@link presignS3Url}.
@@ -148,36 +152,37 @@ export interface PresignS3UrlOptions {
  */
 export const presignS3Url: (
   options: PresignS3UrlOptions,
-) => Effect.Effect<
-  string,
-  Credentials.CredentialsError | SigV4.SigningError,
-  Credentials.Credentials | Region.Region
-> = Effect.fnUntraced(function* (options: PresignS3UrlOptions) {
-  const region = options.region ?? (yield* yield* Region.Region);
-  const customEndpoint = yield* yield* Effect.serviceOption(
-    Endpoint.Endpoint,
-  ).pipe(Effect.map(Option.getOrElse(() => Effect.undefined)));
+) => Effect.Effect<string, PresignError, PresignContext> = Effect.fnUntraced(
+  function* (options: PresignS3UrlOptions) {
+    const region = options.region ?? (yield* yield* Region.Region);
+    const customEndpoint = yield* yield* Effect.serviceOption(
+      Endpoint.Endpoint,
+    ).pipe(Effect.map(Option.getOrElse(() => Effect.undefined)));
 
-  const encodedKey = options.key.split("/").map(encodeURIComponent).join("/");
-  const url = new URL(
-    customEndpoint
-      ? `${customEndpoint.replace(/\/+$/, "")}/${options.bucket}/${encodedKey}`
-      : `https://${options.bucket}.s3.${region}.amazonaws.com/${encodedKey}`,
-  );
-  if (options.responseContentType !== undefined) {
-    url.searchParams.set("response-content-type", options.responseContentType);
-  }
+    const encodedKey = options.key.split("/").map(encodeURIComponent).join("/");
+    const url = new URL(
+      customEndpoint
+        ? `${customEndpoint.replace(/\/+$/, "")}/${options.bucket}/${encodedKey}`
+        : `https://${options.bucket}.s3.${region}.amazonaws.com/${encodedKey}`,
+    );
+    if (options.responseContentType !== undefined) {
+      url.searchParams.set(
+        "response-content-type",
+        options.responseContentType,
+      );
+    }
 
-  return yield* presignUrl({
-    method: options.method ?? "GET",
-    url: url.toString(),
-    service: "s3",
-    region,
-    expiresIn: options.expiresIn,
-    headers:
-      options.contentType !== undefined
-        ? { "content-type": options.contentType }
-        : undefined,
-    datetime: options.datetime,
-  });
-});
+    return yield* presignUrl({
+      method: options.method ?? "GET",
+      url: url.toString(),
+      service: "s3",
+      region,
+      expiresIn: options.expiresIn,
+      headers:
+        options.contentType !== undefined
+          ? { "content-type": options.contentType }
+          : undefined,
+      datetime: options.datetime,
+    });
+  },
+);

--- a/packages/aws/src/rules-engine/expression.ts
+++ b/packages/aws/src/rules-engine/expression.ts
@@ -38,7 +38,7 @@ export interface ConditionObject {
 }
 
 /** Base fields shared by all rule types */
-interface RuleBase {
+export interface RuleBase {
   conditions: ConditionObject[];
   documentation?: string;
 }

--- a/packages/aws/src/traits.ts
+++ b/packages/aws/src/traits.ts
@@ -43,7 +43,7 @@ export { ErrorMessage, errorMessageSymbol };
  * Any type that has an .annotate() method returning itself.
  * This includes Schema.Schema and Schema.PropertySignature (from S.optional).
  */
-type Annotatable = {
+export type Annotatable = {
   annotate(annotations: any): Annotatable;
 };
 

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -503,6 +503,13 @@
       "worker": "./src/services/*.ts",
       "workerd": "./src/services/*.ts",
       "default": "./lib/services/*.js"
+    },
+    "./Protocol": {
+      "types": "./lib/protocol.d.ts",
+      "bun": "./src/protocol.ts",
+      "worker": "./src/protocol.ts",
+      "workerd": "./src/protocol.ts",
+      "default": "./lib/protocol.js"
     }
   },
   "scripts": {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -23,7 +23,7 @@ export * from "effect/Schema";
 
 import * as S from "effect/Schema";
 
-type AnyFn = (...args: any[]) => any;
+export type AnyFn = (...args: any[]) => any;
 
 // Construction surface — collapse to `any` so generics are never instantiated.
 export const optional: AnyFn = S.optional as AnyFn;

--- a/packages/core/src/trait.ts
+++ b/packages/core/src/trait.ts
@@ -2,7 +2,7 @@ export const annotationMetaSymbol = Symbol.for(
   "@distilled.cloud/core/annotation-meta",
 );
 
-type Annotatable = {
+export type Annotatable = {
   annotate(annotations: any): Annotatable;
 };
 

--- a/packages/railway/package.json
+++ b/packages/railway/package.json
@@ -20,6 +20,48 @@
       "bun": "./src/index.ts",
       "worker": "./src/index.ts",
       "default": "./lib/index.js"
+    },
+    "./Credentials": {
+      "types": "./lib/credentials.d.ts",
+      "bun": "./src/credentials.ts",
+      "worker": "./src/credentials.ts",
+      "default": "./lib/credentials.js"
+    },
+    "./Errors": {
+      "types": "./lib/errors.d.ts",
+      "bun": "./src/errors.ts",
+      "worker": "./src/errors.ts",
+      "default": "./lib/errors.js"
+    },
+    "./Pagination": {
+      "types": "./lib/pagination.d.ts",
+      "bun": "./src/pagination.ts",
+      "worker": "./src/pagination.ts",
+      "default": "./lib/pagination.js"
+    },
+    "./Protocol": {
+      "types": "./lib/protocol.d.ts",
+      "bun": "./src/protocol.ts",
+      "worker": "./src/protocol.ts",
+      "default": "./lib/protocol.js"
+    },
+    "./Retry": {
+      "types": "./lib/retry.d.ts",
+      "bun": "./src/retry.ts",
+      "worker": "./src/retry.ts",
+      "default": "./lib/retry.js"
+    },
+    "./Traits": {
+      "types": "./lib/traits.d.ts",
+      "bun": "./src/traits.ts",
+      "worker": "./src/traits.ts",
+      "default": "./lib/traits.js"
+    },
+    "./*": {
+      "types": "./lib/services/*.d.ts",
+      "bun": "./src/services/*.ts",
+      "worker": "./src/services/*.ts",
+      "default": "./lib/services/*.js"
     }
   },
   "scripts": {

--- a/packages/stripe/src/protocol.ts
+++ b/packages/stripe/src/protocol.ts
@@ -92,7 +92,7 @@ import {
 // Per-call request options (v0's StripeRequestOptions, fiber-context style)
 // =============================================================================
 
-type StripeConnectRequestOptions =
+export type StripeConnectRequestOptions =
   | {
       readonly stripeAccount?: string | undefined;
       readonly stripeContext?: never;

--- a/packages/typesense/package.json
+++ b/packages/typesense/package.json
@@ -49,6 +49,18 @@
       "bun": "./src/services/*.ts",
       "worker": "./src/services/*.ts",
       "default": "./lib/services/*.js"
+    },
+    "./Protocol": {
+      "types": "./lib/protocol.d.ts",
+      "bun": "./src/protocol.ts",
+      "worker": "./src/protocol.ts",
+      "default": "./lib/protocol.js"
+    },
+    "./Retry": {
+      "types": "./lib/retry.d.ts",
+      "bun": "./src/retry.ts",
+      "worker": "./src/retry.ts",
+      "default": "./lib/retry.js"
     }
   },
   "scripts": {

--- a/packages/whop/package.json
+++ b/packages/whop/package.json
@@ -68,6 +68,12 @@
       "bun": "./src/services/*.ts",
       "worker": "./src/services/*.ts",
       "default": "./lib/services/*.js"
+    },
+    "./ApiVersion": {
+      "types": "./lib/api-version.d.ts",
+      "bun": "./src/api-version.ts",
+      "worker": "./src/api-version.ts",
+      "default": "./lib/api-version.js"
     }
   },
   "scripts": {

--- a/packages/workos/package.json
+++ b/packages/workos/package.json
@@ -50,6 +50,12 @@
       "bun": "./src/services/*.ts",
       "worker": "./src/services/*.ts",
       "default": "./lib/services/*.js"
+    },
+    "./Protocol": {
+      "types": "./lib/protocol.d.ts",
+      "bun": "./src/protocol.ts",
+      "worker": "./src/protocol.ts",
+      "default": "./lib/protocol.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Public SDK signatures reference types that consumers cannot import directly. For example, AWS presigning exposes `SigningError`, but its SigV4 module had no package entry point, forcing consumers to extract types from `ReturnType`.

Add missing module entry points across AWS, Cloudflare, Railway, Typesense, Whop, and WorkOS, and export seven helper types used in public declarations. AWS now exposes `SigV4` through its subpath and both barrels, plus named `PresignError` and `PresignContext` types from `Presign`.

Validation:
- Full `typecheck:ci` passed.
- Consumer imports and presign error/context type equality checks passed.
- Lint, formatting, and `git diff --check` passed.
- SigV4 bundled successfully for the browser; no actual browser execution was performed.
