### PR TITLE
feat(aws): Effect-native credential providers

### DIFF
--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -349,7 +349,6 @@
     "specs:update": "git submodule update --remote --force --depth=1 specs/spec-mirror-aws"
   },
   "dependencies": {
-    "@aws-sdk/credential-providers": "catalog:",
     "@aws-sdk/types": "catalog:",
     "@distilled.cloud/core": "workspace:*",
     "@smithy/shared-ini-file-loader": "catalog:",

--- a/packages/aws/src/credential-providers/credential-providers.test.ts
+++ b/packages/aws/src/credential-providers/credential-providers.test.ts
@@ -1,0 +1,625 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as Credentials from "../credentials.ts";
+import * as Providers from "./node.ts";
+import { chain, CredentialSourceError } from "./shared.ts";
+
+const ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_CREDENTIAL_EXPIRATION",
+  "AWS_ACCOUNT_ID",
+  "AWS_PROFILE",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+  "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+  "AWS_ROLE_ARN",
+  "AWS_ROLE_SESSION_NAME",
+  "AWS_EC2_METADATA_DISABLED",
+  "AWS_EC2_METADATA_V1_DISABLED",
+  "AWS_EC2_METADATA_SERVICE_ENDPOINT",
+  "AWS_CONFIG_FILE",
+  "AWS_SHARED_CREDENTIALS_FILE",
+] as const;
+
+const inOneHour = () => new Date(Date.now() + 60 * 60 * 1000);
+
+// The default `ConfigProvider` snapshots `process.env` once per process;
+// each run gets a fresh one so `AWS_REGION` set by the test is what
+// `Region.fromEnvironment` reads.
+const run = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(
+    Effect.provideService(
+      effect,
+      ConfigProvider.ConfigProvider,
+      ConfigProvider.fromEnv(),
+    ),
+  );
+/** Run an effect that is expected to fail and return its typed error. */
+const runFail = <A, E>(effect: Effect.Effect<A, E>) => run(Effect.flip(effect));
+
+/** The resolved credentials a `Credentials` layer produces. */
+const resolveLayer = (layer: Layer.Layer<Credentials.Credentials>) =>
+  Effect.flatMap(Credentials.Credentials, (creds) => creds).pipe(
+    Effect.provide(layer),
+  );
+
+/** A fake HTTP client keyed on `${method} ${url}`. */
+const fakeHttp = (
+  handler: (
+    method: string,
+    url: URL,
+    headers: Record<string, string>,
+  ) => Response | undefined,
+) =>
+  Layer.succeed(HttpClient.HttpClient)(
+    HttpClient.make((request, url) =>
+      Effect.sync(() => {
+        const response = handler(request.method, url, request.headers);
+        if (!response) throw new Error(`unexpected request ${url}`);
+        return HttpClientResponse.fromWeb(request, response);
+      }),
+    ),
+  );
+
+const imdsCreds = (accessKeyId: string) =>
+  Response.json({
+    AccessKeyId: accessKeyId,
+    SecretAccessKey: `secret-${accessKeyId}`,
+    Token: `token-${accessKeyId}`,
+    Expiration: inOneHour().toISOString(),
+  });
+
+let saved: Record<string, string | undefined>;
+let home: string;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+  home = mkdtempSync(join(tmpdir(), "distilled-aws-creds-"));
+  mkdirSync(join(home, ".aws"), { recursive: true });
+  saved.HOME = process.env.HOME;
+  process.env.HOME = home;
+  // The smithy loader memoises file contents per path; unique paths per
+  // test keep tests from seeing each other's config.
+  process.env.AWS_CONFIG_FILE = join(home, ".aws", "config");
+  process.env.AWS_SHARED_CREDENTIALS_FILE = join(home, ".aws", "credentials");
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+const writeConfig = (config: string) =>
+  writeFileSync(join(home, ".aws", "config"), config);
+const writeCredentials = (credentials: string) =>
+  writeFileSync(join(home, ".aws", "credentials"), credentials);
+
+describe("fromEnv", () => {
+  test("reads the key pair, token, expiration and account id", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.AWS_SESSION_TOKEN = "session";
+    process.env.AWS_CREDENTIAL_EXPIRATION = "2030-01-01T00:00:00Z";
+    process.env.AWS_ACCOUNT_ID = "123456789012";
+    const creds = await run(Providers.fromEnv);
+    expect(creds).toEqual({
+      accessKeyId: "AKIA",
+      secretAccessKey: "secret",
+      sessionToken: "session",
+      expiration: new Date("2030-01-01T00:00:00Z"),
+      accountId: "123456789012",
+    });
+  });
+
+  test("fails, and lets a chain continue, when the pair is missing", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA";
+    const error = await runFail(Providers.fromEnv);
+    expect(error).toBeInstanceOf(CredentialSourceError);
+    expect(error.tryNextLink).toBeUndefined();
+  });
+
+  test("the Credentials layer carries the region from the environment", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.AWS_REGION = "eu-west-1";
+    const resolved = await run(resolveLayer(Credentials.fromEnv()));
+    expect(Redacted.value(resolved.accessKeyId)).toBe("AKIA");
+    expect(resolved.region).toBe("eu-west-1");
+  });
+
+  test("the Credentials layer reports a typed provider error with hints", async () => {
+    const error = await runFail(resolveLayer(Credentials.fromEnv()));
+    expect(error._tag).toBe("AWS::CredentialProviderError");
+    if (error._tag === "AWS::CredentialProviderError") {
+      expect(error.provider).toBe("env");
+      expect(error.hints?.[0]).toContain("AWS_ACCESS_KEY_ID");
+    }
+  });
+});
+
+describe("chain", () => {
+  const fail = (message: string, tryNextLink?: boolean) =>
+    Effect.fail(new CredentialSourceError({ message, tryNextLink }));
+  const ok = Effect.succeed({ accessKeyId: "a", secretAccessKey: "b" });
+
+  test("returns the first source that succeeds", async () => {
+    expect(await run(chain([fail("one"), ok]))).toEqual({
+      accessKeyId: "a",
+      secretAccessKey: "b",
+    });
+  });
+
+  test("stops at a source that says the failure is final", async () => {
+    const error = await runFail(chain([fail("final", false), ok]));
+    expect(error.message).toBe("final");
+  });
+
+  test("fails with the last error when every source fails", async () => {
+    const error = await runFail(chain([fail("one"), fail("two")]));
+    expect(error.message).toBe("two");
+  });
+});
+
+describe("fromIni", () => {
+  test("static credentials from the credentials file", async () => {
+    writeCredentials(`
+[default]
+aws_access_key_id = AKIA-default
+aws_secret_access_key = secret-default
+
+[other]
+aws_access_key_id = AKIA-other
+aws_secret_access_key = secret-other
+aws_session_token = session-other
+aws_account_id = 999999999999
+`);
+    expect(await run(Providers.fromIni())).toEqual({
+      accessKeyId: "AKIA-default",
+      secretAccessKey: "secret-default",
+      sessionToken: undefined,
+    });
+    process.env.AWS_PROFILE = "other";
+    expect(await run(Providers.fromIni())).toEqual({
+      accessKeyId: "AKIA-other",
+      secretAccessKey: "secret-other",
+      sessionToken: "session-other",
+      accountId: "999999999999",
+    });
+  });
+
+  test("a profile that is not there", async () => {
+    writeCredentials("");
+    const error = await runFail(Providers.fromIni({ profile: "nope" }));
+    expect(error.message).toContain("[nope]");
+  });
+
+  test("role_arn + source_profile assumes the role through STS", async () => {
+    writeCredentials(`
+[base]
+aws_access_key_id = AKIA-base
+aws_secret_access_key = secret-base
+`);
+    writeConfig(`
+[profile admin]
+role_arn = arn:aws:iam::123456789012:role/Admin
+source_profile = base
+region = us-west-2
+external_id = ext
+duration_seconds = 900
+`);
+    const calls: Array<{
+      url: URL;
+      headers: Record<string, string>;
+      body: string;
+    }> = [];
+    const http = Layer.succeed(HttpClient.HttpClient)(
+      HttpClient.make((request, url) =>
+        Effect.gen(function* () {
+          const body =
+            request.body._tag === "Uint8Array"
+              ? new TextDecoder().decode(request.body.body)
+              : "";
+          calls.push({ url, headers: request.headers, body });
+          return HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/Admin/s</Arn>
+      <AssumedRoleId>AROA:s</AssumedRoleId>
+    </AssumedRoleUser>
+    <Credentials>
+      <AccessKeyId>ASIA-admin</AccessKeyId>
+      <SecretAccessKey>secret-admin</SecretAccessKey>
+      <SessionToken>session-admin</SessionToken>
+      <Expiration>${inOneHour().toISOString()}</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`,
+              { status: 200, headers: { "content-type": "text/xml" } },
+            ),
+          );
+        }),
+      ),
+    );
+    const creds = await run(
+      Providers.fromIni({ profile: "admin" }).pipe(Effect.provide(http)),
+    );
+    expect(creds.accessKeyId).toBe("ASIA-admin");
+    expect(creds.secretAccessKey).toBe("secret-admin");
+    expect(creds.sessionToken).toBe("session-admin");
+    expect(creds.accountId).toBe("123456789012");
+    expect(creds.expiration).toBeInstanceOf(Date);
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.url.hostname).toBe("sts.us-west-2.amazonaws.com");
+    expect(call.headers.authorization).toContain("AKIA-base/");
+    expect(call.headers.authorization).toContain("/us-west-2/sts/");
+    expect(call.body).toContain("Action=AssumeRole");
+    expect(call.body).toContain(
+      "RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2FAdmin",
+    );
+    expect(call.body).toContain("ExternalId=ext");
+    expect(call.body).toContain("DurationSeconds=900");
+  });
+
+  test("mfa_serial without a code provider is a final failure", async () => {
+    writeCredentials(`
+[base]
+aws_access_key_id = AKIA-base
+aws_secret_access_key = secret-base
+`);
+    writeConfig(`
+[profile mfa]
+role_arn = arn:aws:iam::123456789012:role/Admin
+source_profile = base
+mfa_serial = arn:aws:iam::123456789012:mfa/me
+`);
+    const error = await runFail(Providers.fromIni({ profile: "mfa" }));
+    expect(error.message).toContain("multi-factor authentication");
+    expect(error.tryNextLink).toBe(false);
+  });
+
+  test("a source_profile cycle is reported", async () => {
+    writeConfig(`
+[profile a]
+role_arn = arn:aws:iam::123456789012:role/A
+source_profile = b
+
+[profile b]
+role_arn = arn:aws:iam::123456789012:role/B
+source_profile = a
+`);
+    const error = await runFail(Providers.fromIni({ profile: "a" }));
+    expect(error.message).toContain("cycle");
+  });
+
+  test("credential_source = Environment without role_arn is the environment", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA-env";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret-env";
+    writeConfig(`
+[profile env]
+credential_source = Environment
+`);
+    // Without role_arn this is not an assume-role profile at all; the SDK
+    // reports it as unresolvable, and so do we.
+    const error = await runFail(Providers.fromIni({ profile: "env" }));
+    expect(error.message).toContain("[env]");
+  });
+
+  test("credential_process runs the command", async () => {
+    writeConfig(`
+[profile proc]
+credential_process = echo '{"Version":1,"AccessKeyId":"AKIA-proc","SecretAccessKey":"secret-proc","SessionToken":"session-proc","AccountId":"111111111111"}'
+`);
+    expect(await run(Providers.fromIni({ profile: "proc" }))).toEqual({
+      accessKeyId: "AKIA-proc",
+      secretAccessKey: "secret-proc",
+      sessionToken: "session-proc",
+      accountId: "111111111111",
+    });
+    expect(await run(Providers.fromProcess({ profile: "proc" }))).toMatchObject(
+      { accessKeyId: "AKIA-proc" },
+    );
+  });
+
+  test("credential_process output is validated", async () => {
+    writeConfig(`
+[profile v2]
+credential_process = echo '{"Version":2,"AccessKeyId":"a","SecretAccessKey":"b"}'
+
+[profile junk]
+credential_process = echo nope
+`);
+    expect(
+      (await runFail(Providers.fromProcess({ profile: "v2" }))).message,
+    ).toContain("did not return Version 1");
+    expect(
+      (await runFail(Providers.fromProcess({ profile: "junk" }))).message,
+    ).toContain("invalid JSON");
+    expect(
+      (await runFail(Providers.fromProcess({ profile: "missing" }))).message,
+    ).toContain("could not be found");
+  });
+});
+
+describe("fromTokenFile", () => {
+  test("posts the token to AssumeRoleWithWebIdentity unsigned", async () => {
+    const tokenFile = join(home, "token");
+    writeFileSync(tokenFile, "jwt-token\n");
+    process.env.AWS_WEB_IDENTITY_TOKEN_FILE = tokenFile;
+    process.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/Pod";
+    process.env.AWS_ROLE_SESSION_NAME = "pod";
+    process.env.AWS_REGION = "ap-southeast-2";
+    const calls: Array<{
+      url: URL;
+      headers: Record<string, string>;
+      body: string;
+    }> = [];
+    const http = Layer.succeed(HttpClient.HttpClient)(
+      HttpClient.make((request, url) =>
+        Effect.sync(() => {
+          const body =
+            request.body._tag === "Uint8Array"
+              ? new TextDecoder().decode(request.body.body)
+              : "";
+          calls.push({ url, headers: request.headers, body });
+          return HttpClientResponse.fromWeb(
+            request,
+            new Response(
+              `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIA-pod</AccessKeyId>
+      <SecretAccessKey>secret-pod</SecretAccessKey>
+      <SessionToken>session-pod</SessionToken>
+      <Expiration>${inOneHour().toISOString()}</Expiration>
+    </Credentials>
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`,
+              { status: 200, headers: { "content-type": "text/xml" } },
+            ),
+          );
+        }),
+      ),
+    );
+    const creds = await run(
+      Providers.fromTokenFile().pipe(Effect.provide(http)),
+    );
+    expect(creds.accessKeyId).toBe("ASIA-pod");
+    expect(calls[0].url.hostname).toBe("sts.ap-southeast-2.amazonaws.com");
+    expect(calls[0].body).toContain("Action=AssumeRoleWithWebIdentity");
+    expect(calls[0].body).toContain("WebIdentityToken=jwt-token");
+    expect(calls[0].body).toContain("RoleSessionName=pod");
+  });
+
+  test("fails when not configured", async () => {
+    const error = await runFail(Providers.fromTokenFile());
+    expect(error.message).toBe("Web identity configuration not specified");
+  });
+});
+
+describe("fromHttp / fromContainerMetadata", () => {
+  test("relative URI resolves against the ECS host with the auth token", async () => {
+    process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = "/v2/credentials/abc";
+    process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN = "Bearer x";
+    const seen: string[] = [];
+    const http = fakeHttp((method, url, headers) => {
+      seen.push(`${method} ${url} ${headers.authorization}`);
+      return imdsCreds("AKIA-ecs");
+    });
+    const viaHttp = await run(Providers.fromHttp().pipe(Effect.provide(http)));
+    const viaContainer = await run(
+      Providers.fromContainerMetadata().pipe(Effect.provide(http)),
+    );
+    expect(viaHttp.accessKeyId).toBe("AKIA-ecs");
+    expect(viaHttp.sessionToken).toBe("token-AKIA-ecs");
+    expect(viaContainer.accessKeyId).toBe("AKIA-ecs");
+    expect(seen).toEqual([
+      "GET http://169.254.170.2/v2/credentials/abc Bearer x",
+      "GET http://169.254.170.2/v2/credentials/abc Bearer x",
+    ]);
+  });
+
+  test("full URI must be https, loopback, or a container host", async () => {
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://example.com/creds";
+    const error = await runFail(Providers.fromHttp());
+    expect(error.message).toContain("URL not accepted");
+  });
+
+  test("token file is read from disk", async () => {
+    const tokenFile = join(home, "auth-token");
+    writeFileSync(tokenFile, "from-file");
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI =
+      "http://localhost:8080/creds";
+    process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = tokenFile;
+    const seen: string[] = [];
+    const http = fakeHttp((_, url, headers) => {
+      seen.push(`${url} ${headers.authorization}`);
+      return imdsCreds("AKIA-local");
+    });
+    await run(Providers.fromHttp().pipe(Effect.provide(http)));
+    expect(seen).toEqual(["http://localhost:8080/creds from-file"]);
+  });
+
+  test("a 4xx surfaces the endpoint's error code", async () => {
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = "http://127.0.0.1/creds";
+    const http = fakeHttp(() =>
+      Response.json({ Code: "AccessDenied", Message: "nope" }, { status: 403 }),
+    );
+    const error = await runFail(
+      Providers.fromHttp({ maxRetries: 0 }).pipe(Effect.provide(http)),
+    );
+    expect(error.message).toBe(
+      "Server responded with status: 403 AccessDenied nope",
+    );
+  });
+
+  test("nothing configured", async () => {
+    expect((await runFail(Providers.fromHttp())).message).toContain(
+      "No HTTP credential provider host",
+    );
+    const container = await runFail(Providers.fromContainerMetadata());
+    expect(container.tryNextLink).toBe(false);
+  });
+});
+
+describe("fromInstanceMetadata", () => {
+  const imds = (options: { tokenStatus?: number; recordTo?: string[] } = {}) =>
+    fakeHttp((method, url, headers) => {
+      options.recordTo?.push(
+        `${method} ${url.pathname} ${headers["x-aws-ec2-metadata-token"] ?? "-"}`,
+      );
+      if (url.hostname !== "169.254.169.254") return;
+      if (method === "PUT" && url.pathname === "/latest/api/token") {
+        return options.tokenStatus
+          ? new Response("", { status: options.tokenStatus })
+          : new Response("imds-token");
+      }
+      if (url.pathname === "/latest/meta-data/iam/security-credentials/") {
+        return new Response("my-role\n");
+      }
+      if (
+        url.pathname === "/latest/meta-data/iam/security-credentials/my-role"
+      ) {
+        return imdsCreds("AKIA-imds");
+      }
+    });
+
+  test("IMDSv2: token, role name, then credentials", async () => {
+    const calls: string[] = [];
+    const creds = await run(
+      Providers.fromInstanceMetadata().pipe(
+        Effect.provide(imds({ recordTo: calls })),
+      ),
+    );
+    expect(creds.accessKeyId).toBe("AKIA-imds");
+    expect(calls).toEqual([
+      "PUT /latest/api/token -",
+      "GET /latest/meta-data/iam/security-credentials/ imds-token",
+      "GET /latest/meta-data/iam/security-credentials/my-role imds-token",
+    ]);
+  });
+
+  test("falls back to IMDSv1 when the token endpoint is 404", async () => {
+    const calls: string[] = [];
+    const creds = await run(
+      Providers.fromInstanceMetadata().pipe(
+        Effect.provide(imds({ tokenStatus: 404, recordTo: calls })),
+      ),
+    );
+    expect(creds.accessKeyId).toBe("AKIA-imds");
+    expect(calls[1]).toBe("GET /latest/meta-data/iam/security-credentials/ -");
+  });
+
+  test("IMDSv1 fallback can be blocked", async () => {
+    process.env.AWS_EC2_METADATA_V1_DISABLED = "true";
+    const error = await runFail(
+      Providers.fromInstanceMetadata().pipe(
+        Effect.provide(imds({ tokenStatus: 404 })),
+      ),
+    );
+    expect(error.message).toContain("v1 fallback has been blocked");
+    expect(error.tryNextLink).toBe(false);
+  });
+
+  test("custom endpoint", async () => {
+    process.env.AWS_EC2_METADATA_SERVICE_ENDPOINT = "http://localhost:1338";
+    const calls: string[] = [];
+    const http = fakeHttp((method, url) => {
+      calls.push(`${method} ${url.host}${url.pathname}`);
+      if (url.pathname === "/latest/api/token") return new Response("t");
+      if (url.pathname.endsWith("/security-credentials/"))
+        return new Response("r");
+      return imdsCreds("AKIA-custom");
+    });
+    await run(Providers.fromInstanceMetadata().pipe(Effect.provide(http)));
+    expect(calls[0]).toBe("PUT localhost:1338/latest/api/token");
+  });
+});
+
+describe("fromNodeProviderChain", () => {
+  test("the environment wins when AWS_PROFILE is unset", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA-env";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret-env";
+    writeCredentials(`
+[default]
+aws_access_key_id = AKIA-file
+aws_secret_access_key = secret-file
+`);
+    expect((await run(Providers.fromNodeProviderChain())).accessKeyId).toBe(
+      "AKIA-env",
+    );
+  });
+
+  test("AWS_PROFILE sends the chain to the profile before the environment", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "AKIA-env";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret-env";
+    process.env.AWS_PROFILE = "file";
+    writeCredentials(`
+[file]
+aws_access_key_id = AKIA-file
+aws_secret_access_key = secret-file
+`);
+    expect((await run(Providers.fromNodeProviderChain())).accessKeyId).toBe(
+      "AKIA-file",
+    );
+  });
+
+  test("falls through to the container endpoint", async () => {
+    writeCredentials("");
+    process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = "/creds";
+    const http = fakeHttp(() => imdsCreds("AKIA-ecs"));
+    expect(
+      (await run(Providers.fromNodeProviderChain().pipe(Effect.provide(http))))
+        .accessKeyId,
+    ).toBe("AKIA-ecs");
+  });
+
+  test("with IMDS disabled and nothing else, fails with the final message", async () => {
+    writeCredentials("");
+    process.env.AWS_EC2_METADATA_DISABLED = "true";
+    const error = await runFail(Providers.fromNodeProviderChain());
+    expect(error.message).toBe("Could not load credentials from any providers");
+    expect(error.tryNextLink).toBe(false);
+  });
+
+  test("Credentials.fromChain reads the region from the profile", async () => {
+    process.env.AWS_PROFILE = "file";
+    writeCredentials(`
+[file]
+aws_access_key_id = AKIA-file
+aws_secret_access_key = secret-file
+`);
+    writeConfig(`
+[profile file]
+region = ca-central-1
+`);
+    const resolved = await run(resolveLayer(Credentials.fromChain()));
+    expect(Redacted.value(resolved.accessKeyId)).toBe("AKIA-file");
+    expect(resolved.region).toBe("ca-central-1");
+  });
+});

--- a/packages/aws/src/credential-providers/node.ts
+++ b/packages/aws/src/credential-providers/node.ts
@@ -1,0 +1,762 @@
+/**
+ * Credential sources that need the file system or a child process, so they
+ * only exist in the Node build: `~/.aws/config` profiles (`fromIni`),
+ * `credential_process`, web identity token files, and the default chain
+ * that strings them together with the browser-safe sources.
+ *
+ * Profiles are read through `@smithy/shared-ini-file-loader`, the same
+ * loader `auth.ts` uses, so both agree on which files and which profile
+ * name apply. STS calls go through the generated `sts` service, loaded on
+ * first use so an application that never assumes a role never pays for it.
+ */
+import {
+  loadSharedConfigFiles,
+  parseKnownFiles,
+} from "@smithy/shared-ini-file-loader";
+import type { AwsCredentialIdentity } from "@smithy/types";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Redacted from "effect/Redacted";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
+import { exec } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import * as Auth from "../auth.ts";
+import {
+  Credentials,
+  fromAwsCredentialIdentity,
+} from "../credentials.browser.ts";
+import * as Region from "../region.ts";
+import {
+  type CredentialSource,
+  CredentialSourceError,
+  chain,
+  env,
+  ENV_CMDS_FULL_URI,
+  ENV_CMDS_RELATIVE_URI,
+  ENV_KEY,
+  ENV_SECRET,
+  fromContainerMetadata,
+  fromEnv,
+  fromHttp as fromHttpShared,
+  fromInstanceMetadata as fromInstanceMetadataShared,
+  type FromInstanceMetadataOptions,
+  withHttpClient,
+} from "./shared.ts";
+
+export * from "./shared.ts";
+
+type Profile = Readonly<Record<string, string | undefined>>;
+type Profiles = Readonly<Record<string, Profile | undefined>>;
+
+const ENV_PROFILE = "AWS_PROFILE";
+const DEFAULT_PROFILE = "default";
+
+/** `profile`, else `AWS_PROFILE`, else `default` — as the AWS CLI. */
+export const getProfileName = (profile?: string): string =>
+  profile || env(ENV_PROFILE) || DEFAULT_PROFILE;
+
+const loadProfiles = (
+  profile?: string,
+): Effect.Effect<Profiles, CredentialSourceError> =>
+  Effect.tryPromise({
+    try: () => parseKnownFiles({ profile }) as Promise<Profiles>,
+    catch: (cause) =>
+      new CredentialSourceError({
+        message: `Could not read the shared config and credentials files: ${String(cause)}`,
+        cause,
+      }),
+  });
+
+/**
+ * The `[profile <name>]` section of `~/.aws/config` alone (no credentials
+ * file), for settings that the config file owns such as `region` and the
+ * IMDS options.
+ */
+export const loadConfigProfile = (
+  profile?: string,
+): Effect.Effect<Profile | undefined> =>
+  Effect.promise(() => loadSharedConfigFiles()).pipe(
+    Effect.map(
+      (files) =>
+        files.configFile?.[getProfileName(profile)] as Profile | undefined,
+    ),
+    Effect.orElseSucceed(() => undefined),
+  );
+
+// ---------------------------------------------------------------------------
+// File system
+// ---------------------------------------------------------------------------
+
+const systemError =
+  (method: string, path: string) =>
+  (cause: unknown): PlatformError.PlatformError =>
+    PlatformError.systemError({
+      _tag: "Unknown",
+      module: "FileSystem",
+      method,
+      pathOrDescriptor: path,
+      cause,
+    });
+
+/**
+ * A minimal Node `FileSystem` — just what these providers and `Auth` read
+ * and write under `~/.aws`. `Auth.Default` uses an `Auth` already in scope
+ * before falling back to constructing one from this.
+ */
+const nodeFileSystem = FileSystem.makeNoop({
+  readFileString: (path) =>
+    Effect.tryPromise({
+      try: () => readFile(path, "utf8"),
+      catch: systemError("readFileString", path),
+    }),
+  writeFileString: (path, data) =>
+    Effect.tryPromise({
+      try: () => writeFile(path, data),
+      catch: systemError("writeFileString", path),
+    }),
+});
+
+const readFileString = (path: string) => nodeFileSystem.readFileString(path);
+
+// ---------------------------------------------------------------------------
+// fromHttp / fromInstanceMetadata with file-system access
+// ---------------------------------------------------------------------------
+
+/** {@link fromHttpShared} plus `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`. */
+export const fromHttp = (
+  options: { timeout?: number; maxRetries?: number } = {},
+): CredentialSource => fromHttpShared({ ...options, readFile: readFileString });
+
+/** {@link fromInstanceMetadataShared} plus the profile's IMDS settings. */
+export const fromInstanceMetadata = (
+  options: Omit<FromInstanceMetadataOptions, "profileConfig"> & {
+    profile?: string;
+  } = {},
+): CredentialSource =>
+  fromInstanceMetadataShared({
+    ...options,
+    profileConfig: loadConfigProfile(options.profile),
+  });
+
+// ---------------------------------------------------------------------------
+// STS
+// ---------------------------------------------------------------------------
+
+const unredact = (value: string | Redacted.Redacted<string>): string =>
+  Redacted.isRedacted(value) ? Redacted.value(value) : value;
+
+/**
+ * The region STS is called in: the profile's own `region`, else the
+ * environment, else the default profile's `region`, else `us-east-1` — the
+ * order of the SDK's `stsRegionDefaultResolver`.
+ */
+const stsRegion = (
+  profileRegion: string | undefined,
+  profile?: string,
+): Effect.Effect<Region.RegionName> =>
+  profileRegion
+    ? Effect.succeed(profileRegion as Region.RegionName)
+    : Region.fromEnvironment.pipe(
+        Effect.catch(() =>
+          Effect.map(
+            loadConfigProfile(profile),
+            (config) => (config?.region ?? "us-east-1") as Region.RegionName,
+          ),
+        ),
+      );
+
+interface StsResponse {
+  Credentials?: {
+    AccessKeyId: string;
+    SecretAccessKey: string | Redacted.Redacted<string>;
+    SessionToken: string;
+    Expiration: Date;
+  };
+  AssumedRoleUser?: { Arn?: string };
+}
+
+const stsCredentials = (
+  roleArn: string,
+  response: StsResponse,
+): Effect.Effect<AwsCredentialIdentity, CredentialSourceError> => {
+  const credentials = response.Credentials;
+  if (!credentials?.AccessKeyId || !credentials.SecretAccessKey) {
+    return Effect.fail(
+      new CredentialSourceError({
+        message: `Invalid response from STS call with role ${roleArn}`,
+        tryNextLink: false,
+      }),
+    );
+  }
+  const arn = response.AssumedRoleUser?.Arn?.split(":");
+  const accountId = arn && arn.length > 4 && arn[4] !== "" ? arn[4] : undefined;
+  return Effect.succeed({
+    accessKeyId: credentials.AccessKeyId,
+    secretAccessKey: unredact(credentials.SecretAccessKey),
+    sessionToken: credentials.SessionToken,
+    expiration: credentials.Expiration,
+    ...(accountId && { accountId }),
+  });
+};
+
+/** An STS failure is final: the chain does not move on to another source. */
+const stsFailure = (cause: unknown) =>
+  new CredentialSourceError({
+    message:
+      typeof cause === "object" && cause !== null && "message" in cause
+        ? String((cause as { message: unknown }).message)
+        : String(cause),
+    cause,
+    tryNextLink: false,
+  });
+
+export interface AssumeRoleParams {
+  RoleArn: string;
+  RoleSessionName: string;
+  ExternalId?: string;
+  DurationSeconds?: number;
+  SerialNumber?: string;
+  TokenCode?: string;
+}
+
+/** `sts:AssumeRole`, signed with `sourceCredentials`. */
+export const assumeRole = (
+  sourceCredentials: AwsCredentialIdentity,
+  params: AssumeRoleParams,
+  region: Region.RegionName,
+): CredentialSource =>
+  Effect.gen(function* () {
+    const STS = yield* Effect.promise(() => import("../services/sts.ts"));
+    const response = yield* STS.assumeRole(params).pipe(
+      Effect.provideService(
+        Credentials,
+        Effect.succeed(fromAwsCredentialIdentity(sourceCredentials, region)),
+      ),
+      withHttpClient,
+      Effect.mapError(stsFailure),
+    );
+    return yield* stsCredentials(params.RoleArn, response);
+  });
+
+export interface AssumeRoleWithWebIdentityParams {
+  RoleArn: string;
+  RoleSessionName: string;
+  WebIdentityToken: string;
+  ProviderId?: string;
+  Policy?: string;
+  DurationSeconds?: number;
+}
+
+/**
+ * `sts:AssumeRoleWithWebIdentity`. The call is unsigned, but the generated
+ * operation still requires a `Credentials` service, so a placeholder
+ * identity is supplied; only its region is used.
+ */
+export const assumeRoleWithWebIdentity = (
+  params: AssumeRoleWithWebIdentityParams,
+  region: Region.RegionName,
+): CredentialSource =>
+  Effect.gen(function* () {
+    const STS = yield* Effect.promise(() => import("../services/sts.ts"));
+    const response = yield* STS.assumeRoleWithWebIdentity(params).pipe(
+      Effect.provideService(
+        Credentials,
+        Effect.succeed(
+          fromAwsCredentialIdentity(
+            { accessKeyId: "", secretAccessKey: "" },
+            region,
+          ),
+        ),
+      ),
+      withHttpClient,
+      Effect.mapError(stsFailure),
+    );
+    return yield* stsCredentials(params.RoleArn, response);
+  });
+
+// ---------------------------------------------------------------------------
+// credential_process
+// ---------------------------------------------------------------------------
+
+/** Run a shell command and return its stdout; interrupt kills the child. */
+const execCommand = (
+  command: string,
+): Effect.Effect<string, CredentialSourceError> =>
+  Effect.callback<string, CredentialSourceError>((resume, signal) => {
+    exec(command, { signal }, (error, stdout) => {
+      resume(
+        error
+          ? Effect.fail(
+              new CredentialSourceError({
+                message: error.message,
+                cause: error,
+              }),
+            )
+          : Effect.succeed(stdout),
+      );
+    });
+  });
+
+interface ProcessOutput {
+  Version?: number;
+  AccessKeyId?: string;
+  SecretAccessKey?: string;
+  SessionToken?: string;
+  Expiration?: string;
+  CredentialScope?: string;
+  AccountId?: string;
+}
+
+const resolveProcessCredentials = (
+  profileName: string,
+  profiles: Profiles,
+): CredentialSource => {
+  const profile = profiles[profileName];
+  if (!profile) {
+    return Effect.fail(
+      new CredentialSourceError({
+        message: `Profile ${profileName} could not be found in shared credentials file.`,
+      }),
+    );
+  }
+  const credentialProcess = profile.credential_process;
+  if (credentialProcess === undefined) {
+    return Effect.fail(
+      new CredentialSourceError({
+        message: `Profile ${profileName} did not contain credential_process.`,
+      }),
+    );
+  }
+  const invalid = (reason: string, cause?: unknown) =>
+    new CredentialSourceError({
+      message: `Profile ${profileName} credential_process ${reason}.`,
+      cause,
+    });
+  return execCommand(credentialProcess).pipe(
+    Effect.flatMap((stdout) =>
+      Effect.try({
+        try: (): ProcessOutput => JSON.parse(stdout.trim()),
+        catch: (cause) => invalid("returned invalid JSON", cause),
+      }),
+    ),
+    Effect.flatMap((data) => {
+      if (data.Version !== 1) {
+        return Effect.fail(invalid("did not return Version 1"));
+      }
+      if (
+        data.AccessKeyId === undefined ||
+        data.SecretAccessKey === undefined
+      ) {
+        return Effect.fail(invalid("returned invalid credentials"));
+      }
+      if (data.Expiration && new Date(data.Expiration) < new Date()) {
+        return Effect.fail(invalid("returned expired credentials"));
+      }
+      const accountId = data.AccountId ?? profile.aws_account_id;
+      return Effect.succeed<AwsCredentialIdentity>({
+        accessKeyId: data.AccessKeyId,
+        secretAccessKey: data.SecretAccessKey,
+        ...(data.SessionToken && { sessionToken: data.SessionToken }),
+        ...(data.Expiration && { expiration: new Date(data.Expiration) }),
+        ...(data.CredentialScope && { credentialScope: data.CredentialScope }),
+        ...(accountId && { accountId }),
+      });
+    }),
+  );
+};
+
+/** Credentials from the profile's `credential_process` command. */
+export const fromProcess = (
+  options: { profile?: string } = {},
+): CredentialSource =>
+  Effect.flatMap(loadProfiles(options.profile), (profiles) =>
+    resolveProcessCredentials(getProfileName(options.profile), profiles),
+  );
+
+// ---------------------------------------------------------------------------
+// Web identity token file
+// ---------------------------------------------------------------------------
+
+const ENV_TOKEN_FILE = "AWS_WEB_IDENTITY_TOKEN_FILE";
+const ENV_ROLE_ARN = "AWS_ROLE_ARN";
+const ENV_ROLE_SESSION_NAME = "AWS_ROLE_SESSION_NAME";
+
+export interface FromTokenFileOptions {
+  readonly webIdentityTokenFile?: string;
+  readonly roleArn?: string;
+  readonly roleSessionName?: string;
+  /** Region to call STS in; defaults per {@link stsRegion}. */
+  readonly region?: string;
+  readonly profile?: string;
+}
+
+/**
+ * Credentials from `sts:AssumeRoleWithWebIdentity` with the token in
+ * `AWS_WEB_IDENTITY_TOKEN_FILE` and the role in `AWS_ROLE_ARN` (or the
+ * options), as on EKS with IAM roles for service accounts.
+ */
+export const fromTokenFile = (
+  options: FromTokenFileOptions = {},
+): CredentialSource =>
+  Effect.gen(function* () {
+    const webIdentityTokenFile =
+      options.webIdentityTokenFile ?? env(ENV_TOKEN_FILE);
+    const roleArn = options.roleArn ?? env(ENV_ROLE_ARN);
+    const roleSessionName =
+      options.roleSessionName ?? env(ENV_ROLE_SESSION_NAME);
+    if (!webIdentityTokenFile || !roleArn) {
+      return yield* new CredentialSourceError({
+        message: "Web identity configuration not specified",
+      });
+    }
+    const webIdentityToken = yield* readFileString(webIdentityTokenFile).pipe(
+      Effect.mapError(
+        (cause) =>
+          new CredentialSourceError({
+            message: `Could not read web identity token file ${webIdentityTokenFile}.`,
+            cause,
+          }),
+      ),
+    );
+    const region = yield* stsRegion(options.region, options.profile);
+    return yield* assumeRoleWithWebIdentity(
+      {
+        RoleArn: roleArn,
+        RoleSessionName: roleSessionName ?? `aws-sdk-js-session-${Date.now()}`,
+        WebIdentityToken: webIdentityToken,
+      },
+      region,
+    );
+  });
+
+// ---------------------------------------------------------------------------
+// fromIni
+// ---------------------------------------------------------------------------
+
+export interface FromIniOptions {
+  readonly profile?: string;
+  /** Answers an `mfa_serial` prompt; without one, MFA profiles fail. */
+  readonly mfaCodeProvider?: (
+    mfaSerial: string,
+  ) => Effect.Effect<string, unknown>;
+}
+
+const isString = (value: unknown): value is string => typeof value === "string";
+const isOptionalString = (value: unknown) =>
+  value === undefined || typeof value === "string";
+
+const isStaticCredsProfile = (profile: Profile) =>
+  isString(profile.aws_access_key_id) &&
+  isString(profile.aws_secret_access_key) &&
+  isOptionalString(profile.aws_session_token) &&
+  isOptionalString(profile.aws_account_id);
+
+const isAssumeRoleProfile = (profile: Profile) =>
+  isString(profile.role_arn) &&
+  isOptionalString(profile.role_session_name) &&
+  isOptionalString(profile.external_id) &&
+  isOptionalString(profile.mfa_serial) &&
+  ((isString(profile.source_profile) &&
+    profile.credential_source === undefined) ||
+    (isString(profile.credential_source) &&
+      profile.source_profile === undefined));
+
+const isWebIdentityProfile = (profile: Profile) =>
+  isString(profile.web_identity_token_file) &&
+  isString(profile.role_arn) &&
+  isOptionalString(profile.role_session_name);
+
+const isProcessProfile = (profile: Profile) =>
+  isString(profile.credential_process);
+
+const isSsoProfile = (profile: Profile) =>
+  isString(profile.sso_start_url) ||
+  isString(profile.sso_account_id) ||
+  isString(profile.sso_session) ||
+  isString(profile.sso_region) ||
+  isString(profile.sso_role_name);
+
+const isCredentialSourceWithoutRoleArn = (profile: Profile) =>
+  !profile.role_arn && !!profile.credential_source;
+
+const staticCredentials = (profile: Profile): AwsCredentialIdentity => ({
+  accessKeyId: profile.aws_access_key_id!,
+  secretAccessKey: profile.aws_secret_access_key!,
+  sessionToken: profile.aws_session_token,
+  ...(profile.aws_credential_scope && {
+    credentialScope: profile.aws_credential_scope,
+  }),
+  ...(profile.aws_account_id && { accountId: profile.aws_account_id }),
+});
+
+/** The `credential_source` of an assume-role profile. */
+const credentialSource = (
+  source: string | undefined,
+  profileName: string,
+): CredentialSource => {
+  switch (source) {
+    case "EcsContainer":
+      return chain([fromHttp(), fromContainerMetadata()]);
+    case "Ec2InstanceMetadata":
+      return fromInstanceMetadata({ profile: profileName });
+    case "Environment":
+      return fromEnv;
+    default:
+      return Effect.fail(
+        new CredentialSourceError({
+          message:
+            `Unsupported credential source in profile ${profileName}. Got ${source}, ` +
+            `expected EcsContainer or Ec2InstanceMetadata or Environment.`,
+        }),
+      );
+  }
+};
+
+const provideNodeServices = <A, E>(
+  effect: Effect.Effect<
+    A,
+    E,
+    FileSystem.FileSystem | Path.Path | HttpClient.HttpClient
+  >,
+): Effect.Effect<A, E> =>
+  effect.pipe(
+    Effect.provideService(FileSystem.FileSystem, nodeFileSystem),
+    Effect.provide(Path.layer),
+    withHttpClient,
+  );
+
+/**
+ * SSO profiles resolve through `Auth`, the same code path `fromSSO` uses,
+ * so the token cache and the role-credentials cache are shared with it.
+ */
+const ssoCredentials = (profileName: string): CredentialSource =>
+  Auth.loadProfileCredentials(profileName).pipe(
+    Effect.map((resolved): AwsCredentialIdentity => ({
+      accessKeyId: Redacted.value(resolved.accessKeyId),
+      secretAccessKey: Redacted.value(resolved.secretAccessKey),
+      sessionToken: resolved.sessionToken
+        ? Redacted.value(resolved.sessionToken)
+        : undefined,
+      expiration:
+        resolved.expiration === undefined
+          ? undefined
+          : new Date(resolved.expiration),
+    })),
+    Effect.mapError(
+      (cause) =>
+        new CredentialSourceError({
+          message: "message" in cause ? cause.message : String(cause),
+          cause,
+          // The SDK never falls through past an SSO profile that fails.
+          tryNextLink: false,
+        }),
+    ),
+    provideNodeServices,
+  );
+
+const resolveProfileData = (
+  profileName: string,
+  profiles: Profiles,
+  options: FromIniOptions,
+  visited: ReadonlySet<string>,
+  isAssumeRoleRecursiveCall = false,
+): CredentialSource => {
+  const profile = profiles[profileName];
+  if (!profile) {
+    return Effect.fail(
+      new CredentialSourceError({
+        message: `Could not resolve credentials using profile: [${profileName}] in configuration/credentials file(s).`,
+      }),
+    );
+  }
+  if (visited.size > 0 && isStaticCredsProfile(profile)) {
+    return Effect.succeed(staticCredentials(profile));
+  }
+  if (isAssumeRoleRecursiveCall || isAssumeRoleProfile(profile)) {
+    return resolveAssumeRoleCredentials(
+      profileName,
+      profiles,
+      options,
+      visited,
+    );
+  }
+  if (isStaticCredsProfile(profile)) {
+    return Effect.succeed(staticCredentials(profile));
+  }
+  if (isWebIdentityProfile(profile)) {
+    return fromTokenFile({
+      webIdentityTokenFile: profile.web_identity_token_file,
+      roleArn: profile.role_arn,
+      roleSessionName: profile.role_session_name,
+      profile: profileName,
+    });
+  }
+  if (isProcessProfile(profile)) {
+    return resolveProcessCredentials(profileName, profiles);
+  }
+  if (isSsoProfile(profile)) {
+    return ssoCredentials(profileName);
+  }
+  return Effect.fail(
+    new CredentialSourceError({
+      message: `Could not resolve credentials using profile: [${profileName}] in configuration/credentials file(s).`,
+    }),
+  );
+};
+
+const resolveAssumeRoleCredentials = (
+  profileName: string,
+  profiles: Profiles,
+  options: FromIniOptions,
+  visited: ReadonlySet<string>,
+): CredentialSource =>
+  Effect.gen(function* () {
+    const profile = profiles[profileName]!;
+    const sourceProfile = profile.source_profile;
+    if (sourceProfile && visited.has(sourceProfile)) {
+      return yield* new CredentialSourceError({
+        message:
+          `Detected a cycle attempting to resolve credentials for profile` +
+          ` ${getProfileName(options.profile)}. Profiles visited: ` +
+          [...visited].join(", "),
+      });
+    }
+    const source = sourceProfile
+      ? resolveProfileData(
+          sourceProfile,
+          profiles,
+          options,
+          new Set([...visited, sourceProfile]),
+          isCredentialSourceWithoutRoleArn(profiles[sourceProfile] ?? {}),
+        )
+      : credentialSource(profile.credential_source, profileName);
+
+    if (isCredentialSourceWithoutRoleArn(profile)) {
+      return yield* source;
+    }
+
+    const params: AssumeRoleParams = {
+      RoleArn: profile.role_arn!,
+      RoleSessionName: profile.role_session_name || `aws-sdk-js-${Date.now()}`,
+      ExternalId: profile.external_id,
+      DurationSeconds: parseInt(profile.duration_seconds || "3600", 10),
+    };
+    if (profile.mfa_serial) {
+      if (!options.mfaCodeProvider) {
+        return yield* new CredentialSourceError({
+          message: `Profile ${profileName} requires multi-factor authentication, but no MFA code callback was provided.`,
+          tryNextLink: false,
+        });
+      }
+      params.SerialNumber = profile.mfa_serial;
+      params.TokenCode = yield* options
+        .mfaCodeProvider(profile.mfa_serial)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CredentialSourceError({
+                message: `MFA code provider failed for profile ${profileName}.`,
+                cause,
+                tryNextLink: false,
+              }),
+          ),
+        );
+    }
+    const sourceCredentials = yield* source;
+    const region = yield* stsRegion(profile.region, options.profile);
+    return yield* assumeRole(sourceCredentials, params, region);
+  });
+
+/**
+ * Credentials from the shared config and credentials files: static keys,
+ * `role_arn` + `source_profile` / `credential_source` (assumed through
+ * STS), `web_identity_token_file`, `credential_process`, and SSO profiles.
+ */
+export const fromIni = (options: FromIniOptions = {}): CredentialSource =>
+  Effect.flatMap(loadProfiles(options.profile), (profiles) =>
+    resolveProfileData(
+      getProfileName(options.profile),
+      profiles,
+      options,
+      new Set(),
+    ),
+  );
+
+// ---------------------------------------------------------------------------
+// Default chain
+// ---------------------------------------------------------------------------
+
+const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
+
+let multipleCredentialSourceWarningEmitted = false;
+
+/** The environment, unless `AWS_PROFILE` says to go to the profile first. */
+const envUnlessProfile = (profile?: string): CredentialSource =>
+  Effect.suspend(() => {
+    const profileName = profile ?? env(ENV_PROFILE);
+    if (profileName) {
+      if (
+        env(ENV_KEY) &&
+        env(ENV_SECRET) &&
+        !multipleCredentialSourceWarningEmitted
+      ) {
+        multipleCredentialSourceWarningEmitted = true;
+        console.warn(`WARNING:
+    Multiple credential sources detected:
+    Both AWS_PROFILE and the pair AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY static credentials are set.
+    This SDK will proceed with the AWS_PROFILE value.
+
+    However, a future version may change this behavior to prefer the ENV static credentials.
+    Please ensure that your environment only sets either the AWS_PROFILE or the
+    AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY pair.
+`);
+      }
+      return Effect.fail(
+        new CredentialSourceError({
+          message: "AWS_PROFILE is set, skipping fromEnv provider.",
+        }),
+      );
+    }
+    return fromEnv;
+  });
+
+/** The container endpoint if configured, else IMDS unless disabled. */
+const remoteProvider = (profile?: string): CredentialSource =>
+  Effect.suspend(() => {
+    if (env(ENV_CMDS_RELATIVE_URI) || env(ENV_CMDS_FULL_URI)) {
+      return chain([fromHttp(), fromContainerMetadata()]);
+    }
+    const disabled = env(ENV_IMDS_DISABLED);
+    if (disabled && disabled !== "false") {
+      return Effect.fail(
+        new CredentialSourceError({
+          message: "EC2 Instance Metadata Service access disabled",
+        }),
+      );
+    }
+    return fromInstanceMetadata({ profile });
+  });
+
+/**
+ * The default Node credential chain, in the SDK's order: environment,
+ * shared config / credentials files, `credential_process`, web identity
+ * token file, then the container or instance metadata endpoints.
+ */
+export const fromNodeProviderChain = (
+  options: FromIniOptions = {},
+): CredentialSource =>
+  chain([
+    envUnlessProfile(options.profile),
+    fromIni(options),
+    fromProcess(options),
+    fromTokenFile(options),
+    remoteProvider(options.profile),
+    Effect.fail(
+      new CredentialSourceError({
+        message: "Could not load credentials from any providers",
+        tryNextLink: false,
+      }),
+    ),
+  ]);

--- a/packages/aws/src/credential-providers/shared.ts
+++ b/packages/aws/src/credential-providers/shared.ts
@@ -1,0 +1,735 @@
+/**
+ * Credential sources that need nothing but an HTTP client, so they are safe
+ * to ship in the browser build as well as the Node one: the environment, the
+ * HTTP / container endpoints, and the EC2 instance metadata service.
+ *
+ * Every source is an `Effect<AwsCredentialIdentity, CredentialSourceError>`.
+ * The resolution rules (which variables are read, how responses are
+ * validated, when a chain may fall through) follow the AWS SDK v3 providers
+ * this module replaces.
+ */
+import type { AwsCredentialIdentity } from "@smithy/types";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schedule from "effect/Schedule";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+
+/**
+ * A single credential source could not produce credentials.
+ *
+ * `tryNextLink` is what a chain looks at: `false` means the failure is
+ * final (e.g. a malformed URL, an MFA prompt that cannot be answered) and
+ * the chain stops there instead of trying the next source.
+ */
+export class CredentialSourceError extends Data.TaggedError(
+  "AWS::CredentialSourceError",
+)<{
+  message: string;
+  tryNextLink?: boolean;
+  cause?: unknown;
+}> {}
+
+export type CredentialSource = Effect.Effect<
+  AwsCredentialIdentity,
+  CredentialSourceError,
+  never
+>;
+
+/** `process.env[name]`, or `undefined` where there is no `process`. */
+export const env = (name: string): string | undefined =>
+  typeof process !== "undefined" ? process.env?.[name] : undefined;
+
+/**
+ * Try each source in order. A source failing with `tryNextLink: false` stops
+ * the chain; otherwise the next one runs. When every source fails, the last
+ * failure is the chain's failure.
+ */
+export const chain = (
+  sources: ReadonlyArray<CredentialSource>,
+): CredentialSource =>
+  Effect.suspend(() => {
+    const step = (
+      index: number,
+      last: CredentialSourceError | undefined,
+    ): CredentialSource => {
+      if (index >= sources.length) {
+        return Effect.fail(
+          last ??
+            new CredentialSourceError({
+              message: "No credential sources configured.",
+              tryNextLink: false,
+            }),
+        );
+      }
+      return sources[index].pipe(
+        Effect.catch((error) =>
+          error.tryNextLink === false
+            ? Effect.fail(error)
+            : step(index + 1, error),
+        ),
+      );
+    };
+    return step(0, undefined);
+  });
+
+/**
+ * Run `effect` with the fiber's `HttpClient` when one is in scope (an
+ * operation always has one), else with the platform `fetch` client. This
+ * keeps every credentials layer free of requirements while still letting a
+ * caller inject a client, e.g. in tests.
+ */
+export const withHttpClient = <A, E>(
+  effect: Effect.Effect<A, E, HttpClient.HttpClient>,
+): Effect.Effect<A, E> =>
+  Effect.serviceOption(HttpClient.HttpClient).pipe(
+    Effect.flatMap((client) =>
+      Option.isSome(client)
+        ? Effect.provideService(effect, HttpClient.HttpClient, client.value)
+        : Effect.provide(effect, FetchHttpClient.layer),
+    ),
+  );
+
+interface TextResponse {
+  readonly status: number;
+  readonly text: string;
+}
+
+/**
+ * Execute a request and read the whole body. Non-2xx statuses are returned,
+ * not failed, because IMDS in particular branches on them.
+ */
+export const requestText = (
+  request: HttpClientRequest.HttpClientRequest,
+  timeoutMs: number,
+): Effect.Effect<TextResponse, CredentialSourceError> =>
+  HttpClient.execute(request).pipe(
+    Effect.flatMap((response) =>
+      Effect.map(response.text, (text) => ({ status: response.status, text })),
+    ),
+    Effect.timeout(timeoutMs),
+    Effect.mapError(
+      (cause) =>
+        new CredentialSourceError({
+          message:
+            cause._tag === "TimeoutError"
+              ? "TimeoutError"
+              : `Request to ${request.url} failed: ${String(cause)}`,
+          cause,
+        }),
+    ),
+    withHttpClient,
+  );
+
+/** Re-run `effect` up to `maxRetries` more times after a failure. */
+export const retry = <A, E>(
+  effect: Effect.Effect<A, E>,
+  maxRetries: number,
+): Effect.Effect<A, E> =>
+  maxRetries > 0 ? Effect.retry(effect, { times: maxRetries }) : effect;
+
+/**
+ * The JSON document the container, HTTP and instance metadata endpoints all
+ * return.
+ */
+interface ImdsCredentials {
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  Token: string;
+  Expiration: string;
+  AccountId?: string;
+}
+
+const isImdsCredentials = (arg: unknown): arg is ImdsCredentials =>
+  typeof arg === "object" &&
+  arg !== null &&
+  typeof (arg as ImdsCredentials).AccessKeyId === "string" &&
+  typeof (arg as ImdsCredentials).SecretAccessKey === "string" &&
+  typeof (arg as ImdsCredentials).Token === "string" &&
+  typeof (arg as ImdsCredentials).Expiration === "string";
+
+const fromImdsCredentials = (
+  creds: ImdsCredentials,
+): AwsCredentialIdentity => ({
+  accessKeyId: creds.AccessKeyId,
+  secretAccessKey: creds.SecretAccessKey,
+  sessionToken: creds.Token,
+  expiration: new Date(creds.Expiration),
+  ...(creds.AccountId && { accountId: creds.AccountId }),
+});
+
+const parseImdsCredentials = (
+  text: string,
+): Effect.Effect<AwsCredentialIdentity, CredentialSourceError> =>
+  Effect.try({
+    try: () => JSON.parse(text) as unknown,
+    catch: (cause) =>
+      new CredentialSourceError({
+        message: "Invalid response received from instance metadata service.",
+        cause,
+      }),
+  }).pipe(
+    Effect.flatMap((parsed) =>
+      isImdsCredentials(parsed)
+        ? Effect.succeed(fromImdsCredentials(parsed))
+        : Effect.fail(
+            new CredentialSourceError({
+              message:
+                "Invalid response received from instance metadata service.",
+            }),
+          ),
+    ),
+  );
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+export const ENV_KEY = "AWS_ACCESS_KEY_ID";
+export const ENV_SECRET = "AWS_SECRET_ACCESS_KEY";
+const ENV_SESSION = "AWS_SESSION_TOKEN";
+const ENV_EXPIRATION = "AWS_CREDENTIAL_EXPIRATION";
+const ENV_CREDENTIAL_SCOPE = "AWS_CREDENTIAL_SCOPE";
+const ENV_ACCOUNT_ID = "AWS_ACCOUNT_ID";
+
+/** `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` and friends. */
+export const fromEnv: CredentialSource = Effect.suspend(() => {
+  const accessKeyId = env(ENV_KEY);
+  const secretAccessKey = env(ENV_SECRET);
+  const sessionToken = env(ENV_SESSION);
+  const expiry = env(ENV_EXPIRATION);
+  const credentialScope = env(ENV_CREDENTIAL_SCOPE);
+  const accountId = env(ENV_ACCOUNT_ID);
+  if (accessKeyId && secretAccessKey) {
+    return Effect.succeed<AwsCredentialIdentity>({
+      accessKeyId,
+      secretAccessKey,
+      ...(sessionToken && { sessionToken }),
+      ...(expiry && { expiration: new Date(expiry) }),
+      ...(credentialScope && { credentialScope }),
+      ...(accountId && { accountId }),
+    });
+  }
+  return Effect.fail(
+    new CredentialSourceError({
+      message: "Unable to find environment variable credentials.",
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// HTTP credential endpoint (ECS / EKS pod identity / local agents)
+// ---------------------------------------------------------------------------
+
+export const ENV_CMDS_FULL_URI = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+export const ENV_CMDS_RELATIVE_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const ENV_CMDS_AUTH_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+const ENV_CMDS_AUTH_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+const CMDS_IP = "169.254.170.2";
+const DEFAULT_LINK_LOCAL_HOST = `http://${CMDS_IP}`;
+
+const DEFAULT_TIMEOUT_MS = 1000;
+
+/**
+ * Only HTTPS, loopback, or the ECS / EKS link-local hosts may serve
+ * credentials over plain HTTP.
+ */
+const checkUrl = (url: URL): CredentialSourceError | undefined => {
+  if (url.protocol === "https:") return;
+  const host = url.hostname;
+  if (
+    host === CMDS_IP ||
+    host === "169.254.170.23" ||
+    host === "[fd00:ec2::23]"
+  )
+    return;
+  if (host.includes("[")) {
+    if (
+      host === "[::1]" ||
+      host === "[0000:0000:0000:0000:0000:0000:0000:0001]"
+    )
+      return;
+  } else {
+    if (host === "localhost") return;
+    const parts = host.split(".");
+    const inRange = (part: string) => {
+      const n = parseInt(part, 10);
+      return 0 <= n && n <= 255;
+    };
+    if (
+      parts.length === 4 &&
+      parts[0] === "127" &&
+      inRange(parts[1]) &&
+      inRange(parts[2]) &&
+      inRange(parts[3])
+    )
+      return;
+  }
+  return new CredentialSourceError({
+    message: `URL not accepted. It must either be HTTPS or match one of the following:
+  - loopback CIDR 127.0.0.0/8 or [::1/128]
+  - ECS container host 169.254.170.2
+  - EKS container host 169.254.170.23 or [fd00:ec2::23]`,
+  });
+};
+
+const validateToken = (token: string) =>
+  token.includes("\r\n")
+    ? Effect.fail(
+        new CredentialSourceError({
+          message: "Authorization token contains invalid \\r\\n sequence.",
+        }),
+      )
+    : Effect.succeed(token);
+
+const getHttpCredentials = (
+  url: URL,
+  authorization: string | undefined,
+  timeoutMs: number,
+): CredentialSource =>
+  requestText(
+    HttpClientRequest.get(url, {
+      headers: authorization ? { Authorization: authorization } : undefined,
+    }),
+    timeoutMs,
+  ).pipe(
+    Effect.flatMap(({ status, text }) => {
+      if (status === 200) {
+        return parseImdsCredentials(text).pipe(
+          Effect.mapError(
+            () =>
+              new CredentialSourceError({
+                message:
+                  "HTTP credential provider response not of the required format, an object matching: " +
+                  "{ AccessKeyId: string, SecretAccessKey: string, Token: string, Expiration: string(rfc3339) }",
+              }),
+          ),
+        );
+      }
+      let detail = "";
+      if (status >= 400 && status < 500) {
+        try {
+          const body = JSON.parse(text) as { Code?: string; Message?: string };
+          if (body.Code || body.Message)
+            detail = ` ${body.Code ?? ""} ${body.Message ?? ""}`.trimEnd();
+        } catch {
+          // The body is optional and need not be JSON.
+        }
+      }
+      return Effect.fail(
+        new CredentialSourceError({
+          message: `Server responded with status: ${status}${detail}`,
+        }),
+      );
+    }),
+  );
+
+export interface FromHttpOptions {
+  /**
+   * Reads `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`. Supplied by the Node
+   * entry point; without it a token file cannot be used.
+   */
+  readonly readFile?: (path: string) => Effect.Effect<string, unknown>;
+  readonly timeout?: number;
+  readonly maxRetries?: number;
+}
+
+let httpWarningsEmitted = false;
+
+/**
+ * Credentials from the endpoint named by
+ * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` (resolved against the ECS
+ * link-local host) or `AWS_CONTAINER_CREDENTIALS_FULL_URI`, optionally with
+ * an `Authorization` token from `AWS_CONTAINER_AUTHORIZATION_TOKEN[_FILE]`.
+ */
+export const fromHttp = (options: FromHttpOptions = {}): CredentialSource =>
+  Effect.suspend(() => {
+    const relative = env(ENV_CMDS_RELATIVE_URI);
+    const full = env(ENV_CMDS_FULL_URI);
+    const token = env(ENV_CMDS_AUTH_TOKEN);
+    const tokenFile = env(ENV_CMDS_AUTH_TOKEN_FILE);
+    if (!httpWarningsEmitted) {
+      if (relative && full) {
+        httpWarningsEmitted = true;
+        console.warn(
+          `Both ${ENV_CMDS_RELATIVE_URI} and ${ENV_CMDS_FULL_URI} are set; ${ENV_CMDS_RELATIVE_URI} takes precedence.`,
+        );
+      }
+      if (token && tokenFile) {
+        httpWarningsEmitted = true;
+        console.warn(
+          `Both ${ENV_CMDS_AUTH_TOKEN} and ${ENV_CMDS_AUTH_TOKEN_FILE} are set; ${ENV_CMDS_AUTH_TOKEN_FILE} takes precedence.`,
+        );
+      }
+    }
+    const host = relative ? `${DEFAULT_LINK_LOCAL_HOST}${relative}` : full;
+    if (!host) {
+      return Effect.fail(
+        new CredentialSourceError({
+          message: `No HTTP credential provider host provided.
+Set ${ENV_CMDS_FULL_URI} or ${ENV_CMDS_RELATIVE_URI}.`,
+        }),
+      );
+    }
+    let url: URL;
+    try {
+      url = new URL(host);
+    } catch (cause) {
+      return Effect.fail(
+        new CredentialSourceError({
+          message: `${host} is not a valid credential provider URL`,
+          cause,
+        }),
+      );
+    }
+    const rejected = checkUrl(url);
+    if (rejected) return Effect.fail(rejected);
+
+    const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+    const authorization: Effect.Effect<
+      string | undefined,
+      CredentialSourceError
+    > = tokenFile
+      ? options.readFile
+        ? options.readFile(tokenFile).pipe(
+            Effect.mapError(
+              (cause) =>
+                new CredentialSourceError({
+                  message: `Could not read ${ENV_CMDS_AUTH_TOKEN_FILE} ${tokenFile}.`,
+                  cause,
+                }),
+            ),
+            Effect.flatMap(validateToken),
+          )
+        : Effect.fail(
+            new CredentialSourceError({
+              message: `${ENV_CMDS_AUTH_TOKEN_FILE} is not supported in this runtime.`,
+            }),
+          )
+      : token
+        ? validateToken(token)
+        : Effect.succeed(undefined);
+
+    const attempt = authorization.pipe(
+      Effect.flatMap((auth) => getHttpCredentials(url, auth, timeoutMs)),
+    );
+    // Like the SDK: up to `maxRetries` retries, waiting `timeout` between.
+    const maxRetries = options.maxRetries ?? 3;
+    return maxRetries > 0
+      ? Effect.retry(attempt, {
+          schedule: Schedule.spaced(Duration.millis(timeoutMs)).pipe(
+            Schedule.upTo({ times: maxRetries }),
+          ),
+        })
+      : attempt;
+  });
+
+/**
+ * The container credential endpoint (`AWS_CONTAINER_CREDENTIALS_*`), as the
+ * ECS agent serves it. Differs from {@link fromHttp} in accepting only the
+ * link-local or loopback hosts, reading the token from the environment
+ * only, and not retrying by default.
+ */
+export const fromContainerMetadata = (
+  options: { timeout?: number; maxRetries?: number } = {},
+): CredentialSource =>
+  retry(
+    Effect.suspend(() => {
+      const relative = env(ENV_CMDS_RELATIVE_URI);
+      const full = env(ENV_CMDS_FULL_URI);
+      let url: URL;
+      if (relative) {
+        url = new URL(relative, DEFAULT_LINK_LOCAL_HOST);
+      } else if (full) {
+        try {
+          url = new URL(full);
+        } catch {
+          return Effect.fail(
+            new CredentialSourceError({
+              message: `${full} is not a valid container metadata service URL`,
+              tryNextLink: false,
+            }),
+          );
+        }
+        if (url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
+          return Effect.fail(
+            new CredentialSourceError({
+              message: `${url.hostname} is not a valid container metadata service hostname`,
+              tryNextLink: false,
+            }),
+          );
+        }
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          return Effect.fail(
+            new CredentialSourceError({
+              message: `${url.protocol} is not a valid container metadata service protocol`,
+              tryNextLink: false,
+            }),
+          );
+        }
+      } else {
+        return Effect.fail(
+          new CredentialSourceError({
+            message:
+              "The container metadata credential provider cannot be used unless" +
+              ` the ${ENV_CMDS_RELATIVE_URI} or ${ENV_CMDS_FULL_URI} environment` +
+              " variable is set",
+            tryNextLink: false,
+          }),
+        );
+      }
+      return getHttpCredentials(
+        url,
+        env(ENV_CMDS_AUTH_TOKEN),
+        options.timeout ?? DEFAULT_TIMEOUT_MS,
+      );
+    }),
+    options.maxRetries ?? 0,
+  );
+
+// ---------------------------------------------------------------------------
+// EC2 instance metadata service
+// ---------------------------------------------------------------------------
+
+const IMDS_PATH = "/latest/meta-data/iam/security-credentials/";
+const IMDS_TOKEN_PATH = "/latest/api/token";
+const X_AWS_EC2_METADATA_TOKEN = "x-aws-ec2-metadata-token";
+const ENV_IMDS_ENDPOINT = "AWS_EC2_METADATA_SERVICE_ENDPOINT";
+const ENV_IMDS_ENDPOINT_MODE = "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE";
+const ENV_IMDS_V1_DISABLED = "AWS_EC2_METADATA_V1_DISABLED";
+
+export interface FromInstanceMetadataOptions {
+  readonly timeout?: number;
+  readonly maxRetries?: number;
+  /** Refuse to fall back to IMDSv1 when no session token can be obtained. */
+  readonly ec2MetadataV1Disabled?: boolean;
+  /**
+   * `~/.aws/config` values for the active profile
+   * (`ec2_metadata_service_endpoint`, `ec2_metadata_service_endpoint_mode`,
+   * `ec2_metadata_v1_disabled`). The Node entry point reads them; the
+   * environment always wins.
+   */
+  readonly profileConfig?: Effect.Effect<
+    Readonly<Record<string, string | undefined>> | undefined
+  >;
+}
+
+const instanceMetadataEndpoint = (
+  profileConfig: Readonly<Record<string, string | undefined>> | undefined,
+): Effect.Effect<string, CredentialSourceError> => {
+  const endpoint =
+    env(ENV_IMDS_ENDPOINT) ?? profileConfig?.ec2_metadata_service_endpoint;
+  if (endpoint) return Effect.succeed(endpoint);
+  const mode =
+    env(ENV_IMDS_ENDPOINT_MODE) ??
+    profileConfig?.ec2_metadata_service_endpoint_mode ??
+    "IPv4";
+  switch (mode) {
+    case "IPv4":
+      return Effect.succeed("http://169.254.169.254");
+    case "IPv6":
+      return Effect.succeed("http://[fd00:ec2::254]");
+    default:
+      return Effect.fail(
+        new CredentialSourceError({
+          message: `Unsupported endpoint mode: ${mode}. Select from IPv4, IPv6`,
+          tryNextLink: false,
+        }),
+      );
+  }
+};
+
+const STATIC_STABILITY_REFRESH_INTERVAL_SECONDS = 5 * 60;
+const STATIC_STABILITY_DOC_URL =
+  "https://docs.aws.amazon.com/sdkref/latest/guide/feature-static-credentials.html";
+
+/**
+ * When IMDS is unreachable, keep using the last credentials it handed out
+ * and retry in 5–10 minutes rather than failing the request outright.
+ */
+const extendCredentials = (
+  credentials: AwsCredentialIdentity,
+): AwsCredentialIdentity => {
+  const refreshInterval =
+    STATIC_STABILITY_REFRESH_INTERVAL_SECONDS +
+    Math.floor(Math.random() * STATIC_STABILITY_REFRESH_INTERVAL_SECONDS);
+  const expiration = new Date(Date.now() + refreshInterval * 1000);
+  console.warn(
+    "Attempting credential expiration extension due to a credential service availability issue. A refresh of these " +
+      `credentials will be attempted after ${expiration}.\nFor more information, please visit: ` +
+      STATIC_STABILITY_DOC_URL,
+  );
+  return { ...credentials, expiration };
+};
+
+/**
+ * Credentials of the instance role, from IMDSv2 with a fall back to IMDSv1
+ * unless `AWS_EC2_METADATA_V1_DISABLED` (or the profile) forbids it.
+ *
+ * Each call to `fromInstanceMetadata` owns its own state: whether v1 is in
+ * use and the last credentials served, for static stability.
+ */
+export const fromInstanceMetadata = (
+  options: FromInstanceMetadataOptions = {},
+): CredentialSource => {
+  const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+  const maxRetries = options.maxRetries ?? 0;
+  let disableFetchToken = false;
+  let pastCredentials: AwsCredentialIdentity | undefined;
+
+  const imdsRequest = (
+    endpoint: string,
+    path: string,
+    method: "GET" | "PUT",
+    headers: Record<string, string>,
+  ) =>
+    requestText(
+      HttpClientRequest.make(method)(`${endpoint}${path}`, { headers }),
+      timeoutMs,
+    ).pipe(
+      Effect.flatMap(({ status, text }) =>
+        status >= 200 && status < 300
+          ? Effect.succeed(text)
+          : Effect.fail(
+              new CredentialSourceError({
+                message: `Error response received from instance metadata service (status ${status})`,
+                cause: { statusCode: status },
+              }),
+            ),
+      ),
+    );
+
+  const statusOf = (error: CredentialSourceError): number | undefined =>
+    typeof error.cause === "object" && error.cause !== null
+      ? (error.cause as { statusCode?: number }).statusCode
+      : undefined;
+
+  const v1FallbackBlocked = (
+    profileConfig: Readonly<Record<string, string | undefined>> | undefined,
+  ): CredentialSourceError | undefined => {
+    const envValue = env(ENV_IMDS_V1_DISABLED);
+    const blockedByEnv = !!envValue && envValue !== "false";
+    const profileValue =
+      envValue === undefined
+        ? profileConfig?.ec2_metadata_v1_disabled
+        : undefined;
+    const blockedByProfile = !!profileValue && profileValue !== "false";
+    if (!options.ec2MetadataV1Disabled && !blockedByEnv && !blockedByProfile)
+      return;
+    const causes: string[] = [];
+    if (options.ec2MetadataV1Disabled)
+      causes.push(
+        "credential provider initialization (runtime option ec2MetadataV1Disabled)",
+      );
+    if (blockedByProfile)
+      causes.push("config file profile (ec2_metadata_v1_disabled)");
+    if (blockedByEnv)
+      causes.push(`process environment variable (${ENV_IMDS_V1_DISABLED})`);
+    return new CredentialSourceError({
+      message: `AWS EC2 Metadata v1 fallback has been blocked by AWS SDK configuration in the following: [${causes.join(", ")}].`,
+      tryNextLink: false,
+    });
+  };
+
+  const getCredentials = (
+    endpoint: string,
+    headers: Record<string, string>,
+    profileConfig: Readonly<Record<string, string | undefined>> | undefined,
+  ): CredentialSource =>
+    Effect.suspend(() => {
+      const isV1 =
+        disableFetchToken || headers[X_AWS_EC2_METADATA_TOKEN] === undefined;
+      if (isV1) {
+        const blocked = v1FallbackBlocked(profileConfig);
+        if (blocked) return Effect.fail(blocked);
+      }
+      const onUnauthorized = (error: CredentialSourceError) => {
+        if (statusOf(error) === 401) disableFetchToken = false;
+        return Effect.fail(error);
+      };
+      return retry(
+        imdsRequest(endpoint, IMDS_PATH, "GET", headers).pipe(
+          Effect.catch(onUnauthorized),
+        ),
+        maxRetries,
+      ).pipe(
+        Effect.flatMap((profile) =>
+          retry(
+            imdsRequest(
+              endpoint,
+              IMDS_PATH + profile.trim(),
+              "GET",
+              headers,
+            ).pipe(
+              Effect.catch(onUnauthorized),
+              Effect.flatMap(parseImdsCredentials),
+            ),
+            maxRetries,
+          ),
+        ),
+      );
+    });
+
+  const resolve: CredentialSource = Effect.gen(function* () {
+    const profileConfig = options.profileConfig
+      ? yield* options.profileConfig
+      : undefined;
+    const endpoint = yield* instanceMetadataEndpoint(profileConfig);
+    if (disableFetchToken) {
+      return yield* getCredentials(endpoint, {}, profileConfig);
+    }
+    const token = yield* imdsRequest(endpoint, IMDS_TOKEN_PATH, "PUT", {
+      "x-aws-ec2-metadata-token-ttl-seconds": "21600",
+    }).pipe(
+      Effect.map((token) => Option.some(token)),
+      Effect.catch((error) => {
+        const status = statusOf(error);
+        if (status === 400) {
+          return Effect.fail(
+            new CredentialSourceError({
+              message: "EC2 Metadata token request returned error",
+              cause: error,
+            }),
+          );
+        }
+        if (
+          error.message === "TimeoutError" ||
+          status === 403 ||
+          status === 404 ||
+          status === 405
+        ) {
+          disableFetchToken = true;
+        }
+        return Effect.succeed(Option.none<string>());
+      }),
+    );
+    return yield* getCredentials(
+      endpoint,
+      Option.isSome(token) ? { [X_AWS_EC2_METADATA_TOKEN]: token.value } : {},
+      profileConfig,
+    );
+  });
+
+  return resolve.pipe(
+    Effect.map((credentials) =>
+      credentials.expiration && credentials.expiration.getTime() < Date.now()
+        ? extendCredentials(credentials)
+        : credentials,
+    ),
+    Effect.catch((error): CredentialSource =>
+      pastCredentials
+        ? Effect.sync(() => {
+            console.warn("Credential renew failed: ", error);
+            return extendCredentials(pastCredentials!);
+          })
+        : Effect.fail(error),
+    ),
+    Effect.map((credentials) => {
+      pastCredentials = credentials;
+      return credentials;
+    }),
+  );
+};

--- a/packages/aws/src/credentials.browser.ts
+++ b/packages/aws/src/credentials.browser.ts
@@ -1,9 +1,4 @@
-import { fromHttp as _fromHttp } from "@aws-sdk/credential-providers";
-
-import {
-  type AwsCredentialIdentity,
-  type AwsCredentialIdentityProvider,
-} from "@smithy/types";
+import type { AwsCredentialIdentity } from "@smithy/types";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -11,6 +6,7 @@ import * as Layer from "effect/Layer";
 import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
 import type { HttpClientError } from "effect/unstable/http/HttpClientError";
+import * as Providers from "./credential-providers/shared.ts";
 import { fromEnvironment as regionFromEnvironment } from "./region.ts";
 import type { RegionName } from "./region.ts";
 export * as AWSTypes from "@aws-sdk/types";
@@ -199,11 +195,11 @@ export const createCachedCredentialsEffect = <E, R>(
 };
 
 /**
- * Create a lazy, cached credentials provider from an AWS SDK credential provider.
+ * Create a lazy, cached credentials layer from a credential source.
  * Credentials are resolved on first access and cached based on their expiration time.
  */
 export const createLazyProvider = (
-  provider: (config: {}) => AwsCredentialIdentityProvider,
+  source: Providers.CredentialSource,
   providerName: ProviderName,
   /**
    * Where this provider's region comes from. Defaults to the environment;
@@ -212,17 +208,17 @@ export const createLazyProvider = (
   region: Effect.Effect<RegionName, CredentialsError> = regionFromEnv,
 ): Layer.Layer<Credentials> => {
   const resolve = Effect.gen(function* () {
-    const hints = providerHints(providerName);
-    const identity = yield* Effect.tryPromise({
-      try: () => provider({})(),
-      catch: (cause) =>
-        new AwsCredentialProviderError({
-          message: `Failed to resolve credentials from ${providerName}.`,
-          provider: providerName,
-          cause,
-          hints,
-        }),
-    });
+    const identity = yield* source.pipe(
+      Effect.mapError(
+        (cause) =>
+          new AwsCredentialProviderError({
+            message: `Failed to resolve credentials from ${providerName}.`,
+            provider: providerName,
+            cause,
+            hints: providerHints(providerName),
+          }),
+      ),
+    );
     return fromAwsCredentialIdentity(identity, yield* region);
   });
 
@@ -246,7 +242,7 @@ export const fromCredentials = (
     ),
   );
 
-export const fromHttp = () => createLazyProvider(_fromHttp, "http");
+export const fromHttp = () => createLazyProvider(Providers.fromHttp(), "http");
 
 export const ssoRegion = (region: string) => Layer.succeed(SsoRegion, region);
 

--- a/packages/aws/src/credentials.ts
+++ b/packages/aws/src/credentials.ts
@@ -1,11 +1,3 @@
-import {
-  fromContainerMetadata as _fromContainerMetadata,
-  fromEnv as _fromEnv,
-  fromIni as _fromIni,
-  fromNodeProviderChain as _fromNodeProviderChain,
-  fromProcess as _fromProcess,
-  fromTokenFile as _fromTokenFile,
-} from "@aws-sdk/credential-providers";
 import * as BrowserCredentials from "./credentials.browser.ts";
 export * from "./credentials.browser.ts";
 
@@ -13,6 +5,7 @@ import { loadSharedConfigFiles } from "@smithy/shared-ini-file-loader";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Auth } from "./auth.ts";
+import * as Providers from "./credential-providers/node.ts";
 import type * as Region from "./region.ts";
 
 /**
@@ -53,36 +46,40 @@ const regionFromEnvOrProfile = BrowserCredentials.regionFromEnv.pipe(
 );
 
 export const fromEnv = () =>
-  BrowserCredentials.createLazyProvider(_fromEnv, "env");
+  BrowserCredentials.createLazyProvider(Providers.fromEnv, "env");
 
 export const fromChain = () =>
   BrowserCredentials.createLazyProvider(
-    () => _fromNodeProviderChain(),
+    Providers.fromNodeProviderChain(),
     "chain",
     regionFromEnvOrProfile,
   );
 
-// export const fromSSO = () => createLazyProvider(_fromSSO);
-
 export const fromIni = () =>
   BrowserCredentials.createLazyProvider(
-    _fromIni,
+    Providers.fromIni(),
     "ini",
     regionFromEnvOrProfile,
   );
 
 export const fromContainerMetadata = () =>
-  BrowserCredentials.createLazyProvider(_fromContainerMetadata, "container");
+  BrowserCredentials.createLazyProvider(
+    Providers.fromContainerMetadata(),
+    "container",
+  );
 
 export const fromProcess = () =>
   BrowserCredentials.createLazyProvider(
-    _fromProcess,
+    Providers.fromProcess(),
     "process",
     regionFromEnvOrProfile,
   );
 
 export const fromTokenFile = () =>
-  BrowserCredentials.createLazyProvider(_fromTokenFile, "token-file");
+  BrowserCredentials.createLazyProvider(
+    Providers.fromTokenFile(),
+    "token-file",
+  );
 
 /**
  * Create a lazy, cached SSO credentials provider.

--- a/packages/aws/src/errors.ts
+++ b/packages/aws/src/errors.ts
@@ -1,6 +1,8 @@
 import * as S from "effect/Schema";
 import type * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as Category from "./category.ts";
+import type * as Credentials from "./credentials.browser.ts";
+import type * as SigV4 from "./sigv4.ts";
 // Imported from the leaf module, not `traits.ts`: that one imports every
 // protocol, and each protocol imports this file, so the annotation would not
 // yet exist when these classes are built. See error-message.ts.
@@ -241,4 +243,6 @@ export type CommonErrors =
   | CommonAwsError
   | EndpointError
   | NoMatchingRuleError
+  | SigV4.SigningError
+  | Credentials.CredentialsError
   | HttpClientError.HttpClientError;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ catalogs:
       specifier: 4.0.0-rc.112
       version: 4.0.0-rc.112
   default:
-    '@aws-sdk/credential-providers':
-      specifier: ^3.1109.0
-      version: 3.1109.0
     '@aws-sdk/types':
       specifier: ^3.974.3
       version: 3.974.3
@@ -278,9 +275,6 @@ importers:
 
   packages/aws:
     dependencies:
-      '@aws-sdk/credential-providers':
-        specifier: 'catalog:'
-        version: 3.1109.0
       '@aws-sdk/types':
         specifier: 'catalog:'
         version: 3.974.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ allowBuilds:
   workerd: true
 
 catalog:
-  "@aws-sdk/credential-providers": "^3.1109.0"
   "@aws-sdk/types": "^3.974.3"
   "@effect/platform-bun": ">=4.0.0-rc.115 || >=4.0.0"
   "@effect/platform-node": ">=4.0.0-rc.115 || >=4.0.0"


### PR DESCRIPTION
Replaces the `@aws-sdk/credential-providers` dependency with in-repo Effect-native credential sources.

## What changed

- New `packages/aws/src/credential-providers/` module:
  - `shared.ts` — browser-safe sources (env, HTTP/container, EC2 IMDS) with `CredentialSourceError` and the chain logic.
  - `node.ts` — Node-only sources (`fromIni`, `credential_process`, web identity token file, default chain) using `@smithy/shared-ini-file-loader` and the generated STS service.
  - `credential-providers.test.ts` — 39 tests covering the providers.
- Rewires `credentials.ts` / `credentials.browser.ts` to the new sources.
- Removes `@aws-sdk/credential-providers` from `packages/aws/package.json`, the pnpm catalog, and the lockfile.
- Adds `SigV4.SigningError` and `Credentials.CredentialsError` to `CommonErrors` in `packages/aws/src/errors.ts`, so signing and credential-resolution failures are part of every generated operation's error channel.

## Verification

- `bun test` credential-providers + auth + sigv4: 49 pass, 0 fail
- `pnpm typecheck`: pass
- `pnpm typecheck:ci` (`tsc -b --noCheck false`): pass
- `pnpm format`: clean